### PR TITLE
fix(ui): logout without full reload; no-cache index.html on static host

### DIFF
--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -35,8 +35,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.removeItem("token");
     localStorage.removeItem("role");
     localStorage.removeItem("actor");
-    // Full reload so all auth-derived state resets and RequireAuth sends to /login.
-    window.location.href = "/login";
+    // Reset auth state in-place (no full page reload). With an empty token the
+    // RequireAuth guard redirects to /login using already-loaded code, so a
+    // stale cached index.html can't blank the page on a fresh deploy.
+    setAuthState({ token: "", role: "viewer", actor: "" });
   }, []);
 
   const headers = useCallback(

--- a/render.yaml
+++ b/render.yaml
@@ -73,6 +73,18 @@ services:
     buildCommand: cd frontend && npm install && npm run build
     staticPublishPath: frontend/dist
     autoDeploy: true
+    # Never cache index.html so a redeploy's new asset hashes are picked up
+    # immediately (prevents stale-chunk white pages); cache hashed assets forever.
+    headers:
+      - path: /index.html
+        name: Cache-Control
+        value: no-cache, no-store, must-revalidate
+      - path: /
+        name: Cache-Control
+        value: no-cache, no-store, must-revalidate
+      - path: /assets/*
+        name: Cache-Control
+        value: public, max-age=31536000, immutable
     routes:
       - type: rewrite
         source: /dashboard


### PR DESCRIPTION
## Problem

After logging out, the page went **white with no login form**. Logout did a full page reload (`window.location.href`), and the browser was serving a **cached `index.html`** that referenced old asset chunks (404 after the recent redeploys) → blank page.

## Fix

- **`logout()` no longer reloads** — it resets auth state in place; the `RequireAuth` guard then redirects to `/login` using already-loaded code, so a stale cached page can't blank the screen.
- **`render.yaml`**: never cache `index.html` on the static site (and cache hashed `/assets/*` forever) so future redeploys pick up new chunks immediately — fixing the recurring stale-chunk white pages.

## Immediate workaround (until this deploys)
On the white `/login` page, press **Ctrl+Shift+R** (hard refresh) or open it in an incognito window — the form appears.

## Validation
- `npm --prefix frontend run build` → ✅ clean

## Files
- `frontend/src/lib/auth.tsx`
- `render.yaml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_