### PR TITLE
feat(roles): enforce inspection permissions (viewer read-only, operator runs)

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -17,6 +17,7 @@ _DEV_AUTH_ACTIVE = _ENABLE_DEV_AUTH and _APP_ENV not in {"production", "prod"}
 _DEV_ROLE_MAP: dict[str, str] = {
     os.getenv("DEV_AUTH_TOKEN", ""): "admin",
     os.getenv("DEV_SPD_MANAGER_TOKEN", ""): "spd_manager",
+    os.getenv("DEV_OPERATOR_TOKEN", ""): "operator",
     os.getenv("DEV_VENDOR_TOKEN", ""): "vendor_user",
     os.getenv("DEV_VIEWER_TOKEN", ""): "viewer",
 } if _DEV_AUTH_ACTIVE else {}

--- a/backend/app/routes/admin_users.py
+++ b/backend/app/routes/admin_users.py
@@ -24,7 +24,7 @@ from app.models.user_role_assignment import UserRoleAssignment
 
 router = APIRouter(prefix="/api/admin", tags=["admin-users"])
 
-ASSIGNABLE_ROLES = {"admin", "spd_manager", "supervisor", "viewer", "vendor_user"}
+ASSIGNABLE_ROLES = {"admin", "spd_manager", "supervisor", "operator", "viewer", "vendor_user"}
 
 
 def _upsert_role(db: Session, username: str, role: str, assigned_by: str) -> UserRoleAssignment:

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -8,13 +8,30 @@ from sqlalchemy.orm import Session
 
 from app.audit import log_audit_event
 from app.authz import require_roles
-from app.deps import get_db
+from app.deps import get_db, get_current_user
 from app.db import models
 from app.enterprise_auth import get_request_tenant_id, require_enterprise_auth
 from app.analytics.risk_engine import calculate_risk
 from app.services.baseline_comparison_scoring_service import analyze_inspection
 
 router = APIRouter(tags=["inspections"])
+
+# Roles permitted to upload images, run AI analysis, and submit inspections.
+# Viewers are read-only. Operators run inspections; spd_manager/admin also override.
+_INSPECTION_RUN_ROLES = {"operator", "spd_manager", "admin"}
+_VIEWER_READONLY_MESSAGE = (
+    "Viewer access is read-only. Ask an admin to assign Operator or SPD Manager "
+    "access to run inspections."
+)
+
+
+def require_inspection_runner(current_user=Depends(get_current_user)):
+    """Allow operator/spd_manager/admin to run inspections; reject viewers with a
+    clear, actionable 403 message (not a silent failure)."""
+    role = getattr(current_user, "role", "viewer")
+    if role not in _INSPECTION_RUN_ROLES:
+        raise HTTPException(status_code=403, detail=_VIEWER_READONLY_MESSAGE)
+    return current_user
 
 _ALLOWED_INSTRUMENT_TYPES = {
     "laparoscopic_grasper", "retractor", "scissors", "needle_holder",
@@ -239,7 +256,7 @@ def inspection_response(row: models.Inspection) -> dict:
 async def get_inspection(
     inspection_id: int,
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles("admin", "spd_manager", "viewer")),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
 ):
     tenant_id = getattr(current_user, "tenant_id", None)
 
@@ -261,7 +278,7 @@ async def create_inspection(
     body: InspectionCreate,
     request: Request,
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles("admin", "spd_manager", "viewer")),
+    current_user=Depends(require_inspection_runner),
 ):
     """Submit a new inspection record. Enforces DQ-01..DQ-14 validation rules."""
     tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
@@ -538,9 +555,12 @@ def get_pilot_metrics(
 async def upload_inspection_images(
     request: Request,
     images: List[UploadFile] = File(...),
+    current_user=Depends(require_inspection_runner),
 ):
-    """Accept multipart inspection image uploads. Stores SHA-256 hash + metadata only — no raw images in DB."""
-    require_enterprise_auth(request)
+    """Accept multipart inspection image uploads. Stores SHA-256 hash + metadata only — no raw images in DB.
+
+    Restricted to operator/spd_manager/admin — viewers are read-only.
+    """
     tenant_id = get_request_tenant_id(request)
 
     results = []

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 os.environ.setdefault("ENABLE_DEV_AUTH", "true")
 os.environ.setdefault("DEV_AUTH_TOKEN", "dev-token")
 os.environ.setdefault("DEV_SPD_MANAGER_TOKEN", "manager-token")
+os.environ.setdefault("DEV_OPERATOR_TOKEN", "operator-token")
 os.environ.setdefault("DEV_VENDOR_TOKEN", "vendor-token")
 os.environ.setdefault("DEV_VIEWER_TOKEN", "viewer-token")
 os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")

--- a/backend/tests/test_baseline_comparison_scoring.py
+++ b/backend/tests/test_baseline_comparison_scoring.py
@@ -22,7 +22,7 @@ from app.services.baseline_comparison_scoring_service import (
 
 client = TestClient(app)
 
-AUTH_TECH = {"Authorization": "Bearer viewer-token"}
+AUTH_TECH = {"Authorization": "Bearer operator-token"}
 
 # Deterministic 64-char hex sha256 used to seed scoring.
 SHA = "a1b2c3d4" + "0" * 56

--- a/backend/tests/test_history_inspection_results.py
+++ b/backend/tests/test_history_inspection_results.py
@@ -13,7 +13,7 @@ from app.models.baseline_library import BaselineLibraryEntry
 client = TestClient(app)
 
 AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
-AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
 
 SHA = "f00dcafe" + "0" * 56
 
@@ -42,7 +42,7 @@ def _create_inspection(instrument_type: str) -> int:
         "has_image": True,
         "image_sha256": SHA,
         "file_name": "hist.jpg",
-    }, headers=AUTH_VIEWER)
+    }, headers=AUTH_OPERATOR)
     assert resp.status_code == 201, resp.text
     return resp.json()["id"]
 

--- a/backend/tests/test_inspection_role_permissions.py
+++ b/backend/tests/test_inspection_role_permissions.py
@@ -1,0 +1,120 @@
+"""Inspection role permissions.
+
+  viewer    → read-only; cannot upload, run AI analysis, or submit (clear 403)
+  operator  → can upload + run AI analysis + submit; cannot override baseline
+  spd_manager / admin → can run + override baseline
+"""
+import io
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+
+client = TestClient(app)
+
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}        # admin
+AUTH_MGR = {"Authorization": "Bearer manager-token"}      # spd_manager
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}  # operator
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}    # viewer
+
+SHA = "ab12cd34" + "0" * 56
+VIEWER_MSG = "Viewer access is read-only"
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == itype).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"perm-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _inspection_payload(itype="scissors"):
+    return {"instrument_type": itype, "site_name": "H", "has_image": True,
+            "image_sha256": SHA, "file_name": "i.jpg"}
+
+
+def _png_upload():
+    return {"images": ("i.png", io.BytesIO(b"\x89PNG\r\n\x1a\n" + b"0" * 64), "image/png")}
+
+
+# ── Viewer: read-only ────────────────────────────────────────────────────────
+
+class TestViewerReadOnly:
+    def test_viewer_cannot_submit_inspection(self):
+        r = client.post("/api/inspections", json=_inspection_payload(), headers=AUTH_VIEWER)
+        assert r.status_code == 403
+        assert VIEWER_MSG in r.json()["detail"]
+
+    def test_viewer_cannot_upload_image(self):
+        r = client.post("/api/inspections/upload-images", files=_png_upload(), headers=AUTH_VIEWER)
+        assert r.status_code == 403
+        assert VIEWER_MSG in r.json()["detail"]
+
+    def test_viewer_403_message_is_actionable(self):
+        r = client.post("/api/inspections", json=_inspection_payload(), headers=AUTH_VIEWER)
+        assert "Operator or SPD Manager" in r.json()["detail"]
+
+
+# ── Operator: can run, cannot override ───────────────────────────────────────
+
+class TestOperator:
+    def test_operator_can_submit_and_get_score(self):
+        _baseline("scissors")
+        r = client.post("/api/inspections", json=_inspection_payload("scissors"), headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        assert r.json()["analysis"]["analysis_status"] == "completed"
+
+    def test_operator_can_upload_image(self):
+        r = client.post("/api/inspections/upload-images", files=_png_upload(), headers=AUTH_OPERATOR)
+        assert r.status_code == 200, r.text
+
+    def test_operator_cannot_override_baseline(self):
+        # Create an inspection needing review first (no baseline)
+        db = SessionLocal()
+        try:
+            db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == "trocar").delete()
+            db.commit()
+        finally:
+            db.close()
+        ins = client.post("/api/inspections", json=_inspection_payload("trocar"), headers=AUTH_OPERATOR)
+        iid = ins.json()["id"]
+        r = client.post(f"/api/inspections/{iid}/baseline-override",
+                        json={"baseline_source": "hospital", "override_reason": "valid reason here"},
+                        headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+
+# ── SPD manager / admin: can override ────────────────────────────────────────
+
+class TestManagerAdminOverride:
+    def _pending_inspection(self) -> int:
+        db = SessionLocal()
+        try:
+            db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == "clip_applier").delete()
+            db.commit()
+        finally:
+            db.close()
+        ins = client.post("/api/inspections", json=_inspection_payload("clip_applier"), headers=AUTH_OPERATOR)
+        return ins.json()["id"]
+
+    def test_spd_manager_can_override(self):
+        iid = self._pending_inspection()
+        r = client.post(f"/api/inspections/{iid}/baseline-override",
+                        json={"baseline_source": "hospital", "override_reason": "manager reviewed baseline"},
+                        headers=AUTH_MGR)
+        assert r.status_code == 200, r.text
+
+    def test_admin_can_override(self):
+        iid = self._pending_inspection()
+        r = client.post(f"/api/inspections/{iid}/baseline-override",
+                        json={"baseline_source": "manufacturer", "override_reason": "admin reviewed baseline"},
+                        headers=AUTH_ADMIN)
+        assert r.status_code == 200, r.text

--- a/backend/tests/test_manufacturer_baseline_flow.py
+++ b/backend/tests/test_manufacturer_baseline_flow.py
@@ -15,6 +15,7 @@ client = TestClient(app)
 AUTH_ADMIN = {"Authorization": "Bearer dev-token"}       # admin
 AUTH_MGR = {"Authorization": "Bearer manager-token"}      # spd_manager
 AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}    # viewer
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}  # operator (runs inspections)
 SHA = "c0ffee00" + "0" * 56
 
 
@@ -82,14 +83,14 @@ class TestEndToEndScoring:
         }, headers=AUTH_ADMIN)
         assert b.status_code == 201, b.text
 
-        # 2. Run an inspection on the same instrument type
+        # 2. Run an inspection on the same instrument type (operator runs inspections)
         ins = client.post("/api/inspections", json={
             "instrument_type": itype,
             "site_name": "Test Hospital",
             "has_image": True,
             "image_sha256": SHA,
             "file_name": "img.jpg",
-        }, headers=AUTH_VIEWER)
+        }, headers=AUTH_OPERATOR)
         assert ins.status_code == 201, ins.text
         analysis = ins.json()["analysis"]
 

--- a/backend/tests/test_p26_baseline_governance.py
+++ b/backend/tests/test_p26_baseline_governance.py
@@ -10,7 +10,9 @@ client = TestClient(app)
 AUTH_ADMIN = {"Authorization": "Bearer dev-token"}      # admin role
 AUTH_MGR = {"Authorization": "Bearer manager-token"}     # spd_manager role
 AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}   # viewer role (cannot override)
-AUTH_TECH = AUTH_VIEWER  # alias: no dedicated technician token; viewer represents restricted role
+# Operators run inspections but cannot override baselines. Viewers are now
+# read-only and cannot submit inspections at all.
+AUTH_TECH = {"Authorization": "Bearer operator-token"}
 
 
 INSPECTION_WITH_IMAGE = {

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -147,8 +147,16 @@ const initialForm: FormFields = {
 // ─── component ────────────────────────────────────────────────────────────────
 
 export default function NewInspectionPage() {
-  const { headers } = useAuth();
+  const { headers, role } = useAuth();
   const navigate = useNavigate();
+  // Operators / SPD managers / admins can run inspections; viewers are read-only.
+  const canRunInspection = role === "operator" || role === "spd_manager" || role === "admin";
+  const VIEWER_READONLY_MESSAGE =
+    "Viewer access is read-only. Ask an admin to assign Operator or SPD Manager access to run inspections.";
+  const ROLE_LABELS: Record<string, string> = {
+    admin: "Admin", spd_manager: "SPD Manager", supervisor: "Supervisor",
+    operator: "Operator", viewer: "Viewer", vendor_user: "Vendor",
+  };
   const [form, setForm] = useState<FormFields>(initialForm);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [inspectionImages, setInspectionImages] = useState<File[]>([]);
@@ -282,6 +290,11 @@ export default function NewInspectionPage() {
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setBanner(null);
+    // Viewers are read-only — block and explain, never fail silently.
+    if (!canRunInspection) {
+      setBanner({ type: "error", message: VIEWER_READONLY_MESSAGE });
+      return;
+    }
     if (!validate()) return;
 
     setSubmitting(true);
@@ -341,9 +354,15 @@ export default function NewInspectionPage() {
         body: JSON.stringify(payload),
       });
 
-      if (res.status === 401 || res.status === 403) {
+      if (res.status === 401) {
         localStorage.removeItem("token");
         navigate("/login", { replace: true });
+        return;
+      }
+      if (res.status === 403) {
+        // Insufficient role (e.g. viewer) — show the server's actionable message.
+        const d = await res.json().catch(() => ({}));
+        setBanner({ type: "error", message: d?.detail || VIEWER_READONLY_MESSAGE });
         return;
       }
       if (!res.ok) {
@@ -408,12 +427,25 @@ export default function NewInspectionPage() {
 
   return (
     <div className="max-w-3xl mx-auto space-y-6 py-6 px-4">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">New Inspection</h1>
-        <p className="text-sm text-gray-500 mt-1">
-          Upload an image — AI will identify findings, check the manufacturer baseline, and generate a risk score automatically.
-        </p>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">New Inspection</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Upload an image — AI will identify findings, check the manufacturer baseline, and generate a risk score automatically.
+          </p>
+        </div>
+        <span className="shrink-0 mt-1 inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
+          Role: {ROLE_LABELS[role] ?? role}
+        </span>
       </div>
+
+      {/* Viewer read-only banner */}
+      {!canRunInspection && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          <p className="font-semibold">Read-only access</p>
+          <p className="mt-0.5">{VIEWER_READONLY_MESSAGE}</p>
+        </div>
+      )}
 
       {/* Field requirements summary */}
       <div className="rounded-lg border border-slate-200 bg-white shadow-sm overflow-hidden">
@@ -672,6 +704,7 @@ export default function NewInspectionPage() {
                 inputRef={inspectionInputRef}
                 onChange={(e) => handleImages(e, setInspectionImages)}
                 onRemove={(i) => removeImage(i, setInspectionImages)}
+                disabled={!canRunInspection}
               />
               <FieldError message={fieldErrors.images} />
             </div>
@@ -684,6 +717,7 @@ export default function NewInspectionPage() {
                 inputRef={borescopeInputRef}
                 onChange={(e) => handleImages(e, setBorescopeImages)}
                 onRemove={(i) => removeImage(i, setBorescopeImages)}
+                disabled={!canRunInspection}
               />
             </div>
             <p className="text-xs text-gray-500">Max 10 MB per file. Only SHA-256 hash is stored — raw images are not retained.</p>
@@ -735,10 +769,15 @@ export default function NewInspectionPage() {
           {/* Submit */}
           <div className="flex flex-col gap-3">
             <button
-              type="submit" disabled={submitting}
+              type="submit" disabled={submitting || !canRunInspection}
+              title={!canRunInspection ? VIEWER_READONLY_MESSAGE : undefined}
               className="w-full rounded-lg bg-blue-600 px-4 py-3 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
-              {submitting ? "Uploading image & running AI analysis…" : "Submit Inspection & Run AI Analysis"}
+              {!canRunInspection
+                ? "Viewer access — cannot run inspections"
+                : submitting
+                  ? "Uploading image & running AI analysis…"
+                  : "Submit Inspection & Run AI Analysis"}
             </button>
             <p className="text-xs text-gray-500 text-center">
               AI findings require qualified human review before clinical action. All AI outputs include human_review_required: true.
@@ -1064,6 +1103,7 @@ function ImageFileInput({
   inputRef,
   onChange,
   onRemove,
+  disabled,
 }: {
   id: string;
   label: string;
@@ -1071,6 +1111,7 @@ function ImageFileInput({
   inputRef: React.RefObject<HTMLInputElement>;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onRemove: (index: number) => void;
+  disabled?: boolean;
 }) {
   const totalBytes = files.reduce((s, f) => s + f.size, 0);
 
@@ -1078,8 +1119,8 @@ function ImageFileInput({
     <div>
       {label && <label htmlFor={id} className="block text-sm font-medium text-gray-700">{label}</label>}
       <input
-        ref={inputRef} id={id} type="file" accept="image/*" multiple onChange={onChange}
-        className="mt-1 block w-full text-sm text-gray-600 file:mr-3 file:rounded file:border-0 file:bg-blue-50 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100"
+        ref={inputRef} id={id} type="file" accept="image/*" multiple onChange={onChange} disabled={disabled}
+        className="mt-1 block w-full text-sm text-gray-600 file:mr-3 file:rounded file:border-0 file:bg-blue-50 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100 disabled:opacity-50 disabled:cursor-not-allowed"
       />
       {files.length > 0 && (
         <div className="mt-2 space-y-1">


### PR DESCRIPTION
## Summary

Enforces inspection permissions by role, server-side and in the UI, and adds the **Operator** role.

| Role | View | Upload image / Run AI / Submit | Override baseline |
|---|---|---|---|
| **Viewer** | ✅ | ❌ (clear 403) | ❌ |
| **Operator** | ✅ | ✅ | ❌ |
| **SPD Manager / Admin** | ✅ | ✅ | ✅ |

### Backend
- New **`operator`** role (assignable in Administration → User Roles; `DEV_OPERATOR_TOKEN` for tests).
- **`require_inspection_runner`** gate on `POST /api/inspections` and `POST /api/inspections/upload-images` — operator/spd_manager/admin allowed; viewers get **403** with the exact message:
  > Viewer access is read-only. Ask an admin to assign Operator or SPD Manager access to run inspections.
- Baseline override stays spd_manager/admin only (operators can't override).
- `GET` inspection still allows viewers (read-only view).

### Frontend (New Inspection page)
- Displays the **current user role**.
- Viewers see a **read-only banner**; image inputs and the submit button are **disabled**.
- Submit is blocked client-side with the message — **never fails silently**.
- A 403 now shows the server's actionable message instead of bouncing to login.

## Validation
- `npm --prefix frontend run build` → ✅ clean
- `python -m pytest tests -q` → ✅ **2109 passed, 2 skipped**
- `ruff check` → ✅ clean
- New tests: viewer cannot upload/submit (clear 403), operator can run + score, operator cannot override, spd_manager + admin can override. Existing inspection tests updated to submit as operator.

## Note
This builds on the role system from #45 — assign Operator/Manager to your team in **Administration → User Roles** once you're admin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_