### PR TITLE
Add Render SPA fallback routing

### DIFF
--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,2 +1,3 @@
 /dashboard /index.html 200
 /dashboard/* /index.html 200
+/* /index.html 200

--- a/render.yaml
+++ b/render.yaml
@@ -80,6 +80,9 @@ services:
       - type: rewrite
         source: /dashboard/*
         destination: /index.html
+      - type: rewrite
+        source: /*
+        destination: /index.html
 
 databases:
   - name: lumen-ai-db


### PR DESCRIPTION
Adds Render SPA fallback routing guidance/configuration so deployed direct links for pilot frontend routes rewrite to /index.html instead of returning 404.