### PR TITLE
fix(db): back-fill missing inspection columns on startup (fixes inspection/history 500s)

### DIFF
--- a/backend/app/db/column_migrator.py
+++ b/backend/app/db/column_migrator.py
@@ -1,0 +1,79 @@
+"""Lightweight, idempotent column back-fill for existing tables.
+
+create_all() adds missing *tables* but never alters existing ones, so columns
+added to a model after a table already exists in production are simply absent —
+and any query/insert that references them returns a 500 (which, because the
+error response is generated above the CORS middleware, surfaces in the browser
+as a misleading "No 'Access-Control-Allow-Origin'" CORS error).
+
+This adds any missing columns via ALTER TABLE ... ADD COLUMN, compiling each
+column's type for the active dialect. Columns are added nullable (with a simple
+DEFAULT when the model defines a scalar one) so the change is safe on tables
+that already contain rows, on both PostgreSQL and SQLite.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import inspect as sqla_inspect, text
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+
+def _default_clause(col, dialect_name: str) -> str:
+    """Return a ' DEFAULT <x>' clause for a simple scalar default, else ''."""
+    default = getattr(col, "default", None)
+    if default is None or not getattr(default, "is_scalar", False):
+        return ""
+    val = default.arg
+    if isinstance(val, bool):
+        if dialect_name == "postgresql":
+            return f" DEFAULT {'true' if val else 'false'}"
+        return f" DEFAULT {1 if val else 0}"
+    if isinstance(val, (int, float)):
+        return f" DEFAULT {val}"
+    if isinstance(val, str):
+        escaped = val.replace("'", "''")
+        return f" DEFAULT '{escaped}'"
+    return ""
+
+
+def ensure_columns(engine: Engine, model) -> list[str]:
+    """Add any columns defined on `model` that are missing from its DB table.
+
+    Returns the list of column names added. Best-effort and non-fatal: a failure
+    on one column is logged and skipped so startup is never blocked.
+    """
+    table = model.__table__
+    added: list[str] = []
+    try:
+        inspector = sqla_inspect(engine)
+        if table.name not in inspector.get_table_names():
+            return added  # create_all will handle brand-new tables
+        existing = {c["name"] for c in inspector.get_columns(table.name)}
+    except Exception as exc:  # pragma: no cover - inspection failure is non-fatal
+        logger.warning("Column back-fill skipped for %s: %s", table.name, exc)
+        return added
+
+    dialect = engine.dialect
+    for col in table.columns:
+        if col.name in existing:
+            continue
+        try:
+            coltype = col.type.compile(dialect=dialect)
+        except Exception:
+            # Some custom types can't compile standalone — skip them safely.
+            continue
+        ddl = f'ALTER TABLE {table.name} ADD COLUMN {col.name} {coltype}'
+        ddl += _default_clause(col, dialect.name)
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(ddl))
+            added.append(col.name)
+        except Exception as exc:  # pragma: no cover - per-column failure is non-fatal
+            logger.warning("Could not add column %s.%s: %s", table.name, col.name, exc)
+
+    if added:
+        logger.info("Back-filled columns on %s: %s", table.name, ", ".join(added))
+    return added

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -113,6 +113,16 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.p25_infrastructure")    # register P25 infrastructure tables
     wait_for_db()
     Base.metadata.create_all(bind=engine)
+    # Back-fill columns added to existing tables (create_all never alters them).
+    # Without this, an old production `inspections` table is missing newer columns
+    # and every inspection/history query 500s (surfacing as a CORS error).
+    try:
+        from app.db.column_migrator import ensure_columns
+        from app.models.inspection import Inspection
+        ensure_columns(engine, Inspection)
+    except Exception as _mig_e:
+        import logging
+        logging.getLogger(__name__).warning("Column back-fill skipped: %s", _mig_e)
     try:
         from apscheduler.schedulers.background import BackgroundScheduler
         from app.services.prediction_scheduler import register_prediction_scheduler

--- a/backend/tests/test_column_migrator.py
+++ b/backend/tests/test_column_migrator.py
@@ -1,0 +1,48 @@
+"""ensure_columns back-fills columns missing from an existing table.
+
+Reproduces the production failure: an old `inspections` table without the newer
+columns caused inspection/history endpoints to 500 (seen in the browser as a
+CORS error). After back-fill the columns exist and queries work.
+"""
+from sqlalchemy import create_engine, text
+
+from app.db.column_migrator import ensure_columns
+from app.models.inspection import Inspection
+
+
+def test_ensure_columns_adds_missing(tmp_path):
+    db_path = tmp_path / "old.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+
+    # Simulate an OLD inspections table missing the newer columns.
+    with engine.begin() as conn:
+        conn.execute(text(
+            "CREATE TABLE inspections ("
+            "id INTEGER PRIMARY KEY, file_name VARCHAR, tenant_id VARCHAR, "
+            "instrument_type VARCHAR)"
+        ))
+        conn.execute(text(
+            "INSERT INTO inspections (file_name, tenant_id, instrument_type) "
+            "VALUES ('old.jpg', 't1', 'scissors')"
+        ))
+
+    added = ensure_columns(engine, Inspection)
+
+    # Newer columns that were missing must now have been added.
+    for col in ("has_image", "baseline_status", "baseline_source",
+                "score_status", "supervisor_review_required", "image_sha256"):
+        assert col in added, f"{col} should have been back-filled"
+
+    # The previously-missing columns are now queryable (no 500).
+    from sqlalchemy import inspect as sqla_inspect
+    cols = {c["name"] for c in sqla_inspect(engine).get_columns("inspections")}
+    assert {"has_image", "baseline_status", "score_status"} <= cols
+
+
+def test_ensure_columns_idempotent(tmp_path):
+    db_path = tmp_path / "idem.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    # Create the table fully from the model, then re-run — nothing to add.
+    Inspection.__table__.create(engine)
+    added = ensure_columns(engine, Inspection)
+    assert added == []


### PR DESCRIPTION
## The actual root cause (found via the browser console)

The console showed a telling pattern:
- `/api/enterprise/*`, `/api/network/*`, `/api/baseline-library` → clean **401/404** (CORS fine)
- `/api/inspections`, `/api/history`, `/api/history/summary`, `/api/analytics/vendors` → **"No 'Access-Control-Allow-Origin'"**

Every "CORS-blocked" endpoint touches the **`inspections` table**; the working ones don't. When a route throws a **500**, Starlette's error handler returns the response *above* the CORS middleware, so it has no CORS headers — and the browser mislabels it as a CORS error.

The 500s happen because the **production `inspections` table is missing newer columns** (`has_image`, `baseline_status`, `baseline_source`, `score_status`, `supervisor_review_required`, …). `create_all` adds new *tables* but never alters existing ones, so those columns were never added — exactly the migration gap flagged in an earlier Codex review.

## Fix

- New `db/column_migrator.ensure_columns`: idempotently `ALTER TABLE … ADD COLUMN` for any model column missing from its existing table (added nullable, with a scalar `DEFAULT` when the model defines one). Safe on populated tables, works on Postgres + SQLite, non-fatal per-column.
- Called at startup after `create_all` for the `Inspection` table.

## Validation
- `python -m pytest tests -q` → ✅ **2124 passed, 2 skipped**
- `ruff check` → ✅ clean
- New tests: back-fills missing columns on a simulated old table; idempotent when the table is already complete.

## After deploy
Redeploy `lumen-AI`. On startup it back-fills the missing columns, so `/api/inspections`, `/api/history`, and the dashboard counts will work — the inspection submit will return the **AI score panel**, and Total Inspections will populate.

## Files
- `backend/app/db/column_migrator.py`
- `backend/app/main.py`
- `backend/tests/test_column_migrator.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_