### PR TITLE
fix(scoring): connect uploaded baselines to the AI comparison engine

### DIFF
--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -88,11 +88,12 @@ def _pseudo(seed: int, salt: int) -> float:
     return int(h[:8], 16) / 0xFFFFFFFF
 
 
-def resolve_baseline(db: Session, instrument_type: str, tenant_id: str) -> dict[str, Any]:
-    """Resolve the most authoritative approved baseline for an instrument.
+# Approval-status values that mean a baseline is cleared for scoring use.
+_APPROVED_VALUES = {"approved", "active", "vendor_approved", "hospital_approved"}
 
-    Checks manufacturer → vendor → hospital. Returns the first approved match.
-    """
+
+def _resolve_from_library(db: Session, instrument_type: str) -> dict[str, Any] | None:
+    """Check the network BaselineLibraryEntry table (manufacturer → vendor → hospital)."""
     from app.models.baseline_library import BaselineLibraryEntry
 
     for source in BASELINE_PRIORITY:
@@ -112,6 +113,82 @@ def resolve_baseline(db: Session, instrument_type: str, tenant_id: str) -> dict[
                 "baseline_entry_id": entry.id,
                 "baseline_version": entry.baseline_version,
             }
+    return None
+
+
+def _resolve_from_uploaded(db: Session, instrument_type: str) -> dict[str, Any] | None:
+    """Check the baselines users actually upload/approve through the UI.
+
+    The baseline upload + review workflow writes to
+    EnterpriseVendorBaselineSubscription (keyed by instrument_category /
+    instrument_name, with a per-record baseline_source of manufacturer /
+    vendor / hospital). Without this bridge, uploaded baselines are invisible
+    to the scoring engine and every image inspection falls through to
+    supervisor review.
+
+    Matches case-insensitively on instrument_category OR instrument_name and
+    only accepts records whose approval/baseline status is cleared for scoring.
+    Honours the manufacturer → vendor → hospital priority by source.
+    """
+    from sqlalchemy import func, or_
+    from app.models.enterprise_quality import EnterpriseVendorBaselineSubscription as Sub
+
+    needle = instrument_type.replace("_", " ").lower()
+
+    rows = (
+        db.query(Sub)
+        .filter(
+            or_(
+                func.lower(Sub.instrument_category) == instrument_type.lower(),
+                func.lower(Sub.instrument_category) == needle,
+                func.lower(Sub.instrument_name) == needle,
+            )
+        )
+        .all()
+    )
+
+    approved = [
+        r for r in rows
+        if (r.approval_status or "").lower() in _APPROVED_VALUES
+        or (r.baseline_status or "").lower() in _APPROVED_VALUES
+    ]
+    if not approved:
+        return None
+
+    # Pick by source priority: manufacturer first, then vendor, then hospital.
+    def _priority(r) -> int:
+        src = (r.baseline_source or "vendor").lower()
+        return BASELINE_PRIORITY.index(src) if src in BASELINE_PRIORITY else len(BASELINE_PRIORITY)
+
+    best = min(approved, key=_priority)
+    source = (best.baseline_source or "vendor").lower()
+    if source not in BASELINE_PRIORITY:
+        source = "vendor"
+    return {
+        "baseline_found": True,
+        "baseline_source": source,
+        "baseline_entry_id": best.id,
+        "baseline_version": best.baseline_version,
+    }
+
+
+def resolve_baseline(db: Session, instrument_type: str, tenant_id: str) -> dict[str, Any]:
+    """Resolve the most authoritative approved baseline for an instrument.
+
+    Looks in two places so the engine sees baselines wherever they live:
+      1. The network BaselineLibraryEntry table.
+      2. The EnterpriseVendorBaselineSubscription table that the baseline
+         upload + review UI actually populates.
+    Both honour manufacturer → vendor → hospital priority. Returns the first
+    approved match.
+    """
+    resolution = _resolve_from_library(db, instrument_type)
+    if resolution is not None:
+        return resolution
+
+    resolution = _resolve_from_uploaded(db, instrument_type)
+    if resolution is not None:
+        return resolution
 
     return {
         "baseline_found": False,

--- a/backend/tests/test_baseline_comparison_scoring.py
+++ b/backend/tests/test_baseline_comparison_scoring.py
@@ -57,6 +57,38 @@ def _clear_baselines(instrument_type: str) -> None:
         db.close()
 
 
+def _add_uploaded_baseline(instrument_type: str, baseline_source: str = "manufacturer",
+                           approval_status: str = "approved") -> int:
+    """Simulate a baseline uploaded + reviewed through the UI (vendor-subscription table)."""
+    from app.models.enterprise_quality import EnterpriseVendorBaselineSubscription
+    db = SessionLocal()
+    try:
+        row = EnterpriseVendorBaselineSubscription(
+            vendor_name="UI Upload",
+            instrument_name=instrument_type.replace("_", " "),
+            instrument_category=instrument_type,
+            baseline_source=baseline_source,
+            approval_status=approval_status,
+        )
+        db.add(row)
+        db.commit()
+        return row.id
+    finally:
+        db.close()
+
+
+def _clear_uploaded(instrument_type: str) -> None:
+    from app.models.enterprise_quality import EnterpriseVendorBaselineSubscription
+    db = SessionLocal()
+    try:
+        db.query(EnterpriseVendorBaselineSubscription).filter(
+            EnterpriseVendorBaselineSubscription.instrument_category == instrument_type,
+        ).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
 # ── Baseline resolution priority ────────────────────────────────────────────
 
 class TestBaselineResolution:
@@ -98,6 +130,7 @@ class TestBaselineResolution:
     def test_missing_baseline_not_found(self):
         itype = "clip_applier"
         _clear_baselines(itype)
+        _clear_uploaded(itype)
         db = SessionLocal()
         try:
             res = resolve_baseline(db, itype, "default-tenant")
@@ -105,6 +138,33 @@ class TestBaselineResolution:
             db.close()
         assert res["baseline_found"] is False
         assert res["baseline_source"] is None
+
+    def test_uploaded_approved_baseline_is_used(self):
+        # A baseline uploaded + approved through the UI (vendor-subscription
+        # table) must be visible to the scoring engine.
+        itype = "needle_holder"
+        _clear_baselines(itype)
+        _clear_uploaded(itype)
+        _add_uploaded_baseline(itype, baseline_source="manufacturer", approval_status="approved")
+        db = SessionLocal()
+        try:
+            res = resolve_baseline(db, itype, "default-tenant")
+        finally:
+            db.close()
+        assert res["baseline_found"] is True
+        assert res["baseline_source"] == "manufacturer"
+
+    def test_uploaded_unapproved_baseline_not_used(self):
+        itype = "stapler"
+        _clear_baselines(itype)
+        _clear_uploaded(itype)
+        _add_uploaded_baseline(itype, baseline_source="manufacturer", approval_status="pending_hospital_review")
+        db = SessionLocal()
+        try:
+            res = resolve_baseline(db, itype, "default-tenant")
+        finally:
+            db.close()
+        assert res["baseline_found"] is False
 
 
 # ── Analysis output ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem (from testing)

Uploading a manufacturer baseline + running an inspection produced **no score and no KPI detection**.

## Root cause

The baseline data lives in **disconnected tables**:
- The **scoring engine** (`resolve_baseline`) only read the network `BaselineLibraryEntry` table.
- The **baseline upload + review UI** writes to `EnterpriseVendorBaselineSubscription`.

They were never connected, so the engine never found the baseline you uploaded → it correctly fell through to "supervisor review required" with no score. The dashboard's **Approved Baselines: 0** confirms nothing was approved in the table the engine reads.

## Fix

`resolve_baseline` now checks **both** tables:
1. `BaselineLibraryEntry` (network library) — unchanged, checked first.
2. `EnterpriseVendorBaselineSubscription` (what the upload/review UI populates) — matched by `instrument_category` OR `instrument_name` (case-insensitive, underscore-normalized), honoring manufacturer → vendor → hospital priority.

The governance gate is preserved: only baselines cleared for scoring (`approved`/`active`/`vendor_approved`/`hospital_approved`) are used. An uploaded-but-unapproved baseline still yields supervisor review.

## To get a score after this deploys
1. Upload a baseline, entering an **instrument name that matches the inspection's instrument type** (e.g. "Laparoscopic Grasper" for `laparoscopic_grasper`).
2. **Approve** it (Baseline Reviews / Vendor portal) — this is the required governance step; that's why Approved Baselines was 0.
3. Run the inspection on the same instrument type → score + KPIs now populate.

## Validation
- `ruff check` → ✅ clean
- Targeted tests (scoring + history + p26) → ✅ 29 passed
- New tests: uploaded approved baseline is used; uploaded unapproved baseline is not; missing baseline unchanged
- Full suite running.

## Files changed
- `backend/app/services/baseline_comparison_scoring_service.py`
- `backend/tests/test_baseline_comparison_scoring.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_