### PR TITLE
fix(cors): make CORS the outermost middleware so preflight is never blocked

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -168,25 +168,6 @@ _CORS_ORIGIN_REGEX = os.getenv(
     "CORS_ORIGIN_REGEX", r"https://([a-z0-9-]+\.)*onrender\.com"
 )
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=settings.CORS_ORIGINS,
-    allow_origin_regex=_CORS_ORIGIN_REGEX,
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=[
-        "Authorization",
-        "Content-Type",
-        "X-LumenAI-Role",
-        "X-LumenAI-Tenant-Id",
-        "X-LumenAI-Tenant-Name",
-        "X-LumenAI-Actor",
-        "X-Tenant-Id",
-        "X-Tenant-Name",
-        "X-Requested-With",
-    ],
-)
-
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
@@ -222,6 +203,29 @@ class CorrelationIDMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(CorrelationIDMiddleware)
+
+# CORS must be the OUTERMOST middleware so it answers OPTIONS preflight before
+# any other middleware can reject it (a 403 on preflight surfaces as a browser
+# "Failed to fetch"). add_middleware stacks last-added = outermost, so this
+# registration intentionally comes after all others.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.CORS_ORIGINS,
+    allow_origin_regex=_CORS_ORIGIN_REGEX,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=[
+        "Authorization",
+        "Content-Type",
+        "X-LumenAI-Role",
+        "X-LumenAI-Tenant-Id",
+        "X-LumenAI-Tenant-Name",
+        "X-LumenAI-Actor",
+        "X-Tenant-Id",
+        "X-Tenant-Name",
+        "X-Requested-With",
+    ],
+)
 
 
 # --- Observability endpoints ---


### PR DESCRIPTION
## Problem

Inspection POSTs still failed with **"Failed to fetch"** even after adding the frontend origin to CORS. A direct probe showed the `OPTIONS` preflight returning **403 with no `Access-Control-Allow-Origin` header** — so the preflight is being rejected before the CORS middleware can answer it.

## Root cause

`CORSMiddleware` was registered **first**, which (with Starlette's stacking) makes it the **innermost** middleware. The `OPTIONS` preflight therefore passed through the other middleware layers first, and one of them rejected it (403) before CORS could short-circuit and return the preflight response.

## Fix

Move the `CORSMiddleware` registration to be the **last** `add_middleware` call, making it the **outermost** layer. Now it answers the preflight immediately, before any other middleware runs.

## Validation
- CORS preflight tests pass (`/api/inspections`, `/upload-images`, arbitrary `*.onrender.com`).
- `ruff check` → clean.
- Full suite running.

## After deploy
Redeploy `lumen-AI`, then re-run an inspection — the preflight will succeed and the analysis call will go through.

## Files
- `backend/app/main.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_