### PR TITLE
fix(auth): add login guard — redirect unauthenticated users to /login

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,9 @@
 import "./index.css";
 import React, { Suspense, lazy } from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter, Routes, Route, Link, useLocation } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Link, Navigate, useLocation } from "react-router-dom";
 import { AppShell } from "@/components/layout/AppShell";
-import { AuthProvider } from "@/lib/auth";
+import { AuthProvider, useAuth } from "@/lib/auth";
 import { NotificationProvider } from "@/lib/notifications";
 import { Spinner } from "@/components/ui/spinner";
 
@@ -233,6 +233,17 @@ function NotFound() {
   );
 }
 
+// ─── Auth guard — redirects unauthenticated users to /login ──────────────────
+
+function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { token } = useAuth();
+  const loc = useLocation();
+  if (!token) {
+    return <Navigate to="/login" state={{ from: loc.pathname }} replace />;
+  }
+  return <>{children}</>;
+}
+
 // ─── App ──────────────────────────────────────────────────────────────────────
 
 function App() {
@@ -254,10 +265,11 @@ function App() {
                 }
               />
 
-              {/* All app routes inside AppShell */}
+              {/* All app routes inside AppShell — require authentication */}
               <Route
                 path="/*"
                 element={
+                  <RequireAuth>
                   <AppShell>
                     <Routes>
                       <Route path="/" element={<Page name="Dashboard"><Dashboard /></Page>} />
@@ -315,6 +327,7 @@ function App() {
                       <Route path="*" element={<NotFound />} />
                     </Routes>
                   </AppShell>
+                  </RequireAuth>
                 }
               />
             </Routes>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,10 +1,14 @@
 import { useState, FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation, Navigate } from "react-router-dom";
 import { useAuth, API_BASE } from "@/lib/auth";
 
 export default function LoginPage() {
-  const { setAuth } = useAuth();
+  const { token, setAuth } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as { from?: string })?.from || "/";
+
+  if (token) return <Navigate to={from} replace />;
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -46,7 +50,7 @@ export default function LoginPage() {
         actor: email,
       });
 
-      navigate("/", { replace: true });
+      navigate(from, { replace: true });
     } catch {
       setError("Unable to reach the server. Please check your connection and try again.");
     } finally {

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, FormEvent, useCallback, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useAuth, API_BASE } from "@/lib/auth";
 import { FormSection } from "@/components/ui/FormSection";
 import { RequiredLabel, FieldError } from "@/components/ui/RequiredField";
@@ -129,6 +129,7 @@ const initialForm: FormFields = {
 
 export default function NewInspectionPage() {
   const { headers } = useAuth();
+  const navigate = useNavigate();
   const [form, setForm] = useState<FormFields>(initialForm);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [inspectionImages, setInspectionImages] = useState<File[]>([]);
@@ -322,7 +323,8 @@ export default function NewInspectionPage() {
       });
 
       if (res.status === 401 || res.status === 403) {
-        setBanner({ type: "error", message: "Access denied. Please log in again." });
+        localStorage.removeItem("token");
+        navigate("/login", { replace: true });
         return;
       }
       if (!res.ok) {


### PR DESCRIPTION
## Summary

- `RequireAuth` wraps all protected routes — unauthenticated users are redirected to `/login` with their destination preserved
- `LoginPage` skips the login form and redirects already-authenticated users back to where they came from
- `NewInspectionPage` navigates to `/login` on 401/403 (clears stale token) instead of showing a dead-end "Access denied" banner

## Test plan
- [ ] Open the app while not logged in → redirected to `/login`
- [ ] Log in → lands on the originally requested page (or `/`)
- [ ] Visit `/login` while already logged in → redirected to `/`
- [ ] Submit inspection with expired token → redirected to `/login`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_