### PR TITLE
fix(auth): redirect to login on expired token; longer token lifetime

### DIFF
--- a/backend/app/routers/auth_simple.py
+++ b/backend/app/routers/auth_simple.py
@@ -36,7 +36,7 @@ if not SECRET_KEY:
         raise RuntimeError("SECRET_KEY environment variable must be set in production.")
     SECRET_KEY = "dev-only-secret-not-for-production"
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "480"))
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 engine = create_engine(DATABASE_URL, pool_pre_ping=True)

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -318,6 +318,12 @@ export default function NewInspectionPage() {
         headers: { Authorization: hdrs["Authorization"] },
         body: fd,
       });
+      if (imgRes.status === 401) {
+        // Token expired/invalid — clear it and send to login to re-authenticate.
+        localStorage.removeItem("token");
+        navigate("/login", { replace: true });
+        return;
+      }
       if (!imgRes.ok) {
         const errBody = await imgRes.json().catch(() => ({}));
         setBanner({ type: "error", message: errBody?.detail || `Image upload failed (${imgRes.status}). Please try again.` });


### PR DESCRIPTION
## Problem

After CORS was fixed, the inspection showed **"Invalid or expired token"** — the login token had expired (60-minute lifetime), and the image-upload step surfaced a dead-end banner instead of prompting re-login.

## Fix

- **`NewInspectionPage`**: a `401` from the image-upload call now clears the token and routes to `/login` (consistent with the inspection POST), so an expired session prompts a clean re-login instead of a dead-end error.
- **Token lifetime** raised from 60 → 480 minutes (8h) so sessions don't expire mid-use. Still overridable via `ACCESS_TOKEN_EXPIRE_MINUTES`.

## Immediate workaround
Log out → log back in → retry; a fresh token is valid.

## Validation
- `npm --prefix frontend run build` → ✅ clean
- `ruff check` → ✅ clean
- Auth/login tests pass; full suite running.

## Files
- `frontend/src/pages/NewInspectionPage.tsx`
- `backend/app/routers/auth_simple.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_