### PR TITLE
fix(history): surface inspection results from the New Inspection workflow

### DIFF
--- a/backend/app/routes/history.py
+++ b/backend/app/routes/history.py
@@ -35,6 +35,19 @@ def inspection_response(row: models.Inspection) -> dict:
         "risk_score": row.risk_score,
         "vendor_name": row.vendor_name,
         "site_name": row.site_name,
+        # Inspection result fields so history shows what each run produced
+        "facility_name": row.facility_name,
+        "department": row.department,
+        "tray_id": row.tray_id,
+        "instrument_barcode": row.instrument_barcode,
+        "instrument_udi": row.instrument_udi,
+        "has_image": row.has_image,
+        "baseline_status": row.baseline_status,
+        "baseline_source": row.baseline_source,
+        "score_status": row.score_status,
+        "supervisor_review_required": row.supervisor_review_required,
+        # inspection_score is the inverse of risk_score (0-100 quality)
+        "inspection_score": (100 - row.risk_score) if row.score_status in ("scored", "scored_after_override") else None,
     }
 
 

--- a/backend/tests/test_history_inspection_results.py
+++ b/backend/tests/test_history_inspection_results.py
@@ -1,0 +1,110 @@
+"""History must surface inspections run via /api/inspections with their results.
+
+Regression: the Inspection History UI read a different table (EnterpriseFinding)
+than the New Inspection form wrote to (inspections), so runs never appeared.
+These tests pin the /api/history contract that the results panel depends on.
+"""
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+
+client = TestClient(app)
+
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+SHA = "f00dcafe" + "0" * 56
+
+
+def _add_baseline(instrument_type: str, baseline_type: str = "manufacturer") -> None:
+    db = SessionLocal()
+    try:
+        db.add(BaselineLibraryEntry(
+            udi=f"hist-udi-{instrument_type}-{baseline_type}",
+            instrument_category=instrument_type,
+            manufacturer_name="HistMfg",
+            model_name="Model-H",
+            baseline_type=baseline_type,
+            approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _create_inspection(instrument_type: str) -> int:
+    resp = client.post("/api/inspections", json={
+        "instrument_type": instrument_type,
+        "site_name": "History Hospital",
+        "facility_name": "History Hospital",
+        "has_image": True,
+        "image_sha256": SHA,
+        "file_name": "hist.jpg",
+    }, headers=AUTH_VIEWER)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+class TestHistoryShowsInspectionResults:
+    def test_run_inspection_appears_in_history(self):
+        itype = "needle_holder"
+        _add_baseline(itype)
+        inspection_id = _create_inspection(itype)
+
+        resp = client.get("/api/history?limit=100", headers=AUTH_ADMIN)
+        assert resp.status_code == 200, resp.text
+        items = resp.json()["items"]
+        ids = [it["id"] for it in items]
+        assert inspection_id in ids
+
+    def test_history_record_includes_result_fields(self):
+        itype = "scissors"
+        _add_baseline(itype)
+        inspection_id = _create_inspection(itype)
+
+        resp = client.get("/api/history?limit=100", headers=AUTH_ADMIN)
+        items = resp.json()["items"]
+        record = next(it for it in items if it["id"] == inspection_id)
+
+        # Result fields the history UI renders
+        for field in (
+            "inspection_score", "score_status", "baseline_status",
+            "baseline_source", "supervisor_review_required", "risk_score",
+            "facility_name", "instrument_type",
+        ):
+            assert field in record, f"missing {field}"
+
+        assert record["score_status"] == "scored"
+        assert record["baseline_source"] == "manufacturer"
+        assert record["inspection_score"] is not None
+        assert 0 <= record["inspection_score"] <= 100
+
+    def test_supervisor_review_record_has_no_score(self):
+        # No baseline → supervisor review, inspection_score should be None
+        itype = "clip_applier"
+        db = SessionLocal()
+        try:
+            db.query(BaselineLibraryEntry).filter(
+                BaselineLibraryEntry.instrument_category == itype,
+            ).delete()
+            db.commit()
+        finally:
+            db.close()
+
+        inspection_id = _create_inspection(itype)
+        resp = client.get("/api/history?limit=100", headers=AUTH_ADMIN)
+        record = next(it for it in resp.json()["items"] if it["id"] == inspection_id)
+        assert record["supervisor_review_required"] is True
+        assert record["inspection_score"] is None
+
+    def test_history_summary_counts_inspections(self):
+        itype = "forceps"
+        _add_baseline(itype)
+        _create_inspection(itype)
+
+        resp = client.get("/api/history/summary", headers=AUTH_ADMIN)
+        assert resp.status_code == 200, resp.text
+        summary = resp.json()
+        assert summary["total_inspections"] >= 1

--- a/frontend/src/components/InspectionResultsHistory.tsx
+++ b/frontend/src/components/InspectionResultsHistory.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useState } from "react";
+import { useAuth, API_BASE } from "@/lib/auth";
+
+type InspectionRecord = {
+  id: number;
+  created_at: string | null;
+  instrument_type: string;
+  facility_name: string | null;
+  site_name: string;
+  detected_issue: string;
+  risk_score: number;
+  inspection_score: number | null;
+  score_status: string;
+  baseline_status: string;
+  baseline_source: string | null;
+  supervisor_review_required: boolean;
+  has_image: boolean;
+  status: string;
+};
+
+function scoreColor(score: number | null): string {
+  if (score == null) return "bg-slate-100 text-slate-500";
+  if (score >= 85) return "bg-emerald-100 text-emerald-800";
+  if (score >= 65) return "bg-amber-100 text-amber-800";
+  if (score >= 40) return "bg-orange-100 text-orange-800";
+  return "bg-red-100 text-red-800";
+}
+
+function riskLabel(score: number | null): string {
+  if (score == null) return "—";
+  if (score >= 85) return "Low";
+  if (score >= 65) return "Medium";
+  if (score >= 40) return "High";
+  return "Critical";
+}
+
+export default function InspectionResultsHistory() {
+  const { headers } = useAuth();
+  const [items, setItems] = useState<InspectionRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(`${API_BASE}/api/history?limit=50`, { headers: headers() });
+      if (!res.ok) {
+        setError(`Failed to load inspection results (${res.status}).`);
+        setItems([]);
+        return;
+      }
+      const data = await res.json();
+      setItems(Array.isArray(data.items) ? data.items : []);
+    } catch {
+      setError("Unable to reach the server.");
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [headers]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white">
+      <div className="flex items-center justify-between border-b border-slate-100 px-5 py-3">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-900">Inspection Results</h3>
+          <p className="text-xs text-slate-500">Every inspection run through the New Inspection workflow, with its AI analysis result.</p>
+        </div>
+        <button
+          onClick={load}
+          className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading && (
+        <div className="px-5 py-10 text-center text-sm text-slate-400">Loading inspection results…</div>
+      )}
+
+      {!loading && error && (
+        <div className="px-5 py-6 text-center">
+          <p className="text-sm text-red-600">{error}</p>
+          <button onClick={load} className="mt-2 text-xs text-blue-600 underline">Try again</button>
+        </div>
+      )}
+
+      {!loading && !error && items.length === 0 && (
+        <div className="px-5 py-10 text-center text-sm text-slate-400">
+          No inspections have been run yet. Submit one from the New Inspection page.
+        </div>
+      )}
+
+      {!loading && !error && items.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 text-left text-xs uppercase tracking-wide text-slate-400">
+                <th className="px-5 py-2 font-medium">#</th>
+                <th className="px-5 py-2 font-medium">Date</th>
+                <th className="px-5 py-2 font-medium">Instrument</th>
+                <th className="px-5 py-2 font-medium">Facility</th>
+                <th className="px-5 py-2 font-medium">Score</th>
+                <th className="px-5 py-2 font-medium">Risk</th>
+                <th className="px-5 py-2 font-medium">Finding</th>
+                <th className="px-5 py-2 font-medium">Baseline</th>
+                <th className="px-5 py-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((r) => (
+                <tr key={r.id} className="border-b border-slate-50 hover:bg-slate-50/60">
+                  <td className="px-5 py-2.5 text-slate-500">{r.id}</td>
+                  <td className="px-5 py-2.5 text-slate-600 whitespace-nowrap">
+                    {r.created_at ? new Date(r.created_at).toLocaleString() : "—"}
+                  </td>
+                  <td className="px-5 py-2.5 capitalize text-slate-800">{r.instrument_type.replace(/_/g, " ")}</td>
+                  <td className="px-5 py-2.5 text-slate-600">{r.facility_name || r.site_name || "—"}</td>
+                  <td className="px-5 py-2.5">
+                    {r.supervisor_review_required ? (
+                      <span className="text-xs text-amber-600 italic">pending review</span>
+                    ) : (
+                      <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-bold ${scoreColor(r.inspection_score)}`}>
+                        {r.inspection_score ?? "—"}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-5 py-2.5 text-slate-700">
+                    {r.supervisor_review_required ? "—" : riskLabel(r.inspection_score)}
+                  </td>
+                  <td className="px-5 py-2.5 capitalize text-slate-600">
+                    {r.detected_issue === "unknown" || r.detected_issue === ""
+                      ? "AI analysis"
+                      : r.detected_issue.replace(/_/g, " ")}
+                  </td>
+                  <td className="px-5 py-2.5 capitalize text-slate-600">
+                    {r.baseline_source ? r.baseline_source.replace(/_/g, " ") : r.baseline_status.replace(/_/g, " ")}
+                  </td>
+                  <td className="px-5 py-2.5">
+                    {r.supervisor_review_required ? (
+                      <span className="inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+                        Supervisor review
+                      </span>
+                    ) : (
+                      <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 capitalize">
+                        {r.score_status.replace(/_/g, " ")}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/IntakeHistoryPage.tsx
+++ b/frontend/src/pages/IntakeHistoryPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { History, ChevronRight } from "lucide-react";
 import EnterpriseIntakeHistoryPanel from "../components/EnterpriseIntakeHistoryPanel";
+import InspectionResultsHistory from "../components/InspectionResultsHistory";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
 export default function IntakeHistoryPage() {
@@ -36,7 +37,10 @@ export default function IntakeHistoryPage() {
         </AlertDescription>
       </Alert>
 
-      {/* Component */}
+      {/* Inspection results from the New Inspection workflow */}
+      <InspectionResultsHistory />
+
+      {/* Enterprise governance intake history */}
       <EnterpriseIntakeHistoryPanel />
     </div>
   );


### PR DESCRIPTION
## Problem

Inspections run through the **New Inspection** workflow never appeared in **Inspection History**, and the dashboard couldn't surface their results.

**Root cause:** two disconnected systems.
- The New Inspection form writes to `/api/inspections` → the `inspections` table (where the AI analysis from #39 lives).
- The Inspection History page read `/api/enterprise/intake/history` → the `EnterpriseFinding` table (a completely separate governance-intake flow).

They never connected, so a technician's runs and their AI results were invisible in history.

## Fix

- **New `InspectionResultsHistory` component** reads `/api/history` (the correct table) and renders each run with: inspection score, risk level, finding, baseline source, and status. Supervisor-review records are shown distinctly (no score until reviewed).
- Added to the Inspection History page above the existing enterprise governance panel.
- **Enriched the `/api/history` response** with the result fields the UI needs: `inspection_score`, `score_status`, `baseline_status`, `baseline_source`, `supervisor_review_required`, facility/department/tray/identity, `has_image`. `inspection_score` is `100 - risk_score` for scored records, `null` while supervisor review is pending.

The dashboard's **Total Inspections** card already reads `/api/history/summary` (the correct table) — a new test pins that it counts runs, so once inspections exist it populates instead of showing "—".

## Validation
- `npm --prefix frontend run build` → ✅ clean
- `python -m pytest tests/ -k "history or inspection or baseline_comparison"` → ✅ 89 passed
- New tests: run-appears-in-history, result fields present, supervisor-review record has no score, summary counts inspections
- Full suite running.

## Files changed
- `backend/app/routes/history.py`
- `backend/tests/test_history_inspection_results.py` (new)
- `frontend/src/components/InspectionResultsHistory.tsx` (new)
- `frontend/src/pages/IntakeHistoryPage.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_