### PR TITLE
Image retention + labeling pipeline and SPD risk-weighted scoring

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -113,6 +113,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.p25_infrastructure")    # register P25 infrastructure tables
     importlib.import_module("app.models.retained_image")        # register opt-in training-image store + labels
     importlib.import_module("app.models.capture_device")        # register borescope capture-device registry
+    importlib.import_module("app.models.supervisor_review")     # register supervisor AI-agreement feedback store
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -542,6 +543,9 @@ app.include_router(ml_images_router, prefix=settings.API_PREFIX)
 
 from app.routes.capture import router as capture_router
 app.include_router(capture_router, prefix=settings.API_PREFIX)
+
+from app.routes.ai_clinical_review import router as ai_clinical_review_router
+app.include_router(ai_clinical_review_router, prefix=settings.API_PREFIX)
 
 app.include_router(agent_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -112,6 +112,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.p24_standards")        # register P24 standards tables
     importlib.import_module("app.models.p25_infrastructure")    # register P25 infrastructure tables
     importlib.import_module("app.models.retained_image")        # register opt-in training-image store + labels
+    importlib.import_module("app.models.capture_device")        # register borescope capture-device registry
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -537,6 +538,9 @@ app.include_router(admin_users_router)
 
 from app.routes.ml_images import router as ml_images_router
 app.include_router(ml_images_router, prefix=settings.API_PREFIX)
+
+from app.routes.capture import router as capture_router
+app.include_router(capture_router, prefix=settings.API_PREFIX)
 
 app.include_router(agent_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -111,6 +111,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.consent_record")       # register P20 consent record table
     importlib.import_module("app.models.p24_standards")        # register P24 standards tables
     importlib.import_module("app.models.p25_infrastructure")    # register P25 infrastructure tables
+    importlib.import_module("app.models.retained_image")        # register opt-in training-image store + labels
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -533,6 +534,9 @@ app.include_router(inspections_router, prefix=settings.API_PREFIX)
 
 from app.routes.admin_users import router as admin_users_router
 app.include_router(admin_users_router)
+
+from app.routes.ml_images import router as ml_images_router
+app.include_router(ml_images_router, prefix=settings.API_PREFIX)
 
 app.include_router(agent_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -236,6 +236,7 @@ app.add_middleware(
         "X-Tenant-Id",
         "X-Tenant-Name",
         "X-Requested-With",
+        "X-Device-Key",
     ],
 )
 

--- a/backend/app/models/capture_device.py
+++ b/backend/app/models/capture_device.py
@@ -1,0 +1,48 @@
+"""Capture-device registry for direct borescope-to-LumenAI ingestion.
+
+A capture device is an unattended appliance ("LumenAI Bridge") or a tablet
+running the browser capture client that pushes borescope frames straight into
+LumenAI over HTTPS — replacing the USB-drive hand-off that hospital IT blocks.
+
+Security:
+- The device key is issued ONCE via secrets.token_urlsafe(40) and stored only as
+  a SHA-256 hash — never retrievable again (matches the platform's API-key rule).
+- Devices are tenant-scoped and can be revoked (active=False).
+- Every ingestion authenticates with the hashed key and is audit-logged.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class CaptureDevice(Base):
+    __tablename__ = "capture_devices"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Free-text location so leaders know which room/scope this device serves.
+    location: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+    # SHA-256 of the issued key — the plaintext is shown once and never stored.
+    key_hash: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    # The inspection role the device acts as (operator by default).
+    role: Mapped[str] = mapped_column(String(50), default="operator", nullable=False)
+
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -71,3 +71,9 @@ class Inspection(Base):
     override_reason: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     override_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
     override_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # SPD risk-weighted verdict — persisted so dashboard/history reflect the SPD
+    # disposition, not just the live analysis panel.
+    risk_level: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    recommended_action: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    overall_cleaning_assessment: Mapped[str | None] = mapped_column(String(80), nullable=True)

--- a/backend/app/models/retained_image.py
+++ b/backend/app/models/retained_image.py
@@ -1,0 +1,116 @@
+"""Retained inspection-image store + labeling models.
+
+Foundation for training a real image-based inspection model. The platform
+otherwise stores **only SHA-256 hashes** — training and baseline-diff require
+the actual image bytes, which is a deliberate, access-controlled, opt-in
+capability (env-gated, OFF by default) with EXIF stripped on ingest.
+
+Security/governance:
+- Retention is OFF unless ``RETAIN_INSPECTION_IMAGES`` is enabled AND consent is
+  recorded — a prerequisite, not a default.
+- EXIF/metadata is stripped before bytes are persisted (no GPS, no device, no
+  embedded thumbnails) — PHI-avoidance.
+- De-identified filename ``{instrument_type}_{seq}`` — never patient/facility
+  identifiers.
+- Every label change is audit-logged by the routes that mutate these rows.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    Integer,
+    LargeBinary,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class RetainedImage(Base):
+    """An inspection/baseline image retained (opt-in) for model training.
+
+    Stores EXIF-stripped bytes plus de-identified metadata. No patient
+    identifiers, MRNs, faces, or documents are permitted in frame.
+    """
+
+    __tablename__ = "retained_images"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    # De-identified handle — never a patient/facility identifier.
+    deident_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    instrument_type: Mapped[str] = mapped_column(
+        String(100), default="unknown", nullable=False, index=True
+    )
+    content_type: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    # SHA-256 of the EXIF-stripped bytes actually stored (integrity + dedupe).
+    sha256: Mapped[str] = mapped_column(String(64), default="", nullable=False, index=True)
+    exif_stripped: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    # Provenance — in-workflow capture, baseline reference, or curated demo set.
+    source: Mapped[str] = mapped_column(String(50), default="inspection", nullable=False)
+    consent_recorded: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    uploaded_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+    # The EXIF-stripped bytes. Nullable so metadata can outlive purged bytes.
+    image_bytes: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+
+    # Labeling lifecycle: unlabeled -> labeled -> in_review -> gold | rejected.
+    label_status: Mapped[str] = mapped_column(
+        String(30), default="unlabeled", nullable=False, index=True
+    )
+
+
+class ImageLabel(Base):
+    """A single (multi-label) annotation applied to a retained image.
+
+    One image may carry several labels (e.g. rust + debris). Critical classes
+    (blood, crack, missing_component) require two reviewers + adjudication before
+    a label is promoted to ``gold``.
+    """
+
+    __tablename__ = "image_labels"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    image_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    # The finding class, e.g. blood / rust / crack / clean.
+    finding_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    present: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    # Per-finding severity using published scales (e.g. none/surface/moderate/heavy).
+    severity: Mapped[str] = mapped_column(String(30), default="", nullable=False)
+    # Optional region for localizable findings: JSON [x,y,w,h] (normalized 0..1).
+    region_json: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, default=1.0, nullable=False)
+
+    reviewer: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    # adjudication state for critical-class two-reviewer rule.
+    adjudicated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    is_gold: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    notes: Mapped[str] = mapped_column(String(1000), default="", nullable=False)

--- a/backend/app/models/supervisor_review.py
+++ b/backend/app/models/supervisor_review.py
@@ -1,0 +1,48 @@
+"""Supervisor AI-agreement feedback — the human-in-the-loop label store.
+
+Captures whether a supervisor agrees with the AI's clinical review, their
+rationale, and any override. This is deliberately a separate table from the
+inspection's qa_* fields so the agreement signal can be exported as labeled
+training data and aggregated for model-performance monitoring.
+
+Governance: only admin/spd_manager submit reviews; comments are required for
+partial-agreement, disagreement, and override; every review is audit-logged.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class SupervisorReview(Base):
+    __tablename__ = "supervisor_reviews"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    reviewer_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    reviewer_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    # agree | partially_agree | disagree
+    agreement: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    rationale: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    # Optional disposition override the supervisor applied.
+    override_action: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    # Snapshot of what the AI said, for training-data provenance.
+    ai_recommendation: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    ai_score: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -1,0 +1,181 @@
+"""Supervisor AI-review capture + model-performance summary.
+
+- POST /api/inspections/{id}/supervisor-review — admin/spd_manager record whether
+  they agree with the AI, with a required comment for partial/disagree/override.
+- GET  /api/model-performance/ai-summary — aggregate agreement/override metrics
+  from real supervisor reviews (no fabricated production numbers).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.supervisor_review import SupervisorReview
+
+router = APIRouter(tags=["ai-clinical-review"])
+
+_AGREEMENT_VALUES = {"agree", "partially_agree", "disagree"}
+# Comment is mandatory for anything other than a clean agreement.
+_COMMENT_REQUIRED = {"partially_agree", "disagree"}
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+class SupervisorReviewIn(BaseModel):
+    agreement: str = Field(..., description="agree | partially_agree | disagree")
+    rationale: str = Field("", max_length=2000)
+    override_action: str = Field("", max_length=50)
+
+
+@router.post("/inspections/{inspection_id}/supervisor-review", status_code=201)
+def submit_supervisor_review(
+    inspection_id: int,
+    body: SupervisorReviewIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Record a supervisor's agreement with the AI clinical review.
+
+    Role-gated to admin/spd_manager (viewers/operators cannot submit). A comment
+    is required for partial agreement, disagreement, or any override.
+    """
+    agreement = body.agreement.strip().lower()
+    if agreement not in _AGREEMENT_VALUES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"agreement must be one of {sorted(_AGREEMENT_VALUES)}",
+        )
+    needs_comment = agreement in _COMMENT_REQUIRED or bool(body.override_action.strip())
+    if needs_comment and not body.rationale.strip():
+        raise HTTPException(
+            status_code=422,
+            detail="A rationale comment is required for partial agreement, disagreement, or override.",
+        )
+
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    inspection = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id)
+        .first()
+    )
+    if inspection is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+
+    review = SupervisorReview(
+        inspection_id=inspection_id,
+        tenant_id=tenant_id,
+        reviewer_name=_actor(current_user),
+        reviewer_role=getattr(current_user, "role", "spd_manager"),
+        agreement=agreement,
+        rationale=body.rationale.strip(),
+        override_action=body.override_action.strip(),
+        ai_recommendation=inspection.recommended_action or "",
+        ai_score=(100 - inspection.risk_score) if inspection.score_status == "scored" else None,
+    )
+    db.add(review)
+
+    # Reflect the override on the inspection when the supervisor applies one.
+    if body.override_action.strip():
+        inspection.override_reason = body.rationale.strip()
+        inspection.override_by = _actor(current_user)
+        inspection.override_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(review)
+
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id,
+        actor_email=_actor(current_user), actor_role=getattr(current_user, "role", "spd_manager"),
+        action_type="supervisor_ai_review", resource_type="inspection",
+        resource_id=str(inspection_id),
+    )
+    return {
+        "id": review.id,
+        "inspection_id": inspection_id,
+        "agreement": agreement,
+        "override_action": review.override_action,
+        "reviewer": review.reviewer_name,
+    }
+
+
+@router.get("/inspections/{inspection_id}/supervisor-reviews")
+def list_supervisor_reviews(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    rows = (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.inspection_id == inspection_id)
+        .order_by(SupervisorReview.id.desc())
+        .all()
+    )
+    return {
+        "inspection_id": inspection_id,
+        "count": len(rows),
+        "reviews": [
+            {
+                "id": r.id, "agreement": r.agreement, "rationale": r.rationale,
+                "override_action": r.override_action, "reviewer": r.reviewer_name,
+                "reviewer_role": r.reviewer_role,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.get("/model-performance/ai-summary")
+def ai_performance_summary(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Aggregate real supervisor-agreement metrics.
+
+    Computed only from actual reviews/inspections — no fabricated production
+    numbers. Fields are zero/None until real reviews exist.
+    """
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+    inspections = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id)
+    total_predictions = inspections.filter(models.Inspection.has_image.is_(True)).count()
+    cases_requiring_review = inspections.filter(
+        models.Inspection.supervisor_review_required.is_(True)
+    ).count()
+    scored = inspections.filter(models.Inspection.score_status == "scored").all()
+    avg_conf = round(sum((r.confidence or 0) for r in scored) / len(scored), 2) if scored else None
+
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    n = len(reviews)
+    agree = sum(1 for r in reviews if r.agreement == "agree")
+    overrides = sum(1 for r in reviews if r.override_action)
+    disagree = sum(1 for r in reviews if r.agreement == "disagree")
+
+    return {
+        "total_ai_predictions": total_predictions,
+        "supervisor_reviews": n,
+        "supervisor_agreement_rate": round(agree / n, 4) if n else None,
+        "override_rate": round(overrides / n, 4) if n else None,
+        # False +/- require adjudicated ground truth; surfaced but not fabricated.
+        "false_positive_count": None,
+        "false_negative_count": None,
+        "disagreement_count": disagree,
+        "average_confidence": avg_conf,
+        "cases_requiring_review": cases_requiring_review,
+        "note": (
+            "Agreement/override rates are computed from real supervisor reviews. "
+            "False positive/negative counts require adjudicated ground truth and "
+            "are not fabricated."
+        ),
+    }

--- a/backend/app/routes/capture.py
+++ b/backend/app/routes/capture.py
@@ -1,0 +1,253 @@
+"""Direct borescope-to-LumenAI capture ingestion.
+
+Two auth models feed the same pipeline:
+  - Browser capture client (tablet/PC with a UVC grabber): uses the logged-in
+    user's token via the existing /api/inspections/* endpoints.
+  - Unattended "LumenAI Bridge" appliance: authenticates with a device key
+    (X-Device-Key) and POSTs frames to /api/capture/ingest — no human login,
+    no USB drive.
+
+Everything is EXIF-stripped, identifier-decoded, scored, and audit-logged, so a
+captured frame becomes an inspection the instant the tech presses capture.
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Request, UploadFile
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.cv.identifier_decoder import decode_from_image_bytes
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.capture_device import CaptureDevice
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.image_retention_service import retain_image
+
+router = APIRouter(prefix="/capture", tags=["capture"])
+
+_ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+_ASSIGNABLE_DEVICE_ROLES = {"operator", "spd_manager"}
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+# ── Device registration (admin) ──────────────────────────────────────────────
+
+class DeviceRegister(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    location: str = Field("", max_length=255)
+    role: str = Field("operator", max_length=50)
+
+
+@router.post("/devices", status_code=201)
+def register_device(
+    body: DeviceRegister,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Register a capture device and return its key ONCE (never retrievable again)."""
+    if body.role not in _ASSIGNABLE_DEVICE_ROLES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"role must be one of {sorted(_ASSIGNABLE_DEVICE_ROLES)}",
+        )
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+    raw_key = secrets.token_urlsafe(40)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    device = CaptureDevice(
+        tenant_id=tenant_id,
+        name=body.name,
+        location=body.location,
+        key_hash=key_hash,
+        role=body.role,
+        active=True,
+    )
+    db.add(device)
+    db.commit()
+    db.refresh(device)
+
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id,
+        actor_email=_actor(current_user), actor_role=getattr(current_user, "role", "admin"),
+        action_type="capture_device_registered", resource_type="capture_device",
+        resource_id=str(device.id),
+    )
+    return {
+        "id": device.id,
+        "name": device.name,
+        "location": device.location,
+        "role": device.role,
+        # Shown ONCE — store it on the device now; it can never be retrieved again.
+        "device_key": raw_key,
+        "note": "Store this key on the capture device now. It is not recoverable.",
+    }
+
+
+@router.get("/devices")
+def list_devices(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    rows = (
+        db.query(CaptureDevice)
+        .filter(CaptureDevice.tenant_id == tenant_id)
+        .order_by(CaptureDevice.id.desc())
+        .all()
+    )
+    return {
+        "count": len(rows),
+        "devices": [
+            {
+                "id": r.id, "name": r.name, "location": r.location, "role": r.role,
+                "active": r.active,
+                "last_seen_at": r.last_seen_at.isoformat() if r.last_seen_at else None,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.post("/devices/{device_id}/revoke")
+def revoke_device(
+    device_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    device = (
+        db.query(CaptureDevice)
+        .filter(CaptureDevice.id == device_id, CaptureDevice.tenant_id == tenant_id)
+        .first()
+    )
+    if device is None:
+        raise HTTPException(status_code=404, detail="Capture device not found.")
+    device.active = False
+    db.commit()
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id,
+        actor_email=_actor(current_user), actor_role=getattr(current_user, "role", "admin"),
+        action_type="capture_device_revoked", resource_type="capture_device",
+        resource_id=str(device.id),
+    )
+    return {"id": device.id, "active": False}
+
+
+# ── Device authentication ─────────────────────────────────────────────────────
+
+def authenticate_device(db: Session, device_key: Optional[str]) -> CaptureDevice:
+    """Resolve an active CaptureDevice from a plaintext X-Device-Key header."""
+    if not device_key:
+        raise HTTPException(status_code=401, detail="Missing X-Device-Key.")
+    key_hash = hashlib.sha256(device_key.encode()).hexdigest()
+    device = (
+        db.query(CaptureDevice)
+        .filter(CaptureDevice.key_hash == key_hash, CaptureDevice.active.is_(True))
+        .first()
+    )
+    if device is None:
+        raise HTTPException(status_code=401, detail="Invalid or revoked device key.")
+    return device
+
+
+# ── Ingestion (unattended appliance) ──────────────────────────────────────────
+
+@router.post("/ingest", status_code=201)
+async def ingest_capture(
+    image: UploadFile = File(...),
+    instrument_type: str = Form("unknown"),
+    instrument_barcode: str = Form(""),
+    instrument_udi: str = Form(""),
+    facility_name: str = Form(""),
+    consent: bool = Form(False),
+    x_device_key: Optional[str] = Header(default=None),
+    db: Session = Depends(get_db),
+):
+    """Ingest a borescope frame from an authenticated capture device.
+
+    Decodes identifiers, optionally retains the EXIF-stripped image, scores it
+    against the approved baseline, and persists the inspection — the same
+    pipeline as a manual New Inspection, but triggered by the device.
+    """
+    device = authenticate_device(db, x_device_key)
+    tenant_id = device.tenant_id
+
+    content_type = image.content_type or ""
+    if content_type not in _ALLOWED_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported type '{content_type}'. Allowed: {sorted(_ALLOWED_TYPES)}",
+        )
+    data = await image.read()
+    if len(data) > _MAX_IMAGE_BYTES:
+        raise HTTPException(status_code=413, detail="Image exceeds 10 MB limit.")
+
+    sha256 = hashlib.sha256(data).hexdigest()
+
+    # Real identifier decode from the frame; declared values win if provided.
+    decoded = decode_from_image_bytes(data)
+    barcode = instrument_barcode or decoded.barcode_value
+    udi = instrument_udi or decoded.qr_value or decoded.udi_value
+    identifier_source = "pyzbar" if (not instrument_barcode and not instrument_udi and (decoded.barcode_value or decoded.qr_value or decoded.udi_value)) else "declared"
+
+    # Opt-in retention (no-op unless enabled + consent).
+    retain_image(
+        db, data=data, tenant_id=tenant_id, instrument_type=instrument_type,
+        content_type=content_type, source="capture_device",
+        uploaded_by=f"device:{device.id}", consent=consent,
+    )
+
+    analysis = analyze_inspection(
+        db, instrument_type=instrument_type, tenant_id=tenant_id, has_image=True,
+        image_sha256=sha256, instrument_barcode=barcode or None,
+        instrument_udi=udi or None, decoder_backend=identifier_source,
+    )
+
+    completed = analysis["analysis_status"] == "completed"
+    row = models.Inspection(
+        file_name=image.filename or "capture.jpg",
+        tenant_id=tenant_id, tenant_name=tenant_id,
+        instrument_type=instrument_type,
+        inference_mode="borescope_capture",
+        risk_score=(100 - int(analysis["inspection_score"])) if completed else 0,
+        vendor_name="unknown", site_name=facility_name or "capture",
+        facility_name=facility_name or None,
+        instrument_barcode=barcode or None, instrument_udi=udi or None,
+        inference_timestamp=datetime.now(timezone.utc),
+        has_image=True, image_sha256=sha256,
+        baseline_status="approved_baseline_found" if completed else "no_approved_baseline",
+        baseline_source=analysis.get("baseline_source"),
+        score_status="scored" if completed else "supervisor_review_required",
+        supervisor_review_required=not completed,
+        risk_level=analysis.get("risk_level"),
+        recommended_action=analysis.get("recommended_action"),
+        overall_cleaning_assessment=analysis.get("overall_cleaning_assessment"),
+    )
+    db.add(row)
+    device.last_seen_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(row)
+
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id,
+        actor_email=f"device:{device.id}", actor_role=device.role,
+        action_type="capture_ingested", resource_type="inspection",
+        resource_id=str(row.id),
+    )
+    return {"inspection_id": row.id, "device_id": device.id, "analysis": analysis}

--- a/backend/app/routes/capture.py
+++ b/backend/app/routes/capture.py
@@ -175,6 +175,7 @@ async def ingest_capture(
     instrument_barcode: str = Form(""),
     instrument_udi: str = Form(""),
     facility_name: str = Form(""),
+    captured_by: str = Form(""),
     consent: bool = Form(False),
     x_device_key: Optional[str] = Header(default=None),
     db: Session = Depends(get_db),
@@ -244,10 +245,18 @@ async def ingest_capture(
     db.commit()
     db.refresh(row)
 
+    # Attribute to the scanning tech when the station provides a badge/PIN,
+    # otherwise to the device itself.
+    actor = captured_by.strip() or f"device:{device.id}"
     log_audit_event(
         db, tenant_id=tenant_id, tenant_name=tenant_id,
-        actor_email=f"device:{device.id}", actor_role=device.role,
+        actor_email=actor, actor_role=device.role,
         action_type="capture_ingested", resource_type="inspection",
         resource_id=str(row.id),
     )
-    return {"inspection_id": row.id, "device_id": device.id, "analysis": analysis}
+    return {
+        "inspection_id": row.id,
+        "device_id": device.id,
+        "captured_by": captured_by.strip(),
+        "analysis": analysis,
+    }

--- a/backend/app/routes/history.py
+++ b/backend/app/routes/history.py
@@ -46,6 +46,10 @@ def inspection_response(row: models.Inspection) -> dict:
         "baseline_source": row.baseline_source,
         "score_status": row.score_status,
         "supervisor_review_required": row.supervisor_review_required,
+        # SPD risk-weighted verdict persisted with the inspection
+        "risk_level": row.risk_level,
+        "recommended_action": row.recommended_action,
+        "overall_cleaning_assessment": row.overall_cleaning_assessment,
         # inspection_score is the inverse of risk_score (0-100 quality)
         "inspection_score": (100 - row.risk_score) if row.score_status in ("scored", "scored_after_override") else None,
     }

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -12,6 +12,7 @@ from app.deps import get_db, get_current_user
 from app.db import models
 from app.enterprise_auth import get_request_tenant_id
 from app.analytics.risk_engine import calculate_risk
+from app.cv.identifier_decoder import decode_from_image_bytes
 from app.services.baseline_comparison_scoring_service import analyze_inspection
 
 router = APIRouter(tags=["inspections"])
@@ -77,6 +78,8 @@ class InspectionCreate(BaseModel):
     instrument_barcode: Optional[str] = Field(None, max_length=255)
     instrument_udi: Optional[str] = Field(None, max_length=255)
     keydot_id: Optional[str] = Field(None, max_length=255)
+    # How identifiers were obtained: "pyzbar" (decoded) or "declared" (typed).
+    identifier_source: Optional[str] = Field(None, max_length=20)
     # Technician-declared finding categories (optional — AI determines findings)
     finding_categories: Optional[List[str]] = Field(None)
 
@@ -323,6 +326,7 @@ async def create_inspection(
             instrument_barcode=body.instrument_barcode,
             instrument_udi=body.instrument_udi,
             keydot_id=body.keydot_id,
+            decoder_backend=body.identifier_source or "declared",
         )
         # Persist the SPD verdict regardless of completion state so history and
         # the dashboard show what the analysis concluded.
@@ -605,6 +609,7 @@ async def upload_inspection_images(
                 detail=f"File '{img.filename}' exceeds 10 MB limit ({len(data) // 1024} KB).",
             )
         sha256 = hashlib.sha256(data).hexdigest()
+        decoded = decode_from_image_bytes(data)
         entry = {
             "filename": img.filename,
             "content_type": content_type,
@@ -613,6 +618,11 @@ async def upload_inspection_images(
             "tenant_id": tenant_id,
             "status": "received",
             "retained": False,
+            # Real identifier decode (pyzbar); empty when none found / lib absent.
+            "barcode_value": decoded.barcode_value,
+            "qr_udi_value": decoded.qr_value or decoded.udi_value,
+            "udi_device_id": decoded.udi_device_id,
+            "decoder_backend": decoded.decoder_backend,
         }
         retained = retain_image(
             db,
@@ -634,6 +644,67 @@ async def upload_inspection_images(
         "images": results,
         "retention_enabled": retention_enabled(),
         "note": "Image hashes recorded. Raw images are retained only when opt-in retention is enabled and consent is given.",
+    }
+
+
+@router.post("/inspections/decode-identifiers")
+async def decode_inspection_identifiers(
+    request: Request,
+    images: List[UploadFile] = File(...),
+    current_user=Depends(require_inspection_runner),
+):
+    """Decode instrument identifiers (barcode / QR / UDI) from uploaded images.
+
+    Real, deterministic decode via pyzbar (ZBar). Degrades gracefully: when the
+    ZBar native library is unavailable the response reports
+    ``decoder_available: false`` and empty values rather than failing — the
+    workflow then falls back to technician-declared identifiers.
+    """
+    decoder_available = False
+    first_values = {"barcode_value": "", "qr_udi_value": "", "udi_device_id": ""}
+    per_image = []
+    for img in images:
+        content_type = img.content_type or ""
+        if content_type not in _ALLOWED_TYPES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"File '{img.filename}' has unsupported type '{content_type}'.",
+            )
+        data = await img.read()
+        if len(data) > _MAX_IMAGE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File '{img.filename}' exceeds 10 MB limit.",
+            )
+        decoded = decode_from_image_bytes(data)
+        if decoded.decoder_backend == "pyzbar":
+            decoder_available = True
+        qr_udi = decoded.qr_value or decoded.udi_value
+        per_image.append({
+            "filename": img.filename,
+            "barcode_value": decoded.barcode_value,
+            "qr_udi_value": qr_udi,
+            "udi_device_id": decoded.udi_device_id,
+            "udi_lot": decoded.udi_lot,
+            "udi_serial": decoded.udi_serial,
+            "decoder_backend": decoded.decoder_backend,
+        })
+        # First non-empty decode wins for the convenience top-level values.
+        if not first_values["barcode_value"] and decoded.barcode_value:
+            first_values["barcode_value"] = decoded.barcode_value
+        if not first_values["qr_udi_value"] and qr_udi:
+            first_values["qr_udi_value"] = qr_udi
+        if not first_values["udi_device_id"] and decoded.udi_device_id:
+            first_values["udi_device_id"] = decoded.udi_device_id
+
+    return {
+        "decoder_available": decoder_available,
+        **first_values,
+        "images": per_image,
+        "note": (
+            "Identifiers decoded from the image when the ZBar library is present; "
+            "otherwise declare them manually."
+        ),
     }
 
 

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -249,6 +249,10 @@ def inspection_response(row: models.Inspection) -> dict:
         "override_reason": row.override_reason,
         "override_by": row.override_by,
         "override_at": row.override_at.isoformat() if row.override_at else None,
+        # SPD risk-weighted verdict
+        "risk_level": row.risk_level,
+        "recommended_action": row.recommended_action,
+        "overall_cleaning_assessment": row.overall_cleaning_assessment,
     }
 
 
@@ -303,6 +307,11 @@ async def create_inspection(
         if c and c != "pending_ai_analysis"
     ]
 
+    # SPD risk-weighted verdict to persist alongside the score.
+    risk_level_val: Optional[str] = None
+    recommended_action_val: Optional[str] = None
+    cleaning_assessment_val: Optional[str] = None
+
     if body.has_image:
         analysis = analyze_inspection(
             db,
@@ -315,6 +324,11 @@ async def create_inspection(
             instrument_udi=body.instrument_udi,
             keydot_id=body.keydot_id,
         )
+        # Persist the SPD verdict regardless of completion state so history and
+        # the dashboard show what the analysis concluded.
+        risk_level_val = analysis.get("risk_level")
+        recommended_action_val = analysis.get("recommended_action")
+        cleaning_assessment_val = analysis.get("overall_cleaning_assessment")
         if analysis["analysis_status"] == "completed":
             baseline_status = "approved_baseline_found"
             baseline_source_val = analysis["baseline_source"]
@@ -358,6 +372,9 @@ async def create_inspection(
         baseline_source=baseline_source_val,
         score_status=score_status,
         supervisor_review_required=supervisor_review_required,
+        risk_level=risk_level_val,
+        recommended_action=recommended_action_val,
+        overall_cleaning_assessment=cleaning_assessment_val,
     )
     db.add(row)
     db.commit()

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -555,13 +555,23 @@ def get_pilot_metrics(
 async def upload_inspection_images(
     request: Request,
     images: List[UploadFile] = File(...),
+    instrument_type: str = "unknown",
+    consent: bool = False,
+    db: Session = Depends(get_db),
     current_user=Depends(require_inspection_runner),
 ):
     """Accept multipart inspection image uploads. Stores SHA-256 hash + metadata only — no raw images in DB.
 
     Restricted to operator/spd_manager/admin — viewers are read-only.
+
+    When opt-in retention is enabled (``RETAIN_INSPECTION_IMAGES``) AND
+    ``consent=true`` is passed, the EXIF-stripped bytes are ALSO retained for
+    model training. Disabled by default — only hashes are kept otherwise.
     """
+    from app.services.image_retention_service import retain_image, retention_enabled
+
     tenant_id = get_request_tenant_id(request)
+    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
 
     results = []
     for img in images:
@@ -578,19 +588,35 @@ async def upload_inspection_images(
                 detail=f"File '{img.filename}' exceeds 10 MB limit ({len(data) // 1024} KB).",
             )
         sha256 = hashlib.sha256(data).hexdigest()
-        results.append({
+        entry = {
             "filename": img.filename,
             "content_type": content_type,
             "size_bytes": len(data),
             "sha256": sha256,
             "tenant_id": tenant_id,
             "status": "received",
-        })
+            "retained": False,
+        }
+        retained = retain_image(
+            db,
+            data=data,
+            tenant_id=tenant_id,
+            instrument_type=instrument_type,
+            content_type=content_type,
+            source="inspection",
+            uploaded_by=actor,
+            consent=consent,
+        )
+        if retained is not None:
+            entry["retained"] = True
+            entry["retained_image_id"] = retained.id
+        results.append(entry)
 
     return {
         "uploaded": len(results),
         "images": results,
-        "note": "Image hashes recorded. Raw images are not stored in the database.",
+        "retention_enabled": retention_enabled(),
+        "note": "Image hashes recorded. Raw images are retained only when opt-in retention is enabled and consent is given.",
     }
 
 

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -1,8 +1,10 @@
 import hashlib
+import io
 from datetime import datetime, timezone
 from typing import List, Literal, Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy.orm import Session
 
@@ -278,6 +280,44 @@ async def get_inspection(
         raise HTTPException(status_code=404, detail="Not Found")
 
     return inspection_response(row)
+
+
+@router.get("/inspections/{inspection_id}/clinical-report.pdf")
+async def inspection_clinical_report(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Phase 13.8 — printable Clinical Decision Support PDF for an inspection.
+
+    Re-runs the deterministic analysis for the stored inspection (identical seed
+    → identical output) and renders the full explainable report.
+    """
+    tenant_id = getattr(current_user, "tenant_id", None)
+    query = db.query(models.Inspection).filter(models.Inspection.id == inspection_id)
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    row = query.first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    from app.services.clinical_report_pdf import build_clinical_report_pdf
+
+    analysis = analyze_inspection(
+        db,
+        instrument_type=row.instrument_type,
+        tenant_id=row.tenant_id,
+        has_image=bool(row.has_image),
+        image_sha256=row.image_sha256,
+        instrument_barcode=row.instrument_barcode,
+        instrument_udi=row.instrument_udi,
+    )
+    pdf = build_clinical_report_pdf(row, analysis)
+    return StreamingResponse(
+        io.BytesIO(pdf),
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'inline; filename="lumenai-inspection-{row.id}.pdf"'},
+    )
 
 
 @router.post("/inspections", status_code=201)

--- a/backend/app/routes/ml_images.py
+++ b/backend/app/routes/ml_images.py
@@ -1,0 +1,441 @@
+"""ML image labeling + dataset-export endpoints.
+
+Backs the training-data pipeline described in
+``docs/ai/model-training-dataset-plan.md``. Retained images (opt-in, EXIF
+stripped) are labeled here, reviewed/adjudicated, and exported as a manifest for
+training a real image-based model that would eventually replace the pilot
+Baseline Comparison Scoring Model.
+
+Governance:
+- Retention/labeling is access-controlled (operator/spd_manager/admin to label;
+  spd_manager/admin to adjudicate/export).
+- Critical classes (blood, crack, missing_component) require two distinct
+  reviewers before a label is promoted to ``gold``.
+- Every label mutation is audit-logged.
+- Output remains advisory tooling — no diagnostic-accuracy/FDA claims.
+"""
+from __future__ import annotations
+
+import io
+import json
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.retained_image import ImageLabel, RetainedImage
+from app.routes.inspections import require_inspection_runner
+from app.services.image_retention_service import (
+    retain_image,
+    retention_enabled,
+)
+
+router = APIRouter(prefix="/ml", tags=["ml-images"])
+
+_ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+# Classes requiring two distinct reviewers before promotion to gold.
+_CRITICAL_CLASSES = {"blood", "crack", "missing_component"}
+
+# Known finding classes (multi-label). "clean" is the negative anchor class.
+_KNOWN_CLASSES = {
+    "blood", "bone", "tissue", "bioburden", "debris", "other_organic_residue",
+    "rust", "discoloration", "corrosion", "pitting", "crack",
+    "insulation_damage", "missing_component", "clean",
+}
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+@router.get("/retention/status")
+def retention_status(current_user=Depends(require_inspection_runner)):
+    """Report whether opt-in image retention is enabled for this deployment."""
+    return {
+        "retention_enabled": retention_enabled(),
+        "note": (
+            "Image retention is opt-in (RETAIN_INSPECTION_IMAGES) and requires "
+            "recorded consent. Bytes are EXIF-stripped on ingest. Disabled by "
+            "default — only SHA-256 hashes are stored otherwise."
+        ),
+    }
+
+
+@router.post("/images", status_code=201)
+async def upload_training_image(
+    request: Request,
+    images: List[UploadFile] = File(...),
+    instrument_type: str = "unknown",
+    source: str = "inspection",
+    consent: bool = False,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_inspection_runner),
+):
+    """Retain EXIF-stripped image bytes for labeling (opt-in).
+
+    No-op (returns ``retained: false``) unless retention is enabled AND
+    ``consent=true`` is passed — the safe default. Images must contain
+    instruments only; PHI in frame is rejected by policy.
+    """
+    if not retention_enabled():
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Image retention is disabled. Set RETAIN_INSPECTION_IMAGES to "
+                "enable the opt-in training-image store."
+            ),
+        )
+    tenant_id = get_request_tenant_id(request)
+    stored = []
+    for img in images:
+        content_type = img.content_type or ""
+        if content_type not in _ALLOWED_TYPES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"File '{img.filename}' has unsupported type '{content_type}'.",
+            )
+        data = await img.read()
+        if len(data) > _MAX_IMAGE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File '{img.filename}' exceeds 10 MB limit.",
+            )
+        row = retain_image(
+            db,
+            data=data,
+            tenant_id=tenant_id,
+            instrument_type=instrument_type,
+            content_type=content_type,
+            source=source,
+            uploaded_by=_actor(current_user),
+            consent=consent,
+        )
+        if row is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Consent is required to retain images (pass consent=true).",
+            )
+        stored.append({
+            "id": row.id,
+            "deident_name": row.deident_name,
+            "sha256": row.sha256,
+            "exif_stripped": row.exif_stripped,
+            "size_bytes": row.size_bytes,
+        })
+        log_audit_event(
+            db,
+            tenant_id=tenant_id,
+            tenant_name=tenant_id,
+            actor_email=_actor(current_user),
+            actor_role=getattr(current_user, "role", "operator"),
+            action_type="training_image_retained",
+            resource_type="retained_image",
+            resource_id=str(row.id),
+        )
+    return {"retained": True, "count": len(stored), "images": stored}
+
+
+@router.get("/images")
+def list_images(
+    request: Request,
+    label_status: Optional[str] = None,
+    instrument_type: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_inspection_runner),
+):
+    """List retained-image metadata (never bytes) for the caller's tenant."""
+    tenant_id = get_request_tenant_id(request)
+    q = db.query(RetainedImage).filter(RetainedImage.tenant_id == tenant_id)
+    if label_status:
+        q = q.filter(RetainedImage.label_status == label_status)
+    if instrument_type:
+        q = q.filter(RetainedImage.instrument_type == instrument_type)
+    rows = q.order_by(RetainedImage.id.desc()).all()
+    return {
+        "count": len(rows),
+        "images": [
+            {
+                "id": r.id,
+                "deident_name": r.deident_name,
+                "instrument_type": r.instrument_type,
+                "sha256": r.sha256,
+                "size_bytes": r.size_bytes,
+                "exif_stripped": r.exif_stripped,
+                "source": r.source,
+                "label_status": r.label_status,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.get("/images/{image_id}/bytes")
+def get_image_bytes(
+    image_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_inspection_runner),
+):
+    """Download the EXIF-stripped bytes for a retained image (access-controlled)."""
+    tenant_id = get_request_tenant_id(request)
+    row = (
+        db.query(RetainedImage)
+        .filter(RetainedImage.id == image_id, RetainedImage.tenant_id == tenant_id)
+        .first()
+    )
+    if row is None or row.image_bytes is None:
+        raise HTTPException(status_code=404, detail="Retained image not found.")
+    return StreamingResponse(
+        io.BytesIO(row.image_bytes),
+        media_type=row.content_type or "application/octet-stream",
+    )
+
+
+class LabelIn(BaseModel):
+    finding_type: str = Field(..., min_length=1, max_length=50)
+    present: bool = True
+    severity: str = Field("", max_length=30)
+    region: Optional[List[float]] = None  # [x, y, w, h] normalized 0..1
+    confidence: float = Field(1.0, ge=0.0, le=1.0)
+    notes: str = Field("", max_length=1000)
+
+
+@router.post("/images/{image_id}/labels", status_code=201)
+def add_label(
+    image_id: int,
+    body: LabelIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_inspection_runner),
+):
+    """Apply a (multi-label) annotation to a retained image."""
+    tenant_id = get_request_tenant_id(request)
+    image = (
+        db.query(RetainedImage)
+        .filter(RetainedImage.id == image_id, RetainedImage.tenant_id == tenant_id)
+        .first()
+    )
+    if image is None:
+        raise HTTPException(status_code=404, detail="Retained image not found.")
+
+    finding = body.finding_type.strip().lower().replace(" ", "_")
+    if finding not in _KNOWN_CLASSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown finding_type '{finding}'. Allowed: {sorted(_KNOWN_CLASSES)}",
+        )
+
+    region_json = json.dumps(body.region) if body.region else ""
+    label = ImageLabel(
+        image_id=image_id,
+        tenant_id=tenant_id,
+        finding_type=finding,
+        present=body.present,
+        severity=body.severity,
+        region_json=region_json,
+        confidence=body.confidence,
+        reviewer=_actor(current_user),
+        notes=body.notes,
+    )
+    db.add(label)
+    if image.label_status == "unlabeled":
+        image.label_status = "labeled"
+    db.commit()
+    db.refresh(label)
+
+    log_audit_event(
+        db,
+        tenant_id=tenant_id,
+        tenant_name=tenant_id,
+        actor_email=_actor(current_user),
+        actor_role=getattr(current_user, "role", "operator"),
+        action_type="image_label_added",
+        resource_type="image_label",
+        resource_id=str(label.id),
+    )
+    return {
+        "id": label.id,
+        "image_id": image_id,
+        "finding_type": label.finding_type,
+        "severity": label.severity,
+        "critical_class": finding in _CRITICAL_CLASSES,
+        "requires_second_reviewer": finding in _CRITICAL_CLASSES,
+    }
+
+
+@router.get("/images/{image_id}/labels")
+def list_labels(
+    image_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_inspection_runner),
+):
+    """Return all labels for an image."""
+    tenant_id = get_request_tenant_id(request)
+    labels = (
+        db.query(ImageLabel)
+        .filter(ImageLabel.image_id == image_id, ImageLabel.tenant_id == tenant_id)
+        .order_by(ImageLabel.id)
+        .all()
+    )
+    return {
+        "image_id": image_id,
+        "count": len(labels),
+        "labels": [
+            {
+                "id": lb.id,
+                "finding_type": lb.finding_type,
+                "present": lb.present,
+                "severity": lb.severity,
+                "region": json.loads(lb.region_json) if lb.region_json else None,
+                "confidence": lb.confidence,
+                "reviewer": lb.reviewer,
+                "adjudicated": lb.adjudicated,
+                "is_gold": lb.is_gold,
+            }
+            for lb in labels
+        ],
+    }
+
+
+@router.post("/images/{image_id}/labels/{label_id}/adjudicate")
+def adjudicate_label(
+    image_id: int,
+    label_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Promote a reviewed label to ``gold``.
+
+    Critical classes (blood, crack, missing_component) require a SECOND distinct
+    reviewer on the same image+class before they can be adjudicated — enforcing
+    the two-reviewer rule from the dataset plan.
+    """
+    tenant_id = get_request_tenant_id(request)
+    label = (
+        db.query(ImageLabel)
+        .filter(
+            ImageLabel.id == label_id,
+            ImageLabel.image_id == image_id,
+            ImageLabel.tenant_id == tenant_id,
+        )
+        .first()
+    )
+    if label is None:
+        raise HTTPException(status_code=404, detail="Label not found.")
+
+    if label.finding_type in _CRITICAL_CLASSES:
+        distinct_reviewers = {
+            lb.reviewer
+            for lb in db.query(ImageLabel).filter(
+                ImageLabel.image_id == image_id,
+                ImageLabel.tenant_id == tenant_id,
+                ImageLabel.finding_type == label.finding_type,
+            )
+        }
+        if len(distinct_reviewers) < 2:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Critical class '{label.finding_type}' requires two distinct "
+                    "reviewers before adjudication."
+                ),
+            )
+
+    label.adjudicated = True
+    label.is_gold = True
+    image = (
+        db.query(RetainedImage)
+        .filter(RetainedImage.id == image_id, RetainedImage.tenant_id == tenant_id)
+        .first()
+    )
+    if image is not None:
+        image.label_status = "gold"
+    db.commit()
+
+    log_audit_event(
+        db,
+        tenant_id=tenant_id,
+        tenant_name=tenant_id,
+        actor_email=_actor(current_user),
+        actor_role=getattr(current_user, "role", "spd_manager"),
+        action_type="image_label_adjudicated",
+        resource_type="image_label",
+        resource_id=str(label.id),
+    )
+    return {"id": label.id, "is_gold": True, "adjudicated": True}
+
+
+@router.get("/dataset/export")
+def export_dataset(
+    request: Request,
+    gold_only: bool = True,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Export a training-dataset manifest (metadata + labels, no bytes inline).
+
+    ``gold_only`` (default) restricts to adjudicated labels — only ``gold`` data
+    should enter validation/test sets per the dataset plan. Bytes are fetched
+    separately via ``/ml/images/{id}/bytes`` so the manifest stays lightweight.
+    """
+    tenant_id = get_request_tenant_id(request)
+    images = (
+        db.query(RetainedImage)
+        .filter(RetainedImage.tenant_id == tenant_id)
+        .order_by(RetainedImage.id)
+        .all()
+    )
+    records = []
+    class_counts: dict[str, int] = {}
+    for img in images:
+        q = db.query(ImageLabel).filter(
+            ImageLabel.image_id == img.id, ImageLabel.tenant_id == tenant_id
+        )
+        if gold_only:
+            q = q.filter(ImageLabel.is_gold.is_(True))
+        labels = q.all()
+        if gold_only and not labels:
+            continue
+        for lb in labels:
+            if lb.present:
+                class_counts[lb.finding_type] = class_counts.get(lb.finding_type, 0) + 1
+        records.append({
+            "image_id": img.id,
+            "deident_name": img.deident_name,
+            "instrument_type": img.instrument_type,
+            "sha256": img.sha256,
+            "bytes_url": f"/api/ml/images/{img.id}/bytes",
+            "source": img.source,
+            "labels": [
+                {
+                    "finding_type": lb.finding_type,
+                    "present": lb.present,
+                    "severity": lb.severity,
+                    "region": json.loads(lb.region_json) if lb.region_json else None,
+                    "is_gold": lb.is_gold,
+                }
+                for lb in labels
+            ],
+        })
+    return {
+        "tenant_id": tenant_id,
+        "gold_only": gold_only,
+        "image_count": len(records),
+        "class_counts": class_counts,
+        "records": records,
+        "note": (
+            "Advisory training tooling. Only gold (adjudicated) labels should "
+            "enter validation/test sets. No diagnostic-accuracy or FDA claims."
+        ),
+    }

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -570,8 +570,8 @@ AI_ROADMAP = [
 
 
 def _overall_result(result: dict) -> str:
-    """Collapse the analysis into one of the four clinical dispositions
-    (PASS / MONITOR / SUPERVISOR REVIEW / REMOVE FROM SERVICE)."""
+    """Collapse the analysis into one of the five clinical dispositions
+    (PASS / MONITOR / SUPERVISOR REVIEW / REPROCESS / REMOVE FROM SERVICE)."""
     if result.get("analysis_status") != "completed":
         return "SUPERVISOR REVIEW"
     f = {x["type"]: x for x in result["predicted_findings"]}
@@ -579,19 +579,126 @@ def _overall_result(result: dict) -> str:
     def idx(kpi: str) -> int:
         return f.get(kpi, {}).get("severity_index", 0)
 
+    # Structural integrity concern → remove from service.
     if any(idx(k) >= 1 for k in _STRUCTURAL_KPIS) or idx("corrosion") >= 3:
         return "REMOVE FROM SERVICE"
-    contam = (
-        idx("blood") >= 2 or idx("tissue") >= 1 or idx("other_organic_residue") >= 1
-        or idx("debris") >= 1 or idx("bone") >= 1
-    )
+    # Residual contamination → return for cleaning/reprocessing.
+    if (idx("blood") >= 2 or idx("tissue") >= 1 or idx("other_organic_residue") >= 1
+            or idx("debris") >= 1 or idx("bone") >= 1):
+        return "REPROCESS"
+    # Condition change / baseline concern → supervisor review.
     moderate_condition = idx("corrosion") == 2 or idx("rust") == 2
     mismatch = result.get("identification", {}).get("identification_status") == "mismatch"
-    if contam or moderate_condition or mismatch or (result.get("baseline_match_score") or 1) < 0.70:
+    if moderate_condition or mismatch or (result.get("baseline_match_score") or 1) < 0.70:
         return "SUPERVISOR REVIEW"
+    # Minor cosmetic only → monitor.
     if idx("discoloration") == 1 or idx("rust") == 1:
         return "MONITOR"
     return "PASS"
+
+
+# Exact SPD recommended-action text per outcome (Phase: AI Clinical Review).
+_ACTION_TEXT = {
+    "PASS": "Accept inspection. Continue routine processing.",
+    "MONITOR": "Accept with monitoring. Recheck during next inspection.",
+    "SUPERVISOR REVIEW": "Hold instrument pending supervisor review.",
+    "REPROCESS": "Return for cleaning/reprocessing.",
+    "REMOVE FROM SERVICE": "Remove from service and escalate for repair/replacement.",
+}
+
+_INTERPRETATION = {
+    "PASS": (
+        "The observed surface characteristics are consistent with the approved "
+        "manufacturer baseline. No contamination or structural defect requiring "
+        "intervention was identified."
+    ),
+    "MONITOR": (
+        "Minor cosmetic variation was observed that does not require intervention "
+        "now. Recheck the instrument during the next inspection."
+    ),
+    "SUPERVISOR REVIEW": (
+        "Instrument cleanliness or condition may require verification. Detected "
+        "changes should be reviewed by a supervisor before release."
+    ),
+    "REPROCESS": (
+        "Residual contamination indicators were identified. Return the instrument "
+        "for cleaning/reprocessing and re-inspect before release."
+    ),
+    "REMOVE FROM SERVICE": (
+        "A structural integrity concern was identified. Remove the instrument from "
+        "service and escalate for repair or replacement."
+    ),
+}
+
+
+def evidence_strength(result: dict) -> dict:
+    """Strong / Moderate / Limited with a 5-star rating.
+
+    Strong:   baseline match >= 90% AND confidence >= 85%.
+    Moderate: baseline match 75–89% OR confidence 65–84%.
+    Limited:  baseline missing, or low confidence.
+    """
+    match = result.get("baseline_match_score")
+    conf = result.get("confidence")
+    if match is None or conf is None:
+        return {"level": "Limited", "stars": 1, "reason": "No approved baseline available."}
+    match_pct = match * 100
+    conf_pct = conf * 100
+    if match_pct >= 90 and conf_pct >= 85:
+        return {"level": "Strong", "stars": 5,
+                "reason": f"Baseline match {round(match_pct)}% and confidence {round(conf_pct)}% are both high."}
+    if match_pct >= 75 or conf_pct >= 65:
+        return {"level": "Moderate", "stars": 3,
+                "reason": f"Baseline match {round(match_pct)}% / confidence {round(conf_pct)}% are moderate."}
+    return {"level": "Limited", "stars": 1,
+            "reason": f"Baseline match {round(match_pct)}% and confidence {round(conf_pct)}% are low."}
+
+
+def baseline_difference(result: dict) -> dict:
+    """Plain-language baseline-difference summary (no fabricated localization)."""
+    findings = {x["type"]: x for x in result.get("predicted_findings", [])}
+    match = result.get("baseline_match_score")
+    differences: list[str] = []
+    contamination = False
+    condition = False
+
+    for kpi in CLEANING_KPIS:
+        fx = findings.get(kpi)
+        if fx and fx["severity_index"] >= 1:
+            contamination = True
+            differences.append(f"{KPI_LABELS[kpi].capitalize()} indicators detected.")
+    for kpi in ("rust", "corrosion", "discoloration", "pitting"):
+        fx = findings.get(kpi)
+        if fx and fx["severity_index"] >= 1:
+            condition = True
+            differences.append(f"{fx['severity'].capitalize()} {KPI_LABELS[kpi]} observed.")
+    for kpi in _STRUCTURAL_KPIS:
+        fx = findings.get(kpi)
+        if fx and fx["severity_index"] >= 1:
+            condition = True
+            differences.append(f"Possible {KPI_LABELS[kpi]} observed.")
+
+    if not contamination:
+        differences.append("No visible contamination detected.")
+    if not condition:
+        differences.append("No structural defect detected.")
+    differences.append("No lumen obstruction detected.")
+
+    category = (
+        "contamination and condition" if contamination and condition
+        else "contamination" if contamination
+        else "condition" if condition
+        else "none"
+    )
+    return {
+        "baseline_match_pct": round(match * 100) if match is not None else None,
+        "differences": differences,
+        "category": category,
+        "localization_note": (
+            "Detailed image difference localization is planned for a future "
+            "computer vision release."
+        ),
+    }
 
 
 def _integrity_status(findings_by_kpi: dict) -> str:
@@ -737,8 +844,22 @@ def build_clinical_decision(result: dict) -> dict:
         "integrity": {"items": integrity_items, "overall_status": integrity_status},
         # 13.5
         "clinical_reasoning": clinical_reasoning(result),
+        # AI Clinical Review — outcome + plain-language interpretation.
+        "ai_clinical_review": {
+            "outcome": overall,
+            "reasoning": clinical_reasoning(result),
+            "interpretation": _INTERPRETATION.get(overall, ""),
+        },
+        # Evidence Strength (Strong / Moderate / Limited + stars).
+        "evidence_strength": evidence_strength(result),
+        # Baseline Difference (plain language; no fabricated localization).
+        "baseline_difference": baseline_difference(result),
         # 13.6
-        "recommendation": {"result": overall, "action": result.get("recommended_action")},
+        "recommendation": {
+            "result": overall,
+            "action": result.get("recommended_action"),
+            "action_text": _ACTION_TEXT.get(overall, result.get("recommended_action")),
+        },
         # 13.7 Evidence (no fabricated CV overlays)
         "evidence": {
             "baseline_source": result.get("baseline_source"),
@@ -750,15 +871,21 @@ def build_clinical_decision(result: dict) -> dict:
         },
         # 13.9
         "executive_summary": executive_summary(result, overall),
-        # 13.10 Audit fields (persisted/loggable)
+        # 13.10 / Audit fields (persisted/loggable)
         "audit": {
+            "model_version": "baseline-comparison-pilot-1",
+            "dataset_version": "v0-pilot",
             "baseline_version": result.get("baseline_version"),
             "baseline_source": result.get("baseline_source"),
             "model_label": result.get("model_label"),
-            "model_version": "baseline-comparison-pilot-1",
+            "score": result.get("inspection_score"),
             "confidence": result.get("confidence_level"),
+            "evidence_strength": evidence_strength(result)["level"],
             "recommendation": overall,
             "reasoning_captured": True,
+            # Populated when a supervisor reviews (see supervisor-review endpoint).
+            "supervisor_agreement": None,
+            "override_reason": None,
             "human_review_required": result.get("human_review_required", True),
         },
         # 13.11

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -546,6 +546,226 @@ def scoring_explanation(
     return lines
 
 
+# ── Phase 13: Explainable Clinical Decision Support ──────────────────────────
+
+# KPIs that describe structural/condition integrity (vs contamination).
+INTEGRITY_KPIS = [
+    "rust", "corrosion", "pitting", "crack", "discoloration",
+    "insulation_damage", "missing_component",
+]
+_STRUCTURAL_KPIS = {"crack", "missing_component", "insulation_damage"}
+
+# Static forward-looking roadmap (Phase 13.11) — advisory, no fabricated CV yet.
+AI_ROADMAP = [
+    "Visual heatmaps",
+    "Bounding boxes",
+    "Segmented contamination detection",
+    "Multi-image comparison",
+    "Temporal baseline drift",
+    "Predictive instrument degradation",
+    "Rust progression",
+    "Corrosion progression",
+    "Life-cycle prediction",
+]
+
+
+def _overall_result(result: dict) -> str:
+    """Collapse the analysis into one of the four clinical dispositions
+    (PASS / MONITOR / SUPERVISOR REVIEW / REMOVE FROM SERVICE)."""
+    if result.get("analysis_status") != "completed":
+        return "SUPERVISOR REVIEW"
+    f = {x["type"]: x for x in result["predicted_findings"]}
+
+    def idx(kpi: str) -> int:
+        return f.get(kpi, {}).get("severity_index", 0)
+
+    if any(idx(k) >= 1 for k in _STRUCTURAL_KPIS) or idx("corrosion") >= 3:
+        return "REMOVE FROM SERVICE"
+    contam = (
+        idx("blood") >= 2 or idx("tissue") >= 1 or idx("other_organic_residue") >= 1
+        or idx("debris") >= 1 or idx("bone") >= 1
+    )
+    moderate_condition = idx("corrosion") == 2 or idx("rust") == 2
+    mismatch = result.get("identification", {}).get("identification_status") == "mismatch"
+    if contam or moderate_condition or mismatch or (result.get("baseline_match_score") or 1) < 0.70:
+        return "SUPERVISOR REVIEW"
+    if idx("discoloration") == 1 or idx("rust") == 1:
+        return "MONITOR"
+    return "PASS"
+
+
+def _integrity_status(findings_by_kpi: dict) -> str:
+    def idx(kpi: str) -> int:
+        return findings_by_kpi.get(kpi, {}).get("severity_index", 0)
+
+    if any(idx(k) >= 1 for k in _STRUCTURAL_KPIS) or idx("corrosion") >= 3 or idx("rust") >= 3:
+        return "Remove From Service"
+    if idx("corrosion") >= 2 or idx("rust") >= 2 or idx("pitting") >= 2:
+        return "Repair Required"
+    if any(idx(k) == 1 for k in ("rust", "corrosion", "pitting", "discoloration")):
+        return "Monitor"
+    return "Acceptable"
+
+
+def _finding_view(f: dict) -> dict:
+    """Compact per-KPI view for the cleaning/integrity cards."""
+    return {
+        "type": f["type"],
+        "label": f["label"],
+        "detected": f["severity_index"] >= 1,
+        "probability": f["probability"],
+        "probability_pct": round(f["probability"] * 100),
+        "confidence": f["confidence"],
+        "confidence_pct": round(f["confidence"] * 100),
+        "severity": f["severity"],
+        "spd_risk": f.get("spd_risk", "none"),
+        "spd_risk_impact": f.get("spd_risk_impact", "Clear"),
+    }
+
+
+def clinical_reasoning(result: dict) -> list[str]:
+    """Narrative clinical reasoning grounded in the actual analysis output."""
+    f = {x["type"]: x for x in result["predicted_findings"]}
+    lines: list[str] = []
+    src = BASELINE_LABELS.get(result.get("baseline_source"), "Baseline")
+    match = result.get("baseline_match_score")
+    if match is not None:
+        lines.append(f"{src} matched at {round(match * 100)}%.")
+
+    for kpi in ("blood", "tissue", "other_organic_residue", "debris", "bone"):
+        fx = f.get(kpi)
+        if not fx:
+            continue
+        if fx["severity_index"] == 0:
+            lines.append(f"No {KPI_LABELS[kpi]} detected.")
+        else:
+            lines.append(f"{fx['severity'].capitalize()} {KPI_LABELS[kpi]} detected.")
+
+    structural = [KPI_LABELS[k] for k in _STRUCTURAL_KPIS if f.get(k, {}).get("severity_index", 0) >= 1]
+    condition = [
+        f"{f[k]['severity']}" for k in ("rust", "corrosion", "pitting")
+        if f.get(k, {}).get("severity_index", 0) >= 2
+    ]
+    cosmetic = [
+        KPI_LABELS[k] for k in ("discoloration", "rust")
+        if f.get(k, {}).get("severity_index", 0) == 1
+    ]
+    if structural:
+        lines.append("Structural concern identified: " + ", ".join(structural) + ".")
+    elif condition:
+        lines.append("Condition concern: " + ", ".join(condition) + ".")
+    elif cosmetic:
+        lines.append("Minor cosmetic " + " / ".join(cosmetic) + " detected; treated as low-risk.")
+    else:
+        lines.append("No structural defects identified.")
+
+    lines.append(result.get("recommended_action", "Routine processing recommended."))
+    return lines
+
+
+def executive_summary(result: dict, overall_result: str) -> list[str]:
+    """One-card plain-language executive summary."""
+    if result.get("analysis_status") != "completed":
+        return [
+            "No approved baseline available for this instrument.",
+            "Final scoring withheld pending supervisor review.",
+        ]
+    src = BASELINE_LABELS.get(result.get("baseline_source"), "Baseline")
+    lines = [
+        "Inspection completed.",
+        f"{src} matched at {round((result['baseline_match_score'] or 0) * 100)}%.",
+    ]
+    cleaning = result.get("overall_cleaning_assessment", "")
+    lines.append("No contamination detected." if cleaning == "Clean" else f"Cleaning: {cleaning}.")
+    integrity = result.get("clinical_decision_integrity_status")
+    if integrity:
+        lines.append(
+            "Instrument structurally intact."
+            if integrity == "Acceptable" else f"Instrument integrity: {integrity}."
+        )
+    lines.append(f"Recommended: {overall_result}.")
+    lines.append(result.get("recommended_action", ""))
+    return [ln for ln in lines if ln]
+
+
+def build_clinical_decision(result: dict) -> dict:
+    """Assemble the full Explainable-AI Clinical Decision Support payload
+    (Phases 13.1–13.11) from an already-computed analysis result."""
+    findings = {x["type"]: x for x in result.get("predicted_findings", [])}
+    overall = _overall_result(result)
+
+    # Integrity status is needed by the executive summary — stash it on result.
+    integrity_status = _integrity_status(findings) if findings else "Acceptable"
+    result["clinical_decision_integrity_status"] = integrity_status
+
+    # 13.2 Score breakdown
+    adj = {a["kpi"]: a["points"] for a in result.get("score_adjustments", [])}
+    breakdown_kpis = ["blood", "tissue", "other_organic_residue", "debris", "corrosion", "discoloration"]
+    match = result.get("baseline_match_score")
+    score_breakdown = {
+        "baseline_match_points": round(match * 100) if match is not None else None,
+        "items": [
+            {"label": KPI_LABELS[k], "points": adj.get(k, 0)}
+            for k in breakdown_kpis if k in findings
+        ],
+        "final_score": result.get("inspection_score"),
+        "note": "Final score starts from the baseline match, subtracts weighted "
+                "penalties, and may add a small identification-match bonus.",
+    }
+
+    # 13.3 Cleaning + 13.4 Integrity cards
+    cleaning_items = [_finding_view(findings[k]) for k in CLEANING_KPIS if k in findings]
+    integrity_items = [_finding_view(findings[k]) for k in INTEGRITY_KPIS if k in findings]
+
+    return {
+        # 13.1 Clinical Decision Summary
+        "overall_result": overall,
+        "summary": {
+            "inspection_score": result.get("inspection_score"),
+            "cleaning_assessment": result.get("overall_cleaning_assessment"),
+            "integrity_assessment": integrity_status,
+            "overall_risk": result.get("risk_level"),
+            "confidence": result.get("confidence_level"),
+            "confidence_pct": round((result.get("confidence") or 0) * 100),
+            "baseline_source": result.get("baseline_source"),
+        },
+        # 13.2
+        "score_breakdown": score_breakdown,
+        # 13.3
+        "cleaning": {"items": cleaning_items, "overall_status": result.get("overall_cleaning_assessment")},
+        # 13.4
+        "integrity": {"items": integrity_items, "overall_status": integrity_status},
+        # 13.5
+        "clinical_reasoning": clinical_reasoning(result),
+        # 13.6
+        "recommendation": {"result": overall, "action": result.get("recommended_action")},
+        # 13.7 Evidence (no fabricated CV overlays)
+        "evidence": {
+            "baseline_source": result.get("baseline_source"),
+            "baseline_comparison_label": result.get("baseline_comparison_label"),
+            "baseline_match_pct": round(match * 100) if match is not None else None,
+            "highest_risk_drivers": result.get("top_risk_drivers", []),
+            "confidence": result.get("confidence_level"),
+            "image_evidence_note": "Image evidence visualization coming in a future computer vision release.",
+        },
+        # 13.9
+        "executive_summary": executive_summary(result, overall),
+        # 13.10 Audit fields (persisted/loggable)
+        "audit": {
+            "baseline_version": result.get("baseline_version"),
+            "baseline_source": result.get("baseline_source"),
+            "model_label": result.get("model_label"),
+            "model_version": "baseline-comparison-pilot-1",
+            "confidence": result.get("confidence_level"),
+            "recommendation": overall,
+            "reasoning_captured": True,
+            "human_review_required": result.get("human_review_required", True),
+        },
+        # 13.11
+        "roadmap": AI_ROADMAP,
+    }
+
+
 def analyze_inspection(
     db: Session,
     *,
@@ -575,16 +795,22 @@ def analyze_inspection(
 
     # ── Governance gate: no approved baseline → no final score ──────────────
     if not resolution["baseline_found"]:
-        return {
+        no_baseline = {
             "analysis_status": "supervisor_review_required",
             "baseline_source": None,
+            "baseline_version": None,
+            "baseline_comparison_label": None,
             "baseline_match_score": None,
             "baseline_deviation_score": None,
             "inspection_score": None,
             "risk_level": None,
+            "confidence_level": None,
+            "confidence": None,
             "predicted_findings": [],
             "kpi_summary": {},
             "identification": {},
+            "score_adjustments": [],
+            "model_label": "Baseline Comparison Scoring Model (pilot)",
             "recommendation": (
                 "No approved baseline found. Supervisor review required before final scoring."
             ),
@@ -600,6 +826,8 @@ def analyze_inspection(
             "human_review_required": True,
             "placeholder_scoring": True,
         }
+        no_baseline["clinical_decision"] = build_clinical_decision(no_baseline)
+        return no_baseline
 
     seed = _seed_from(image_sha256, f"{instrument_type}:{instrument_barcode or ''}")
 
@@ -867,7 +1095,7 @@ def analyze_inspection(
         if "Identifier mismatch" not in top_risk_drivers:
             top_risk_drivers = ["Identifier mismatch", *top_risk_drivers]
 
-    return {
+    result = {
         "analysis_status": "completed",
         "baseline_source": source,
         "baseline_role": _baseline_role(source),
@@ -905,3 +1133,6 @@ def analyze_inspection(
         "model_label": "Baseline Comparison Scoring Model (pilot)",
         "production_validated": False,
     }
+    # Phase 13: Explainable Clinical Decision Support payload.
+    result["clinical_decision"] = build_clinical_decision(result)
+    return result

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -300,6 +300,7 @@ def _resolve_from_library(db: Session, instrument_type: str) -> dict[str, Any] |
                 "baseline_source": source,
                 "baseline_entry_id": entry.id,
                 "baseline_version": entry.baseline_version,
+                "baseline_udi": entry.udi or "",
             }
     return None
 
@@ -357,6 +358,8 @@ def _resolve_from_uploaded(db: Session, instrument_type: str) -> dict[str, Any] 
         "baseline_source": source,
         "baseline_entry_id": best.id,
         "baseline_version": best.baseline_version,
+        # Uploaded vendor-subscription baselines carry no UDI to verify against.
+        "baseline_udi": "",
     }
 
 
@@ -383,7 +386,35 @@ def resolve_baseline(db: Session, instrument_type: str, tenant_id: str) -> dict[
         "baseline_source": None,
         "baseline_entry_id": None,
         "baseline_version": None,
+        "baseline_udi": "",
     }
+
+
+def _normalize_identifier(value: str) -> str:
+    """Strip GS1 AI parentheses, spaces, and case for tolerant comparison."""
+    return "".join(ch for ch in (value or "") if ch.isalnum()).lower()
+
+
+def identifier_match(decoded: str, baseline_udi: str) -> tuple[str, bool]:
+    """Compare a decoded identifier against the approved baseline's UDI.
+
+    Returns (status, is_match) where status is one of:
+      not_detected — nothing decoded/declared
+      unverified   — value present but baseline has no UDI to check against
+      match        — decoded value matches the baseline UDI (or its device id)
+      mismatch     — decoded value present and does NOT match — wrong instrument
+    """
+    if not decoded:
+        return "not_detected", False
+    if not baseline_udi:
+        return "unverified", False
+    d = _normalize_identifier(decoded)
+    b = _normalize_identifier(baseline_udi)
+    if not d or not b:
+        return "unverified", False
+    if d == b or b in d or d in b:
+        return "match", True
+    return "mismatch", False
 
 
 def _risk_level(score: int) -> str:
@@ -526,6 +557,7 @@ def analyze_inspection(
     instrument_barcode: Optional[str] = None,
     instrument_udi: Optional[str] = None,
     keydot_id: Optional[str] = None,
+    decoder_backend: str = "declared",
 ) -> dict[str, Any]:
     """Run the deterministic baseline-comparison analysis.
 
@@ -606,16 +638,40 @@ def analyze_inspection(
             "spd_risk_impact": spd_risk_impact(spd_tier),
         })
 
-    # ── Identification detection / match ────────────────────────────────────
+    # ── Identification detection / match (real decode-vs-baseline) ──────────
+    # Values may be decoded from the image (pyzbar) or technician-declared; the
+    # match is a real comparison against the approved baseline's UDI.
+    baseline_udi = resolution.get("baseline_udi", "")
+    barcode_status, barcode_match = identifier_match(instrument_barcode or "", baseline_udi)
+    udi_status, udi_match = identifier_match(instrument_udi or "", baseline_udi)
+    # KeyDot has no UDI to verify against — detection only.
+    keydot_detected = bool(keydot_id)
+
+    # Overall identification verdict, worst-case first.
+    if barcode_status == "mismatch" or udi_status == "mismatch":
+        identification_status = "mismatch"
+    elif barcode_status == "match" or udi_status == "match":
+        identification_status = "verified"
+    elif instrument_barcode or instrument_udi or keydot_id:
+        identification_status = "unverified"
+    else:
+        identification_status = "not_detected"
+
     identification = {
         "barcode_detected": bool(instrument_barcode),
         "qr_udi_detected": bool(instrument_udi),
-        "keydot_detected": bool(keydot_id),
-        # Placeholder: a detected identifier is treated as a match against the
-        # resolved baseline. Real CV will compare decoded values.
-        "barcode_match": bool(instrument_barcode),
-        "qr_udi_match": bool(instrument_udi),
-        "keydot_match": bool(keydot_id),
+        "keydot_detected": keydot_detected,
+        "barcode_value": instrument_barcode or "",
+        "qr_udi_value": instrument_udi or "",
+        "keydot_value": keydot_id or "",
+        "barcode_match": barcode_match,
+        "qr_udi_match": udi_match,
+        "keydot_match": keydot_detected,
+        "barcode_status": barcode_status,
+        "qr_udi_status": udi_status,
+        "identification_status": identification_status,
+        "baseline_udi": baseline_udi,
+        "decoder_backend": decoder_backend,
     }
 
     # ── Baseline match / deviation ──────────────────────────────────────────
@@ -676,9 +732,13 @@ def analyze_inspection(
         if kpi_summary[f["type"]] and f["spd_risk"] == "high"
     ]
 
+    # A decoded identifier that does NOT match the approved baseline means the
+    # wrong instrument may be in front of the camera — force supervisor review.
+    identifier_mismatch = identification["identification_status"] == "mismatch"
+
     if remove_flags or spd_critical:
         risk_level = "critical"
-    elif critical_flags or spd_high:
+    elif critical_flags or spd_high or identifier_mismatch:
         risk_level = "high"
     else:
         risk_level = _risk_level(inspection_score)
@@ -792,6 +852,21 @@ def analyze_inspection(
     explanation = scoring_explanation(findings_by_kpi, baseline_match_score, source)
     top_risk_drivers = risk_drivers
 
+    # Surface identification verification in the explanation + action.
+    id_status = identification["identification_status"]
+    if id_status == "verified":
+        explanation.append("Instrument identifier matched the approved baseline.")
+    elif id_status == "mismatch":
+        explanation.append(
+            "Decoded identifier does NOT match the approved baseline — possible wrong instrument."
+        )
+        action = (
+            "Supervisor review required — decoded identifier does not match the "
+            "approved baseline (possible wrong instrument)."
+        )
+        if "Identifier mismatch" not in top_risk_drivers:
+            top_risk_drivers = ["Identifier mismatch", *top_risk_drivers]
+
     return {
         "analysis_status": "completed",
         "baseline_source": source,
@@ -806,6 +881,8 @@ def analyze_inspection(
         "predicted_findings": predicted_findings,
         "kpi_summary": kpi_summary,
         "identification": identification,
+        "identification_status": identification["identification_status"],
+        "decoder_backend": decoder_backend,
         "findings_summary": findings_summary,
         "confidence": overall_conf,
         "confidence_level": confidence_level,

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -48,12 +48,18 @@ def _baseline_comparison_label(source: str) -> str:
     return label if source == "manufacturer" else f"{label} (fallback)"
 
 # KPI categories the analysis reports on.
-CONTAMINATION_KPIS = ["blood", "bone", "tissue", "bioburden", "debris", "other_organic_residue"]
+# NOTE: "bioburden" is intentionally NOT a standalone KPI — it is a clinical
+# umbrella term. An Overall Cleaning Assessment is derived instead from the
+# concrete contamination KPIs below (see CLEANING_KPIS / overall_cleaning_assessment).
+CONTAMINATION_KPIS = ["blood", "bone", "tissue", "debris", "other_organic_residue"]
 CONDITION_KPIS = ["rust", "discoloration", "corrosion", "pitting", "crack", "insulation_damage", "missing_component"]
+
+# Concrete contamination KPIs that feed the Overall Cleaning Assessment.
+CLEANING_KPIS = ["blood", "bone", "tissue", "other_organic_residue", "debris"]
 
 # Human-readable KPI labels for findings summaries.
 KPI_LABELS = {
-    "blood": "blood", "bone": "bone", "tissue": "tissue", "bioburden": "bioburden",
+    "blood": "blood", "bone": "bone", "tissue": "tissue",
     "debris": "debris", "other_organic_residue": "organic residue",
     "rust": "rust", "discoloration": "discoloration", "corrosion": "corrosion",
     "pitting": "pitting", "crack": "crack", "insulation_damage": "insulation damage",
@@ -63,13 +69,14 @@ KPI_LABELS = {
 # Critical KPI thresholds (probability). Exceeding one drives risk up and changes
 # the recommendation toward reprocess / supervisor review / remove from service.
 _CRITICAL_THRESHOLDS = {
-    "blood": 0.30, "bone": 0.30, "tissue": 0.30, "bioburden": 0.30,
+    "blood": 0.30, "bone": 0.30, "tissue": 0.30,
+    "other_organic_residue": 0.30,
     "rust": 0.60, "corrosion": 0.60, "crack": 0.30, "missing_component": 0.30,
 }
 # KPIs whose critical breach means the instrument should leave service.
 _REMOVE_FROM_SERVICE = {"crack", "missing_component"}
 # Contamination KPIs whose critical breach means reprocess + re-inspect.
-_REPROCESS = {"blood", "bone", "tissue", "bioburden"}
+_REPROCESS = {"blood", "bone", "tissue", "other_organic_residue"}
 
 
 def severity_from_probability(p: float) -> str:
@@ -113,8 +120,20 @@ _SEVERITY_SCALES = {
     "blood": ["none", "trace", "visible", "heavy"],
     "rust": ["none", "surface rust", "moderate rust", "heavy rust"],
     "corrosion": ["none", "minor", "moderate", "severe"],
+    "discoloration": ["none", "minor", "moderate", "severe"],
+    # Structural-damage scale for crack / missing component / insulation damage.
+    "crack": ["none", "cosmetic wear", "functional concern", "structural failure"],
+    "missing_component": ["none", "cosmetic wear", "functional concern", "structural failure"],
+    "insulation_damage": ["none", "cosmetic wear", "functional concern", "structural failure"],
+    "pitting": ["none", "cosmetic wear", "functional concern", "structural failure"],
 }
 _GENERIC_SCALE = ["none", "low", "moderate", "high"]
+
+# Every severity token that can appear in a predicted finding's "severity"
+# field — exposed so callers/tests can validate the richer SPD vocabulary.
+ALL_SEVERITY_TOKENS = {
+    tok for scale in _SEVERITY_SCALES.values() for tok in scale
+} | set(_GENERIC_SCALE)
 
 
 def kpi_severity(kpi: str, p: float) -> str:
@@ -152,7 +171,7 @@ _DECLARED_TO_KPI = {
 #   low_medium     — bone (low unless organic contamination suspected)
 #   low            — cosmetic / wear unless structural integrity affected
 _RISK_TIER = {
-    "blood": "high", "bioburden": "high", "tissue": "high",
+    "blood": "high", "tissue": "high",
     "other_organic_residue": "high", "crack": "high", "missing_component": "high",
     "insulation_damage": "high",
     "corrosion": "severity_based", "rust": "severity_based",
@@ -172,11 +191,68 @@ def risk_tier(kpi: str, p: float) -> str:
     return tier
 
 
+# ── SPD risk weighting ───────────────────────────────────────────────────────
+# Maps each KPI (and, where severity matters, its severity band) onto an SPD
+# operational risk tier. This is what drives the "SPD Risk Impact" column and
+# the override rule that forces High/Critical regardless of total score.
+#
+#   critical — must reprocess / remove from service before any use
+#   high     — supervisor review before release
+#   low      — monitor; cosmetic / wear only
+#
+# Severity bands use _severity_index(p): 0 none, 1 minor, 2 moderate, 3 severe.
+_SPD_ALWAYS_CRITICAL = {
+    "tissue", "other_organic_residue", "crack", "missing_component",
+    "insulation_damage",
+}
+_SPD_ALWAYS_HIGH = {"debris", "bone", "pitting"}
+
+
+def spd_risk_tier(kpi: str, p: float) -> str:
+    """SPD operational risk tier for a KPI at probability ``p``.
+
+    Returns "none" when the finding is absent (severity index 0), otherwise
+    "critical" / "high" / "low" per SPD priorities:
+      - blood: visible/heavy → critical, trace → high
+      - heavy rust / severe corrosion → critical; moderate → high; surface/minor → low
+      - tissue / organic residue / crack / missing component / insulation damage → critical
+      - debris / bone / pitting → high
+      - discoloration and other cosmetic findings → low
+    """
+    idx = _severity_index(p)
+    if idx == 0:
+        return "none"
+    if kpi == "blood":
+        return "critical" if idx >= 2 else "high"
+    if kpi in ("rust", "corrosion"):
+        return "critical" if idx >= 3 else "high" if idx == 2 else "low"
+    if kpi in _SPD_ALWAYS_CRITICAL:
+        return "critical"
+    if kpi in _SPD_ALWAYS_HIGH:
+        return "high"
+    # discoloration + anything cosmetic
+    return "low"
+
+
+# SPD Risk Impact label shown in the panel for each KPI.
+_SPD_IMPACT_LABEL = {
+    "none": "Clear",
+    "low": "Monitor",
+    "high": "Review",
+    "critical": "Reprocess",
+}
+
+
+def spd_risk_impact(tier: str) -> str:
+    """Human label for the SPD Risk Impact column (Clear/Monitor/Review/Reprocess)."""
+    return _SPD_IMPACT_LABEL.get(tier, "Review")
+
+
 # Per-KPI risk weight — how much a positive finding deducts from the score.
 # Contamination (blood/bioburden/tissue/organic), cracks, and missing components
 # deduct far more aggressively than cosmetic discoloration / wear.
 _KPI_WEIGHT = {
-    "blood": 36, "bioburden": 33, "tissue": 31, "other_organic_residue": 29,
+    "blood": 36, "tissue": 31, "other_organic_residue": 29,
     "crack": 38, "missing_component": 35, "insulation_damage": 30,
     "corrosion": 24, "rust": 18,            # severity scales via probability
     "bone": 16, "debris": 16,               # low–medium
@@ -320,6 +396,125 @@ def _risk_level(score: int) -> str:
     return "critical"
 
 
+def overall_cleaning_assessment(findings_by_kpi: dict[str, dict]) -> str:
+    """Derive the Overall Cleaning Assessment from the concrete contamination KPIs
+    (blood, bone, tissue, organic residue, debris) — replacing the standalone
+    "bioburden" KPI with a clinically meaningful summary.
+
+      Clean                            — no contamination signal
+      Residual contamination suspected — minor/uncertain contamination present
+      Cleaning failure                 — clear contamination (blood/tissue/organic
+                                         residue at moderate+ severity)
+    """
+    failure = False
+    residual = False
+    for kpi in CLEANING_KPIS:
+        f = findings_by_kpi.get(kpi)
+        if not f:
+            continue
+        idx = f["severity_index"]
+        if idx == 0:
+            continue
+        residual = True
+        if kpi in ("blood", "tissue", "other_organic_residue") and idx >= 2:
+            failure = True
+        if kpi == "debris" and idx >= 3:
+            failure = True
+    if failure:
+        return "Cleaning failure"
+    if residual:
+        return "Residual contamination suspected"
+    return "Clean"
+
+
+def recommended_action(findings_by_kpi: dict[str, dict], baseline_match_score: float) -> str:
+    """Map findings onto an SPD recommended action.
+
+    Priority: reprocess/remove > supervisor review > monitor > pass.
+    """
+    def present(kpi: str) -> dict | None:
+        f = findings_by_kpi.get(kpi)
+        return f if f and f["severity_index"] >= 1 else None
+
+    # REPROCESS / REMOVE FROM SERVICE
+    reprocess = []
+    for kpi in ("blood", "tissue", "other_organic_residue", "crack",
+                "missing_component", "insulation_damage"):
+        f = present(kpi)
+        if f and (kpi != "blood" or f["severity_index"] >= 2):
+            reprocess.append(KPI_LABELS[kpi])
+    for kpi in ("corrosion",):
+        f = present(kpi)
+        if f and f["severity_index"] >= 3:  # severe corrosion
+            reprocess.append("severe corrosion")
+    if reprocess:
+        return (
+            "Reprocess / remove from service — "
+            + ", ".join(sorted(set(reprocess)))
+            + ". Supervisor review required before any further use."
+        )
+
+    # SUPERVISOR REVIEW
+    supervisor = []
+    for kpi in ("debris", "bone"):
+        if present(kpi):
+            supervisor.append(KPI_LABELS[kpi])
+    for kpi in ("corrosion", "rust"):
+        f = present(kpi)
+        if f and f["severity_index"] == 2:  # moderate
+            supervisor.append(f["severity"])
+    if baseline_match_score < 0.70:
+        supervisor.append("baseline mismatch")
+    if supervisor:
+        return (
+            "Supervisor review recommended before release — "
+            + ", ".join(sorted(set(supervisor))) + "."
+        )
+
+    # MONITOR
+    monitor = []
+    for kpi in ("discoloration", "rust"):
+        f = present(kpi)
+        if f and f["severity_index"] == 1:  # minor / surface
+            monitor.append(f["severity"])
+    if monitor:
+        return (
+            "Monitor — low-risk findings only ("
+            + ", ".join(sorted(set(monitor)))
+            + "). Continue routine processing."
+        )
+
+    # PASS
+    return "Pass — no high-risk findings and baseline match strong. Release for use."
+
+
+def scoring_explanation(
+    findings_by_kpi: dict[str, dict],
+    baseline_match_score: float,
+    baseline_source: str,
+) -> list[str]:
+    """Plain-language, per-KPI reasons the score is what it is."""
+    label = BASELINE_LABELS.get(baseline_source, "Baseline")
+    lines = [f"{label} matched at {round(baseline_match_score * 100)}%."]
+    for kpi in ("blood", "tissue", "other_organic_residue", "debris", "bone",
+                "corrosion", "rust", "discoloration"):
+        f = findings_by_kpi.get(kpi)
+        if not f:
+            continue
+        idx = f["severity_index"]
+        name = KPI_LABELS[kpi]
+        if idx == 0:
+            lines.append(f"No {name} detected.")
+        elif f["spd_risk"] == "low":
+            lines.append(
+                f"{f['severity'].capitalize()} {name} was treated as low-risk "
+                "cosmetic variation."
+            )
+        else:
+            lines.append(f"{f['severity'].capitalize()} {name} reduced the score.")
+    return lines
+
+
 def analyze_inspection(
     db: Session,
     *,
@@ -361,6 +556,14 @@ def analyze_inspection(
             "recommendation": (
                 "No approved baseline found. Supervisor review required before final scoring."
             ),
+            "recommended_action": "Supervisor review required before release.",
+            "overall_cleaning_assessment": "Supervisor review required",
+            "top_risk_drivers": ["No approved baseline"],
+            "severity_by_kpi": {},
+            "scoring_explanation": [
+                "No approved baseline found for this instrument.",
+                "Final scoring is withheld until a supervisor reviews.",
+            ],
             "message": "No approved baseline found. Supervisor review required before final scoring.",
             "human_review_required": True,
             "placeholder_scoring": True,
@@ -385,17 +588,22 @@ def analyze_inspection(
 
         present = probability >= 0.5
         kpi_summary[kpi] = present
+        spd_tier = spd_risk_tier(kpi, probability)
         predicted_findings.append({
             "type": kpi,
             "label": KPI_LABELS.get(kpi, kpi),
             "probability": probability,
             "confidence": confidence,
             # KPI-specific severity scale (blood: trace/visible/heavy,
-            # rust: surface/moderate/heavy, corrosion: minor/moderate/severe).
+            # rust: surface/moderate/heavy, corrosion: minor/moderate/severe,
+            # damage: cosmetic wear/functional concern/structural failure).
             "severity": kpi_severity(kpi, probability),
             "severity_index": _severity_index(probability),
             "status": status_from_probability(probability),
             "risk_tier": risk_tier(kpi, probability),
+            # SPD operational weighting surfaced to the panel.
+            "spd_risk": spd_tier,
+            "spd_risk_impact": spd_risk_impact(spd_tier),
         })
 
     # ── Identification detection / match ────────────────────────────────────
@@ -454,9 +662,23 @@ def analyze_inspection(
     remove_flags = [k for k in critical_flags if k in _REMOVE_FROM_SERVICE]
     reprocess_flags = [k for k in critical_flags if k in _REPROCESS]
 
-    if remove_flags:
+    # ── SPD-weighted override ───────────────────────────────────────────────
+    # Any present finding whose SPD tier is critical/high forces the risk level
+    # up regardless of the numeric score (visible blood, tissue, organic
+    # residue, crack, missing component, severe corrosion, significant debris,
+    # bone residue, etc.).
+    spd_critical = [
+        f["type"] for f in predicted_findings
+        if kpi_summary[f["type"]] and f["spd_risk"] == "critical"
+    ]
+    spd_high = [
+        f["type"] for f in predicted_findings
+        if kpi_summary[f["type"]] and f["spd_risk"] == "high"
+    ]
+
+    if remove_flags or spd_critical:
         risk_level = "critical"
-    elif critical_flags:
+    elif critical_flags or spd_high:
         risk_level = "high"
     else:
         risk_level = _risk_level(inspection_score)
@@ -464,7 +686,7 @@ def analyze_inspection(
     pass_fail = "FAIL" if critical_flags else "PASS"
 
     # ── Findings summary (one line per key KPI) ─────────────────────────────
-    summary_kpis = ["blood", "bone", "tissue", "bioburden", "corrosion", "rust", "discoloration", "crack"]
+    summary_kpis = ["blood", "bone", "tissue", "corrosion", "rust", "discoloration", "crack"]
     findings_summary: list[str] = []
     if not critical_flags:
         findings_summary.append("No critical contamination detected")
@@ -553,6 +775,23 @@ def analyze_inspection(
     }
 
     source = resolution["baseline_source"]
+
+    # ── SPD-weighted summaries (severity, cleaning, action, explanation) ─────
+    findings_by_kpi = {f["type"]: f for f in predicted_findings}
+    severity_by_kpi = {
+        f["type"]: {
+            "severity": f["severity"],
+            "probability": f["probability"],
+            "spd_risk": f["spd_risk"],
+            "spd_risk_impact": f["spd_risk_impact"],
+        }
+        for f in predicted_findings
+    }
+    cleaning_assessment = overall_cleaning_assessment(findings_by_kpi)
+    action = recommended_action(findings_by_kpi, baseline_match_score)
+    explanation = scoring_explanation(findings_by_kpi, baseline_match_score, source)
+    top_risk_drivers = risk_drivers
+
     return {
         "analysis_status": "completed",
         "baseline_source": source,
@@ -571,6 +810,14 @@ def analyze_inspection(
         "confidence": overall_conf,
         "confidence_level": confidence_level,
         "recommendation": recommendation,
+        # SPD risk-weighted intelligence (new contract additions).
+        "recommended_action": action,
+        "overall_cleaning_assessment": cleaning_assessment,
+        "top_risk_drivers": top_risk_drivers,
+        "severity_by_kpi": severity_by_kpi,
+        "scoring_explanation": explanation,
+        "spd_critical_drivers": spd_critical,
+        "spd_high_drivers": spd_high,
         "reason": reason,
         "critical_flags": critical_flags,
         "score_adjustments": score_adjustments,

--- a/backend/app/services/clinical_report_pdf.py
+++ b/backend/app/services/clinical_report_pdf.py
@@ -1,0 +1,185 @@
+"""Phase 13.8 — Clinical Report Generator (printable PDF).
+
+Renders an inspection's Explainable-AI Clinical Decision Support output as a
+printable PDF for the quality record: decision, score breakdown, cleaning +
+integrity assessments, clinical reasoning, recommendation, evidence, audit
+trail, and signature lines.
+
+Advisory pilot output — the report carries the pilot-model label and the
+human-review requirement; no FDA/production-accuracy claims.
+"""
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+from typing import Any
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    HRFlowable,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+
+def _styles():
+    ss = getSampleStyleSheet()
+    ss.add(ParagraphStyle("H", parent=ss["Heading2"], spaceBefore=10, spaceAfter=4, textColor=colors.HexColor("#0f172a")))
+    ss.add(ParagraphStyle("Small", parent=ss["Normal"], fontSize=8, textColor=colors.HexColor("#64748b")))
+    return ss
+
+
+def _kv_table(rows: list[tuple[str, str]]) -> Table:
+    t = Table([[k, v] for k, v in rows], colWidths=[2.1 * inch, 4.0 * inch])
+    t.setStyle(TableStyle([
+        ("FONTSIZE", (0, 0), (-1, -1), 9),
+        ("TEXTCOLOR", (0, 0), (0, -1), colors.HexColor("#475569")),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+    ]))
+    return t
+
+
+def _findings_table(items: list[dict], integrity: bool) -> Table:
+    header = ["Finding", "Detected", "Prob", "Severity", "Confidence", "SPD Risk"]
+    data = [header]
+    for it in items:
+        data.append([
+            it["label"],
+            "yes" if it.get("detected") else "no",
+            f"{it['probability_pct']}%",
+            it["severity"],
+            f"{it['confidence_pct']}%",
+            it.get("spd_risk_impact", "Clear"),
+        ])
+    t = Table(data, colWidths=[1.6 * inch, 0.7 * inch, 0.6 * inch, 1.4 * inch, 0.9 * inch, 0.9 * inch])
+    t.setStyle(TableStyle([
+        ("FONTSIZE", (0, 0), (-1, -1), 8),
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e2e8f0")),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.HexColor("#0f172a")),
+        ("GRID", (0, 0), (-1, -1), 0.4, colors.HexColor("#cbd5e1")),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+        ("TOPPADDING", (0, 0), (-1, -1), 3),
+    ]))
+    return t
+
+
+_RESULT_COLOR = {
+    "PASS": "#059669", "MONITOR": "#d97706",
+    "SUPERVISOR REVIEW": "#ea580c", "REMOVE FROM SERVICE": "#dc2626",
+}
+
+
+def build_clinical_report_pdf(row: Any, analysis: dict) -> bytes:
+    """Return the PDF bytes for an inspection + its analysis payload."""
+    ss = _styles()
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf, pagesize=letter,
+        topMargin=0.6 * inch, bottomMargin=0.6 * inch,
+        leftMargin=0.7 * inch, rightMargin=0.7 * inch,
+        title=f"LumenAI Clinical Report — Inspection {getattr(row, 'id', '')}",
+    )
+    cd = analysis.get("clinical_decision", {})
+    summary = cd.get("summary", {})
+    story: list[Any] = []
+
+    story.append(Paragraph("LumenAI — Clinical Inspection Report", ss["Title"]))
+    story.append(Paragraph("Explainable AI Clinical Decision Support (pilot — advisory, human review required)", ss["Small"]))
+    story.append(HRFlowable(width="100%", color=colors.HexColor("#94a3b8")))
+    story.append(Spacer(1, 6))
+
+    result = cd.get("overall_result", "SUPERVISOR REVIEW")
+    story.append(Paragraph(
+        f'<font color="{_RESULT_COLOR.get(result, "#334155")}"><b>Overall Result: {result}</b></font>',
+        ss["Heading2"],
+    ))
+
+    # Identity / context
+    story.append(Paragraph("Inspection", ss["H"]))
+    story.append(_kv_table([
+        ("Facility", getattr(row, "facility_name", None) or getattr(row, "site_name", "") or "—"),
+        ("Inspection ID", str(getattr(row, "id", "—"))),
+        ("Instrument", getattr(row, "instrument_type", "—")),
+        ("Barcode / UDI", getattr(row, "instrument_barcode", None) or getattr(row, "instrument_udi", None) or "—"),
+        ("Baseline Source", str(summary.get("baseline_source") or "—")),
+        ("Inspection Date", (getattr(row, "created_at", None) or datetime.now(timezone.utc)).strftime("%Y-%m-%d %H:%M UTC")),
+    ]))
+
+    # Decision summary
+    story.append(Paragraph("Clinical Decision Summary", ss["H"]))
+    story.append(_kv_table([
+        ("Inspection Score", f"{summary.get('inspection_score', '—')} / 100"),
+        ("Cleaning Assessment", str(summary.get("cleaning_assessment") or "—")),
+        ("Integrity Assessment", str(summary.get("integrity_assessment") or "—")),
+        ("Overall Risk", str(summary.get("overall_risk") or "—")),
+        ("Confidence", f"{summary.get('confidence') or '—'} ({summary.get('confidence_pct', 0)}%)"),
+    ]))
+
+    # Cleaning + integrity tables
+    cleaning = cd.get("cleaning", {})
+    if cleaning.get("items"):
+        story.append(Paragraph(f"Cleaning Assessment — {cleaning.get('overall_status', '—')}", ss["H"]))
+        story.append(_findings_table(cleaning["items"], integrity=False))
+    integrity = cd.get("integrity", {})
+    if integrity.get("items"):
+        story.append(Paragraph(f"Instrument Integrity — {integrity.get('overall_status', '—')}", ss["H"]))
+        story.append(_findings_table(integrity["items"], integrity=True))
+
+    # Reasoning
+    story.append(Paragraph("Clinical Reasoning", ss["H"]))
+    for line in cd.get("clinical_reasoning", []):
+        story.append(Paragraph(f"• {line}", ss["Normal"]))
+
+    # Recommendation
+    rec = cd.get("recommendation", {})
+    story.append(Paragraph("Recommendation", ss["H"]))
+    story.append(Paragraph(f"<b>{rec.get('result', result)}</b> — {rec.get('action', '')}", ss["Normal"]))
+
+    # Evidence
+    ev = cd.get("evidence", {})
+    story.append(Paragraph("Evidence Used", ss["H"]))
+    story.append(_kv_table([
+        ("Baseline", str(ev.get("baseline_comparison_label") or ev.get("baseline_source") or "—")),
+        ("Baseline Match", f"{ev.get('baseline_match_pct', '—')}%"),
+        ("Highest Risk Drivers", ", ".join(ev.get("highest_risk_drivers", []) or ["—"])),
+        ("Confidence", str(ev.get("confidence") or "—")),
+    ]))
+    story.append(Paragraph(ev.get("image_evidence_note", ""), ss["Small"]))
+
+    # Audit
+    audit = cd.get("audit", {})
+    story.append(Paragraph("Audit Trail", ss["H"]))
+    story.append(_kv_table([
+        ("AI Model", f"{audit.get('model_label', '')} ({audit.get('model_version', '')})"),
+        ("Baseline Version", str(audit.get("baseline_version") or "—")),
+        ("Recommendation", str(audit.get("recommendation") or "—")),
+        ("Human Review Required", "Yes" if audit.get("human_review_required", True) else "No"),
+        ("Generated", datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")),
+    ]))
+
+    # Signatures
+    story.append(Spacer(1, 18))
+    sig = Table([
+        ["Technician: ______________________", "Supervisor: ______________________"],
+        ["Date: __________________________", "Date: __________________________"],
+    ], colWidths=[3.0 * inch, 3.0 * inch])
+    sig.setStyle(TableStyle([("FONTSIZE", (0, 0), (-1, -1), 9), ("TOPPADDING", (0, 0), (-1, -1), 10)]))
+    story.append(sig)
+
+    story.append(Spacer(1, 10))
+    story.append(Paragraph(
+        "Pilot advisory output. Not validated for production diagnostic accuracy; no FDA clearance is claimed. "
+        "Qualified human review is required before any disposition.",
+        ss["Small"],
+    ))
+
+    doc.build(story)
+    return buf.getvalue()

--- a/backend/app/services/image_retention_service.py
+++ b/backend/app/services/image_retention_service.py
@@ -1,0 +1,118 @@
+"""Opt-in image retention for model training.
+
+Retention is a deliberate, access-controlled capability — NOT a default. The
+platform normally stores only SHA-256 hashes. This service persists actual image
+bytes ONLY when:
+
+  1. ``RETAIN_INSPECTION_IMAGES`` is enabled (env), AND
+  2. consent is recorded for the action.
+
+Before any bytes are stored, EXIF/metadata is stripped (no GPS, device, or
+embedded thumbnails) to avoid PHI/identifying metadata. Images must be of
+instruments only — callers are responsible for rejecting frames containing PHI.
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+
+from sqlalchemy.orm import Session
+
+from app.models.retained_image import RetainedImage
+
+_TRUTHY = {"1", "true", "yes", "on", "enabled"}
+
+
+def retention_enabled() -> bool:
+    """Whether opt-in image retention is turned on for this deployment."""
+    return os.getenv("RETAIN_INSPECTION_IMAGES", "").strip().lower() in _TRUTHY
+
+
+def strip_exif(data: bytes, content_type: str = "") -> tuple[bytes, bool]:
+    """Return (clean_bytes, stripped). Re-encodes the image WITHOUT EXIF/metadata.
+
+    Degrades gracefully: if Pillow is unavailable or the bytes are not a
+    decodable image, returns the original bytes with ``stripped=False`` so the
+    caller can decide. We never want metadata stripping to crash an upload.
+    """
+    try:
+        from PIL import Image  # local import — optional/heavy dependency
+    except Exception:
+        return data, False
+
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            fmt = img.format or _format_from_content_type(content_type)
+            # Re-create the image from pixel data only — drops EXIF, GPS, ICC, etc.
+            clean = Image.new(img.mode, img.size)
+            clean.paste(img)
+            out = io.BytesIO()
+            save_fmt = fmt if fmt in {"JPEG", "PNG", "WEBP", "BMP"} else "PNG"
+            clean.save(out, format=save_fmt)
+            return out.getvalue(), True
+    except Exception:
+        return data, False
+
+
+def _format_from_content_type(content_type: str) -> str:
+    ct = (content_type or "").lower()
+    if "jpeg" in ct or "jpg" in ct:
+        return "JPEG"
+    if "png" in ct:
+        return "PNG"
+    if "webp" in ct:
+        return "WEBP"
+    return "PNG"
+
+
+def retain_image(
+    db: Session,
+    *,
+    data: bytes,
+    tenant_id: str,
+    instrument_type: str = "unknown",
+    content_type: str = "",
+    source: str = "inspection",
+    uploaded_by: str = "",
+    consent: bool = False,
+    seq: int | None = None,
+) -> RetainedImage | None:
+    """Persist an EXIF-stripped image IF retention is enabled and consent given.
+
+    Returns the created ``RetainedImage`` row, or ``None`` when retention is
+    disabled or consent is absent (the no-op default path).
+    """
+    if not retention_enabled() or not consent:
+        return None
+
+    clean_bytes, stripped = strip_exif(data, content_type)
+    sha256 = hashlib.sha256(clean_bytes).hexdigest()
+
+    if seq is None:
+        seq = (
+            db.query(RetainedImage)
+            .filter(RetainedImage.tenant_id == tenant_id)
+            .count()
+            + 1
+        )
+    deident_name = f"{(instrument_type or 'unknown').replace(' ', '_')}_{seq}"
+
+    row = RetainedImage(
+        tenant_id=tenant_id,
+        deident_name=deident_name,
+        instrument_type=instrument_type or "unknown",
+        content_type=content_type,
+        size_bytes=len(clean_bytes),
+        sha256=sha256,
+        exif_stripped=stripped,
+        source=source,
+        consent_recorded=True,
+        uploaded_by=uploaded_by,
+        image_bytes=clean_bytes,
+        label_status="unlabeled",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,7 +29,8 @@ boto3
 
 Pillow==12.2.0
 PyJWT==2.13.0
-passlib[bcrypt]>=1.7.4
+passlib>=1.7.4
+bcrypt<4.0
 cryptography>=41.0.0
 starlette==1.3.1
 httpx

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,6 +28,11 @@ apscheduler
 boto3
 
 Pillow==12.2.0
+# Identifier decode (barcode/QR/UDI). The Python wrapper installs cleanly; real
+# decoding additionally needs the ZBar native lib (Debian/Ubuntu: `libzbar0`).
+# Decoding degrades gracefully to "declared identifiers" if ZBar is absent, so
+# this is safe to ship even where the system library is not installed.
+pyzbar==0.1.9
 PyJWT==2.13.0
 passlib>=1.7.4
 bcrypt<4.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,7 @@ boto3
 
 Pillow==12.2.0
 PyJWT==2.13.0
+passlib[bcrypt]>=1.7.4
 cryptography>=41.0.0
 starlette==1.3.1
 httpx

--- a/backend/tests/test_ai_clinical_review.py
+++ b/backend/tests/test_ai_clinical_review.py
@@ -1,0 +1,182 @@
+"""AI Clinical Review, Evidence Strength, Baseline Difference, Supervisor Notes."""
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"acr-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+        )
+    finally:
+        db.close()
+
+
+class TestAIClinicalReview:
+    def test_pass_reasoning_and_interpretation(self):
+        cd = _analyze("retractor")["clinical_decision"]
+        review = cd["ai_clinical_review"]
+        assert review["outcome"] in (
+            "PASS", "MONITOR", "SUPERVISOR REVIEW", "REPROCESS", "REMOVE FROM SERVICE"
+        )
+        # Reasoning is grounded (baseline line) and interpretation is non-generic.
+        assert any("matched at" in ln for ln in review["reasoning"])
+        assert review["interpretation"]
+
+    def test_reprocess_outcome_on_blood(self):
+        cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
+        assert cd["ai_clinical_review"]["outcome"] in ("REPROCESS", "REMOVE FROM SERVICE")
+        assert cd["recommendation"]["action_text"]
+
+    def test_five_action_texts(self):
+        from app.services.baseline_comparison_scoring_service import _ACTION_TEXT
+        assert set(_ACTION_TEXT) == {
+            "PASS", "MONITOR", "SUPERVISOR REVIEW", "REPROCESS", "REMOVE FROM SERVICE"
+        }
+
+
+class TestEvidenceStrength:
+    def test_strong_when_match_and_confidence_high(self):
+        from app.services.baseline_comparison_scoring_service import evidence_strength
+        es = evidence_strength({"baseline_match_score": 0.95, "confidence": 0.90})
+        assert es["level"] == "Strong"
+        assert es["stars"] == 5
+
+    def test_moderate_band(self):
+        from app.services.baseline_comparison_scoring_service import evidence_strength
+        es = evidence_strength({"baseline_match_score": 0.80, "confidence": 0.60})
+        assert es["level"] == "Moderate"
+
+    def test_limited_when_baseline_missing(self):
+        from app.services.baseline_comparison_scoring_service import evidence_strength
+        es = evidence_strength({"baseline_match_score": None, "confidence": None})
+        assert es["level"] == "Limited"
+        assert es["stars"] == 1
+
+    def test_evidence_strength_in_clinical_decision(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        assert cd["evidence_strength"]["level"] in ("Strong", "Moderate", "Limited")
+
+
+class TestBaselineDifference:
+    def test_difference_section_present(self):
+        cd = _analyze("forceps")["clinical_decision"]
+        bd = cd["baseline_difference"]
+        assert bd["baseline_match_pct"] is not None
+        assert bd["differences"]
+        assert "future" in bd["localization_note"].lower()
+
+    def test_no_fabricated_localization(self):
+        cd = _analyze("forceps")["clinical_decision"]
+        # No bounding-box / heatmap fabrication — only plain observations.
+        assert bd_ok(cd["baseline_difference"]["differences"])
+
+
+def bd_ok(diffs):
+    joined = " ".join(diffs).lower()
+    return "bounding box" not in joined and "heatmap" not in joined
+
+
+class TestAuditTrail:
+    def test_audit_has_model_and_baseline_version(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        audit = cd["audit"]
+        assert audit["model_version"]
+        assert "baseline_version" in audit
+        assert "dataset_version" in audit
+        assert "evidence_strength" in audit
+        assert "supervisor_agreement" in audit
+
+
+class TestSupervisorReviewAPI:
+    def _create(self, itype):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_operator_cannot_submit(self):
+        iid = self._create("scissors")
+        r = client.post(f"/api/inspections/{iid}/supervisor-review",
+                        json={"agreement": "agree"}, headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+    def test_manager_can_agree(self):
+        iid = self._create("scissors")
+        r = client.post(f"/api/inspections/{iid}/supervisor-review",
+                        json={"agreement": "agree"}, headers=AUTH_MGR)
+        assert r.status_code == 201, r.text
+        assert r.json()["agreement"] == "agree"
+
+    def test_disagree_requires_comment(self):
+        iid = self._create("scissors")
+        r = client.post(f"/api/inspections/{iid}/supervisor-review",
+                        json={"agreement": "disagree", "rationale": ""}, headers=AUTH_MGR)
+        assert r.status_code == 422
+
+    def test_disagree_with_comment_ok(self):
+        iid = self._create("scissors")
+        r = client.post(f"/api/inspections/{iid}/supervisor-review",
+                        json={"agreement": "disagree", "rationale": "Debris still present in hinge."},
+                        headers=AUTH_MGR)
+        assert r.status_code == 201
+
+    def test_override_requires_comment(self):
+        iid = self._create("scissors")
+        r = client.post(f"/api/inspections/{iid}/supervisor-review",
+                        json={"agreement": "agree", "override_action": "reprocess"},
+                        headers=AUTH_MGR)
+        assert r.status_code == 422
+
+    def test_invalid_agreement_rejected(self):
+        iid = self._create("scissors")
+        r = client.post(f"/api/inspections/{iid}/supervisor-review",
+                        json={"agreement": "maybe"}, headers=AUTH_MGR)
+        assert r.status_code == 422
+
+    def test_performance_summary_counts_reviews(self):
+        iid = self._create("forceps")
+        client.post(f"/api/inspections/{iid}/supervisor-review",
+                    json={"agreement": "agree"}, headers=AUTH_MGR)
+        r = client.get("/api/model-performance/ai-summary", headers=AUTH_MGR)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["supervisor_reviews"] >= 1
+        assert body["supervisor_agreement_rate"] is not None
+        # No fabricated production ground-truth.
+        assert body["false_positive_count"] is None
+
+    def test_performance_summary_operator_blocked(self):
+        r = client.get("/api/model-performance/ai-summary", headers=AUTH_OPERATOR)
+        assert r.status_code == 403

--- a/backend/tests/test_analysis_panel_output.py
+++ b/backend/tests/test_analysis_panel_output.py
@@ -67,10 +67,13 @@ class TestCompletedOutput:
         assert out["pass_fail"] in ("PASS", "FAIL")
 
     def test_kpi_findings_have_severity_and_status(self):
+        from app.services.baseline_comparison_scoring_service import ALL_SEVERITY_TOKENS
         out = _analyze("forceps")
         for f in out["predicted_findings"]:
-            assert f["severity"] in ("none", "low", "moderate", "high")
+            assert f["severity"] in ALL_SEVERITY_TOKENS
             assert f["status"] in ("clear", "monitor", "review", "escalate")
+            assert f["spd_risk"] in ("none", "low", "high", "critical")
+            assert f["spd_risk_impact"] in ("Clear", "Monitor", "Review", "Reprocess")
             assert "label" in f
 
     def test_explainability_present(self):

--- a/backend/tests/test_baseline_comparison_scoring.py
+++ b/backend/tests/test_baseline_comparison_scoring.py
@@ -261,7 +261,9 @@ class TestAnalysisOutput:
         assert out["kpi_summary"]["tissue"] is True
         assert out["kpi_summary"]["debris"] is True
 
-    def test_identification_match_reported(self):
+    def test_identification_detection_and_mismatch(self):
+        # _add_baseline stores udi "udi-{itype}-manufacturer"; the decoded values
+        # here do not match it → real comparison must report a mismatch.
         itype = "scissors"
         _clear_baselines(itype)
         _add_baseline(itype, "manufacturer")
@@ -278,7 +280,27 @@ class TestAnalysisOutput:
         assert ident["barcode_detected"] is True
         assert ident["qr_udi_detected"] is True
         assert ident["keydot_detected"] is True
+        # Decoded values differ from the baseline UDI → mismatch, not a fake match.
+        assert ident["barcode_match"] is False
+        assert ident["identification_status"] == "mismatch"
+        assert out["risk_level"] in ("high", "critical")
+
+    def test_identification_match_against_baseline_udi(self):
+        itype = "scissors"
+        _clear_baselines(itype)
+        _add_baseline(itype, "manufacturer")  # udi = "udi-scissors-manufacturer"
+        db = SessionLocal()
+        try:
+            out = analyze_inspection(
+                db, instrument_type=itype, tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+                instrument_barcode="udi-scissors-manufacturer",
+            )
+        finally:
+            db.close()
+        ident = out["identification"]
         assert ident["barcode_match"] is True
+        assert ident["identification_status"] == "verified"
 
 
 # ── End-to-end via API ──────────────────────────────────────────────────────

--- a/backend/tests/test_capture_ingest.py
+++ b/backend/tests/test_capture_ingest.py
@@ -1,0 +1,119 @@
+"""Borescope capture-device registration + direct ingestion."""
+import io
+
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+
+client = TestClient(app)
+
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+
+def _png():
+    img = Image.new("RGB", (10, 10), (30, 30, 30))
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    out.seek(0)
+    return out
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"cap-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _register_device():
+    r = client.post(
+        "/api/capture/devices",
+        json={"name": "OR-3 Bridge", "location": "SPD Room 3", "role": "operator"},
+        headers=AUTH_ADMIN,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestDeviceRegistration:
+    def test_register_returns_key_once(self):
+        d = _register_device()
+        assert d["device_key"]
+        assert len(d["device_key"]) > 20
+        # Listing never returns the key again.
+        lst = client.get("/api/capture/devices", headers=AUTH_ADMIN).json()
+        assert all("device_key" not in dev for dev in lst["devices"])
+
+    def test_viewer_cannot_register(self):
+        r = client.post(
+            "/api/capture/devices",
+            json={"name": "x", "role": "operator"},
+            headers=AUTH_VIEWER,
+        )
+        assert r.status_code == 403
+
+    def test_invalid_role_rejected(self):
+        r = client.post(
+            "/api/capture/devices",
+            json={"name": "x", "role": "admin"},
+            headers=AUTH_ADMIN,
+        )
+        assert r.status_code == 422
+
+
+class TestIngest:
+    def test_ingest_requires_device_key(self):
+        r = client.post(
+            "/api/capture/ingest",
+            files={"image": ("f.png", _png(), "image/png")},
+            data={"instrument_type": "scissors"},
+        )
+        assert r.status_code == 401
+
+    def test_ingest_rejects_bad_key(self):
+        r = client.post(
+            "/api/capture/ingest",
+            files={"image": ("f.png", _png(), "image/png")},
+            data={"instrument_type": "scissors"},
+            headers={"X-Device-Key": "not-a-real-key"},
+        )
+        assert r.status_code == 401
+
+    def test_ingest_creates_scored_inspection(self):
+        _baseline("scissors")
+        key = _register_device()["device_key"]
+        r = client.post(
+            "/api/capture/ingest",
+            files={"image": ("frame.png", _png(), "image/png")},
+            data={"instrument_type": "scissors", "facility_name": "Mercy"},
+            headers={"X-Device-Key": key},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["inspection_id"]
+        assert body["analysis"]["analysis_status"] == "completed"
+        assert body["analysis"]["risk_level"] in ("low", "medium", "high", "critical")
+
+    def test_revoked_device_cannot_ingest(self):
+        reg = _register_device()
+        key, did = reg["device_key"], reg["id"]
+        assert client.post(f"/api/capture/devices/{did}/revoke", headers=AUTH_ADMIN).status_code == 200
+        r = client.post(
+            "/api/capture/ingest",
+            files={"image": ("f.png", _png(), "image/png")},
+            data={"instrument_type": "scissors"},
+            headers={"X-Device-Key": key},
+        )
+        assert r.status_code == 401

--- a/backend/tests/test_capture_ingest.py
+++ b/backend/tests/test_capture_ingest.py
@@ -106,6 +106,18 @@ class TestIngest:
         assert body["analysis"]["analysis_status"] == "completed"
         assert body["analysis"]["risk_level"] in ("low", "medium", "high", "critical")
 
+    def test_ingest_records_captured_by(self):
+        _baseline("scissors")
+        key = _register_device()["device_key"]
+        r = client.post(
+            "/api/capture/ingest",
+            files={"image": ("frame.png", _png(), "image/png")},
+            data={"instrument_type": "scissors", "captured_by": "badge-4471"},
+            headers={"X-Device-Key": key},
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["captured_by"] == "badge-4471"
+
     def test_revoked_device_cannot_ingest(self):
         reg = _register_device()
         key, did = reg["device_key"], reg["id"]

--- a/backend/tests/test_clinical_decision.py
+++ b/backend/tests/test_clinical_decision.py
@@ -1,0 +1,154 @@
+"""Phase 13 — Explainable Clinical Decision Support payload + PDF report."""
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import (
+    analyze_inspection,
+    AI_ROADMAP,
+)
+
+client = TestClient(app)
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"cd-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+        )
+    finally:
+        db.close()
+
+
+class TestClinicalDecisionShape:
+    def test_all_phases_present(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        for key in (
+            "overall_result", "summary", "score_breakdown", "cleaning",
+            "integrity", "clinical_reasoning", "recommendation", "evidence",
+            "executive_summary", "audit", "roadmap",
+        ):
+            assert key in cd, f"missing {key}"
+
+    def test_overall_result_is_one_of_four(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        assert cd["overall_result"] in (
+            "PASS", "MONITOR", "SUPERVISOR REVIEW", "REMOVE FROM SERVICE"
+        )
+
+    def test_summary_fields(self):
+        s = _analyze("forceps")["clinical_decision"]["summary"]
+        for k in ("inspection_score", "cleaning_assessment", "integrity_assessment",
+                  "overall_risk", "confidence", "baseline_source"):
+            assert k in s
+
+    def test_cleaning_separates_from_integrity(self):
+        cd = _analyze("forceps")["clinical_decision"]
+        cleaning_types = {i["type"] for i in cd["cleaning"]["items"]}
+        integrity_types = {i["type"] for i in cd["integrity"]["items"]}
+        assert "blood" in cleaning_types
+        assert "crack" in integrity_types
+        assert not (cleaning_types & integrity_types)  # no overlap
+
+    def test_cleaning_items_have_required_fields(self):
+        items = _analyze("scissors")["clinical_decision"]["cleaning"]["items"]
+        for it in items:
+            for k in ("detected", "probability", "confidence", "severity", "spd_risk"):
+                assert k in it
+
+    def test_integrity_status_values(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        assert cd["integrity"]["overall_status"] in (
+            "Acceptable", "Monitor", "Repair Required", "Remove From Service"
+        )
+
+    def test_crack_forces_remove_from_service(self):
+        cd = _analyze("forceps", declared=["crack"])["clinical_decision"]
+        assert cd["overall_result"] == "REMOVE FROM SERVICE"
+        assert cd["integrity"]["overall_status"] == "Remove From Service"
+
+    def test_blood_forces_supervisor_or_remove(self):
+        cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
+        assert cd["overall_result"] in ("SUPERVISOR REVIEW", "REMOVE FROM SERVICE")
+
+    def test_reasoning_is_grounded(self):
+        cd = _analyze("needle_holder")["clinical_decision"]
+        assert cd["clinical_reasoning"]
+        assert any("matched at" in ln for ln in cd["clinical_reasoning"])
+
+    def test_score_breakdown_math(self):
+        cd = _analyze("scissors", declared=["debris"])["clinical_decision"]
+        sb = cd["score_breakdown"]
+        assert sb["baseline_match_points"] is not None
+        assert sb["final_score"] is not None
+        # debris penalty should appear as a negative-or-zero item
+        labels = {i["label"]: i["points"] for i in sb["items"]}
+        assert "debris" in labels
+
+    def test_evidence_no_fabricated_heatmap(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        assert "coming in a future computer vision release" in cd["evidence"]["image_evidence_note"]
+
+    def test_roadmap_present(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        assert cd["roadmap"] == AI_ROADMAP
+        assert "Visual heatmaps" in cd["roadmap"]
+
+    def test_no_baseline_still_has_clinical_decision(self):
+        db = SessionLocal()
+        try:
+            db.query(BaselineLibraryEntry).filter(
+                BaselineLibraryEntry.instrument_category == "clip_applier"
+            ).delete()
+            db.commit()
+            out = analyze_inspection(
+                db, instrument_type="clip_applier", tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+            )
+        finally:
+            db.close()
+        assert out["clinical_decision"]["overall_result"] == "SUPERVISOR REVIEW"
+
+
+class TestClinicalReportPDF:
+    def _create(self, itype):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_pdf_report_generated(self):
+        iid = self._create("scissors")
+        r = client.get(f"/api/inspections/{iid}/clinical-report.pdf", headers=AUTH_OPERATOR)
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"] == "application/pdf"
+        assert r.content[:4] == b"%PDF"
+        assert len(r.content) > 1000
+
+    def test_pdf_404_for_missing(self):
+        r = client.get("/api/inspections/999999/clinical-report.pdf", headers=AUTH_OPERATOR)
+        assert r.status_code == 404

--- a/backend/tests/test_clinical_decision.py
+++ b/backend/tests/test_clinical_decision.py
@@ -54,7 +54,7 @@ class TestClinicalDecisionShape:
     def test_overall_result_is_one_of_four(self):
         cd = _analyze("scissors")["clinical_decision"]
         assert cd["overall_result"] in (
-            "PASS", "MONITOR", "SUPERVISOR REVIEW", "REMOVE FROM SERVICE"
+            "PASS", "MONITOR", "SUPERVISOR REVIEW", "REPROCESS", "REMOVE FROM SERVICE"
         )
 
     def test_summary_fields(self):
@@ -88,9 +88,9 @@ class TestClinicalDecisionShape:
         assert cd["overall_result"] == "REMOVE FROM SERVICE"
         assert cd["integrity"]["overall_status"] == "Remove From Service"
 
-    def test_blood_forces_supervisor_or_remove(self):
+    def test_blood_forces_reprocess_or_remove(self):
         cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
-        assert cd["overall_result"] in ("SUPERVISOR REVIEW", "REMOVE FROM SERVICE")
+        assert cd["overall_result"] in ("REPROCESS", "REMOVE FROM SERVICE")
 
     def test_reasoning_is_grounded(self):
         cd = _analyze("needle_holder")["clinical_decision"]

--- a/backend/tests/test_history_inspection_results.py
+++ b/backend/tests/test_history_inspection_results.py
@@ -99,6 +99,35 @@ class TestHistoryShowsInspectionResults:
         assert record["supervisor_review_required"] is True
         assert record["inspection_score"] is None
 
+    def test_spd_verdict_persisted_and_in_history(self):
+        # The SPD risk-weighted verdict must be stored and surfaced in history,
+        # not just shown in the live analysis panel.
+        itype = "scissors"
+        _add_baseline(itype)
+        create = client.post("/api/inspections", json={
+            "instrument_type": itype,
+            "site_name": "History Hospital",
+            "has_image": True,
+            "image_sha256": SHA,
+            "file_name": "spd.jpg",
+            "finding_categories": ["blood"],
+        }, headers=AUTH_OPERATOR)
+        assert create.status_code == 201, create.text
+        body = create.json()
+        # Persisted on the create response
+        assert body["risk_level"] in ("low", "medium", "high", "critical")
+        assert body["recommended_action"]
+        assert body["overall_cleaning_assessment"]
+        # And the live analysis verdict matches what was stored
+        assert body["risk_level"] == body["analysis"]["risk_level"]
+
+        inspection_id = body["id"]
+        resp = client.get("/api/history?limit=100", headers=AUTH_ADMIN)
+        record = next(it for it in resp.json()["items"] if it["id"] == inspection_id)
+        assert record["risk_level"] == body["risk_level"]
+        assert record["recommended_action"] == body["recommended_action"]
+        assert record["overall_cleaning_assessment"] == body["overall_cleaning_assessment"]
+
     def test_history_summary_counts_inspections(self):
         itype = "forceps"
         _add_baseline(itype)

--- a/backend/tests/test_identifier_decode.py
+++ b/backend/tests/test_identifier_decode.py
@@ -3,7 +3,6 @@
 Covers the real pyzbar decoder, the GS1 UDI parser, graceful degradation when
 ZBar is unavailable, and the /api/inspections/decode-identifiers endpoint.
 """
-import importlib.util
 import io
 
 from fastapi.testclient import TestClient
@@ -18,8 +17,6 @@ from app.cv.identifier_decoder import (
 client = TestClient(app)
 AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
 AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
-
-_HAS_ZBAR = importlib.util.find_spec("pyzbar") is not None
 
 
 def _png_upload():
@@ -54,8 +51,10 @@ def test_decode_endpoint_runs_and_reports_backend():
     )
     assert r.status_code == 200, r.text
     body = r.json()
-    assert "decoder_available" in body
-    assert body["decoder_available"] is _HAS_ZBAR
+    # decoder_available reflects whether the ZBar NATIVE lib actually decoded —
+    # not merely whether the pyzbar wrapper is importable (it may be installed
+    # without libzbar0). Either way the endpoint must succeed and report a bool.
+    assert isinstance(body["decoder_available"], bool)
     # A blank image has no symbols regardless of backend.
     assert body["barcode_value"] == ""
     assert body["images"][0]["decoder_backend"] in ("none", "error", "pyzbar")

--- a/backend/tests/test_identifier_decode.py
+++ b/backend/tests/test_identifier_decode.py
@@ -1,0 +1,79 @@
+"""Identifier decode wired into the inspection workflow.
+
+Covers the real pyzbar decoder, the GS1 UDI parser, graceful degradation when
+ZBar is unavailable, and the /api/inspections/decode-identifiers endpoint.
+"""
+import importlib.util
+import io
+
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from app.main import app
+from app.cv.identifier_decoder import (
+    decode_from_image_bytes,
+    parse_gs1_udi,
+)
+
+client = TestClient(app)
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+_HAS_ZBAR = importlib.util.find_spec("pyzbar") is not None
+
+
+def _png_upload():
+    img = Image.new("RGB", (12, 12), (240, 240, 240))
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    out.seek(0)
+    return {"images": ("inst.png", out, "image/png")}
+
+
+def test_gs1_udi_parser():
+    parsed = parse_gs1_udi("(01)00844588003288(17)271231(10)LOT42(21)SER99")
+    assert parsed["device_id"] == "00844588003288"
+    assert parsed["expiry"] == "271231"
+    assert parsed["lot"] == "LOT42"
+    assert parsed["serial"] == "SER99"
+
+
+def test_decode_degrades_gracefully_on_garbage():
+    # Not a decodable image / no symbols → never raises, returns empty values.
+    decoded = decode_from_image_bytes(b"not-an-image")
+    assert decoded.barcode_value == ""
+    assert decoded.qr_value == ""
+    assert decoded.decoder_backend in ("none", "error", "pyzbar")
+
+
+def test_decode_endpoint_runs_and_reports_backend():
+    r = client.post(
+        "/api/inspections/decode-identifiers",
+        files=_png_upload(),
+        headers=AUTH_OPERATOR,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "decoder_available" in body
+    assert body["decoder_available"] is _HAS_ZBAR
+    # A blank image has no symbols regardless of backend.
+    assert body["barcode_value"] == ""
+    assert body["images"][0]["decoder_backend"] in ("none", "error", "pyzbar")
+
+
+def test_decode_endpoint_requires_runner_role():
+    r = client.post(
+        "/api/inspections/decode-identifiers",
+        files=_png_upload(),
+        headers=AUTH_VIEWER,
+    )
+    assert r.status_code == 403
+
+
+def test_decode_endpoint_rejects_bad_type():
+    r = client.post(
+        "/api/inspections/decode-identifiers",
+        files={"images": ("x.txt", io.BytesIO(b"hi"), "text/plain")},
+        headers=AUTH_OPERATOR,
+    )
+    assert r.status_code == 422

--- a/backend/tests/test_image_retention_pipeline.py
+++ b/backend/tests/test_image_retention_pipeline.py
@@ -1,0 +1,75 @@
+"""Image retention + labeling pipeline.
+
+Covers the opt-in retention gate, EXIF stripping, labeling, the two-reviewer
+rule for critical classes, and dataset export.
+"""
+import io
+
+from PIL import Image
+
+from app.db.session import SessionLocal
+from app.services import image_retention_service as svc
+
+
+def _png_with_exif() -> bytes:
+    """A small PNG; we mostly assert re-encode produces clean, decodable bytes."""
+    img = Image.new("RGB", (8, 8), (120, 30, 30))
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    return out.getvalue()
+
+
+def test_strip_exif_returns_decodable_image():
+    data = _png_with_exif()
+    clean, stripped = svc.strip_exif(data, "image/png")
+    assert stripped is True
+    # Clean bytes are still a valid image.
+    with Image.open(io.BytesIO(clean)) as reopened:
+        assert reopened.size == (8, 8)
+
+
+def test_retention_disabled_is_default(monkeypatch):
+    monkeypatch.delenv("RETAIN_INSPECTION_IMAGES", raising=False)
+    assert svc.retention_enabled() is False
+
+
+def test_retain_image_noop_when_disabled(monkeypatch):
+    monkeypatch.delenv("RETAIN_INSPECTION_IMAGES", raising=False)
+    db = SessionLocal()
+    try:
+        row = svc.retain_image(db, data=_png_with_exif(), tenant_id="t1", consent=True)
+        assert row is None
+    finally:
+        db.close()
+
+
+def test_retain_image_noop_without_consent(monkeypatch):
+    monkeypatch.setenv("RETAIN_INSPECTION_IMAGES", "true")
+    db = SessionLocal()
+    try:
+        row = svc.retain_image(db, data=_png_with_exif(), tenant_id="t1", consent=False)
+        assert row is None
+    finally:
+        db.close()
+
+
+def test_retain_image_stores_when_enabled_and_consented(monkeypatch):
+    monkeypatch.setenv("RETAIN_INSPECTION_IMAGES", "true")
+    db = SessionLocal()
+    try:
+        row = svc.retain_image(
+            db,
+            data=_png_with_exif(),
+            tenant_id="t1",
+            instrument_type="needle driver",
+            content_type="image/png",
+            consent=True,
+        )
+    finally:
+        db.close()
+    assert row is not None
+    assert row.consent_recorded is True
+    assert row.exif_stripped is True
+    assert row.image_bytes is not None
+    assert row.deident_name.startswith("needle_driver_")
+    assert row.label_status == "unlabeled"

--- a/backend/tests/test_ml_images_api.py
+++ b/backend/tests/test_ml_images_api.py
@@ -1,0 +1,127 @@
+"""ML image labeling + dataset-export API.
+
+Drives the routes end-to-end via the real auth/role surface, including the
+opt-in retention gate, multi-label annotation, the two-reviewer rule for
+critical classes, and gold-only dataset export.
+"""
+import io
+
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from app.main import app
+
+client = TestClient(app)
+
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+
+def _png_upload():
+    img = Image.new("RGB", (8, 8), (10, 10, 10))
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    out.seek(0)
+    return {"images": ("inst.png", out, "image/png")}
+
+
+def _upload(monkeypatch_env=True):
+    return client.post(
+        "/api/ml/images?instrument_type=forceps&consent=true",
+        files=_png_upload(),
+        headers=AUTH_OPERATOR,
+    )
+
+
+def test_retention_status_endpoint():
+    r = client.get("/api/ml/retention/status", headers=AUTH_OPERATOR)
+    assert r.status_code == 200
+    assert "retention_enabled" in r.json()
+
+
+def test_upload_blocked_when_retention_disabled(monkeypatch):
+    monkeypatch.delenv("RETAIN_INSPECTION_IMAGES", raising=False)
+    r = _upload()
+    assert r.status_code == 409
+
+
+def test_viewer_cannot_upload(monkeypatch):
+    monkeypatch.setenv("RETAIN_INSPECTION_IMAGES", "true")
+    r = client.post(
+        "/api/ml/images?consent=true", files=_png_upload(), headers=AUTH_VIEWER
+    )
+    assert r.status_code == 403
+
+
+def test_label_and_export_flow(monkeypatch):
+    monkeypatch.setenv("RETAIN_INSPECTION_IMAGES", "true")
+    up = _upload()
+    assert up.status_code == 201, up.text
+    image_id = up.json()["images"][0]["id"]
+    assert up.json()["images"][0]["exif_stripped"] is True
+
+    # Non-critical label -> can be adjudicated by one reviewer.
+    lab = client.post(
+        f"/api/ml/images/{image_id}/labels",
+        json={"finding_type": "rust", "severity": "moderate", "region": [0.1, 0.1, 0.2, 0.2]},
+        headers=AUTH_OPERATOR,
+    )
+    assert lab.status_code == 201, lab.text
+    assert lab.json()["requires_second_reviewer"] is False
+    label_id = lab.json()["id"]
+
+    adj = client.post(
+        f"/api/ml/images/{image_id}/labels/{label_id}/adjudicate", headers=AUTH_MGR
+    )
+    assert adj.status_code == 200
+    assert adj.json()["is_gold"] is True
+
+    exp = client.get("/api/ml/dataset/export?gold_only=true", headers=AUTH_MGR)
+    assert exp.status_code == 200
+    body = exp.json()
+    assert body["class_counts"].get("rust", 0) >= 1
+    assert any(rec["image_id"] == image_id for rec in body["records"])
+
+
+def test_critical_class_requires_two_reviewers(monkeypatch):
+    monkeypatch.setenv("RETAIN_INSPECTION_IMAGES", "true")
+    image_id = _upload().json()["images"][0]["id"]
+
+    # First reviewer labels blood (critical).
+    l1 = client.post(
+        f"/api/ml/images/{image_id}/labels",
+        json={"finding_type": "blood", "severity": "visible"},
+        headers=AUTH_OPERATOR,
+    )
+    assert l1.json()["requires_second_reviewer"] is True
+    label_id = l1.json()["id"]
+
+    # Adjudicating with only one reviewer is blocked.
+    blocked = client.post(
+        f"/api/ml/images/{image_id}/labels/{label_id}/adjudicate", headers=AUTH_MGR
+    )
+    assert blocked.status_code == 409
+
+    # A second distinct reviewer labels the same class, then adjudication passes.
+    client.post(
+        f"/api/ml/images/{image_id}/labels",
+        json={"finding_type": "blood", "severity": "visible"},
+        headers=AUTH_ADMIN,
+    )
+    ok = client.post(
+        f"/api/ml/images/{image_id}/labels/{label_id}/adjudicate", headers=AUTH_MGR
+    )
+    assert ok.status_code == 200
+
+
+def test_unknown_finding_type_rejected(monkeypatch):
+    monkeypatch.setenv("RETAIN_INSPECTION_IMAGES", "true")
+    image_id = _upload().json()["images"][0]["id"]
+    r = client.post(
+        f"/api/ml/images/{image_id}/labels",
+        json={"finding_type": "sparkles"},
+        headers=AUTH_OPERATOR,
+    )
+    assert r.status_code == 422

--- a/backend/tests/test_spd_risk_weighting.py
+++ b/backend/tests/test_spd_risk_weighting.py
@@ -1,0 +1,167 @@
+"""SPD risk-weighted scoring refinement.
+
+Verifies the SPD risk weighting model, severity-aware overrides, the removal of
+bioburden as a standalone KPI in favour of an Overall Cleaning Assessment, the
+recommended-action rules, and the explainable scoring output.
+"""
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import (
+    analyze_inspection,
+    CONTAMINATION_KPIS,
+    CONDITION_KPIS,
+    spd_risk_tier,
+    spd_risk_impact,
+    overall_cleaning_assessment,
+)
+
+SHA = "5e1f00d0" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"spd-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+        )
+    finally:
+        db.close()
+
+
+def _finding(out, kpi):
+    return {f["type"]: f for f in out["predicted_findings"]}[kpi]
+
+
+# ── SPD risk-tier unit rules ─────────────────────────────────────────────────
+
+class TestSpdRiskTier:
+    def test_blood_visible_is_critical(self):
+        assert spd_risk_tier("blood", 0.45) == "critical"   # visible
+        assert spd_risk_tier("blood", 0.80) == "critical"   # heavy
+        assert spd_risk_tier("blood", 0.20) == "high"       # trace
+        assert spd_risk_tier("blood", 0.05) == "none"
+
+    def test_severe_corrosion_critical_moderate_high(self):
+        assert spd_risk_tier("corrosion", 0.80) == "critical"  # severe
+        assert spd_risk_tier("corrosion", 0.45) == "high"      # moderate
+        assert spd_risk_tier("corrosion", 0.20) == "low"       # minor
+
+    def test_heavy_rust_critical(self):
+        assert spd_risk_tier("rust", 0.80) == "critical"
+        assert spd_risk_tier("rust", 0.45) == "high"
+
+    def test_debris_and_bone_high(self):
+        assert spd_risk_tier("debris", 0.45) == "high"
+        assert spd_risk_tier("bone", 0.45) == "high"
+
+    def test_minor_discoloration_low(self):
+        assert spd_risk_tier("discoloration", 0.45) == "low"
+
+    def test_structural_findings_critical(self):
+        assert spd_risk_tier("crack", 0.45) == "critical"
+        assert spd_risk_tier("missing_component", 0.45) == "critical"
+        assert spd_risk_tier("insulation_damage", 0.45) == "critical"
+
+    def test_impact_labels(self):
+        assert spd_risk_impact("none") == "Clear"
+        assert spd_risk_impact("low") == "Monitor"
+        assert spd_risk_impact("high") == "Review"
+        assert spd_risk_impact("critical") == "Reprocess"
+
+
+# ── Bioburden removed / cleaning assessment ──────────────────────────────────
+
+class TestBioburdenRemoved:
+    def test_bioburden_not_a_kpi(self):
+        assert "bioburden" not in CONTAMINATION_KPIS
+        assert "bioburden" not in CONDITION_KPIS
+        out = _analyze("scissors")
+        assert "bioburden" not in out["kpi_summary"]
+        assert all(f["type"] != "bioburden" for f in out["predicted_findings"])
+
+    def test_overall_cleaning_assessment_present(self):
+        out = _analyze("scissors")
+        assert out["overall_cleaning_assessment"] in (
+            "Clean", "Residual contamination suspected",
+            "Cleaning failure", "Supervisor review required",
+        )
+
+    def test_clean_when_no_contamination(self):
+        assert overall_cleaning_assessment({}) == "Clean"
+
+    def test_cleaning_failure_on_visible_blood(self):
+        findings = {"blood": {"severity_index": 3}}
+        assert overall_cleaning_assessment(findings) == "Cleaning failure"
+
+
+# ── Override + risk rules ────────────────────────────────────────────────────
+
+class TestRiskOverride:
+    def test_blood_high_probability_forces_high_risk(self):
+        out = _analyze("scissors", declared=["blood"])
+        assert out["risk_level"] in ("high", "critical")
+        assert "blood" in out["spd_critical_drivers"]
+
+    def test_debris_forces_supervisor_review(self):
+        out = _analyze("forceps", declared=["debris"])
+        assert "debris" in out["spd_high_drivers"]
+        assert "Supervisor review" in out["recommended_action"] \
+            or "Reprocess" in out["recommended_action"]
+
+    def test_bone_forces_supervisor_review(self):
+        out = _analyze("retractor", declared=["bone"])
+        assert "bone" in out["spd_high_drivers"]
+        assert out["risk_level"] in ("high", "critical")
+
+    def test_missing_component_forces_high_risk(self):
+        # missing_component is not technician-declarable, so assert the SPD rule
+        # that forces it critical (which overrides risk to high/critical).
+        assert spd_risk_tier("missing_component", 0.5) == "critical"
+
+    def test_crack_removes_from_service(self):
+        out = _analyze("forceps", declared=["crack"])
+        assert out["risk_level"] == "critical"
+        assert "crack" in out["spd_critical_drivers"]
+
+    def test_normal_wear_does_not_fail(self):
+        out = _analyze("retractor")  # no declared findings
+        if not out["critical_flags"] and not out["spd_critical_drivers"]:
+            assert out["pass_fail"] == "PASS"
+
+
+# ── Explanation + drivers ────────────────────────────────────────────────────
+
+class TestExplanation:
+    def test_top_risk_drivers_and_explanation(self):
+        out = _analyze("scissors", declared=["blood"])
+        assert out["top_risk_drivers"], "must surface top risk drivers"
+        assert out["scoring_explanation"], "must explain the score"
+        assert any("matched at" in line for line in out["scoring_explanation"])
+
+    def test_severity_by_kpi_present(self):
+        out = _analyze("forceps")
+        sev = out["severity_by_kpi"]
+        assert "blood" in sev and "spd_risk_impact" in sev["blood"]
+
+    def test_minor_discoloration_low_penalty(self):
+        # Discoloration weight is small relative to contamination.
+        from app.services.baseline_comparison_scoring_service import _KPI_WEIGHT
+        assert _KPI_WEIGHT["discoloration"] < _KPI_WEIGHT["blood"]
+        assert _KPI_WEIGHT["discoloration"] <= 5

--- a/docs/ai/lumenai-dataset-versioning-plan.md
+++ b/docs/ai/lumenai-dataset-versioning-plan.md
@@ -1,0 +1,97 @@
+# LumenAI Dataset Versioning Plan
+
+**Status:** Draft for review
+**Purpose:** Version the labeled image data that will train and validate a real
+image-based inspection model, and govern how supervisor feedback becomes ground
+truth.
+
+> ⚠️ Advisory pilot. No production diagnostic-accuracy or FDA/regulatory claims.
+> Every model output remains `human_review_required: true`.
+
+---
+
+## Dataset versions
+
+### Dataset v1 — pilot bootstrap
+- ~100 labeled lumen images.
+- Manufacturer/vendor **baseline reference images** for the covered instruments.
+- **Inspection images** captured in-workflow (browser capture / station kiosk).
+- **Supervisor labels**: agreement/disagreement on the AI clinical review, with
+  rationale, captured via the supervisor-review endpoint.
+- Goal: establish the labeling pipeline and a first calibration set. Not for
+  accuracy claims.
+
+### Dataset v2 — breadth
+- 500+ labeled images.
+- **Multiple manufacturers** and instrument families.
+- **Multiple contamination types** (blood, tissue, organic residue, debris,
+  bone) at graded severities.
+- **Varied lighting and capture devices** (different borescopes, UVC grabbers,
+  station vs per-workstation).
+- Goal: class balance + severity spread sufficient to begin shadow-mode
+  evaluation of a candidate model.
+
+### Dataset v3 — real-world generalization
+- **Multi-hospital** images (consented sites).
+- **Multi-device capture** across borescope makes/models.
+- **Real-world variation**: soil load, wear, reprocessing states.
+- **Longitudinal instrument tracking** (same instrument over time) for
+  degradation/drift modeling.
+- Goal: in-domain generalization; promotion gated on held-out multi-site metrics.
+
+---
+
+## Labeling process
+- Multi-label per image (an image may carry several findings) with per-finding
+  severity using the published scales.
+- Instrument type recorded; images labeled against the **approved baseline** so
+  normal machining/weld marks are not mislabeled.
+- **Supervisor feedback** (agree / partially agree / disagree + rationale +
+  override) is captured on real inspections and joined to the image as a label
+  signal.
+- Critical classes (blood, crack, missing component) require **two reviewers**
+  with adjudication before a label is promoted to `gold`.
+- `uncertain` is a valid label and routes to supervisor review; excluded from
+  the positive training set until resolved.
+
+## Supervisor validation
+1. Technician/labeler applies labels + regions.
+2. SPD supervisor/SME reviews; critical classes use the two-reviewer rule.
+3. Adjudicated labels marked `gold`; only `gold` enters validation/test sets.
+4. Every label change is audit-logged (actor, timestamp, before/after).
+
+## Model evaluation plan
+- Metrics via `app/analytics/model_evaluation.py`: precision, recall, FPR/FNR,
+  confusion matrix, reviewer agreement (Cohen's kappa).
+- Critical contamination/damage classes optimize for **recall** and are reported
+  separately.
+- Candidate models run in **shadow mode** (no disposition change) until they pass
+  the promotion thresholds on a held-out, multi-instrument test set.
+
+## False positive / false negative review
+- Every shadow-mode **false negative** on a critical class is re-reviewed and
+  added to the training set.
+- **False positives** that would cause unnecessary reprocessing are tracked and
+  thresholds tuned per class, not globally.
+- Supervisor `disagree` / `override` events are a primary source of FP/FN signal.
+
+## Dataset governance
+- Each version is immutable once released; changes create a new version.
+- `source` tracked per image (in-workflow / baseline / demo / web).
+- Train/test split keeps **no instrument in both** sets (prevents leakage).
+- Access-controlled storage; retention is opt-in (`RETAIN_INSPECTION_IMAGES`)
+  with recorded consent.
+
+## PHI avoidance
+- Images are of **instruments only** — no patients, faces, names, MRNs, or
+  documents in frame; reject any image containing PHI.
+- EXIF/metadata stripped on ingest; de-identified filenames
+  (`{instrument_type}_{seq}`).
+- Only SHA-256 hashes are stored unless retention is explicitly enabled.
+
+## Image rights and consent guidance
+- In-workflow images require site retention **consent** before storage.
+- Public web images may be used **only for research/prototyping**, never as
+  validated clinical training data unless rights and labeling are confirmed;
+  tag `source=web` and exclude from validation/test.
+- Never treat web-sourced labels as ground truth for accuracy claims.

--- a/docs/ai/spd-risk-weighted-training-plan.md
+++ b/docs/ai/spd-risk-weighted-training-plan.md
@@ -1,0 +1,114 @@
+# SPD Risk-Weighted Training Dataset Plan
+
+**Status:** Draft for review
+**Scope:** Training/validation data for the SPD risk-weighted inspection model
+that will eventually replace the pilot **Baseline Comparison Scoring Model**.
+
+> ⚠️ No production diagnostic-accuracy claims. No FDA/regulatory claims. Every
+> output stays advisory (`human_review_required: true`). The current scoring is a
+> deterministic placeholder, not pixel-level computer vision.
+
+This plan complements `docs/ai/model-training-dataset-plan.md` and focuses on the
+**SPD risk weighting** the patch introduced: critical contamination and
+structural damage must drive disposition far more aggressively than cosmetic
+discoloration or normal wear.
+
+---
+
+## 1. Classes and example imagery to collect
+
+Capture instrument-only images (no PHI) across these classes. Severity bands
+mirror the scoring engine.
+
+| Class | Severity bands | Example imagery to source |
+|---|---|---|
+| Blood | none / trace / visible / heavy | dried and fresh blood in lumens, hinges, box locks, serrations |
+| Tissue | none / low / moderate / high | soft-tissue / protein residue in channels and jaws |
+| Organic residue | none / low / moderate / high | mixed biological soil, dried fluids, films |
+| Bone | none / low / moderate / high | calcified fragments / bone dust in cannulated shafts |
+| Debris | none / low / moderate / high | particulate, lint, brush bristles, packaging fragments |
+| Rust | none / surface / moderate / heavy | surface bloom → pitted heavy rust on stainless |
+| Corrosion | none / minor / moderate / severe | galvanic/pitting corrosion, stained welds |
+| Discoloration | none / minor / moderate / severe | heat tint, detergent staining, passivation color |
+| Damage (crack / missing component / insulation) | none / cosmetic wear / functional concern / structural failure | cracked jaws, missing screws/inserts, breached insulation |
+
+Each class needs a **clean / known-good** counterpart for the same instrument
+type so normal machining/weld marks are not mislabeled as defects.
+
+## 2. Labeling rules
+
+- **Multi-label:** one image may carry several findings (e.g. rust + debris).
+- **Per-finding severity** using the bands above. The label drives the SPD risk
+  tier: blood visible/heavy, heavy rust, severe corrosion, crack, missing
+  component, insulation damage → **critical**; debris, bone, moderate rust /
+  corrosion, pitting → **high**; minor discoloration / cosmetic wear → **low**.
+- **No standalone "bioburden" label.** Bioburden is a clinical umbrella term;
+  label the concrete contaminants (blood, bone, tissue, organic residue, debris)
+  and let the Overall Cleaning Assessment summarize them.
+- **Region annotation** (box/mask) for localizable findings — feeds the future
+  evidence map.
+- **Two-reviewer rule** for critical classes (blood, crack, missing component);
+  disagreements go to adjudication. Only adjudicated `gold` labels enter
+  validation/test sets.
+- **Uncertain** is a valid label — routes to supervisor review, excluded from the
+  positive training set until resolved.
+- **No causation / clinical-outcome labels** — label what is visible, not harm.
+
+## 3. Image quality rules
+
+- In focus, instrument fills the frame, even diffuse lighting (avoid blown
+  highlights / deep shadow that hide or fake residue).
+- Consistent scale reference where possible; capture lumens/channels with
+  adequate illumination.
+- Multiple angles for 3-D findings (hinges, box locks, cannulated shafts).
+- Reject images with motion blur, heavy glare, or anything obscuring the finding.
+- **No PHI in frame** — no patients, faces, names, MRNs, labels, or paperwork.
+  Strip EXIF/metadata on ingest (the retention store does this automatically).
+
+## 4. Supervisor validation process
+
+1. Technician/labeler applies labels + severity + regions.
+2. SPD supervisor / SME reviews each labeled image; critical classes require the
+   two-reviewer + adjudication rule.
+3. Adjudicated labels are marked `gold`; only `gold` enters validation/test.
+4. All label changes are audit-logged (actor, timestamp, before/after).
+
+## 5. Minimum dataset targets (pilot start)
+
+Production targets are higher; these are minimums to begin training.
+
+| Class group | Min positives per class |
+|---|---|
+| Clean / known-good | 500 (spread across instrument types) |
+| Blood, tissue, organic residue | 300 each |
+| Bone, debris | 200 each |
+| Rust, corrosion (per severity band) | 150 per band |
+| Discoloration | 150 |
+| Crack, missing component, insulation damage | 200 each (oversample/augment — rare + critical) |
+
+Augmentation (rotation, lighting, crop, mild blur) is allowed to balance classes
+but **never** to fabricate a defect that isn't there.
+
+## 6. False positive / false negative review process
+
+- Compute per-class precision, recall, FPR, FNR with
+  `app/analytics/model_evaluation.py`.
+- **Critical contamination/damage classes optimize for recall** — a missed
+  contaminated/cracked instrument is the costly error. Report critical-class
+  recall separately and gate promotion on it.
+- Maintain a **false-negative review queue**: every missed critical finding in
+  shadow mode is re-reviewed by a supervisor and added to the training set.
+- Track **false positives** that would cause unnecessary reprocessing; tune
+  thresholds per class rather than globally.
+- A model is promoted only after passing thresholds in **shadow mode**, and even
+  then output remains advisory.
+
+## 7. Web image usage caution
+
+- **Do not** scrape clinical/patient images from the web.
+- Public web images of instruments may be used **only for research and
+  prototyping**, never as validated clinical training data unless image **rights
+  and labeling are confirmed**.
+- Tag every web-sourced image `source=web`, exclude it from validation/test sets,
+  and never treat web labels as ground truth for accuracy claims.
+- Production metrics are computed only on in-domain, consented data.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,33 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LumenAI</title>
+    <!--
+      Self-healing white-page guard. This inline script runs even when the app
+      bundle fails to load (e.g. a stale cached index.html pointing at purged
+      /assets hashes after a redeploy). If the app has not mounted into #root a
+      few seconds after load, force ONE cache-busting reload to fetch a fresh
+      document + asset manifest. Guarded per session so it can never loop.
+    -->
+    <script>
+      (function () {
+        window.addEventListener("load", function () {
+          window.setTimeout(function () {
+            var root = document.getElementById("root");
+            var mounted = root && root.childElementCount > 0;
+            if (mounted) {
+              sessionStorage.removeItem("__spa_recover");
+              return;
+            }
+            if (!sessionStorage.getItem("__spa_recover")) {
+              sessionStorage.setItem("__spa_recover", "1");
+              var u = new URL(window.location.href);
+              u.searchParams.set("_cb", Date.now().toString());
+              window.location.replace(u.toString());
+            }
+          }, 5000);
+        });
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/AiModelPerformanceCard.tsx
+++ b/frontend/src/components/AiModelPerformanceCard.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from "react";
+import { useAuth, API_BASE } from "@/lib/auth";
+
+/**
+ * AI model-performance monitoring card for the Executive Dashboard.
+ * Shows real supervisor-agreement metrics; false +/- are surfaced as "n/a"
+ * because they require adjudicated ground truth (never fabricated).
+ * Silently hides for non-supervisor roles (endpoint is admin/spd_manager only).
+ */
+type Summary = {
+  total_ai_predictions: number;
+  supervisor_reviews: number;
+  supervisor_agreement_rate: number | null;
+  override_rate: number | null;
+  false_positive_count: number | null;
+  false_negative_count: number | null;
+  disagreement_count: number;
+  average_confidence: number | null;
+  cases_requiring_review: number;
+};
+
+function pct(v: number | null): string {
+  return v == null ? "—" : `${Math.round(v * 100)}%`;
+}
+
+export default function AiModelPerformanceCard() {
+  const { headers, role } = useAuth();
+  const [data, setData] = useState<Summary | null>(null);
+  const [hidden, setHidden] = useState(false);
+  const canView = role === "admin" || role === "spd_manager";
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/model-performance/ai-summary`, { headers: headers() });
+      if (res.status === 403) { setHidden(true); return; }
+      if (!res.ok) return;
+      setData(await res.json());
+    } catch {
+      /* non-fatal on a dashboard */
+    }
+  }, [headers]);
+
+  useEffect(() => { if (canView) load(); }, [canView, load]);
+
+  if (!canView || hidden) return null;
+
+  const cells: { label: string; value: string }[] = [
+    { label: "AI Predictions", value: data ? String(data.total_ai_predictions) : "—" },
+    { label: "Supervisor Reviews", value: data ? String(data.supervisor_reviews) : "—" },
+    { label: "Agreement Rate", value: pct(data?.supervisor_agreement_rate ?? null) },
+    { label: "Override Rate", value: pct(data?.override_rate ?? null) },
+    { label: "Avg Confidence", value: pct(data?.average_confidence ?? null) },
+    { label: "Cases Needing Review", value: data ? String(data.cases_requiring_review) : "—" },
+    { label: "Disagreements", value: data ? String(data.disagreement_count) : "—" },
+    { label: "False +/− (adjudicated)", value: "n/a" },
+  ];
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-slate-800">AI Model Performance</h3>
+        <span className="text-xs text-slate-400">supervisor-verified</span>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {cells.map((c) => (
+          <div key={c.label} className="rounded-lg bg-slate-50 px-3 py-2">
+            <div className="text-lg font-bold text-slate-900">{c.value}</div>
+            <div className="text-xs text-slate-500">{c.label}</div>
+          </div>
+        ))}
+      </div>
+      <p className="mt-3 text-xs text-slate-400">
+        Agreement/override computed from real supervisor reviews. False positive/negative
+        counts require adjudicated ground truth and are not fabricated.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -1,0 +1,233 @@
+import { useState } from "react";
+import { useAuth, API_BASE } from "@/lib/auth";
+
+/**
+ * Phase 13 — Explainable AI Clinical Decision Support panel.
+ * Renders the `clinical_decision` payload as clinician-readable cards:
+ * decision summary, score breakdown, cleaning + integrity assessments,
+ * reasoning, recommendation, evidence, executive summary, audit, roadmap,
+ * and a printable PDF report.
+ */
+type Finding = {
+  type: string; label: string; detected: boolean;
+  probability_pct: number; confidence_pct: number;
+  severity: string; spd_risk: string; spd_risk_impact: string;
+};
+type ClinicalDecision = {
+  overall_result: string;
+  summary: {
+    inspection_score: number | null; cleaning_assessment: string | null;
+    integrity_assessment: string | null; overall_risk: string | null;
+    confidence: string | null; confidence_pct: number; baseline_source: string | null;
+  };
+  score_breakdown: { baseline_match_points: number | null; items: { label: string; points: number }[]; final_score: number | null; note: string };
+  cleaning: { items: Finding[]; overall_status: string | null };
+  integrity: { items: Finding[]; overall_status: string | null };
+  clinical_reasoning: string[];
+  recommendation: { result: string; action?: string };
+  evidence: { baseline_comparison_label?: string; baseline_source?: string | null; baseline_match_pct: number | null; highest_risk_drivers: string[]; confidence?: string | null; image_evidence_note: string };
+  executive_summary: string[];
+  audit: Record<string, unknown>;
+  roadmap: string[];
+};
+
+const RESULT_STYLE: Record<string, string> = {
+  PASS: "bg-emerald-600",
+  MONITOR: "bg-amber-500",
+  "SUPERVISOR REVIEW": "bg-orange-600",
+  "REMOVE FROM SERVICE": "bg-red-600",
+};
+const IMPACT_STYLE: Record<string, string> = {
+  Clear: "bg-emerald-100 text-emerald-800",
+  Monitor: "bg-amber-100 text-amber-800",
+  Review: "bg-orange-100 text-orange-800",
+  Reprocess: "bg-red-100 text-red-800",
+};
+
+function FindingsTable({ items }: { items: Finding[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="text-left text-slate-400">
+            <th className="py-1 pr-3 font-medium">Finding</th>
+            <th className="py-1 px-2 font-medium">Detected</th>
+            <th className="py-1 px-2 font-medium">Prob</th>
+            <th className="py-1 px-2 font-medium">Severity</th>
+            <th className="py-1 px-2 font-medium">Confidence</th>
+            <th className="py-1 px-2 font-medium">SPD Risk</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((it) => (
+            <tr key={it.type} className="border-t border-slate-100">
+              <td className="py-1 pr-3 font-medium text-slate-700 capitalize">{it.label}</td>
+              <td className="py-1 px-2">{it.detected ? "Yes" : "No"}</td>
+              <td className="py-1 px-2">{it.probability_pct}%</td>
+              <td className="py-1 px-2 capitalize">{it.severity}</td>
+              <td className="py-1 px-2">{it.confidence_pct}%</td>
+              <td className="py-1 px-2">
+                <span className={`rounded-full px-2 py-0.5 font-medium ${IMPACT_STYLE[it.spd_risk_impact] ?? "bg-slate-100 text-slate-600"}`}>
+                  {it.spd_risk_impact}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+export default function ClinicalDecisionPanel({
+  cd,
+  inspectionId,
+}: {
+  cd: ClinicalDecision;
+  inspectionId?: number;
+}) {
+  const { headers } = useAuth();
+  const [pdfBusy, setPdfBusy] = useState(false);
+  const result = cd.overall_result;
+
+  async function downloadPdf() {
+    if (!inspectionId) return;
+    setPdfBusy(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/inspections/${inspectionId}/clinical-report.pdf`, {
+        headers: { Authorization: headers()["Authorization"] },
+      });
+      if (!res.ok) return;
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      window.open(url, "_blank", "noopener,noreferrer");
+      setTimeout(() => URL.revokeObjectURL(url), 30000);
+    } finally {
+      setPdfBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 13.1 Clinical Decision Summary */}
+      <div className="rounded-lg border border-slate-200 bg-white overflow-hidden">
+        <div className={`px-5 py-4 text-white ${RESULT_STYLE[result] ?? "bg-slate-600"}`}>
+          <div className="text-xs uppercase tracking-wide opacity-80">Clinical Decision</div>
+          <div className="text-2xl font-extrabold tracking-wide">{result}</div>
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 p-4 text-sm">
+          <div><div className="text-xs text-slate-500">Score</div><div className="text-xl font-bold text-slate-900">{cd.summary.inspection_score ?? "—"}</div></div>
+          <div><div className="text-xs text-slate-500">Cleaning</div><div className="font-medium text-slate-800">{cd.summary.cleaning_assessment ?? "—"}</div></div>
+          <div><div className="text-xs text-slate-500">Integrity</div><div className="font-medium text-slate-800">{cd.summary.integrity_assessment ?? "—"}</div></div>
+          <div><div className="text-xs text-slate-500">Risk</div><div className="font-medium text-slate-800 capitalize">{cd.summary.overall_risk ?? "—"}</div></div>
+          <div><div className="text-xs text-slate-500">Confidence</div><div className="font-medium text-slate-800">{cd.summary.confidence ?? "—"} ({cd.summary.confidence_pct}%)</div></div>
+          <div><div className="text-xs text-slate-500">Baseline</div><div className="font-medium text-slate-800 capitalize">{cd.summary.baseline_source ?? "—"}</div></div>
+        </div>
+      </div>
+
+      {/* 13.9 Executive Summary */}
+      {cd.executive_summary.length > 0 && (
+        <Card title="Executive Summary">
+          <ul className="space-y-0.5 text-sm text-slate-700">
+            {cd.executive_summary.map((l, i) => <li key={i}>• {l}</li>)}
+          </ul>
+        </Card>
+      )}
+
+      {/* 13.2 Score Breakdown */}
+      <Card title="Score Breakdown">
+        <div className="space-y-1 text-sm">
+          <div className="flex justify-between"><span className="text-slate-600">Baseline match</span><span className="font-medium text-emerald-700">+{cd.score_breakdown.baseline_match_points ?? "—"}</span></div>
+          {cd.score_breakdown.items.map((it) => (
+            <div key={it.label} className="flex justify-between">
+              <span className="capitalize text-slate-600">{it.label}</span>
+              <span className={it.points < 0 ? "font-medium text-red-600" : "text-slate-400"}>{it.points < 0 ? it.points : "0 penalty"}</span>
+            </div>
+          ))}
+          <div className="flex justify-between border-t border-slate-200 pt-1 font-semibold text-slate-900">
+            <span>Final Score</span><span>{cd.score_breakdown.final_score ?? "—"}</span>
+          </div>
+        </div>
+        <p className="mt-1.5 text-xs text-slate-400">{cd.score_breakdown.note}</p>
+      </Card>
+
+      {/* 13.3 Cleaning Assessment */}
+      {cd.cleaning.items.length > 0 && (
+        <Card title={`Cleaning Assessment — ${cd.cleaning.overall_status ?? "—"}`}>
+          <FindingsTable items={cd.cleaning.items} />
+        </Card>
+      )}
+
+      {/* 13.4 Instrument Integrity Assessment */}
+      {cd.integrity.items.length > 0 && (
+        <Card title={`Instrument Integrity — ${cd.integrity.overall_status ?? "—"}`}>
+          <FindingsTable items={cd.integrity.items} />
+        </Card>
+      )}
+
+      {/* 13.5 Clinical Reasoning */}
+      <Card title="Clinical Reasoning">
+        <ul className="space-y-0.5 text-sm text-slate-700">
+          {cd.clinical_reasoning.map((l, i) => (
+            <li key={i} className="flex items-start gap-1.5">
+              <span className={l.startsWith("No ") ? "text-emerald-500" : "text-amber-500"}>•</span>
+              <span>{l}</span>
+            </li>
+          ))}
+        </ul>
+      </Card>
+
+      {/* 13.6 Recommendation */}
+      <div className={`rounded-lg border px-4 py-3 ${result === "PASS" ? "border-emerald-300 bg-emerald-50" : "border-orange-300 bg-orange-50"}`}>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1">Recommendation</p>
+        <p className="text-sm font-semibold text-slate-900">{cd.recommendation.result}</p>
+        {cd.recommendation.action && <p className="text-sm text-slate-700">{cd.recommendation.action}</p>}
+      </div>
+
+      {/* 13.7 Evidence */}
+      <Card title="Evidence Used">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 text-sm text-slate-700">
+          <p><span className="text-slate-500">Baseline:</span> {cd.evidence.baseline_comparison_label ?? cd.evidence.baseline_source ?? "—"}</p>
+          <p><span className="text-slate-500">Baseline match:</span> {cd.evidence.baseline_match_pct ?? "—"}%</p>
+          <p className="sm:col-span-2"><span className="text-slate-500">Highest risk drivers:</span> {(cd.evidence.highest_risk_drivers || []).join(", ") || "—"}</p>
+          <p><span className="text-slate-500">Confidence:</span> {cd.evidence.confidence ?? "—"}</p>
+        </div>
+        <div className="mt-2 rounded border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-xs text-slate-500">
+          {cd.evidence.image_evidence_note} (heatmaps / bounding boxes not fabricated)
+        </div>
+      </Card>
+
+      {/* 13.8 PDF + 13.11 Roadmap */}
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          onClick={downloadPdf}
+          disabled={!inspectionId || pdfBusy}
+          className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-900 disabled:opacity-50"
+        >
+          {pdfBusy ? "Generating…" : "Download Clinical Report (PDF)"}
+        </button>
+      </div>
+
+      <details className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+        <summary className="cursor-pointer text-sm font-semibold text-slate-700">AI Roadmap (upcoming)</summary>
+        <ul className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-x-4 text-sm text-slate-600">
+          {cd.roadmap.map((r) => <li key={r}>• {r}</li>)}
+        </ul>
+      </details>
+
+      <p className="text-xs text-slate-400 italic">
+        Explainable pilot decision support — advisory only, not validated for production diagnostic accuracy, no FDA
+        clearance claimed. Qualified human review is required.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useAuth, API_BASE } from "@/lib/auth";
+import SupervisorNotes from "@/components/SupervisorNotes";
 
 /**
  * Phase 13 — Explainable AI Clinical Decision Support panel.
@@ -97,92 +98,6 @@ function Stars({ n }: { n: number }) {
     <span className="text-amber-500 text-lg tracking-tight" aria-label={`${n} of 5`}>
       {"★".repeat(n)}<span className="text-slate-300">{"☆".repeat(Math.max(0, 5 - n))}</span>
     </span>
-  );
-}
-
-const AGREEMENT_OPTIONS = [
-  { value: "agree", label: "Agree with AI" },
-  { value: "partially_agree", label: "Partially agree" },
-  { value: "disagree", label: "Disagree with AI" },
-];
-
-function SupervisorNotes({ inspectionId }: { inspectionId?: number }) {
-  const { headers } = useAuth();
-  const [agreement, setAgreement] = useState("agree");
-  const [rationale, setRationale] = useState("");
-  const [override, setOverride] = useState("");
-  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
-  const [busy, setBusy] = useState(false);
-  const commentRequired = agreement !== "agree" || !!override.trim();
-
-  async function submit() {
-    if (!inspectionId) return;
-    if (commentRequired && !rationale.trim()) {
-      setMsg({ ok: false, text: "A comment is required for partial agreement, disagreement, or override." });
-      return;
-    }
-    setBusy(true);
-    setMsg(null);
-    try {
-      const res = await fetch(`${API_BASE}/api/inspections/${inspectionId}/supervisor-review`, {
-        method: "POST",
-        headers: headers(),
-        body: JSON.stringify({ agreement, rationale: rationale.trim(), override_action: override.trim() }),
-      });
-      if (res.status === 403) { setMsg({ ok: false, text: "Supervisor access (admin/SPD manager) required." }); return; }
-      if (!res.ok) {
-        const b = await res.json().catch(() => ({}));
-        setMsg({ ok: false, text: b?.detail || `Submit failed (${res.status}).` });
-        return;
-      }
-      setMsg({ ok: true, text: "Supervisor review recorded." });
-      setRationale("");
-      setOverride("");
-    } catch {
-      setMsg({ ok: false, text: "Unable to reach the server." });
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <Card title="Supervisor Review Notes">
-      <div className="flex flex-wrap gap-2 mb-2">
-        {AGREEMENT_OPTIONS.map((o) => (
-          <button
-            key={o.value}
-            onClick={() => setAgreement(o.value)}
-            className={`rounded-full px-3 py-1 text-xs font-medium border ${
-              agreement === o.value ? "bg-blue-600 text-white border-blue-600" : "border-slate-300 text-slate-600"
-            }`}
-          >
-            {o.label}
-          </button>
-        ))}
-      </div>
-      <textarea
-        value={rationale}
-        onChange={(e) => setRationale(e.target.value)}
-        placeholder={commentRequired ? "Rationale (required)" : "Rationale (optional)"}
-        className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
-        rows={2}
-      />
-      <input
-        value={override}
-        onChange={(e) => setOverride(e.target.value)}
-        placeholder="Override action (optional, e.g. reprocess / remove)"
-        className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
-      />
-      <div className="mt-2 flex items-center gap-3">
-        <button onClick={submit} disabled={busy} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
-          {busy ? "Saving…" : "Submit review"}
-        </button>
-        {msg && <span className={`text-sm ${msg.ok ? "text-emerald-700" : "text-red-700"}`}>{msg.text}</span>}
-      </div>
-      <p className="mt-2 text-xs text-slate-400">
-        Feedback is stored as labeled training data. Operators/viewers cannot submit.
-      </p>
-    </Card>
   );
 }
 

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -24,7 +24,10 @@ type ClinicalDecision = {
   cleaning: { items: Finding[]; overall_status: string | null };
   integrity: { items: Finding[]; overall_status: string | null };
   clinical_reasoning: string[];
-  recommendation: { result: string; action?: string };
+  ai_clinical_review: { outcome: string; reasoning: string[]; interpretation: string };
+  evidence_strength: { level: string; stars: number; reason: string };
+  baseline_difference: { baseline_match_pct: number | null; differences: string[]; category: string; localization_note: string };
+  recommendation: { result: string; action?: string; action_text?: string };
   evidence: { baseline_comparison_label?: string; baseline_source?: string | null; baseline_match_pct: number | null; highest_risk_drivers: string[]; confidence?: string | null; image_evidence_note: string };
   executive_summary: string[];
   audit: Record<string, unknown>;
@@ -35,6 +38,7 @@ const RESULT_STYLE: Record<string, string> = {
   PASS: "bg-emerald-600",
   MONITOR: "bg-amber-500",
   "SUPERVISOR REVIEW": "bg-orange-600",
+  REPROCESS: "bg-red-500",
   "REMOVE FROM SERVICE": "bg-red-600",
 };
 const IMPACT_STYLE: Record<string, string> = {
@@ -88,6 +92,100 @@ function Card({ title, children }: { title: string; children: React.ReactNode })
   );
 }
 
+function Stars({ n }: { n: number }) {
+  return (
+    <span className="text-amber-500 text-lg tracking-tight" aria-label={`${n} of 5`}>
+      {"★".repeat(n)}<span className="text-slate-300">{"☆".repeat(Math.max(0, 5 - n))}</span>
+    </span>
+  );
+}
+
+const AGREEMENT_OPTIONS = [
+  { value: "agree", label: "Agree with AI" },
+  { value: "partially_agree", label: "Partially agree" },
+  { value: "disagree", label: "Disagree with AI" },
+];
+
+function SupervisorNotes({ inspectionId }: { inspectionId?: number }) {
+  const { headers } = useAuth();
+  const [agreement, setAgreement] = useState("agree");
+  const [rationale, setRationale] = useState("");
+  const [override, setOverride] = useState("");
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const commentRequired = agreement !== "agree" || !!override.trim();
+
+  async function submit() {
+    if (!inspectionId) return;
+    if (commentRequired && !rationale.trim()) {
+      setMsg({ ok: false, text: "A comment is required for partial agreement, disagreement, or override." });
+      return;
+    }
+    setBusy(true);
+    setMsg(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/inspections/${inspectionId}/supervisor-review`, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ agreement, rationale: rationale.trim(), override_action: override.trim() }),
+      });
+      if (res.status === 403) { setMsg({ ok: false, text: "Supervisor access (admin/SPD manager) required." }); return; }
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        setMsg({ ok: false, text: b?.detail || `Submit failed (${res.status}).` });
+        return;
+      }
+      setMsg({ ok: true, text: "Supervisor review recorded." });
+      setRationale("");
+      setOverride("");
+    } catch {
+      setMsg({ ok: false, text: "Unable to reach the server." });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card title="Supervisor Review Notes">
+      <div className="flex flex-wrap gap-2 mb-2">
+        {AGREEMENT_OPTIONS.map((o) => (
+          <button
+            key={o.value}
+            onClick={() => setAgreement(o.value)}
+            className={`rounded-full px-3 py-1 text-xs font-medium border ${
+              agreement === o.value ? "bg-blue-600 text-white border-blue-600" : "border-slate-300 text-slate-600"
+            }`}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+      <textarea
+        value={rationale}
+        onChange={(e) => setRationale(e.target.value)}
+        placeholder={commentRequired ? "Rationale (required)" : "Rationale (optional)"}
+        className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+        rows={2}
+      />
+      <input
+        value={override}
+        onChange={(e) => setOverride(e.target.value)}
+        placeholder="Override action (optional, e.g. reprocess / remove)"
+        className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+      />
+      <div className="mt-2 flex items-center gap-3">
+        <button onClick={submit} disabled={busy} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
+          {busy ? "Saving…" : "Submit review"}
+        </button>
+        {msg && <span className={`text-sm ${msg.ok ? "text-emerald-700" : "text-red-700"}`}>{msg.text}</span>}
+      </div>
+      <p className="mt-2 text-xs text-slate-400">
+        Feedback is stored as labeled training data. Operators/viewers cannot submit.
+      </p>
+    </Card>
+  );
+}
+
 export default function ClinicalDecisionPanel({
   cd,
   inspectionId,
@@ -95,9 +193,10 @@ export default function ClinicalDecisionPanel({
   cd: ClinicalDecision;
   inspectionId?: number;
 }) {
-  const { headers } = useAuth();
+  const { headers, role } = useAuth();
   const [pdfBusy, setPdfBusy] = useState(false);
   const result = cd.overall_result;
+  const canReview = role === "admin" || role === "spd_manager";
 
   async function downloadPdf() {
     if (!inspectionId) return;
@@ -133,6 +232,42 @@ export default function ClinicalDecisionPanel({
           <div><div className="text-xs text-slate-500">Baseline</div><div className="font-medium text-slate-800 capitalize">{cd.summary.baseline_source ?? "—"}</div></div>
         </div>
       </div>
+
+      {/* AI Clinical Review — outcome + interpretation + evidence strength */}
+      <Card title="AI Clinical Review">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="text-sm">
+            <span className="text-slate-500">Inspection outcome: </span>
+            <span className="font-semibold text-slate-900">{cd.ai_clinical_review.outcome}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-slate-500">Evidence Strength</span>
+            <Stars n={cd.evidence_strength.stars} />
+            <span className="text-sm font-medium text-slate-700">{cd.evidence_strength.level}</span>
+          </div>
+        </div>
+        <p className="mt-2 text-sm text-slate-700">{cd.ai_clinical_review.interpretation}</p>
+        <p className="mt-1 text-xs text-slate-400">{cd.evidence_strength.reason}</p>
+      </Card>
+
+      {/* Baseline Difference */}
+      <Card title="Baseline Difference">
+        <p className="text-sm text-slate-700 mb-1">
+          Baseline match <span className="font-semibold">{cd.baseline_difference.baseline_match_pct ?? "—"}%</span>
+          {" · "}differences are <span className="font-medium capitalize">{cd.baseline_difference.category}</span>-related
+        </p>
+        <ul className="space-y-0.5 text-sm text-slate-700">
+          {cd.baseline_difference.differences.map((d, i) => (
+            <li key={i} className="flex items-start gap-1.5">
+              <span className={d.toLowerCase().startsWith("no ") ? "text-emerald-500" : "text-amber-500"}>•</span>
+              <span>{d}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-2 rounded border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-xs text-slate-500">
+          {cd.baseline_difference.localization_note}
+        </div>
+      </Card>
 
       {/* 13.9 Executive Summary */}
       {cd.executive_summary.length > 0 && (
@@ -190,8 +325,11 @@ export default function ClinicalDecisionPanel({
       <div className={`rounded-lg border px-4 py-3 ${result === "PASS" ? "border-emerald-300 bg-emerald-50" : "border-orange-300 bg-orange-50"}`}>
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1">Recommendation</p>
         <p className="text-sm font-semibold text-slate-900">{cd.recommendation.result}</p>
-        {cd.recommendation.action && <p className="text-sm text-slate-700">{cd.recommendation.action}</p>}
+        <p className="text-sm text-slate-700">{cd.recommendation.action_text ?? cd.recommendation.action}</p>
       </div>
+
+      {/* Supervisor Review Notes — admin/spd_manager only */}
+      {canReview && <SupervisorNotes inspectionId={inspectionId} />}
 
       {/* 13.7 Evidence */}
       <Card title="Evidence Used">

--- a/frontend/src/components/CreateManufacturerBaseline.tsx
+++ b/frontend/src/components/CreateManufacturerBaseline.tsx
@@ -20,7 +20,7 @@ const INSTRUMENT_TYPES = [
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/tiff"];
 
 export default function CreateManufacturerBaseline({ onCreated }: { onCreated?: () => void }) {
-  const { headers, role } = useAuth();
+  const { headers, role, logout } = useAuth();
   const [instrumentType, setInstrumentType] = useState("");
   const [manufacturer, setManufacturer] = useState("");
   const [model, setModel] = useState("");
@@ -51,8 +51,7 @@ export default function CreateManufacturerBaseline({ onCreated }: { onCreated?: 
         body: fd,
       });
       if (imgRes.status === 401) {
-        localStorage.removeItem("token");
-        window.location.href = "/login";
+        logout();
         return;
       }
       if (!imgRes.ok) {
@@ -75,8 +74,7 @@ export default function CreateManufacturerBaseline({ onCreated }: { onCreated?: 
         }),
       });
       if (res.status === 401) {
-        localStorage.removeItem("token");
-        window.location.href = "/login";
+        logout();
         return;
       }
       if (res.status === 403) {

--- a/frontend/src/components/InspectionResultsHistory.tsx
+++ b/frontend/src/components/InspectionResultsHistory.tsx
@@ -16,6 +16,24 @@ type InspectionRecord = {
   supervisor_review_required: boolean;
   has_image: boolean;
   status: string;
+  // SPD risk-weighted verdict persisted with the inspection
+  risk_level: string | null;
+  recommended_action: string | null;
+  overall_cleaning_assessment: string | null;
+};
+
+const RISK_LEVEL_STYLE: Record<string, string> = {
+  low: "bg-emerald-100 text-emerald-800",
+  medium: "bg-amber-100 text-amber-800",
+  high: "bg-orange-100 text-orange-800",
+  critical: "bg-red-100 text-red-800",
+};
+
+const CLEANING_STYLE: Record<string, string> = {
+  Clean: "text-emerald-700",
+  "Residual contamination suspected": "text-amber-700",
+  "Cleaning failure": "text-red-700 font-semibold",
+  "Supervisor review required": "text-orange-700",
 };
 
 function scoreColor(score: number | null): string {
@@ -105,6 +123,7 @@ export default function InspectionResultsHistory() {
                 <th className="px-5 py-2 font-medium">Facility</th>
                 <th className="px-5 py-2 font-medium">Score</th>
                 <th className="px-5 py-2 font-medium">Risk</th>
+                <th className="px-5 py-2 font-medium">Cleaning</th>
                 <th className="px-5 py-2 font-medium">Finding</th>
                 <th className="px-5 py-2 font-medium">Baseline</th>
                 <th className="px-5 py-2 font-medium">Status</th>
@@ -129,7 +148,21 @@ export default function InspectionResultsHistory() {
                     )}
                   </td>
                   <td className="px-5 py-2.5 text-slate-700">
-                    {r.supervisor_review_required ? "—" : riskLabel(r.inspection_score)}
+                    {r.risk_level ? (
+                      <span
+                        title={r.recommended_action ?? undefined}
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-bold capitalize ${RISK_LEVEL_STYLE[r.risk_level] ?? "bg-slate-100 text-slate-600"}`}
+                      >
+                        {r.risk_level}
+                      </span>
+                    ) : r.supervisor_review_required ? (
+                      "—"
+                    ) : (
+                      riskLabel(r.inspection_score)
+                    )}
+                  </td>
+                  <td className={`px-5 py-2.5 text-xs ${r.overall_cleaning_assessment ? (CLEANING_STYLE[r.overall_cleaning_assessment] ?? "text-slate-600") : "text-slate-400"}`}>
+                    {r.overall_cleaning_assessment ?? "—"}
                   </td>
                   <td className="px-5 py-2.5 capitalize text-slate-600">
                     {r.detected_issue === "unknown" || r.detected_issue === ""

--- a/frontend/src/components/InspectionResultsHistory.tsx
+++ b/frontend/src/components/InspectionResultsHistory.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { useAuth, API_BASE } from "@/lib/auth";
+import SupervisorNotes from "@/components/SupervisorNotes";
 
 type InspectionRecord = {
   id: number;
@@ -53,10 +54,26 @@ function riskLabel(score: number | null): string {
 }
 
 export default function InspectionResultsHistory() {
-  const { headers } = useAuth();
+  const { headers, role } = useAuth();
   const [items, setItems] = useState<InspectionRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const canReview = role === "admin" || role === "spd_manager";
+
+  async function openPdf(id: number) {
+    try {
+      const res = await fetch(`${API_BASE}/api/inspections/${id}/clinical-report.pdf`, {
+        headers: { Authorization: headers()["Authorization"] },
+      });
+      if (!res.ok) return;
+      const url = URL.createObjectURL(await res.blob());
+      window.open(url, "_blank", "noopener,noreferrer");
+      setTimeout(() => URL.revokeObjectURL(url), 30000);
+    } catch {
+      /* ignore — best-effort */
+    }
+  }
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -127,11 +144,13 @@ export default function InspectionResultsHistory() {
                 <th className="px-5 py-2 font-medium">Finding</th>
                 <th className="px-5 py-2 font-medium">Baseline</th>
                 <th className="px-5 py-2 font-medium">Status</th>
+                <th className="px-5 py-2 font-medium">Actions</th>
               </tr>
             </thead>
             <tbody>
               {items.map((r) => (
-                <tr key={r.id} className="border-b border-slate-50 hover:bg-slate-50/60">
+                <Fragment key={r.id}>
+                <tr className="border-b border-slate-50 hover:bg-slate-50/60">
                   <td className="px-5 py-2.5 text-slate-500">{r.id}</td>
                   <td className="px-5 py-2.5 text-slate-600 whitespace-nowrap">
                     {r.created_at ? new Date(r.created_at).toLocaleString() : "—"}
@@ -192,7 +211,26 @@ export default function InspectionResultsHistory() {
                       </span>
                     )}
                   </td>
+                  <td className="px-5 py-2.5 whitespace-nowrap">
+                    <button onClick={() => openPdf(r.id)} className="text-xs text-blue-600 underline">PDF</button>
+                    {canReview && (
+                      <button
+                        onClick={() => setExpanded(expanded === r.id ? null : r.id)}
+                        className="ml-3 text-xs text-blue-600 underline"
+                      >
+                        {expanded === r.id ? "Close" : "Review"}
+                      </button>
+                    )}
+                  </td>
                 </tr>
+                {expanded === r.id && canReview && (
+                  <tr className="bg-slate-50/60">
+                    <td colSpan={11} className="px-5 py-3">
+                      <SupervisorNotes inspectionId={r.id} onSubmitted={() => setExpanded(null)} />
+                    </td>
+                  </tr>
+                )}
+                </Fragment>
               ))}
             </tbody>
           </table>

--- a/frontend/src/components/SupervisorNotes.tsx
+++ b/frontend/src/components/SupervisorNotes.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { useAuth, API_BASE } from "@/lib/auth";
+
+/**
+ * Supervisor Review Notes — human-in-the-loop AI agreement capture.
+ * Role-gated at the call site (admin/spd_manager); the backend also enforces it.
+ * A comment is required for partial agreement, disagreement, or override.
+ */
+const AGREEMENT_OPTIONS = [
+  { value: "agree", label: "Agree with AI" },
+  { value: "partially_agree", label: "Partially agree" },
+  { value: "disagree", label: "Disagree with AI" },
+];
+
+export default function SupervisorNotes({
+  inspectionId,
+  onSubmitted,
+}: {
+  inspectionId?: number;
+  onSubmitted?: () => void;
+}) {
+  const { headers } = useAuth();
+  const [agreement, setAgreement] = useState("agree");
+  const [rationale, setRationale] = useState("");
+  const [override, setOverride] = useState("");
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const commentRequired = agreement !== "agree" || !!override.trim();
+
+  async function submit() {
+    if (!inspectionId) return;
+    if (commentRequired && !rationale.trim()) {
+      setMsg({ ok: false, text: "A comment is required for partial agreement, disagreement, or override." });
+      return;
+    }
+    setBusy(true);
+    setMsg(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/inspections/${inspectionId}/supervisor-review`, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ agreement, rationale: rationale.trim(), override_action: override.trim() }),
+      });
+      if (res.status === 403) { setMsg({ ok: false, text: "Supervisor access (admin/SPD manager) required." }); return; }
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        setMsg({ ok: false, text: b?.detail || `Submit failed (${res.status}).` });
+        return;
+      }
+      setMsg({ ok: true, text: "Supervisor review recorded." });
+      setRationale("");
+      setOverride("");
+      onSubmitted?.();
+    } catch {
+      setMsg({ ok: false, text: "Unable to reach the server." });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">Supervisor Review Notes</p>
+      <div className="flex flex-wrap gap-2 mb-2">
+        {AGREEMENT_OPTIONS.map((o) => (
+          <button
+            key={o.value}
+            onClick={() => setAgreement(o.value)}
+            className={`rounded-full px-3 py-1 text-xs font-medium border ${
+              agreement === o.value ? "bg-blue-600 text-white border-blue-600" : "border-slate-300 text-slate-600"
+            }`}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+      <textarea
+        value={rationale}
+        onChange={(e) => setRationale(e.target.value)}
+        placeholder={commentRequired ? "Rationale (required)" : "Rationale (optional)"}
+        className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+        rows={2}
+      />
+      <input
+        value={override}
+        onChange={(e) => setOverride(e.target.value)}
+        placeholder="Override action (optional, e.g. reprocess / remove)"
+        className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+      />
+      <div className="mt-2 flex items-center gap-3">
+        <button onClick={submit} disabled={busy} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
+          {busy ? "Saving…" : "Submit review"}
+        </button>
+        {msg && <span className={`text-sm ${msg.ok ? "text-emerald-700" : "text-red-700"}`}>{msg.text}</span>}
+      </div>
+      <p className="mt-2 text-xs text-slate-400">
+        Feedback is stored as labeled training data. Operators/viewers cannot submit.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -193,7 +193,8 @@ function NavItem({
 }
 
 function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
-  const role = localStorage.getItem("role") || "viewer";
+  const { role: authRole, logout } = useAuth();
+  const role = authRole || localStorage.getItem("role") || "viewer";
   const groups = visibleGroups(role);
   return (
     <aside
@@ -247,10 +248,7 @@ function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => 
             "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-slate-600 hover:bg-slate-100",
             collapsed && "justify-center"
           )}
-          onClick={() => {
-            localStorage.removeItem("token");
-            window.location.href = "/";
-          }}
+          onClick={() => logout()}
           title={collapsed ? "Sign out" : undefined}
         >
           <LogOut className="h-4 w-4 shrink-0" />

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -61,6 +61,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: "Inspection Intelligence",
     items: [
       { to: "/inspection/new", label: "New Inspection", icon: FilePlus },
+      { to: "/inspection/capture", label: "Borescope Capture", icon: Camera },
       { to: "/intake-history", label: "Inspection History", icon: History },
       { to: "/findings", label: "Review Queue", icon: ClipboardCheck },
       { to: "/analytics", label: "Inspection Analytics", icon: LineChart },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -59,6 +59,7 @@ const Dashboard = lazy(() => import("./pages/Dashboard"));
 const VendorIntake = lazy(() => import("./pages/VendorIntake"));
 const OperationsDashboard = lazy(() => import("./pages/OperationsDashboard"));
 const NewInspectionPage = lazy(() => import("./pages/NewInspectionPage"));
+const CapturePage = lazy(() => import("./pages/CapturePage"));
 const FindingsQueuePage = lazy(() => import("./pages/FindingsQueuePage"));
 const CapaQueuePage = lazy(() => import("./pages/CapaQueuePage"));
 const AnalyticsDashboardPage = lazy(() => import("./pages/AnalyticsDashboardPage"));
@@ -296,6 +297,7 @@ function App() {
                       <Route path="/vendor-intake" element={<Page name="VendorIntake"><VendorIntake /></Page>} />
                       <Route path="/operations" element={<Page name="Operations"><OperationsDashboard /></Page>} />
                       <Route path="/inspection/new" element={<Page name="NewInspection"><NewInspectionPage /></Page>} />
+                      <Route path="/inspection/capture" element={<Page name="Capture"><CapturePage /></Page>} />
                       <Route path="/findings" element={<Page name="Findings"><FindingsQueuePage /></Page>} />
                       <Route path="/capa" element={<Page name="CAPA"><CapaQueuePage /></Page>} />
                       <Route path="/analytics" element={<Page name="Analytics"><AnalyticsDashboardPage /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,13 +9,22 @@ import { Spinner } from "@/components/ui/spinner";
 
 // ─── Global error recovery ───────────────────────────────────────────────────
 // Chunk-load failures (e.g. after a deploy re-hashes asset filenames) cause a
-// white page because the browser cached the old chunk URL which is now a 404.
-// Reload once per session to pick up the new asset manifest.
+// white page because the browser cached an OLD index.html that references chunk
+// URLs which are now 404s. A plain reload() can just re-serve that same cached
+// HTML, so we reload with a cache-busting query to force a fresh document +
+// asset manifest. Guarded to run once per session so it can never loop.
+function recoverFromStaleAssets() {
+  if (sessionStorage.getItem("chunk_reload")) return;
+  sessionStorage.setItem("chunk_reload", "1");
+  const url = new URL(window.location.href);
+  url.searchParams.set("_cb", Date.now().toString());
+  window.location.replace(url.toString());
+}
+
 window.addEventListener("error", (e) => {
   const src = (e.target as HTMLScriptElement | null)?.src ?? "";
-  if (src.includes("/assets/") && !sessionStorage.getItem("chunk_reload")) {
-    sessionStorage.setItem("chunk_reload", "1");
-    window.location.reload();
+  if (src.includes("/assets/")) {
+    recoverFromStaleAssets();
   }
 }, true); // capture phase so it fires before React's own handlers
 
@@ -24,13 +33,23 @@ window.addEventListener("error", (e) => {
 window.addEventListener("unhandledrejection", (e) => {
   const msg = String(e.reason?.message ?? e.reason ?? "");
   if (
-    (msg.includes("Failed to fetch dynamically imported module") ||
-      msg.includes("Importing a module script failed")) &&
-    !sessionStorage.getItem("chunk_reload")
+    msg.includes("Failed to fetch dynamically imported module") ||
+    msg.includes("Importing a module script failed")
   ) {
-    sessionStorage.setItem("chunk_reload", "1");
-    window.location.reload();
+    recoverFromStaleAssets();
   }
+});
+
+// Once the app has actually mounted (root has content), clear the guard so a
+// genuine future deploy can self-heal again in this same tab/session. Only clear
+// on a real mount so a persistently-blank page can never enter a reload loop.
+window.addEventListener("load", () => {
+  window.setTimeout(() => {
+    const root = document.getElementById("root");
+    if (root && root.childElementCount > 0) {
+      sessionStorage.removeItem("chunk_reload");
+    }
+  }, 4000);
 });
 
 // All pages are lazy so any single page crash is caught by PageErrorBoundary

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -60,6 +60,7 @@ const VendorIntake = lazy(() => import("./pages/VendorIntake"));
 const OperationsDashboard = lazy(() => import("./pages/OperationsDashboard"));
 const NewInspectionPage = lazy(() => import("./pages/NewInspectionPage"));
 const CapturePage = lazy(() => import("./pages/CapturePage"));
+const StationPage = lazy(() => import("./pages/StationPage"));
 const FindingsQueuePage = lazy(() => import("./pages/FindingsQueuePage"));
 const CapaQueuePage = lazy(() => import("./pages/CapaQueuePage"));
 const AnalyticsDashboardPage = lazy(() => import("./pages/AnalyticsDashboardPage"));
@@ -282,6 +283,16 @@ function App() {
                 element={
                   <Page name="Login">
                     <LoginPage />
+                  </Page>
+                }
+              />
+
+              {/* Shared borescope station — KIOSK, device-key auth, no AppShell/login */}
+              <Route
+                path="/station"
+                element={
+                  <Page name="Station">
+                    <StationPage />
                   </Page>
                 }
               />

--- a/frontend/src/pages/CapturePage.tsx
+++ b/frontend/src/pages/CapturePage.tsx
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth, API_BASE } from "@/lib/auth";
+
+/**
+ * Direct borescope capture — live UVC/webcam preview → capture frame → analyze.
+ *
+ * Runs entirely in the browser on hospital-managed hardware (tablet/PC with a
+ * UVC video grabber attached to the borescope). No native install, no USB
+ * drive: the captured frame is uploaded straight into the inspection pipeline.
+ */
+type CaptureResult = {
+  inspection_score: number | null;
+  risk_level: string | null;
+  recommended_action?: string;
+  overall_cleaning_assessment?: string;
+  baseline_source?: string | null;
+};
+
+const RISK_STYLE: Record<string, string> = {
+  low: "bg-emerald-100 text-emerald-800",
+  medium: "bg-amber-100 text-amber-800",
+  high: "bg-orange-100 text-orange-800",
+  critical: "bg-red-100 text-red-800",
+};
+
+export default function CapturePage() {
+  const { headers, role } = useAuth();
+  const navigate = useNavigate();
+  const canRun = role === "operator" || role === "spd_manager" || role === "admin";
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [deviceId, setDeviceId] = useState<string>("");
+  const [camError, setCamError] = useState<string>("");
+  const [captured, setCaptured] = useState<Blob | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string>("");
+
+  const [instrumentType, setInstrumentType] = useState("");
+  const [facility, setFacility] = useState("");
+  const [barcode, setBarcode] = useState("");
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<CaptureResult | null>(null);
+
+  const startStream = useCallback(async (id?: string) => {
+    setCamError("");
+    try {
+      if (streamRef.current) streamRef.current.getTracks().forEach((t) => t.stop());
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: id ? { deviceId: { exact: id } } : true,
+        audio: false,
+      });
+      streamRef.current = stream;
+      if (videoRef.current) videoRef.current.srcObject = stream;
+      // Device labels are only populated after permission is granted.
+      const all = await navigator.mediaDevices.enumerateDevices();
+      setDevices(all.filter((d) => d.kind === "videoinput"));
+    } catch (e) {
+      setCamError(
+        e instanceof Error && e.name === "NotAllowedError"
+          ? "Camera access was blocked. Allow camera access to use the borescope feed."
+          : "No camera/borescope feed found. Connect a UVC video grabber and reload.",
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    if (canRun) startStream();
+    return () => {
+      if (streamRef.current) streamRef.current.getTracks().forEach((t) => t.stop());
+    };
+  }, [canRun, startStream]);
+
+  function switchDevice(id: string) {
+    setDeviceId(id);
+    startStream(id);
+  }
+
+  function capture() {
+    const video = videoRef.current;
+    if (!video || !video.videoWidth) {
+      setError("The video feed is not ready yet.");
+      return;
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0);
+    canvas.toBlob((blob) => {
+      if (!blob) return;
+      setCaptured(blob);
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(URL.createObjectURL(blob));
+      setResult(null);
+      setError("");
+    }, "image/jpeg", 0.92);
+  }
+
+  async function analyze() {
+    if (!captured) return;
+    if (!instrumentType.trim()) {
+      setError("Enter the instrument type before analyzing.");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    setResult(null);
+    try {
+      const hdrs = headers();
+      // 1. Upload the captured frame (also decodes identifiers).
+      const fd = new FormData();
+      fd.append("images", captured, "capture.jpg");
+      const up = await fetch(
+        `${API_BASE}/api/inspections/upload-images?instrument_type=${encodeURIComponent(instrumentType)}`,
+        { method: "POST", headers: { Authorization: hdrs["Authorization"] }, body: fd },
+      );
+      if (up.status === 401) { navigate("/login", { replace: true }); return; }
+      if (!up.ok) {
+        const b = await up.json().catch(() => ({}));
+        setError(b?.detail || `Upload failed (${up.status}).`);
+        return;
+      }
+      const upData = await up.json();
+      const img = upData?.images?.[0] || {};
+      const sha = img.sha256;
+      const decodedBarcode = img.barcode_value || "";
+      const decodedUdi = img.qr_udi_value || "";
+
+      // 2. Create the inspection (AI scores it against the baseline).
+      const res = await fetch(`${API_BASE}/api/inspections`, {
+        method: "POST",
+        headers: hdrs,
+        body: JSON.stringify({
+          instrument_type: instrumentType,
+          site_name: facility || "capture",
+          facility_name: facility || undefined,
+          has_image: true,
+          image_sha256: sha,
+          file_name: "capture.jpg",
+          instrument_barcode: barcode || decodedBarcode || undefined,
+          instrument_udi: decodedUdi || undefined,
+          identifier_source: !barcode && (decodedBarcode || decodedUdi) ? "pyzbar" : "declared",
+        }),
+      });
+      if (res.status === 401) { navigate("/login", { replace: true }); return; }
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        setError(b?.detail || `Analysis failed (${res.status}).`);
+        return;
+      }
+      const data = await res.json();
+      const a = data.analysis || {};
+      setResult({
+        inspection_score: a.inspection_score ?? (data.inspection_score ?? null),
+        risk_level: a.risk_level ?? data.risk_level ?? null,
+        recommended_action: a.recommended_action,
+        overall_cleaning_assessment: a.overall_cleaning_assessment,
+        baseline_source: a.baseline_source,
+      });
+    } catch {
+      setError("Unable to reach the server. Check the connection and try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!canRun) {
+    return (
+      <div className="p-6">
+        <h2 className="text-xl font-semibold text-slate-900">Borescope Capture</h2>
+        <p className="mt-2 text-sm text-amber-700">
+          Viewer access is read-only. Ask an admin for Operator or SPD Manager access to capture inspections.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5 p-1">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Borescope Capture</h2>
+        <p className="text-sm text-slate-500 mt-0.5">
+          Live capture from a connected borescope (UVC video grabber). Capture a frame and analyze it directly —
+          no phone photos, no USB drive.
+        </p>
+      </div>
+
+      {/* Camera / device selector */}
+      {devices.length > 1 && (
+        <div>
+          <label className="block text-xs font-medium text-slate-500 mb-1">Capture source</label>
+          <select
+            value={deviceId}
+            onChange={(e) => switchDevice(e.target.value)}
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm"
+          >
+            <option value="">Default camera</option>
+            {devices.map((d) => (
+              <option key={d.deviceId} value={d.deviceId}>{d.label || "Camera"}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {camError ? (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800">
+          {camError}
+          <button onClick={() => startStream(deviceId)} className="ml-2 underline">Retry</button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="rounded-lg border border-slate-200 bg-black overflow-hidden">
+            <video ref={videoRef} autoPlay playsInline muted className="w-full aspect-video object-contain" />
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-slate-50 overflow-hidden flex items-center justify-center">
+            {previewUrl ? (
+              <img src={previewUrl} alt="Captured frame" className="w-full aspect-video object-contain" />
+            ) : (
+              <span className="text-sm text-slate-400">Captured frame will appear here</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          onClick={capture}
+          disabled={!!camError}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Capture frame
+        </button>
+      </div>
+
+      {/* Instrument context */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-slate-500 mb-1">Instrument type *</label>
+          <input value={instrumentType} onChange={(e) => setInstrumentType(e.target.value)}
+            placeholder="e.g. rigid scope" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-slate-500 mb-1">Facility</label>
+          <input value={facility} onChange={(e) => setFacility(e.target.value)}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-slate-500 mb-1">Barcode / UDI (optional)</label>
+          <input value={barcode} onChange={(e) => setBarcode(e.target.value)}
+            placeholder="auto-decoded if blank" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" />
+        </div>
+      </div>
+
+      <button
+        onClick={analyze}
+        disabled={!captured || busy}
+        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+      >
+        {busy ? "Analyzing…" : "Analyze captured frame"}
+      </button>
+
+      {error && (
+        <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">{error}</div>
+      )}
+
+      {result && (
+        <div className="rounded-lg border border-emerald-300 bg-emerald-50 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700 mb-2">Analysis Complete</p>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+            <div>
+              <div className="text-xs text-slate-500">Inspection Score</div>
+              <div className="text-2xl font-bold text-slate-900">{result.inspection_score ?? "—"}<span className="text-sm text-slate-400"> / 100</span></div>
+            </div>
+            <div>
+              <div className="text-xs text-slate-500">Risk Level</div>
+              <span className={`mt-1 inline-flex items-center rounded-full px-2.5 py-1 text-sm font-bold capitalize ${RISK_STYLE[result.risk_level ?? ""] ?? "bg-slate-200 text-slate-700"}`}>
+                {result.risk_level ?? "—"}
+              </span>
+            </div>
+            <div>
+              <div className="text-xs text-slate-500">Cleaning</div>
+              <div className="text-sm font-medium text-slate-800">{result.overall_cleaning_assessment ?? "—"}</div>
+            </div>
+            <div>
+              <div className="text-xs text-slate-500">Baseline</div>
+              <div className="text-sm font-medium text-slate-800 capitalize">{result.baseline_source ?? "—"}</div>
+            </div>
+          </div>
+          {result.recommended_action && (
+            <p className="mt-3 text-sm font-medium text-slate-900">{result.recommended_action}</p>
+          )}
+          <button onClick={() => navigate("/intake-history")} className="mt-3 text-sm text-blue-600 underline">
+            View in Inspection History
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth, API_BASE } from "@/lib/auth";
+import AiModelPerformanceCard from "@/components/AiModelPerformanceCard";
 
 type Summary = {
   total_inspections?: number;
@@ -360,6 +361,9 @@ export default function Dashboard() {
           </AlertDescription>
         </Alert>
       )}
+
+      {/* AI model-performance monitoring (supervisor-verified; admin/SPD only) */}
+      <AiModelPerformanceCard />
 
       {/* ── Operational KPIs ── */}
       <section>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -8,12 +8,15 @@ export default function LoginPage() {
   const location = useLocation();
   const from = (location.state as { from?: string })?.from || "/";
 
-  if (token) return <Navigate to={from} replace />;
-
+  // NOTE: all hooks must run before any conditional return, or React throws
+  // "rendered fewer hooks than expected" (a white-page crash) when an already
+  // authenticated user lands on /login and the early return fires.
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  if (token) return <Navigate to={from} replace />;
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, FormEvent, useCallback, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth, API_BASE } from "@/lib/auth";
+import ClinicalDecisionPanel from "@/components/ClinicalDecisionPanel";
 import { FormSection } from "@/components/ui/FormSection";
 import { RequiredLabel, FieldError } from "@/components/ui/RequiredField";
 import { StatusBanner } from "@/components/ui/StatusBanner";
@@ -97,6 +98,8 @@ type Analysis = {
   placeholder_scoring?: boolean;
   model_label?: string;
   production_validated?: boolean;
+  // Phase 13 — Explainable Clinical Decision Support payload.
+  clinical_decision?: Parameters<typeof ClinicalDecisionPanel>[0]["cd"];
 };
 
 type AIPrediction = {
@@ -967,9 +970,21 @@ function AIPredictionPanel({
           } />
         </div>
 
-        {/* Full AI analysis output (placeholder scoring service) */}
+        {/* Phase 13 — Explainable Clinical Decision Support (primary view) */}
+        {prediction.analysis?.clinical_decision && (
+          <ClinicalDecisionPanel cd={prediction.analysis.clinical_decision} inspectionId={prediction.id} />
+        )}
+
+        {/* Detailed KPI breakdown (retained below the clinical summary) */}
         {prediction.analysis && prediction.analysis.analysis_status === "completed" && (
-          <AnalysisDetails analysis={prediction.analysis} />
+          <details className="rounded-lg border border-slate-200 bg-white">
+            <summary className="cursor-pointer px-4 py-2 text-sm font-semibold text-slate-700">
+              Full KPI detail
+            </summary>
+            <div className="p-1">
+              <AnalysisDetails analysis={prediction.analysis} />
+            </div>
+          </details>
         )}
 
         <p className="text-xs text-slate-500">

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -189,7 +189,7 @@ const initialForm: FormFields = {
 // ─── component ────────────────────────────────────────────────────────────────
 
 export default function NewInspectionPage() {
-  const { headers, role } = useAuth();
+  const { headers, role, logout } = useAuth();
   const navigate = useNavigate();
   // Operators / SPD managers / admins can run inspections; viewers are read-only.
   const canRunInspection = role === "operator" || role === "spd_manager" || role === "admin";
@@ -361,8 +361,10 @@ export default function NewInspectionPage() {
         body: fd,
       });
       if (imgRes.status === 401) {
-        // Token expired/invalid — clear it and send to login to re-authenticate.
-        localStorage.removeItem("token");
+        // Token expired/invalid — clear BOTH localStorage and in-memory auth
+        // state (logout), otherwise /login sees the stale token and bounces
+        // straight back to the landing page without letting you re-authenticate.
+        logout();
         navigate("/login", { replace: true });
         return;
       }
@@ -428,7 +430,7 @@ export default function NewInspectionPage() {
       });
 
       if (res.status === 401) {
-        localStorage.removeItem("token");
+        logout();
         navigate("/login", { replace: true });
         return;
       }

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -74,7 +74,9 @@ type Analysis = {
   pass_fail?: string;
   predicted_findings: PredictedFinding[];
   kpi_summary: Record<string, boolean>;
-  identification: Record<string, boolean>;
+  identification: Record<string, boolean | string>;
+  identification_status?: string;
+  decoder_backend?: string;
   findings_summary?: string[];
   confidence?: number;
   confidence_level?: string;
@@ -373,6 +375,22 @@ export default function NewInspectionPage() {
       const imgData = await imgRes.json();
       imageSha256 = imgData?.images?.[0]?.sha256;
 
+      // Real identifier decode (pyzbar): auto-fill when the technician didn't
+      // type a value. Typed values always win. Tracks the source so the
+      // analysis can label decoded vs declared identifiers.
+      const decodedImg = (imgData?.images ?? []).find(
+        (im: { barcode_value?: string; qr_udi_value?: string }) =>
+          im?.barcode_value || im?.qr_udi_value,
+      );
+      const decodedBarcode = decodedImg?.barcode_value || "";
+      const decodedUdi = decodedImg?.qr_udi_value || "";
+      const barcodeFinal = form.barcode || decodedBarcode || undefined;
+      const udiFinal = form.udi || decodedUdi || undefined;
+      const identifierSource =
+        !form.barcode && !form.udi && (decodedBarcode || decodedUdi)
+          ? "pyzbar"
+          : "declared";
+
       // Step 2: Submit inspection record (findings optional — AI will determine)
       const payload: Record<string, unknown> = {
         instrument_type: form.instrument_type,
@@ -381,9 +399,10 @@ export default function NewInspectionPage() {
         facility_name: form.facility_name,
         department: form.department || undefined,
         tray_id: form.tray_id || undefined,
-        instrument_barcode: form.barcode || undefined,
-        instrument_udi: form.udi || undefined,
+        instrument_barcode: barcodeFinal,
+        instrument_udi: udiFinal,
         keydot_id: form.keydot_id || undefined,
+        identifier_source: identifierSource,
         file_name: allImages[0]?.name || "inspection_image",
         has_image: true,
         image_sha256: imageSha256,
@@ -1095,6 +1114,18 @@ const CLEANING_STYLE: Record<string, string> = {
   "Cleaning failure": "border-red-300 bg-red-50 text-red-900",
   "Supervisor review required": "border-orange-300 bg-orange-50 text-orange-900",
 };
+const ID_STATUS_STYLE: Record<string, string> = {
+  verified: "bg-emerald-100 text-emerald-800",
+  mismatch: "bg-red-100 text-red-800",
+  unverified: "bg-amber-100 text-amber-800",
+  not_detected: "bg-slate-100 text-slate-500",
+};
+const ID_STATUS_LABEL: Record<string, string> = {
+  verified: "Verified",
+  mismatch: "Mismatch",
+  unverified: "Unverified",
+  not_detected: "Not detected",
+};
 
 function AnalysisDetails({ analysis }: { analysis: Analysis }) {
   const score = analysis.inspection_score ?? 0;
@@ -1218,9 +1249,24 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
         </div>
       )}
 
-      {/* Identification */}
+      {/* Identification — real decode-vs-baseline verification */}
       <div>
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">Identification</p>
+        <div className="mb-2 flex items-center gap-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Identification</p>
+          {analysis.identification_status && (
+            <span className={`rounded-full px-2 py-0.5 text-xs font-bold ${ID_STATUS_STYLE[analysis.identification_status] ?? "bg-slate-100 text-slate-600"}`}>
+              {ID_STATUS_LABEL[analysis.identification_status] ?? analysis.identification_status}
+            </span>
+          )}
+          {analysis.decoder_backend === "pyzbar" && (
+            <span className="text-xs text-slate-400">decoded from image</span>
+          )}
+        </div>
+        {analysis.identification_status === "mismatch" && (
+          <p className="mb-2 text-xs font-medium text-red-700">
+            Decoded identifier does not match the approved baseline — verify this is the correct instrument.
+          </p>
+        )}
         <div className="flex flex-wrap gap-2 text-xs">
           {[
             { key: "barcode_detected", label: "Barcode" },

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -40,7 +40,14 @@ type PredictedFinding = {
   confidence: number;
   severity: string;
   status?: string;
+  spd_risk?: string;
+  spd_risk_impact?: string;
 };
+
+type SeverityByKpi = Record<
+  string,
+  { severity: string; probability: number; spd_risk: string; spd_risk_impact: string }
+>;
 
 type ScoreAdjustment = { kpi: string; label: string; points: number; severity: string; risk_tier: string };
 
@@ -72,6 +79,13 @@ type Analysis = {
   confidence?: number;
   confidence_level?: string;
   recommendation: string;
+  recommended_action?: string;
+  overall_cleaning_assessment?: string;
+  top_risk_drivers?: string[];
+  severity_by_kpi?: SeverityByKpi;
+  scoring_explanation?: string[];
+  spd_critical_drivers?: string[];
+  spd_high_drivers?: string[];
   reason?: string[];
   critical_flags?: string[];
   score_adjustments?: ScoreAdjustment[];
@@ -116,7 +130,7 @@ const FINDING_CATEGORIES: { value: FindingCategory; label: string; tooltip: stri
   { value: "blood", label: "Blood", tooltip: "Visible blood residue in lumen or on instrument surface" },
   { value: "bone", label: "Bone", tooltip: "Calcified tissue or bone fragment visible in channel" },
   { value: "tissue", label: "Tissue", tooltip: "Soft tissue or protein residue visible in lumen" },
-  { value: "debris", label: "Debris / Bioburden", tooltip: "Non-specific particulate, organic matter, or buildup" },
+  { value: "debris", label: "Debris / Particulate", tooltip: "Non-specific particulate, organic matter, or buildup" },
   { value: "corrosion", label: "Corrosion", tooltip: "Rust, pitting, or surface degradation of metal" },
   { value: "crack", label: "Crack / Fracture", tooltip: "Visible structural break, fracture, or delamination" },
   { value: "insulation_damage", label: "Insulation Damage", tooltip: "Damage to electrical insulation on monopolar/bipolar instruments" },
@@ -1030,7 +1044,6 @@ const KPI_DISPLAY: { key: string; label: string }[] = [
   { key: "blood", label: "Blood" },
   { key: "bone", label: "Bone" },
   { key: "tissue", label: "Tissue" },
-  { key: "bioburden", label: "Bioburden" },
   { key: "debris", label: "Debris" },
   { key: "other_organic_residue", label: "Other Organic Residue" },
   { key: "rust", label: "Rust" },
@@ -1068,6 +1081,19 @@ const SEVERITY_STYLE: Record<string, string> = {
   Low: "text-amber-600",
   Moderate: "text-orange-600",
   High: "text-red-600 font-semibold",
+};
+// SPD Risk Impact chip styling (Clear / Monitor / Review / Reprocess).
+const SPD_IMPACT_STYLE: Record<string, string> = {
+  Clear: "bg-emerald-100 text-emerald-800",
+  Monitor: "bg-amber-100 text-amber-800",
+  Review: "bg-orange-100 text-orange-800",
+  Reprocess: "bg-red-100 text-red-800",
+};
+const CLEANING_STYLE: Record<string, string> = {
+  Clean: "border-emerald-300 bg-emerald-50 text-emerald-900",
+  "Residual contamination suspected": "border-amber-300 bg-amber-50 text-amber-900",
+  "Cleaning failure": "border-red-300 bg-red-50 text-red-900",
+  "Supervisor review required": "border-orange-300 bg-orange-50 text-orange-900",
 };
 
 function AnalysisDetails({ analysis }: { analysis: Analysis }) {
@@ -1144,26 +1170,53 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
             const status = finding?.status
               ? finding.status.charAt(0).toUpperCase() + finding.status.slice(1)
               : statusOf(p);
+            const impact = finding?.spd_risk_impact ?? "Clear";
             return (
               <div key={key} className="rounded-lg border border-slate-200 bg-white px-3 py-2">
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-slate-700">{label}</span>
-                  <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLE[status] ?? "bg-slate-100 text-slate-600"}`}>
-                    {status}
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${SPD_IMPACT_STYLE[impact] ?? "bg-slate-100 text-slate-600"}`}>
+                    {impact}
                   </span>
                 </div>
                 <div className="mt-1 flex items-center justify-between text-xs">
                   <span className="text-slate-500">Probability <span className="font-semibold text-slate-700">{pct}%</span></span>
                   <span className={SEVERITY_STYLE[severity] ?? "text-slate-500"}>Severity: {severity}</span>
                 </div>
+                <div className="mt-0.5 text-xs text-slate-400">
+                  SPD Risk Impact: <span className="font-medium text-slate-600">{impact}</span>
+                </div>
               </div>
             );
           })}
         </div>
         <p className="mt-1.5 text-xs text-slate-400">
-          Status: 0–10% Clear · 11–30% Monitor · 31–60% Review · 61%+ Escalate.
+          SPD Risk Impact: Clear (no action) · Monitor (low-risk) · Review (supervisor) · Reprocess (remove/clean).
         </p>
       </div>
+
+      {/* Overall Cleaning Assessment (replaces standalone bioburden KPI) */}
+      {analysis.overall_cleaning_assessment && (
+        <div className={`rounded-lg border px-4 py-3 ${CLEANING_STYLE[analysis.overall_cleaning_assessment] ?? "border-slate-200 bg-slate-50 text-slate-800"}`}>
+          <p className="text-xs font-semibold uppercase tracking-wide opacity-70 mb-0.5">Overall Cleaning Assessment</p>
+          <p className="text-sm font-semibold">{analysis.overall_cleaning_assessment}</p>
+          <p className="mt-0.5 text-xs opacity-70">
+            Derived from blood, bone, tissue, organic residue and debris — not a standalone bioburden score.
+          </p>
+        </div>
+      )}
+
+      {/* Top risk drivers */}
+      {analysis.top_risk_drivers && analysis.top_risk_drivers.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Top Risk Drivers</p>
+          <div className="flex flex-wrap gap-1.5">
+            {analysis.top_risk_drivers.map((d, i) => (
+              <span key={i} className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium capitalize text-slate-700">{d}</span>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Identification */}
       <div>
@@ -1234,8 +1287,26 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
             ))}
           </ul>
         )}
-        <p className="text-sm font-medium text-slate-800">{analysis.recommendation}</p>
+        {analysis.recommended_action && (
+          <p className="text-sm font-semibold text-slate-900">{analysis.recommended_action}</p>
+        )}
+        <p className="text-sm text-slate-700">{analysis.recommendation}</p>
       </div>
+
+      {/* Why the score changed — plain-language explanation */}
+      {analysis.scoring_explanation && analysis.scoring_explanation.length > 0 && (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Reason Score Changed</p>
+          <ul className="space-y-0.5 text-sm text-slate-700">
+            {analysis.scoring_explanation.map((line, i) => (
+              <li key={i} className="flex items-start gap-1.5">
+                <span className={line.startsWith("No ") ? "text-emerald-500" : "text-amber-500"}>•</span>
+                <span>{line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {/* Explainability */}
       {analysis.explainability && (

--- a/frontend/src/pages/StationPage.tsx
+++ b/frontend/src/pages/StationPage.tsx
@@ -1,0 +1,276 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { API_BASE } from "@/lib/auth";
+
+/**
+ * Shared borescope station — KIOSK mode.
+ *
+ * Runs on a small tablet/mini-PC at a shared, standalone borescope station with
+ * a UVC video grabber on the scope's video-out. Authenticated as a registered
+ * capture DEVICE (device key), not a personal login, so it is always ready.
+ *
+ * Flow (scan-first, hands-light, auto-reset for the next tech):
+ *   scan instrument barcode → capture the live frame → analyze against the
+ *   baseline → show a big glanceable PASS / SUPERVISOR REVIEW / REPROCESS
+ *   verdict → auto-reset. Optional tech badge/PIN attributes the capture.
+ *
+ * Full-screen and outside the app shell — no sidebar, no per-capture login.
+ */
+const DEVICE_KEY_STORAGE = "lumenai_station_device_key";
+const STATION_TYPE_STORAGE = "lumenai_station_instrument_type";
+
+type Verdict = "PASS" | "MONITOR" | "SUPERVISOR REVIEW" | "REPROCESS" | "UNKNOWN";
+
+function verdictFrom(risk: string | null | undefined, action: string | undefined): Verdict {
+  const a = (action || "").toLowerCase();
+  if (a.includes("reprocess") || a.includes("remove from service")) return "REPROCESS";
+  if (a.includes("supervisor review")) return "SUPERVISOR REVIEW";
+  if (a.startsWith("monitor")) return "MONITOR";
+  if (risk === "low" || a.startsWith("pass")) return "PASS";
+  if (risk === "critical" || risk === "high") return "SUPERVISOR REVIEW";
+  if (risk === "medium") return "MONITOR";
+  return "UNKNOWN";
+}
+
+const VERDICT_STYLE: Record<Verdict, string> = {
+  PASS: "bg-emerald-600",
+  MONITOR: "bg-amber-500",
+  "SUPERVISOR REVIEW": "bg-orange-600",
+  REPROCESS: "bg-red-600",
+  UNKNOWN: "bg-slate-600",
+};
+
+export default function StationPage() {
+  const [deviceKey, setDeviceKey] = useState<string>(() => localStorage.getItem(DEVICE_KEY_STORAGE) || "");
+  const [keyInput, setKeyInput] = useState("");
+  const [instrumentType, setInstrumentType] = useState<string>(() => localStorage.getItem(STATION_TYPE_STORAGE) || "");
+  const [techId, setTechId] = useState("");
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const scanRef = useRef<HTMLInputElement | null>(null);
+  const [camError, setCamError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState("");
+  const [result, setResult] = useState<{ verdict: Verdict; score: number | null; risk: string | null; action?: string; cleaning?: string } | null>(null);
+
+  // ── Camera ────────────────────────────────────────────────────────────────
+  const startStream = useCallback(async () => {
+    setCamError("");
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+      streamRef.current = stream;
+      if (videoRef.current) videoRef.current.srcObject = stream;
+    } catch {
+      setCamError("No borescope feed found. Connect the UVC video grabber and reload.");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (deviceKey) startStream();
+    return () => { if (streamRef.current) streamRef.current.getTracks().forEach((t) => t.stop()); };
+  }, [deviceKey, startStream]);
+
+  // Keep the scan field focused so a barcode gun always lands there.
+  const focusScan = useCallback(() => { scanRef.current?.focus(); }, []);
+  useEffect(() => {
+    if (!deviceKey) return;
+    focusScan();
+    const iv = window.setInterval(focusScan, 1500);
+    return () => window.clearInterval(iv);
+  }, [deviceKey, focusScan, result, busy]);
+
+  function captureBlob(): Promise<Blob | null> {
+    return new Promise((resolve) => {
+      const video = videoRef.current;
+      if (!video || !video.videoWidth) return resolve(null);
+      const canvas = document.createElement("canvas");
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return resolve(null);
+      ctx.drawImage(video, 0, 0);
+      canvas.toBlob((b) => resolve(b), "image/jpeg", 0.92);
+    });
+  }
+
+  async function handleScan(barcode: string) {
+    const code = barcode.trim();
+    if (!code || busy) return;
+    if (!instrumentType.trim()) {
+      setStatus("Set the instrument type for this station first (Station setup).");
+      return;
+    }
+    setBusy(true);
+    setResult(null);
+    setStatus("Capturing…");
+    try {
+      const blob = await captureBlob();
+      if (!blob) { setStatus("Video feed not ready — try again."); return; }
+      setStatus("Analyzing…");
+      const fd = new FormData();
+      fd.append("image", blob, "capture.jpg");
+      fd.append("instrument_type", instrumentType.trim());
+      fd.append("instrument_barcode", code);
+      if (techId.trim()) fd.append("captured_by", techId.trim());
+      const res = await fetch(`${API_BASE}/api/capture/ingest`, {
+        method: "POST",
+        headers: { "X-Device-Key": deviceKey },
+        body: fd,
+      });
+      if (res.status === 401) {
+        setStatus("This station's device key is invalid or revoked. Re-enter it in Station setup.");
+        localStorage.removeItem(DEVICE_KEY_STORAGE);
+        setDeviceKey("");
+        return;
+      }
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        setStatus(b?.detail || `Analysis failed (${res.status}).`);
+        return;
+      }
+      const data = await res.json();
+      const a = data.analysis || {};
+      const verdict = verdictFrom(a.risk_level, a.recommended_action);
+      setResult({
+        verdict,
+        score: a.inspection_score ?? null,
+        risk: a.risk_level ?? null,
+        action: a.recommended_action,
+        cleaning: a.overall_cleaning_assessment,
+      });
+      setStatus("");
+      // Auto-reset for the next tech.
+      window.setTimeout(() => { setResult(null); setStatus(""); focusScan(); }, 9000);
+    } catch {
+      setStatus("Unable to reach the server. Check the connection.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // ── Setup screen (no device key yet) ────────────────────────────────────────
+  if (!deviceKey) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-900 text-white p-8">
+        <div className="w-full max-w-md space-y-4">
+          <h1 className="text-2xl font-bold">Borescope Station Setup</h1>
+          <p className="text-sm text-slate-300">
+            Enter this station's device key (issued once by an admin under Capture Devices).
+            It is stored on this device only.
+          </p>
+          <input
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            placeholder="Device key"
+            className="w-full rounded-lg px-3 py-2 text-slate-900"
+          />
+          <input
+            value={instrumentType}
+            onChange={(e) => setInstrumentType(e.target.value)}
+            placeholder="Default instrument type (e.g. rigid scope)"
+            className="w-full rounded-lg px-3 py-2 text-slate-900"
+          />
+          <button
+            onClick={() => {
+              if (!keyInput.trim()) return;
+              localStorage.setItem(DEVICE_KEY_STORAGE, keyInput.trim());
+              localStorage.setItem(STATION_TYPE_STORAGE, instrumentType.trim());
+              setDeviceKey(keyInput.trim());
+            }}
+            className="w-full rounded-lg bg-blue-600 px-4 py-3 font-semibold hover:bg-blue-700"
+          >
+            Start station
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Kiosk ───────────────────────────────────────────────────────────────────
+  return (
+    <div className="min-h-screen bg-slate-900 text-white flex flex-col">
+      <div className="flex items-center justify-between px-6 py-3 border-b border-slate-700">
+        <div className="font-bold text-lg">LumenAI · Borescope Station</div>
+        <div className="text-xs text-slate-400">
+          {instrumentType || "no type set"} ·{" "}
+          <button
+            className="underline"
+            onClick={() => {
+              const t = window.prompt("Station instrument type", instrumentType) ?? instrumentType;
+              setInstrumentType(t);
+              localStorage.setItem(STATION_TYPE_STORAGE, t.trim());
+            }}
+          >
+            change
+          </button>
+          {" · "}
+          <button className="underline" onClick={() => { localStorage.removeItem(DEVICE_KEY_STORAGE); setDeviceKey(""); }}>
+            setup
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-2 gap-4 p-4">
+        {/* Live feed */}
+        <div className="rounded-xl border border-slate-700 bg-black overflow-hidden flex items-center justify-center">
+          {camError ? (
+            <div className="p-6 text-center text-amber-300">
+              {camError}
+              <button onClick={startStream} className="ml-2 underline">Retry</button>
+            </div>
+          ) : (
+            <video ref={videoRef} autoPlay playsInline muted className="w-full h-full object-contain" />
+          )}
+        </div>
+
+        {/* Verdict / prompt */}
+        <div className="rounded-xl border border-slate-700 bg-slate-800 flex flex-col items-center justify-center p-6 text-center">
+          {result ? (
+            <>
+              <div className={`w-full rounded-xl py-8 text-4xl font-extrabold tracking-wide ${VERDICT_STYLE[result.verdict]}`}>
+                {result.verdict}
+              </div>
+              <div className="mt-6 grid grid-cols-3 gap-6 w-full">
+                <div><div className="text-xs text-slate-400">Score</div><div className="text-3xl font-bold">{result.score ?? "—"}</div></div>
+                <div><div className="text-xs text-slate-400">Risk</div><div className="text-2xl font-bold capitalize">{result.risk ?? "—"}</div></div>
+                <div><div className="text-xs text-slate-400">Cleaning</div><div className="text-sm font-medium">{result.cleaning ?? "—"}</div></div>
+              </div>
+              {result.action && <p className="mt-5 text-base text-slate-200">{result.action}</p>}
+              <button onClick={() => { setResult(null); focusScan(); }} className="mt-6 text-sm text-blue-300 underline">
+                Next instrument
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="text-2xl font-semibold text-slate-200">
+                {busy ? (status || "Working…") : "Scan the instrument barcode to inspect"}
+              </div>
+              <p className="mt-2 text-sm text-slate-400">{status && !busy ? status : "Position the lumen in the borescope, then scan."}</p>
+            </>
+          )}
+
+          {/* Hidden-ish scan field: a barcode gun types here + Enter. */}
+          <input
+            ref={scanRef}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                const v = (e.target as HTMLInputElement).value;
+                (e.target as HTMLInputElement).value = "";
+                handleScan(v);
+              }
+            }}
+            placeholder="Barcode"
+            className="mt-8 w-2/3 rounded-lg px-3 py-2 text-slate-900 text-center"
+          />
+          <input
+            value={techId}
+            onChange={(e) => setTechId(e.target.value)}
+            placeholder="Tech badge / ID (optional)"
+            className="mt-3 w-1/2 rounded-lg px-3 py-1.5 text-slate-900 text-center text-sm"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/render.yaml
+++ b/render.yaml
@@ -73,18 +73,20 @@ services:
     buildCommand: cd frontend && npm install && npm run build
     staticPublishPath: frontend/dist
     autoDeploy: true
-    # Never cache index.html so a redeploy's new asset hashes are picked up
-    # immediately (prevents stale-chunk white pages); cache hashed assets forever.
+    # Hashed assets are immutable and cached forever; every HTML document route
+    # is never cached so a redeploy's new asset hashes are picked up immediately.
+    # NOTE: header rules match the REQUEST path. Every SPA route (/login,
+    # /dashboard, baseline pages, …) serves index.html under its own path, so the
+    # no-cache rule MUST be a catch-all (/*) — covering only / and /index.html
+    # let /login cache a stale HTML that pointed at purged bundles → white page.
+    # /assets/* is listed first so hashed assets stay immutable.
     headers:
-      - path: /index.html
-        name: Cache-Control
-        value: no-cache, no-store, must-revalidate
-      - path: /
-        name: Cache-Control
-        value: no-cache, no-store, must-revalidate
       - path: /assets/*
         name: Cache-Control
         value: public, max-age=31536000, immutable
+      - path: /*
+        name: Cache-Control
+        value: no-cache, no-store, must-revalidate
     routes:
       - type: rewrite
         source: /dashboard


### PR DESCRIPTION
## Summary

Two related pieces of inspection-intelligence work on this branch.

### 1. Opt-in image retention + labeling pipeline
Foundation for training a real image-based model (the platform otherwise stores
only SHA-256 hashes). Env-gated (`RETAIN_INSPECTION_IMAGES`, **OFF by default**)
and consent-required; EXIF stripped on ingest; de-identified filenames. New
`/api/ml/*` routes for upload, list, byte download, labeling, two-reviewer
adjudication of critical classes, and gold-only dataset export. Role-gated and
audit-logged.

### 2. SPD risk-weighted scoring refinement
Turns generic KPI percentages into SPD-risk-weighted intelligence:
- **SPD risk weighting model** — each KPI + severity band maps to
  critical/high/low (blood visible/heavy, heavy rust, severe corrosion, crack,
  missing component, insulation damage → critical; debris, bone, moderate
  rust/corrosion, pitting → high; minor discoloration/wear → low).
- **Bioburden removed** as a standalone KPI; replaced by an **Overall Cleaning
  Assessment** derived from blood/bone/tissue/organic residue/debris.
- Added discoloration + structural-damage severity scales.
- **Override rule**: any present critical/high finding forces risk High/Critical
  regardless of numeric score.
- **Recommended-action rules**: PASS / MONITOR / SUPERVISOR REVIEW /
  REPROCESS-REMOVE.
- New response fields: `recommended_action`, `overall_cleaning_assessment`,
  `top_risk_drivers`, `severity_by_kpi`, `scoring_explanation`, plus
  `spd_risk` / `spd_risk_impact` per finding.
- **Frontend panel**: KPI cards show Probability · Severity · **SPD Risk Impact**;
  added Overall Cleaning Assessment, Top Risk Drivers, and a plain-language
  "Reason Score Changed" section.

### CI
Also fixes a pre-existing CI gap: `passlib` was missing from `requirements.txt`
(collection aborted), and pinned `bcrypt<4.0` for passlib 1.7.4 compatibility.

## Governance
Retention OFF by default + consent required + EXIF stripped; critical-class
two-reviewer rule; no causation language; `human_review_required` always true;
pilot-model labeling; no FDA claims.

## Validation
- [x] Backend: full suite **2179 passed, 2 skipped**
- [x] Frontend: `npm run build` clean
- [x] Lint clean
- [x] New tests: `test_spd_risk_weighting.py`, `test_image_retention_pipeline.py`,
  `test_ml_images_api.py`; updated panel-output assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)