### PR TITLE
feat(admin): founder admin bootstrap + user role management

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -7,7 +7,6 @@ from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
-from app.db import models
 
 _ENABLE_DEV_AUTH = os.getenv("ENABLE_DEV_AUTH", "false").strip().lower() in {"1", "true", "yes"}
 _APP_ENV = os.getenv("APP_ENV", "development").strip().lower()
@@ -91,15 +90,14 @@ def get_current_user(
     if payload:
         username = payload.get("sub")
         if username:
-            user = (
-                db.query(models.User)
-                .filter(models.User.username == username)
-                .first()
-            )
-            if user:
-                return user
-            # Return a namespace if user row doesn't exist but JWT is valid
-            return SimpleNamespace(id=0, email=username, role="viewer")
+            # Resolve the real role from the admin-managed assignment table
+            # (falls back to users.role, then viewer).
+            try:
+                from app.routers.auth_simple import _user_role
+                role = _user_role(username)
+            except Exception:
+                role = "viewer"
+            return SimpleNamespace(id=0, email=username, username=username, role=role)
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -101,6 +101,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.recall_signal")        # register P15 recall signal tables
     importlib.import_module("app.models.instrument_registry")  # register P15 instrument registry table
     importlib.import_module("app.models.baseline_library")     # register P15 baseline library table
+    importlib.import_module("app.models.user_role_assignment") # register admin role-assignment table
     importlib.import_module("app.models.integrations")         # register P17 integration tables
     importlib.import_module("app.models.mobile")               # register P18 mobile tables
     importlib.import_module("app.models.quality_intelligence") # register P21 quality intelligence tables
@@ -505,6 +506,9 @@ app.include_router(inspect_router, prefix=settings.API_PREFIX)
 app.include_router(history_router, prefix=settings.API_PREFIX)
 app.include_router(reports_router, prefix=settings.API_PREFIX)
 app.include_router(inspections_router, prefix=settings.API_PREFIX)
+
+from app.routes.admin_users import router as admin_users_router
+app.include_router(admin_users_router)
 
 app.include_router(agent_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/models/user_role_assignment.py
+++ b/backend/app/models/user_role_assignment.py
@@ -1,0 +1,27 @@
+"""Role assignments managed by the founder/admins.
+
+A dedicated table (created by create_all) that maps a login username/email to a
+role, independent of the fragmented users-table schema. Role resolution reads
+this first so admins can grant Admin / Manager / Supervisor / Viewer to anyone.
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class UserRoleAssignment(Base):
+    __tablename__ = "user_role_assignments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    username: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String(50), nullable=False, default="viewer")
+    assigned_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )

--- a/backend/app/routers/auth_simple.py
+++ b/backend/app/routers/auth_simple.py
@@ -65,7 +65,22 @@ def _verify_user(u: str, password: str) -> Optional[str]:
 
 def _user_role(username: str) -> str:
     """Return the stored role for a user so the frontend gets the real role,
-    not a hard-coded 'viewer' default. Falls back to 'viewer' if unavailable."""
+    not a hard-coded 'viewer' default.
+
+    Resolution order: admin-managed role assignment table → users.role column →
+    'viewer'. The assignment table is the source of truth for roles granted via
+    the User Management UI / bootstrap.
+    """
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(
+                text("SELECT role FROM user_role_assignments WHERE username=:u"),
+                {"u": username},
+            ).fetchone()
+            if row and row.role:
+                return row.role
+    except Exception:
+        pass
     try:
         with engine.begin() as conn:
             row = conn.execute(

--- a/backend/app/routes/admin_users.py
+++ b/backend/app/routes/admin_users.py
@@ -1,0 +1,137 @@
+"""Founder/admin user-management: bootstrap the first admin and assign roles.
+
+- POST /api/admin/bootstrap  — one-time elevation of an account to admin,
+  gated by the ADMIN_BOOTSTRAP_TOKEN env secret (inert if the secret is unset).
+- GET  /api/admin/users      — list role assignments (admin only).
+- POST /api/admin/users/role — assign a role to a user (admin only).
+
+Roles: admin, spd_manager (Manager), supervisor, viewer.
+"""
+from __future__ import annotations
+
+import hmac
+import os
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.deps import get_db
+from app.models.user_role_assignment import UserRoleAssignment
+
+router = APIRouter(prefix="/api/admin", tags=["admin-users"])
+
+ASSIGNABLE_ROLES = {"admin", "spd_manager", "supervisor", "viewer", "vendor_user"}
+
+
+def _upsert_role(db: Session, username: str, role: str, assigned_by: str) -> UserRoleAssignment:
+    row = (
+        db.query(UserRoleAssignment)
+        .filter(UserRoleAssignment.username == username)
+        .first()
+    )
+    now = datetime.now(timezone.utc)
+    if row:
+        row.role = role
+        row.assigned_by = assigned_by
+        row.updated_at = now
+    else:
+        row = UserRoleAssignment(username=username, role=role, assigned_by=assigned_by)
+        db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+class BootstrapRequest(BaseModel):
+    username: str = Field(..., min_length=1, max_length=255, description="Email/username to elevate")
+
+
+@router.post("/bootstrap")
+def bootstrap_admin(
+    body: BootstrapRequest,
+    db: Session = Depends(get_db),
+    x_bootstrap_token: str | None = Header(default=None),
+):
+    """Grant admin to an account using the server-side ADMIN_BOOTSTRAP_TOKEN.
+
+    The deployment owner sets ADMIN_BOOTSTRAP_TOKEN in the environment, then
+    calls this once with the matching X-Bootstrap-Token header. Inert (404)
+    when the secret is not configured so it can't be abused by default.
+    """
+    secret = os.getenv("ADMIN_BOOTSTRAP_TOKEN", "").strip()
+    if not secret:
+        raise HTTPException(status_code=404, detail="Not found")
+    if not x_bootstrap_token or not hmac.compare_digest(x_bootstrap_token, secret):
+        raise HTTPException(status_code=403, detail="Invalid bootstrap token")
+
+    row = _upsert_role(db, body.username, "admin", assigned_by="bootstrap")
+    log_audit_event(
+        db,
+        tenant_id="platform",
+        tenant_name="platform",
+        actor_email=body.username,
+        actor_role="admin",
+        action_type="admin_bootstrap_granted",
+        resource_type="user_role_assignment",
+        resource_id=str(row.id),
+        compliance_flag=True,
+    )
+    return {"username": row.username, "role": row.role, "status": "admin granted"}
+
+
+@router.get("/users")
+def list_user_roles(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin")),
+):
+    rows = db.query(UserRoleAssignment).order_by(UserRoleAssignment.username).all()
+    return {
+        "users": [
+            {
+                "username": r.username,
+                "role": r.role,
+                "assigned_by": r.assigned_by,
+                "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+            }
+            for r in rows
+        ],
+        "assignable_roles": sorted(ASSIGNABLE_ROLES),
+    }
+
+
+class RoleAssignment(BaseModel):
+    username: str = Field(..., min_length=1, max_length=255)
+    role: str = Field(...)
+
+
+@router.post("/users/role")
+def assign_role(
+    body: RoleAssignment,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin")),
+):
+    if body.role not in ASSIGNABLE_ROLES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"role must be one of {sorted(ASSIGNABLE_ROLES)}",
+        )
+    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "admin")
+    row = _upsert_role(db, body.username, body.role, assigned_by=actor)
+
+    log_audit_event(
+        db,
+        tenant_id=getattr(current_user, "tenant_id", "") or "platform",
+        tenant_name="platform",
+        actor_email=actor,
+        actor_role="admin",
+        action_type="user_role_assigned",
+        resource_type="user_role_assignment",
+        resource_id=str(row.id),
+        details={"username": row.username, "role": row.role},
+        compliance_flag=True,
+    )
+    return {"username": row.username, "role": row.role, "assigned_by": row.assigned_by}

--- a/backend/tests/test_admin_user_management.py
+++ b/backend/tests/test_admin_user_management.py
@@ -1,0 +1,88 @@
+"""Founder/admin user-management: bootstrap + role assignment."""
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.user_role_assignment import UserRoleAssignment
+
+client = TestClient(app)
+
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}       # admin (dev)
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}   # viewer (dev)
+
+
+def _clear(username: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(UserRoleAssignment).filter(UserRoleAssignment.username == username).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestBootstrap:
+    def test_bootstrap_inert_without_secret(self, monkeypatch):
+        monkeypatch.delenv("ADMIN_BOOTSTRAP_TOKEN", raising=False)
+        r = client.post("/api/admin/bootstrap", json={"username": "founder@lumen.ai"})
+        assert r.status_code == 404
+
+    def test_bootstrap_rejects_bad_token(self, monkeypatch):
+        monkeypatch.setenv("ADMIN_BOOTSTRAP_TOKEN", "s3cret")
+        r = client.post("/api/admin/bootstrap", json={"username": "founder@lumen.ai"},
+                        headers={"X-Bootstrap-Token": "wrong"})
+        assert r.status_code == 403
+
+    def test_bootstrap_grants_admin(self, monkeypatch):
+        _clear("founder@lumen.ai")
+        monkeypatch.setenv("ADMIN_BOOTSTRAP_TOKEN", "s3cret")
+        r = client.post("/api/admin/bootstrap", json={"username": "founder@lumen.ai"},
+                        headers={"X-Bootstrap-Token": "s3cret"})
+        assert r.status_code == 200, r.text
+        assert r.json()["role"] == "admin"
+        # Persisted
+        db = SessionLocal()
+        try:
+            row = db.query(UserRoleAssignment).filter_by(username="founder@lumen.ai").first()
+            assert row is not None and row.role == "admin"
+        finally:
+            db.close()
+
+
+class TestRoleAssignment:
+    def test_admin_can_assign_roles(self):
+        _clear("tech@lumen.ai")
+        r = client.post("/api/admin/users/role",
+                        json={"username": "tech@lumen.ai", "role": "spd_manager"},
+                        headers=AUTH_ADMIN)
+        assert r.status_code == 200, r.text
+        assert r.json()["role"] == "spd_manager"
+
+    def test_assign_supervisor_role(self):
+        _clear("sup@lumen.ai")
+        r = client.post("/api/admin/users/role",
+                        json={"username": "sup@lumen.ai", "role": "supervisor"},
+                        headers=AUTH_ADMIN)
+        assert r.status_code == 200, r.text
+        assert r.json()["role"] == "supervisor"
+
+    def test_viewer_cannot_assign_roles(self):
+        r = client.post("/api/admin/users/role",
+                        json={"username": "x@lumen.ai", "role": "admin"},
+                        headers=AUTH_VIEWER)
+        assert r.status_code == 403
+
+    def test_invalid_role_rejected(self):
+        r = client.post("/api/admin/users/role",
+                        json={"username": "x@lumen.ai", "role": "superuser"},
+                        headers=AUTH_ADMIN)
+        assert r.status_code == 422
+
+    def test_admin_can_list_users(self):
+        _clear("listed@lumen.ai")
+        client.post("/api/admin/users/role",
+                    json={"username": "listed@lumen.ai", "role": "viewer"}, headers=AUTH_ADMIN)
+        r = client.get("/api/admin/users", headers=AUTH_ADMIN)
+        assert r.status_code == 200, r.text
+        usernames = [u["username"] for u in r.json()["users"]]
+        assert "listed@lumen.ai" in usernames
+        assert "supervisor" in r.json()["assignable_roles"]

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -141,6 +141,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: "Administration",
     roles: ["admin", "spd_manager"],
     items: [
+      { to: "/user-management", label: "User Roles", icon: UserCheck },
       { to: "/users", label: "Users", icon: Users },
       { to: "/roles", label: "Roles", icon: UserCheck },
       { to: "/settings", label: "Settings", icon: Settings },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -68,6 +68,7 @@ const InstrumentPassportPage = lazy(() => import("./pages/InstrumentPassportPage
 const AuditEvidencePage = lazy(() => import("./pages/AuditEvidencePage"));
 const UsersPage = lazy(() => import("./pages/UsersPage"));
 const RolesPage = lazy(() => import("./pages/RolesPage"));
+const UserManagementPage = lazy(() => import("./pages/UserManagementPage"));
 const SettingsPage = lazy(() => import("./pages/SettingsPage"));
 const ExecutiveCommandCenterPage = lazy(() => import("./pages/ExecutiveCommandCenterPage"));
 const GlobalRegistryPage = lazy(() => import("./pages/GlobalRegistryPage"));
@@ -304,6 +305,7 @@ function App() {
                       <Route path="/audit-evidence" element={<Page name="AuditEvidence"><AuditEvidencePage /></Page>} />
                       <Route path="/users" element={<Page name="Users"><UsersPage /></Page>} />
                       <Route path="/roles" element={<Page name="Roles"><RolesPage /></Page>} />
+                      <Route path="/user-management" element={<Page name="UserManagement"><UserManagementPage /></Page>} />
                       <Route path="/settings" element={<Page name="Settings"><SettingsPage /></Page>} />
                       <Route path="/demo-image-library" element={<Page name="DemoImageLibrary"><DemoImageLibraryPage /></Page>} />
                       <Route path="/baseline-image-upload" element={<Page name="BaselineImageUpload"><BaselineImageUploadPage /></Page>} />

--- a/frontend/src/pages/UserManagementPage.tsx
+++ b/frontend/src/pages/UserManagementPage.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { UserCheck, ChevronRight } from "lucide-react";
+import { useAuth, API_BASE } from "@/lib/auth";
+
+type RoleRow = { username: string; role: string; assigned_by: string; updated_at: string | null };
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: "Admin",
+  spd_manager: "Manager",
+  supervisor: "Supervisor",
+  viewer: "Viewer",
+  vendor_user: "Vendor",
+};
+
+export default function UserManagementPage() {
+  const { headers, role } = useAuth();
+  const [users, setUsers] = useState<RoleRow[]>([]);
+  const [assignable, setAssignable] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [newUser, setNewUser] = useState("");
+  const [newRole, setNewRole] = useState("spd_manager");
+  const [saving, setSaving] = useState(false);
+  const [banner, setBanner] = useState<{ type: "success" | "error"; message: string } | null>(null);
+
+  const isAdmin = role === "admin";
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(`${API_BASE}/api/admin/users`, { headers: headers() });
+      if (res.status === 403) { setError("Admin access required to manage users."); setUsers([]); return; }
+      if (!res.ok) { setError(`Failed to load users (${res.status}).`); return; }
+      const data = await res.json();
+      setUsers(data.users ?? []);
+      setAssignable(data.assignable_roles ?? []);
+    } catch {
+      setError("Unable to reach the server.");
+    } finally {
+      setLoading(false);
+    }
+  }, [headers]);
+
+  useEffect(() => { if (isAdmin) load(); else setLoading(false); }, [load, isAdmin]);
+
+  async function assign(e: React.FormEvent) {
+    e.preventDefault();
+    setBanner(null);
+    if (!newUser.trim()) { setBanner({ type: "error", message: "Enter the user's email/username." }); return; }
+    setSaving(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/admin/users/role`, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ username: newUser.trim(), role: newRole }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        setBanner({ type: "error", message: d?.detail || `Failed (${res.status}).` });
+        return;
+      }
+      setBanner({ type: "success", message: `${newUser.trim()} is now ${ROLE_LABELS[newRole] ?? newRole}.` });
+      setNewUser("");
+      load();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <nav className="flex items-center gap-1.5 text-xs text-slate-400">
+        <Link to="/" className="hover:text-slate-600">Dashboard</Link>
+        <ChevronRight className="h-3 w-3" />
+        <span className="text-slate-600 font-medium">User Roles</span>
+      </nav>
+
+      <div className="flex items-start gap-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-100">
+          <UserCheck className="h-5 w-5 text-indigo-600" />
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900">User Roles</h2>
+          <p className="text-sm text-slate-500 mt-0.5">
+            Assign Admin, Manager, Supervisor, or Viewer access. Managers and supervisors can review
+            baselines and inspections; admins can manage users.
+          </p>
+        </div>
+      </div>
+
+      {!isAdmin && (
+        <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+          Admin access is required to manage user roles. Your current role is {role}.
+        </div>
+      )}
+
+      {isAdmin && (
+        <>
+          {/* Assign role */}
+          <form onSubmit={assign} className="rounded-xl border border-slate-200 bg-white p-5 space-y-3">
+            <h3 className="text-sm font-semibold text-slate-900">Assign a role</h3>
+            {banner && (
+              <div className={`rounded-lg px-3 py-2 text-sm ${banner.type === "success" ? "bg-emerald-50 border border-emerald-200 text-emerald-800" : "bg-red-50 border border-red-200 text-red-700"}`}>
+                {banner.message}
+              </div>
+            )}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div className="sm:col-span-2">
+                <label className="block text-xs font-medium text-slate-700 mb-1">User email / username</label>
+                <input
+                  value={newUser}
+                  onChange={(e) => setNewUser(e.target.value)}
+                  placeholder="person@hospital.org"
+                  className="block w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-slate-700 mb-1">Role</label>
+                <select
+                  value={newRole}
+                  onChange={(e) => setNewRole(e.target.value)}
+                  className="block w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+                >
+                  {(assignable.length ? assignable : ["admin", "spd_manager", "supervisor", "viewer"]).map((r) => (
+                    <option key={r} value={r}>{ROLE_LABELS[r] ?? r}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <button type="submit" disabled={saving}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
+              {saving ? "Saving…" : "Assign role"}
+            </button>
+          </form>
+
+          {/* Current assignments */}
+          <div className="rounded-xl border border-slate-200 bg-white">
+            <div className="border-b border-slate-100 px-5 py-3">
+              <h3 className="text-sm font-semibold text-slate-900">Current role assignments</h3>
+            </div>
+            {loading && <div className="px-5 py-8 text-center text-sm text-slate-400">Loading…</div>}
+            {error && <div className="px-5 py-6 text-center text-sm text-red-600">{error}</div>}
+            {!loading && !error && users.length === 0 && (
+              <div className="px-5 py-8 text-center text-sm text-slate-400">No roles assigned yet.</div>
+            )}
+            {!loading && !error && users.length > 0 && (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 text-left text-xs uppercase tracking-wide text-slate-400">
+                    <th className="px-5 py-2 font-medium">User</th>
+                    <th className="px-5 py-2 font-medium">Role</th>
+                    <th className="px-5 py-2 font-medium">Assigned by</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {users.map((u) => (
+                    <tr key={u.username} className="border-b border-slate-50">
+                      <td className="px-5 py-2.5 text-slate-800">{u.username}</td>
+                      <td className="px-5 py-2.5">
+                        <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
+                          {ROLE_LABELS[u.role] ?? u.role}
+                        </span>
+                      </td>
+                      <td className="px-5 py-2.5 text-slate-500">{u.assigned_by || "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What this adds

As the founder, you can now grant yourself admin and assign roles (Admin, Manager, Supervisor, Viewer) to others. Previously login always returned "viewer" and no admin role was reachable, so admin-gated actions (creating/approving baselines) were impossible.

### Backend
- **`user_role_assignments` table** — admin-managed source of truth for roles. Resolved first by login and by `get_current_user` (falls back to `users.role`, then `viewer`).
- **`POST /api/admin/bootstrap`** — one-time admin grant, gated by an `ADMIN_BOOTSTRAP_TOKEN` env secret you set in Render. Returns 404 when the secret is unset, so it's inert by default and can't be abused.
- **`GET /api/admin/users`** and **`POST /api/admin/users/role`** — admin-only list and assign (roles: admin, spd_manager/Manager, supervisor, viewer, vendor_user).
- Fixed a latent bug in `get_current_user`'s JWT path (it referenced a `users.username` column that doesn't exist on that model); it now resolves role from the assignment table.

### Frontend
- **User Roles** page under the Administration nav (admin-only): assign a role to any email + view current assignments.

## How you get admin (one-time)
1. In Render, set env var **`ADMIN_BOOTSTRAP_TOKEN`** to a secret value of your choice; redeploy.
2. Call once:
   `POST https://<your-api>/api/admin/bootstrap` with header `X-Bootstrap-Token: <that secret>` and body `{"username": "<your login email>"}`.
3. Log out/in — you're now Admin. Use **Administration → User Roles** to assign Manager/Supervisor/Viewer to your team.

(I can walk you through step 2 with a copy-paste curl once you've set the env var.)

## Validation
- `npm --prefix frontend run build` → ✅ clean
- `ruff check` → ✅ clean
- Full suite → ✅ **2101 passed, 2 skipped**
- Tests: bootstrap inert without secret / rejects bad token / grants admin; admin assigns roles incl. supervisor; viewer denied; invalid role rejected; admin lists users.

## Files
- `backend/app/models/user_role_assignment.py`, `backend/app/routes/admin_users.py`
- `backend/app/routers/auth_simple.py`, `backend/app/deps.py`, `backend/app/main.py`
- `backend/tests/test_admin_user_management.py`
- `frontend/src/pages/UserManagementPage.tsx`, `frontend/src/main.tsx`, `frontend/src/components/layout/AppShell.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_