### PR TITLE
feat(inspection): complete AI analysis output with baseline-comparison scoring

### DIFF
--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -12,6 +12,7 @@ from app.deps import get_db
 from app.db import models
 from app.enterprise_auth import get_request_tenant_id, require_enterprise_auth
 from app.analytics.risk_engine import calculate_risk
+from app.services.baseline_comparison_scoring_service import analyze_inspection
 
 router = APIRouter(tags=["inspections"])
 
@@ -58,6 +59,9 @@ class InspectionCreate(BaseModel):
     tray_id: Optional[str] = Field(None, max_length=100)
     instrument_barcode: Optional[str] = Field(None, max_length=255)
     instrument_udi: Optional[str] = Field(None, max_length=255)
+    keydot_id: Optional[str] = Field(None, max_length=255)
+    # Technician-declared finding categories (optional — AI determines findings)
+    finding_categories: Optional[List[str]] = Field(None)
 
     @field_validator("instrument_type")
     @classmethod
@@ -106,17 +110,6 @@ class BaselineOverride(BaseModel):
         if v not in _ALLOWED_BASELINE_SOURCES:
             raise ValueError(f"baseline_source '{v}' not in allowed list: {sorted(_ALLOWED_BASELINE_SOURCES)}")
         return v
-
-
-def _check_manufacturer_baseline(db: Session, instrument_type: str, tenant_id: str) -> bool:
-    """Return True if an approved manufacturer baseline exists for instrument_type."""
-    from app.models.baseline_library import BaselineLibraryEntry
-    entry = db.query(BaselineLibraryEntry).filter(
-        BaselineLibraryEntry.instrument_category == instrument_type,
-        BaselineLibraryEntry.baseline_type == "manufacturer",
-        BaselineLibraryEntry.approval_status == "approved",
-    ).first()
-    return entry is not None
 
 
 def inspection_response(row: models.Inspection) -> dict:
@@ -194,18 +187,37 @@ async def create_inspection(
     material_type = body.material_type or "unknown"
     stain_detected = body.stain_detected if body.stain_detected is not None else False
 
-    # Baseline governance: check for approved manufacturer baseline when image present
-    baseline_found = False
+    # Baseline governance + AI analysis when an image is present.
     supervisor_review_required = False
     baseline_status = "not_checked"
     score_status = "pending"
     risk_score_val = 0
+    baseline_source_val: Optional[str] = None
+    analysis: Optional[dict] = None
+
+    # Clean declared findings — drop the "pending_ai_analysis" placeholder.
+    declared = [
+        c for c in (body.finding_categories or [])
+        if c and c != "pending_ai_analysis"
+    ]
 
     if body.has_image:
-        baseline_found = _check_manufacturer_baseline(db, body.instrument_type, tenant_id)
-        if baseline_found:
+        analysis = analyze_inspection(
+            db,
+            instrument_type=body.instrument_type,
+            tenant_id=tenant_id,
+            has_image=True,
+            image_sha256=body.image_sha256,
+            declared_findings=declared,
+            instrument_barcode=body.instrument_barcode,
+            instrument_udi=body.instrument_udi,
+            keydot_id=body.keydot_id,
+        )
+        if analysis["analysis_status"] == "completed":
             baseline_status = "approved_baseline_found"
-            risk_score_val = calculate_risk(detected_issue, conf_val)
+            baseline_source_val = analysis["baseline_source"]
+            # inspection_score is 0–100 quality; risk_score is 0–100 risk (inverse).
+            risk_score_val = 100 - int(analysis["inspection_score"])
             score_status = "scored"
         else:
             baseline_status = "no_approved_baseline"
@@ -228,7 +240,7 @@ async def create_inspection(
         status="pending" if not supervisor_review_required else "pending",
         instrument_type=body.instrument_type,
         detected_issue=detected_issue,
-        inference_mode="manual" if not body.has_image else "image_pending_baseline",
+        inference_mode="manual" if not body.has_image else "baseline_comparison_scoring",
         risk_score=risk_score_val,
         vendor_name=body.vendor_name or "unknown",
         site_name=body.site_name,
@@ -241,6 +253,7 @@ async def create_inspection(
         has_image=body.has_image,
         image_sha256=body.image_sha256,
         baseline_status=baseline_status,
+        baseline_source=baseline_source_val,
         score_status=score_status,
         supervisor_review_required=supervisor_review_required,
     )
@@ -260,7 +273,11 @@ async def create_inspection(
         resource_id=str(row.id),
     )
 
-    return inspection_response(row)
+    response = inspection_response(row)
+    if analysis is not None:
+        # Attach the full explainable AI analysis output (placeholder scoring).
+        response["analysis"] = analysis
+    return response
 
 
 class StatusUpdate(BaseModel):

--- a/backend/app/routes/p22_operations.py
+++ b/backend/app/routes/p22_operations.py
@@ -107,6 +107,7 @@ class StepIn(BaseModel):
              dependencies=[Depends(require_roles("admin", "manager"))])
 def create_workflow(request: Request, body: WorkflowIn = ...,
                     db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     if body.workflow_type not in _WORKFLOW_TYPES:
         raise HTTPException(400, f"workflow_type must be one of {_WORKFLOW_TYPES}")
     if body.priority not in _PRIORITIES:
@@ -124,6 +125,7 @@ def create_workflow(request: Request, body: WorkflowIn = ...,
 def list_workflows(request: Request,
                    workflow_type: Optional[str] = Query(None),
                    db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     q = db.query(OperationsWorkflow).filter_by(tenant_id=tenant_id, status="active")
     if workflow_type:
         q = q.filter_by(workflow_type=workflow_type)
@@ -138,6 +140,7 @@ def list_workflows(request: Request,
              dependencies=[Depends(require_roles("admin", "manager"))])
 def add_step(workflow_id: int, request: Request, body: StepIn = ...,
              db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     wf = db.query(OperationsWorkflow).filter_by(id=workflow_id, tenant_id=tenant_id).first()
     if not wf:
         raise HTTPException(404, "Workflow not found")
@@ -158,6 +161,7 @@ def add_step(workflow_id: int, request: Request, body: StepIn = ...,
 @router.get("/workflows/{workflow_id}/steps",
             dependencies=[Depends(require_roles("admin", "manager", "technician", "executive"))])
 def list_steps(workflow_id: int, request: Request, db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     wf = db.query(OperationsWorkflow).filter_by(id=workflow_id, tenant_id=tenant_id).first()
     if not wf:
         raise HTTPException(404, "Workflow not found")
@@ -190,6 +194,7 @@ class ApprovalIn(BaseModel):
              dependencies=[Depends(require_roles("admin", "manager", "technician"))])
 def execute_workflow(workflow_id: int, request: Request,
                      body: ExecutionIn = ..., db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     wf = db.query(OperationsWorkflow).filter_by(
         id=workflow_id, tenant_id=tenant_id, status="active").first()
     if not wf:
@@ -262,6 +267,7 @@ def execute_workflow(workflow_id: int, request: Request,
 def list_executions(request: Request,
                     status: Optional[str] = Query(None),
                     db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     q = db.query(WorkflowExecution).filter_by(tenant_id=tenant_id)
     if status:
         q = q.filter_by(status=status)
@@ -276,6 +282,7 @@ def list_executions(request: Request,
              dependencies=[Depends(require_roles("admin", "manager", "executive"))])
 def approve_execution(execution_id: int, request: Request,
                       body: ApprovalIn = ..., db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     ex = db.query(WorkflowExecution).filter_by(id=execution_id, tenant_id=tenant_id).first()
     if not ex:
         raise HTTPException(404, "Execution not found")
@@ -300,6 +307,7 @@ def approve_execution(execution_id: int, request: Request,
 def complete_step(execution_id: int, step_id: int, request: Request,
                   assignee_email: str = Query(...), outcome: str = Query(...),
                   notes: Optional[str] = Query(None), db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     ex = db.query(WorkflowExecution).filter_by(id=execution_id, tenant_id=tenant_id).first()
     if not ex:
         raise HTTPException(404, "Execution not found")
@@ -336,6 +344,7 @@ def complete_step(execution_id: int, step_id: int, request: Request,
 def escalate_execution(execution_id: int, request: Request,
                         escalated_by: str = Query(...), reason: str = Query(...),
                         db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     ex = db.query(WorkflowExecution).filter_by(id=execution_id, tenant_id=tenant_id).first()
     if not ex:
         raise HTTPException(404, "Execution not found")
@@ -369,6 +378,7 @@ class QueueItemIn(BaseModel):
              dependencies=[Depends(require_roles("admin", "manager", "technician"))])
 def add_queue_item(request: Request, body: QueueItemIn = ...,
                    db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     if body.queue_type not in _QUEUE_TYPES:
         raise HTTPException(400, f"queue_type must be one of {_QUEUE_TYPES}")
     if body.priority not in _PRIORITIES:
@@ -390,6 +400,7 @@ def list_queue_items(request: Request,
                      status: Optional[str] = Query(None),
                      priority: Optional[str] = Query(None),
                      db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     q = db.query(WorkQueueItem).filter_by(tenant_id=tenant_id)
     if queue_type:
         q = q.filter_by(queue_type=queue_type)
@@ -411,6 +422,7 @@ def list_queue_items(request: Request,
              dependencies=[Depends(require_roles("admin", "manager", "technician"))])
 def claim_queue_item(item_id: int, request: Request,
                      claimed_by: str = Query(...), db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     item = db.query(WorkQueueItem).filter_by(id=item_id, tenant_id=tenant_id).first()
     if not item:
         raise HTTPException(404, "Queue item not found")
@@ -431,6 +443,7 @@ def complete_queue_item(item_id: int, request: Request,
                          completed_by: str = Query(...),
                          notes: Optional[str] = Query(None),
                          db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     item = db.query(WorkQueueItem).filter_by(id=item_id, tenant_id=tenant_id).first()
     if not item:
         raise HTTPException(404, "Queue item not found")
@@ -450,6 +463,7 @@ def complete_queue_item(item_id: int, request: Request,
              dependencies=[Depends(require_roles("admin", "manager"))])
 def escalate_queue_item(item_id: int, request: Request,
                          escalated_by: str = Query(...), db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     item = db.query(WorkQueueItem).filter_by(id=item_id, tenant_id=tenant_id).first()
     if not item:
         raise HTTPException(404, "Queue item not found")
@@ -490,6 +504,7 @@ class RiskSnapshotIn(BaseModel):
              dependencies=[Depends(require_roles("admin", "executive"))])
 def create_snapshot(request: Request, body: RiskSnapshotIn = ...,
                     db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     if body.snapshot_type not in _SNAPSHOT_TYPES:
         raise HTTPException(400, f"snapshot_type must be one of {_SNAPSHOT_TYPES}")
     snap = OperationalRiskSnapshot(tenant_id=tenant_id, **body.model_dump())
@@ -507,6 +522,7 @@ def create_snapshot(request: Request, body: RiskSnapshotIn = ...,
 def list_snapshots(request: Request,
                    snapshot_type: Optional[str] = Query(None),
                    db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     q = db.query(OperationalRiskSnapshot).filter_by(tenant_id=tenant_id)
     if snapshot_type:
         q = q.filter_by(snapshot_type=snapshot_type)
@@ -522,6 +538,7 @@ def list_snapshots(request: Request,
             dependencies=[Depends(require_roles("admin", "executive", "manager"))])
 def get_dashboard(request: Request, db: Session = Depends(get_db)):
     """Live aggregate dashboard — derived from queue and execution state."""
+    tenant_id = get_request_tenant_id(request)
     open_items = db.query(WorkQueueItem).filter(
         WorkQueueItem.tenant_id == tenant_id,
         WorkQueueItem.status.in_(("open", "claimed", "in_progress")),
@@ -658,6 +675,7 @@ def scan_step_timeouts(request: Request, db: Session = Depends(get_db)):
       skip     — mark step completed with outcome=skipped
       block    — leave step pending; mark execution escalated for human review
     """
+    tenant_id = get_request_tenant_id(request)
     now = datetime.now(timezone.utc)
     processed = []
 
@@ -712,6 +730,7 @@ def scan_step_timeouts(request: Request, db: Session = Depends(get_db)):
              dependencies=[Depends(require_roles("admin", "manager", "executive"))])
 def submit_copilot_query(request: Request, body: CopilotQueryIn = ...,
                           db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     if body.query_type not in _QUERY_TYPES:
         raise HTTPException(400, f"query_type must be one of {_QUERY_TYPES}")
 
@@ -765,6 +784,7 @@ def submit_copilot_query(request: Request, body: CopilotQueryIn = ...,
 def list_recommendations(request: Request,
                           review_status: Optional[str] = Query(None),
                           db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     q = db.query(CopilotRecommendation).filter_by(tenant_id=tenant_id)
     if review_status:
         q = q.filter_by(review_status=review_status)
@@ -781,6 +801,7 @@ def list_recommendations(request: Request,
 def review_recommendation(rec_id: int, request: Request,
                             body: RecommendationReviewIn = ...,
                             db: Session = Depends(get_db)):
+    tenant_id = get_request_tenant_id(request)
     if body.review_status not in _REVIEW_STATUSES:
         raise HTTPException(400, f"review_status must be one of {_REVIEW_STATUSES}")
     rec = db.query(CopilotRecommendation).filter_by(id=rec_id, tenant_id=tenant_id).first()

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -1,0 +1,262 @@
+"""Baseline Comparison Scoring Service.
+
+⚠️  THIS IS A DETERMINISTIC PLACEHOLDER — NOT PRODUCTION COMPUTER VISION.
+
+This service produces a structured, explainable inspection analysis using:
+  - baseline presence/resolution (manufacturer → vendor → hospital)
+  - image metadata (SHA-256 hash as a stable deterministic seed)
+  - technician-declared / demo finding indicators
+  - safe heuristic scoring rules
+
+It exists so the end-to-end inspection workflow (upload → analyze → score →
+display) functions before a real computer-vision model is integrated. The
+response shape is intentionally identical to the future real-AI response so
+the model can be swapped in without changing the API contract or frontend.
+
+Governance:
+  - No causation language; findings are "potential" / "possible".
+  - When no approved baseline exists, NO final score is generated and the
+    result is flagged supervisor_review_required.
+  - human_review_required is always True on every output.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+# Baseline resolution order — most authoritative first.
+BASELINE_PRIORITY = ["manufacturer", "vendor", "hospital"]
+
+# KPI categories the analysis reports on.
+CONTAMINATION_KPIS = ["blood", "bone", "tissue", "bioburden", "debris", "other_organic_residue"]
+CONDITION_KPIS = ["rust", "discoloration", "corrosion", "pitting", "crack", "insulation_damage", "missing_component"]
+
+# Map technician-declared finding_categories onto KPI keys.
+_DECLARED_TO_KPI = {
+    "blood": "blood",
+    "bone": "bone",
+    "tissue": "tissue",
+    "debris": "debris",
+    "corrosion": "corrosion",
+    "crack": "crack",
+    "insulation_damage": "insulation_damage",
+    "other": "other_organic_residue",
+}
+
+# Per-KPI risk weight (how much a positive finding deducts from the score).
+_KPI_WEIGHT = {
+    "blood": 28, "bone": 24, "tissue": 24, "bioburden": 20,
+    "debris": 16, "other_organic_residue": 10,
+    "rust": 14, "discoloration": 8, "corrosion": 22, "pitting": 16,
+    "crack": 30, "insulation_damage": 30, "missing_component": 26,
+}
+
+
+def _seed_from(image_sha256: Optional[str], fallback: str) -> int:
+    """Stable integer seed so the same image always scores the same."""
+    basis = image_sha256 or hashlib.sha256(fallback.encode()).hexdigest()
+    return int(basis[:8], 16)
+
+
+def _pseudo(seed: int, salt: int) -> float:
+    """Deterministic pseudo-value in [0, 1) derived from seed + salt.
+
+    Uses SHA-256 of the combined inputs — stable across runs/machines,
+    unlike Python's hash().
+    """
+    h = hashlib.sha256(f"{seed}:{salt}".encode()).hexdigest()
+    return int(h[:8], 16) / 0xFFFFFFFF
+
+
+def resolve_baseline(db: Session, instrument_type: str, tenant_id: str) -> dict[str, Any]:
+    """Resolve the most authoritative approved baseline for an instrument.
+
+    Checks manufacturer → vendor → hospital. Returns the first approved match.
+    """
+    from app.models.baseline_library import BaselineLibraryEntry
+
+    for source in BASELINE_PRIORITY:
+        entry = (
+            db.query(BaselineLibraryEntry)
+            .filter(
+                BaselineLibraryEntry.instrument_category == instrument_type,
+                BaselineLibraryEntry.baseline_type == source,
+                BaselineLibraryEntry.approval_status == "approved",
+            )
+            .first()
+        )
+        if entry is not None:
+            return {
+                "baseline_found": True,
+                "baseline_source": source,
+                "baseline_entry_id": entry.id,
+                "baseline_version": entry.baseline_version,
+            }
+
+    return {
+        "baseline_found": False,
+        "baseline_source": None,
+        "baseline_entry_id": None,
+        "baseline_version": None,
+    }
+
+
+def _severity(probability: float) -> str:
+    if probability >= 0.6:
+        return "high"
+    if probability >= 0.3:
+        return "medium"
+    if probability >= 0.1:
+        return "low"
+    return "none"
+
+
+def _risk_level(score: int) -> str:
+    if score >= 85:
+        return "low"
+    if score >= 65:
+        return "medium"
+    if score >= 40:
+        return "high"
+    return "critical"
+
+
+def analyze_inspection(
+    db: Session,
+    *,
+    instrument_type: str,
+    tenant_id: str,
+    has_image: bool,
+    image_sha256: Optional[str] = None,
+    declared_findings: Optional[list[str]] = None,
+    instrument_barcode: Optional[str] = None,
+    instrument_udi: Optional[str] = None,
+    keydot_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Run the deterministic baseline-comparison analysis.
+
+    Returns the explainable analysis payload. When no approved baseline is
+    found, returns analysis_status="supervisor_review_required" with NO final
+    score, per governance rules.
+    """
+    declared = {
+        _DECLARED_TO_KPI[c]
+        for c in (declared_findings or [])
+        if c in _DECLARED_TO_KPI
+    }
+
+    resolution = resolve_baseline(db, instrument_type, tenant_id)
+
+    # ── Governance gate: no approved baseline → no final score ──────────────
+    if not resolution["baseline_found"]:
+        return {
+            "analysis_status": "supervisor_review_required",
+            "baseline_source": None,
+            "baseline_match_score": None,
+            "baseline_deviation_score": None,
+            "inspection_score": None,
+            "risk_level": None,
+            "predicted_findings": [],
+            "kpi_summary": {},
+            "identification": {},
+            "recommendation": (
+                "No approved baseline found. Supervisor review required before final scoring."
+            ),
+            "message": "No approved baseline found. Supervisor review required before final scoring.",
+            "human_review_required": True,
+            "placeholder_scoring": True,
+        }
+
+    seed = _seed_from(image_sha256, f"{instrument_type}:{instrument_barcode or ''}")
+
+    # ── KPI detection (contamination + condition) ───────────────────────────
+    kpi_summary: dict[str, bool] = {}
+    predicted_findings: list[dict[str, Any]] = []
+
+    for idx, kpi in enumerate(CONTAMINATION_KPIS + CONDITION_KPIS):
+        base = _pseudo(seed, idx)
+        if kpi in declared:
+            # Technician declared this finding — high probability.
+            probability = round(0.55 + base * 0.40, 2)
+            confidence = round(0.80 + base * 0.18, 2)
+        else:
+            # Low baseline probability from deterministic heuristic.
+            probability = round(base * 0.12, 2)
+            confidence = round(0.70 + base * 0.25, 2)
+
+        present = probability >= 0.5
+        kpi_summary[kpi] = present
+        predicted_findings.append({
+            "type": kpi,
+            "probability": probability,
+            "confidence": confidence,
+            "severity": _severity(probability),
+        })
+
+    # ── Identification detection / match ────────────────────────────────────
+    identification = {
+        "barcode_detected": bool(instrument_barcode),
+        "qr_udi_detected": bool(instrument_udi),
+        "keydot_detected": bool(keydot_id),
+        # Placeholder: a detected identifier is treated as a match against the
+        # resolved baseline. Real CV will compare decoded values.
+        "barcode_match": bool(instrument_barcode),
+        "qr_udi_match": bool(instrument_udi),
+        "keydot_match": bool(keydot_id),
+    }
+
+    # ── Baseline match / deviation ──────────────────────────────────────────
+    # Deviation grows with declared/positive findings; match is its complement.
+    deviation_seed = _pseudo(seed, 999)
+    positive_count = sum(1 for v in kpi_summary.values() if v)
+    deviation = min(0.04 + deviation_seed * 0.06 + positive_count * 0.08, 0.95)
+    baseline_match_score = round(1.0 - deviation, 2)
+    baseline_deviation_score = round(deviation, 2)
+
+    # ── Inspection score ────────────────────────────────────────────────────
+    # Start from baseline match, deduct weighted KPI penalties, add a small
+    # identification-match bonus.
+    score = baseline_match_score * 100.0
+    for kpi, present in kpi_summary.items():
+        if present:
+            finding = next(f for f in predicted_findings if f["type"] == kpi)
+            score -= _KPI_WEIGHT.get(kpi, 10) * finding["probability"]
+
+    id_matches = sum(
+        1 for k in ("barcode_match", "qr_udi_match", "keydot_match") if identification[k]
+    )
+    score += id_matches * 2.0
+    inspection_score = max(0, min(100, round(score)))
+    risk_level = _risk_level(inspection_score)
+
+    # ── Recommendation (no causation language) ──────────────────────────────
+    flagged = [k.replace("_", " ") for k, v in kpi_summary.items() if v]
+    if not flagged:
+        recommendation = "Accept inspection. No findings above threshold; routine processing recommended."
+    elif risk_level in ("high", "critical"):
+        recommendation = (
+            f"Quality review recommended. Possible {', '.join(flagged)} — "
+            "hold instrument for supervisor review before release."
+        )
+    else:
+        recommendation = (
+            f"Accept inspection with supervisor review of {', '.join(flagged)} finding(s)."
+        )
+
+    return {
+        "analysis_status": "completed",
+        "baseline_source": resolution["baseline_source"],
+        "baseline_version": resolution["baseline_version"],
+        "baseline_match_score": baseline_match_score,
+        "baseline_deviation_score": baseline_deviation_score,
+        "inspection_score": inspection_score,
+        "risk_level": risk_level,
+        "predicted_findings": predicted_findings,
+        "kpi_summary": kpi_summary,
+        "identification": identification,
+        "recommendation": recommendation,
+        "human_review_required": True,
+        "placeholder_scoring": True,
+    }

--- a/backend/tests/test_baseline_comparison_scoring.py
+++ b/backend/tests/test_baseline_comparison_scoring.py
@@ -1,0 +1,273 @@
+"""Tests for the baseline_comparison_scoring_service and AI analysis output.
+
+Covers:
+  - manufacturer baseline used first
+  - vendor baseline fallback
+  - hospital baseline fallback
+  - missing baseline requires supervisor review (no score)
+  - rust / discoloration KPIs returned
+  - blood / bone / tissue / debris KPIs returned
+  - inspection_score + risk_level returned
+  - explainable response shape
+"""
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import (
+    analyze_inspection,
+    resolve_baseline,
+)
+
+client = TestClient(app)
+
+AUTH_TECH = {"Authorization": "Bearer viewer-token"}
+
+# Deterministic 64-char hex sha256 used to seed scoring.
+SHA = "a1b2c3d4" + "0" * 56
+
+
+def _add_baseline(instrument_type: str, baseline_type: str, status: str = "approved") -> int:
+    db = SessionLocal()
+    try:
+        entry = BaselineLibraryEntry(
+            udi=f"udi-{instrument_type}-{baseline_type}",
+            instrument_category=instrument_type,
+            manufacturer_name="TestMfg",
+            model_name="Model-X",
+            baseline_type=baseline_type,
+            approval_status=status,
+        )
+        db.add(entry)
+        db.commit()
+        return entry.id
+    finally:
+        db.close()
+
+
+def _clear_baselines(instrument_type: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == instrument_type,
+        ).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+# ── Baseline resolution priority ────────────────────────────────────────────
+
+class TestBaselineResolution:
+    def test_manufacturer_used_first(self):
+        itype = "needle_holder"
+        _clear_baselines(itype)
+        _add_baseline(itype, "manufacturer")
+        _add_baseline(itype, "vendor")
+        db = SessionLocal()
+        try:
+            res = resolve_baseline(db, itype, "default-tenant")
+        finally:
+            db.close()
+        assert res["baseline_found"] is True
+        assert res["baseline_source"] == "manufacturer"
+
+    def test_vendor_fallback_when_no_manufacturer(self):
+        itype = "trocar"
+        _clear_baselines(itype)
+        _add_baseline(itype, "vendor")
+        db = SessionLocal()
+        try:
+            res = resolve_baseline(db, itype, "default-tenant")
+        finally:
+            db.close()
+        assert res["baseline_source"] == "vendor"
+
+    def test_hospital_fallback_when_no_manufacturer_or_vendor(self):
+        itype = "stapler"
+        _clear_baselines(itype)
+        _add_baseline(itype, "hospital")
+        db = SessionLocal()
+        try:
+            res = resolve_baseline(db, itype, "default-tenant")
+        finally:
+            db.close()
+        assert res["baseline_source"] == "hospital"
+
+    def test_missing_baseline_not_found(self):
+        itype = "clip_applier"
+        _clear_baselines(itype)
+        db = SessionLocal()
+        try:
+            res = resolve_baseline(db, itype, "default-tenant")
+        finally:
+            db.close()
+        assert res["baseline_found"] is False
+        assert res["baseline_source"] is None
+
+
+# ── Analysis output ─────────────────────────────────────────────────────────
+
+class TestAnalysisOutput:
+    def test_missing_baseline_requires_supervisor_review(self):
+        itype = "clip_applier"
+        _clear_baselines(itype)
+        db = SessionLocal()
+        try:
+            out = analyze_inspection(
+                db, instrument_type=itype, tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+            )
+        finally:
+            db.close()
+        assert out["analysis_status"] == "supervisor_review_required"
+        assert out["inspection_score"] is None
+        assert out["risk_level"] is None
+        assert "Supervisor review required" in out["recommendation"]
+        assert out["human_review_required"] is True
+
+    def test_completed_analysis_returns_score_and_risk(self):
+        itype = "scissors"
+        _clear_baselines(itype)
+        _add_baseline(itype, "manufacturer")
+        db = SessionLocal()
+        try:
+            out = analyze_inspection(
+                db, instrument_type=itype, tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+            )
+        finally:
+            db.close()
+        assert out["analysis_status"] == "completed"
+        assert out["baseline_source"] == "manufacturer"
+        assert isinstance(out["inspection_score"], int)
+        assert 0 <= out["inspection_score"] <= 100
+        assert out["risk_level"] in ("low", "medium", "high", "critical")
+        assert 0.0 <= out["baseline_match_score"] <= 1.0
+        assert 0.0 <= out["baseline_deviation_score"] <= 1.0
+
+    def test_kpi_summary_includes_all_categories(self):
+        itype = "scissors"
+        _clear_baselines(itype)
+        _add_baseline(itype, "manufacturer")
+        db = SessionLocal()
+        try:
+            out = analyze_inspection(
+                db, instrument_type=itype, tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+            )
+        finally:
+            db.close()
+        for kpi in ("blood", "bone", "tissue", "debris", "rust", "discoloration", "corrosion", "crack"):
+            assert kpi in out["kpi_summary"]
+
+    def test_rust_kpi_returned_when_declared(self):
+        # "corrosion" declared maps to corrosion; rust is a separate condition KPI
+        # that is always reported. Verify rust is present in predicted_findings.
+        itype = "forceps"
+        _clear_baselines(itype)
+        _add_baseline(itype, "manufacturer")
+        db = SessionLocal()
+        try:
+            out = analyze_inspection(
+                db, instrument_type=itype, tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+            )
+        finally:
+            db.close()
+        types = {f["type"] for f in out["predicted_findings"]}
+        assert "rust" in types
+        assert "discoloration" in types
+
+    def test_declared_blood_raises_blood_kpi(self):
+        itype = "retractor"
+        _clear_baselines(itype)
+        _add_baseline(itype, "manufacturer")
+        db = SessionLocal()
+        try:
+            out = analyze_inspection(
+                db, instrument_type=itype, tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+                declared_findings=["blood", "bone", "tissue", "debris"],
+            )
+        finally:
+            db.close()
+        assert out["kpi_summary"]["blood"] is True
+        assert out["kpi_summary"]["bone"] is True
+        assert out["kpi_summary"]["tissue"] is True
+        assert out["kpi_summary"]["debris"] is True
+
+    def test_identification_match_reported(self):
+        itype = "scissors"
+        _clear_baselines(itype)
+        _add_baseline(itype, "manufacturer")
+        db = SessionLocal()
+        try:
+            out = analyze_inspection(
+                db, instrument_type=itype, tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+                instrument_barcode="BC123", instrument_udi="UDI456", keydot_id="KD789",
+            )
+        finally:
+            db.close()
+        ident = out["identification"]
+        assert ident["barcode_detected"] is True
+        assert ident["qr_udi_detected"] is True
+        assert ident["keydot_detected"] is True
+        assert ident["barcode_match"] is True
+
+
+# ── End-to-end via API ──────────────────────────────────────────────────────
+
+class TestInspectionApiAnalysis:
+    def test_api_returns_analysis_when_baseline_exists(self):
+        itype = "scissors"
+        _clear_baselines(itype)
+        _add_baseline(itype, "manufacturer")
+        resp = client.post("/api/inspections", json={
+            "instrument_type": itype,
+            "site_name": "Test Hospital",
+            "has_image": True,
+            "image_sha256": SHA,
+            "file_name": "img.jpg",
+        }, headers=AUTH_TECH)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert "analysis" in data
+        assert data["analysis"]["analysis_status"] == "completed"
+        assert data["analysis"]["inspection_score"] is not None
+        assert data["analysis"]["risk_level"] in ("low", "medium", "high", "critical")
+        assert data["baseline_source"] == "manufacturer"
+
+    def test_api_supervisor_review_when_no_baseline(self):
+        itype = "clip_applier"
+        _clear_baselines(itype)
+        resp = client.post("/api/inspections", json={
+            "instrument_type": itype,
+            "site_name": "Test Hospital",
+            "has_image": True,
+            "image_sha256": SHA,
+            "file_name": "img.jpg",
+        }, headers=AUTH_TECH)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["supervisor_review_required"] is True
+        assert data["analysis"]["analysis_status"] == "supervisor_review_required"
+        assert data["analysis"]["inspection_score"] is None
+
+    def test_api_vendor_baseline_fallback(self):
+        itype = "trocar"
+        _clear_baselines(itype)
+        _add_baseline(itype, "vendor")
+        resp = client.post("/api/inspections", json={
+            "instrument_type": itype,
+            "site_name": "Test Hospital",
+            "has_image": True,
+            "image_sha256": SHA,
+            "file_name": "img.jpg",
+        }, headers=AUTH_TECH)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["baseline_source"] == "vendor"
+        assert data["analysis"]["baseline_source"] == "vendor"

--- a/backend/tests/test_p22_operations.py
+++ b/backend/tests/test_p22_operations.py
@@ -900,10 +900,11 @@ def test_copilot_action_mentions_escalated_and_overdue():
 
 def test_scan_timeouts_no_timeouts_returns_zero():
     """Scanning a tenant with no overdue steps returns zero processed."""
+    # Tenant is now derived from the auth context (X-LumenAI-Tenant-Id),
+    # not a caller-supplied query param. Route the clean tenant via header.
     r = client.post(
         "/api/operations/executions/scan-timeouts",
-        params={"tenant_id": f"p22-clean-{TS}"},
-        headers=HEADERS,
+        headers={**HEADERS, "X-LumenAI-Tenant-Id": f"p22-clean-{TS}"},
     )
     assert r.status_code == 200
     data = r.json()

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -33,6 +33,28 @@ type FormFields = {
 
 type FieldErrors = Partial<Record<keyof FormFields | "images", string>>;
 
+type PredictedFinding = {
+  type: string;
+  probability: number;
+  confidence: number;
+  severity: string;
+};
+
+type Analysis = {
+  analysis_status: string;
+  baseline_source: string | null;
+  baseline_match_score: number | null;
+  baseline_deviation_score: number | null;
+  inspection_score: number | null;
+  risk_level: string | null;
+  predicted_findings: PredictedFinding[];
+  kpi_summary: Record<string, boolean>;
+  identification: Record<string, boolean>;
+  recommendation: string;
+  human_review_required: boolean;
+  placeholder_scoring?: boolean;
+};
+
 type AIPrediction = {
   id: string;
   risk_score: number;
@@ -43,6 +65,7 @@ type AIPrediction = {
   detected_issue: string;
   confidence: number;
   instrument_type: string;
+  analysis: Analysis | null;
 };
 
 // ─── constants ────────────────────────────────────────────────────────────────
@@ -291,6 +314,7 @@ export default function NewInspectionPage() {
         tray_id: form.tray_id || undefined,
         instrument_barcode: form.barcode || undefined,
         instrument_udi: form.udi || undefined,
+        keydot_id: form.keydot_id || undefined,
         file_name: allImages[0]?.name || "inspection_image",
         has_image: true,
         image_sha256: imageSha256,
@@ -345,6 +369,7 @@ export default function NewInspectionPage() {
         detected_issue: data.detected_issue ?? "unknown",
         confidence: data.confidence ?? 0,
         instrument_type: data.instrument_type ?? form.instrument_type,
+        analysis: data.analysis ?? null,
       });
 
       setBanner({
@@ -812,6 +837,11 @@ function AIPredictionPanel({
           } />
         </div>
 
+        {/* Full AI analysis output (placeholder scoring service) */}
+        {prediction.analysis && prediction.analysis.analysis_status === "completed" && (
+          <AnalysisDetails analysis={prediction.analysis} />
+        )}
+
         <p className="text-xs text-slate-500">
           Human review required. All AI findings represent potential associations only — qualified clinician review is mandatory before any clinical action.
         </p>
@@ -887,6 +917,119 @@ function PredictionField({ label, value }: { label: string; value: string }) {
     <div className="flex flex-col">
       <span className="text-xs text-slate-500 font-medium">{label}</span>
       <span className="mt-1 text-sm font-semibold text-slate-800 capitalize">{value}</span>
+    </div>
+  );
+}
+
+// ─── sub-component: full AI analysis output ──────────────────────────────────
+
+const RISK_LEVEL_STYLE: Record<string, string> = {
+  low: "bg-emerald-100 text-emerald-800",
+  medium: "bg-amber-200 text-amber-900",
+  high: "bg-orange-500 text-white",
+  critical: "bg-red-600 text-white",
+};
+
+// KPI cards the analysis panel always surfaces (contamination + condition).
+const KPI_DISPLAY: { key: string; label: string }[] = [
+  { key: "blood", label: "Blood" },
+  { key: "bone", label: "Bone" },
+  { key: "tissue", label: "Tissue" },
+  { key: "bioburden", label: "Bioburden" },
+  { key: "debris", label: "Debris" },
+  { key: "rust", label: "Rust" },
+  { key: "discoloration", label: "Discoloration" },
+  { key: "corrosion", label: "Corrosion" },
+  { key: "pitting", label: "Pitting" },
+  { key: "crack", label: "Crack" },
+  { key: "insulation_damage", label: "Insulation Damage" },
+  { key: "missing_component", label: "Missing Component" },
+];
+
+function AnalysisDetails({ analysis }: { analysis: Analysis }) {
+  const score = analysis.inspection_score ?? 0;
+  const risk = analysis.risk_level ?? "unknown";
+  const matchPct = analysis.baseline_match_score != null
+    ? `${Math.round(analysis.baseline_match_score * 100)}%`
+    : "—";
+
+  return (
+    <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
+      {/* Score + risk + baseline headline */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="flex flex-col">
+          <span className="text-xs text-slate-500 font-medium">Inspection Score</span>
+          <span className="mt-1 text-2xl font-bold text-slate-900">{score}<span className="text-sm text-slate-400"> / 100</span></span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-xs text-slate-500 font-medium">Risk Level</span>
+          <span className={`mt-1 inline-flex w-fit items-center rounded-full px-2.5 py-1 text-sm font-bold capitalize ${RISK_LEVEL_STYLE[risk] ?? "bg-slate-200 text-slate-700"}`}>
+            {risk}
+          </span>
+        </div>
+        <PredictionField label="Baseline Source" value={analysis.baseline_source?.replace(/_/g, " ") ?? "—"} />
+        <PredictionField label="Baseline Match" value={matchPct} />
+      </div>
+
+      {/* KPI finding cards */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">KPI Findings</p>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          {KPI_DISPLAY.map(({ key, label }) => {
+            const present = analysis.kpi_summary[key] === true;
+            const finding = analysis.predicted_findings.find((f) => f.type === key);
+            return (
+              <div
+                key={key}
+                className={`flex items-center justify-between rounded-lg border px-3 py-2 text-sm ${
+                  present ? "border-red-300 bg-red-50" : "border-slate-200 bg-slate-50"
+                }`}
+              >
+                <span className="font-medium text-slate-700">{label}</span>
+                <span className="flex items-center gap-1.5">
+                  {finding && (
+                    <span className="text-xs text-slate-400">{Math.round(finding.probability * 100)}%</span>
+                  )}
+                  <span className={`inline-block h-2.5 w-2.5 rounded-full ${present ? "bg-red-500" : "bg-emerald-400"}`} />
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Identification */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">Identification</p>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {[
+            { key: "barcode_detected", label: "Barcode" },
+            { key: "qr_udi_detected", label: "QR / UDI" },
+            { key: "keydot_detected", label: "KeyDot" },
+          ].map(({ key, label }) => (
+            <span
+              key={key}
+              className={`rounded-full px-2.5 py-1 font-medium ${
+                analysis.identification[key] ? "bg-blue-100 text-blue-800" : "bg-slate-100 text-slate-500"
+              }`}
+            >
+              {label}: {analysis.identification[key] ? "detected" : "not detected"}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Recommended action */}
+      <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1">Recommended Action</p>
+        <p className="text-sm text-slate-700">{analysis.recommendation}</p>
+      </div>
+
+      {analysis.placeholder_scoring && (
+        <p className="text-xs text-slate-400 italic">
+          Scoring produced by deterministic baseline-comparison service (placeholder). Not production computer vision.
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Completes the inspection AI analysis output so "Run AI Analysis" returns the inspection score, risk level, baseline match, and KPI findings the UI expects.

A **deterministic placeholder scoring service** (`baseline_comparison_scoring_service`) is added. It is clearly named and documented as **not production computer vision** — it uses image metadata (SHA-256 as a stable seed), baseline presence/resolution, technician-declared finding indicators, and safe heuristics. Its response shape is identical to the planned real-AI response so the model can be swapped in without changing the API or frontend.

### Backend
- **`baseline_comparison_scoring_service.py`** (new)
  - `resolve_baseline`: manufacturer → vendor → hospital priority
  - Missing approved baseline → `analysis_status: supervisor_review_required`, **no final score**, message "No approved baseline found. Supervisor review required before final scoring."
  - KPI detection — contamination (blood/bone/tissue/bioburden/debris/other organic residue), instrument condition (rust/discoloration/corrosion/pitting/crack/insulation damage/missing component), identification (barcode/QR-UDI/KeyDot detected + match)
  - `baseline_match_score`, `baseline_deviation_score`, `inspection_score` (0–100), `risk_level` (low/medium/high/critical), `predicted_findings[]`, `kpi_summary`, `recommendation`
  - `human_review_required: true` on every output; no causation language
- **`inspections.py`**: `create_inspection` runs the analysis on image submissions, persists `baseline_source`, and returns the full `analysis` payload. No new DB columns added — avoids the Alembic migration requirement (analysis is computed and returned, governance fields reuse existing columns).
- Accepts `keydot_id` and `finding_categories` on `InspectionCreate`.

### Frontend
- `AIPredictionPanel` now renders: inspection score, risk level, baseline source, baseline match %, KPI finding cards (blood/bone/tissue/debris/rust/discoloration/corrosion/crack/…), identification chips, and recommended action.
- Sends `keydot_id`; handles both `completed` and `supervisor_review_required` states.

### Regression fix
- **`p22_operations.py`**: the prior tenant-isolation change (PR #38) updated function signatures to `request: Request` but a faulty regex never inserted the `tenant_id` extraction into the bodies, causing `NameError` at runtime. Inserted the extraction into all 21 handlers. (Caught by the full test run.)

## Validation
- `npm --prefix frontend run build` → ✅ clean
- `cd backend && python -m pytest tests -q` → ✅ **2081 passed**
- `ruff check` on changed files → ✅ clean

## Files changed
- `backend/app/services/baseline_comparison_scoring_service.py` (new)
- `backend/app/routes/inspections.py`
- `backend/app/routes/p22_operations.py`
- `backend/tests/test_baseline_comparison_scoring.py` (new, 13 tests)
- `backend/tests/test_p22_operations.py`
- `frontend/src/pages/NewInspectionPage.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_