### PR TITLE
feat(baseline): clarify which baseline the AI comparison used (manufacturer primary, vendor fallback)

### DIFF
--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -29,6 +29,24 @@ from sqlalchemy.orm import Session
 # Baseline resolution order — most authoritative first.
 BASELINE_PRIORITY = ["manufacturer", "vendor", "hospital"]
 
+# Human-readable labels + role (manufacturer is the authoritative primary;
+# vendor and hospital are fallbacks used only when no manufacturer baseline
+# is approved). Surfaced so the UI can state exactly what was compared.
+BASELINE_LABELS = {
+    "manufacturer": "Manufacturer baseline",
+    "vendor": "Vendor baseline",
+    "hospital": "Hospital baseline",
+}
+
+
+def _baseline_role(source: str) -> str:
+    return "primary" if source == "manufacturer" else "fallback"
+
+
+def _baseline_comparison_label(source: str) -> str:
+    label = BASELINE_LABELS.get(source, source)
+    return label if source == "manufacturer" else f"{label} (fallback)"
+
 # KPI categories the analysis reports on.
 CONTAMINATION_KPIS = ["blood", "bone", "tissue", "bioburden", "debris", "other_organic_residue"]
 CONDITION_KPIS = ["rust", "discoloration", "corrosion", "pitting", "crack", "insulation_damage", "missing_component"]
@@ -245,9 +263,12 @@ def analyze_inspection(
             f"Accept inspection with supervisor review of {', '.join(flagged)} finding(s)."
         )
 
+    source = resolution["baseline_source"]
     return {
         "analysis_status": "completed",
-        "baseline_source": resolution["baseline_source"],
+        "baseline_source": source,
+        "baseline_role": _baseline_role(source),
+        "baseline_comparison_label": _baseline_comparison_label(source),
         "baseline_version": resolution["baseline_version"],
         "baseline_match_score": baseline_match_score,
         "baseline_deviation_score": baseline_deviation_score,

--- a/backend/tests/test_baseline_comparison_scoring.py
+++ b/backend/tests/test_baseline_comparison_scoring.py
@@ -141,6 +141,9 @@ class TestAnalysisOutput:
             db.close()
         assert out["analysis_status"] == "completed"
         assert out["baseline_source"] == "manufacturer"
+        # Manufacturer is the authoritative primary comparison
+        assert out["baseline_role"] == "primary"
+        assert out["baseline_comparison_label"] == "Manufacturer baseline"
         assert isinstance(out["inspection_score"], int)
         assert 0 <= out["inspection_score"] <= 100
         assert out["risk_level"] in ("low", "medium", "high", "critical")
@@ -271,3 +274,26 @@ class TestInspectionApiAnalysis:
         data = resp.json()
         assert data["baseline_source"] == "vendor"
         assert data["analysis"]["baseline_source"] == "vendor"
+        # Vendor is clearly labeled a fallback, not the primary comparison
+        assert data["analysis"]["baseline_role"] == "fallback"
+        assert data["analysis"]["baseline_comparison_label"] == "Vendor baseline (fallback)"
+
+    def test_manufacturer_preferred_over_vendor_for_comparison(self):
+        # Both exist → comparison must use manufacturer (primary), not vendor
+        itype = "scissors"
+        _clear_baselines(itype)
+        _add_baseline(itype, "vendor")
+        _add_baseline(itype, "manufacturer")
+        resp = client.post("/api/inspections", json={
+            "instrument_type": itype,
+            "site_name": "Test Hospital",
+            "has_image": True,
+            "image_sha256": SHA,
+            "file_name": "img.jpg",
+        }, headers=AUTH_TECH)
+        assert resp.status_code == 201, resp.text
+        analysis = resp.json()["analysis"]
+        assert analysis["baseline_source"] == "manufacturer"
+        assert analysis["baseline_role"] == "primary"
+        # Clean up so other suites that expect no scissors baseline aren't polluted
+        _clear_baselines(itype)

--- a/frontend/src/components/InspectionResultsHistory.tsx
+++ b/frontend/src/components/InspectionResultsHistory.tsx
@@ -137,7 +137,16 @@ export default function InspectionResultsHistory() {
                       : r.detected_issue.replace(/_/g, " ")}
                   </td>
                   <td className="px-5 py-2.5 capitalize text-slate-600">
-                    {r.baseline_source ? r.baseline_source.replace(/_/g, " ") : r.baseline_status.replace(/_/g, " ")}
+                    {r.baseline_source ? (
+                      <>
+                        {r.baseline_source.replace(/_/g, " ")}
+                        {r.baseline_source !== "manufacturer" && (
+                          <span className="ml-1 text-xs text-amber-600 normal-case">(fallback)</span>
+                        )}
+                      </>
+                    ) : (
+                      r.baseline_status.replace(/_/g, " ")
+                    )}
                   </td>
                   <td className="px-5 py-2.5">
                     {r.supervisor_review_required ? (

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -43,6 +43,8 @@ type PredictedFinding = {
 type Analysis = {
   analysis_status: string;
   baseline_source: string | null;
+  baseline_role?: string;
+  baseline_comparison_label?: string;
   baseline_match_score: number | null;
   baseline_deviation_score: number | null;
   inspection_score: number | null;
@@ -953,8 +955,27 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
     ? `${Math.round(analysis.baseline_match_score * 100)}%`
     : "—";
 
+  const comparisonLabel = analysis.baseline_comparison_label
+    ?? (analysis.baseline_source
+      ? `${analysis.baseline_source.replace(/_/g, " ")} baseline`
+      : "—");
+  const isFallback = analysis.baseline_role === "fallback";
+
   return (
     <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
+      {/* Which baseline was used for the comparison */}
+      <div className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+        isFallback ? "border-amber-300 bg-amber-50 text-amber-900" : "border-blue-200 bg-blue-50 text-blue-900"
+      }`}>
+        <span className="font-semibold">Compared against:</span>
+        <span className="capitalize">{comparisonLabel}</span>
+        {isFallback && (
+          <span className="text-xs text-amber-700">
+            — no approved manufacturer baseline; used fallback
+          </span>
+        )}
+      </div>
+
       {/* Score + risk + baseline headline */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <div className="flex flex-col">


### PR DESCRIPTION
## Context

You asked which baseline lumen-ai compares against, and whether manufacturer and vendor baselines are the same. After tracing the code:

- **lumen-ai compares against the manufacturer baseline first.** The scoring engine uses a strict priority: manufacturer → vendor → hospital, taking the first approved match. Vendor/hospital are only used as fallbacks when no approved manufacturer baseline exists.
- **They are not the same data.** Manufacturer baselines are the OEM reference; vendor baselines (`EnterpriseVendorBaselineSubscription`) are subscription-sourced records with extra fields (IFU reference, acceptable/unacceptable condition notes, subscription tier) and their own audit/governance trail.

Per your decision (**keep both, clarify the UI**), this PR makes the comparison source explicit instead of deleting anything.

## Changes
- Scoring service now returns `baseline_role` (`primary`/`fallback`) and `baseline_comparison_label` (e.g. "Manufacturer baseline", "Vendor baseline (fallback)").
- The inspection result panel shows a **"Compared against: …"** banner — blue for manufacturer (primary), amber for a fallback with a note that no manufacturer baseline was approved.
- Inspection History marks non-manufacturer sources as **"(fallback)"**.
- Tests: manufacturer is preferred over vendor when both exist; vendor is labeled a fallback; role/label assertions.

**No deletion** — the vendor baseline subscription/governance feature and its audit trail are untouched.

## Validation
- `npm --prefix frontend run build` → ✅ clean
- `ruff check` → ✅ clean
- Targeted tests (scoring + history + p26 governance) → ✅ 27 passed
- Full suite running.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_