### PR TITLE
feat(analysis): explainable, clinically-useful AI results panel

### DIFF
--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -51,6 +51,60 @@ def _baseline_comparison_label(source: str) -> str:
 CONTAMINATION_KPIS = ["blood", "bone", "tissue", "bioburden", "debris", "other_organic_residue"]
 CONDITION_KPIS = ["rust", "discoloration", "corrosion", "pitting", "crack", "insulation_damage", "missing_component"]
 
+# Human-readable KPI labels for findings summaries.
+KPI_LABELS = {
+    "blood": "blood", "bone": "bone", "tissue": "tissue", "bioburden": "bioburden",
+    "debris": "debris", "other_organic_residue": "organic residue",
+    "rust": "rust", "discoloration": "discoloration", "corrosion": "corrosion",
+    "pitting": "pitting", "crack": "crack", "insulation_damage": "insulation damage",
+    "missing_component": "missing component",
+}
+
+# Critical KPI thresholds (probability). Exceeding one drives risk up and changes
+# the recommendation toward reprocess / supervisor review / remove from service.
+_CRITICAL_THRESHOLDS = {
+    "blood": 0.30, "bone": 0.30, "tissue": 0.30, "bioburden": 0.30,
+    "rust": 0.60, "corrosion": 0.60, "crack": 0.30, "missing_component": 0.30,
+}
+# KPIs whose critical breach means the instrument should leave service.
+_REMOVE_FROM_SERVICE = {"crack", "missing_component"}
+# Contamination KPIs whose critical breach means reprocess + re-inspect.
+_REPROCESS = {"blood", "bone", "tissue", "bioburden"}
+
+
+def severity_from_probability(p: float) -> str:
+    """0–10% None, 11–30% Low, 31–60% Moderate, 61%+ High (probability 0–1)."""
+    pct = p * 100
+    if pct <= 10:
+        return "none"
+    if pct <= 30:
+        return "low"
+    if pct <= 60:
+        return "moderate"
+    return "high"
+
+
+def status_from_probability(p: float) -> str:
+    """0–10% Clear, 11–30% Monitor, 31–60% Review, 61%+ Escalate (probability 0–1)."""
+    pct = p * 100
+    if pct <= 10:
+        return "clear"
+    if pct <= 30:
+        return "monitor"
+    if pct <= 60:
+        return "review"
+    return "escalate"
+
+
+def _finding_phrase(label: str, severity: str) -> str:
+    if severity == "none":
+        return f"No {label} detected"
+    if severity == "low":
+        return f"Minor {label} detected"
+    if severity == "moderate":
+        return f"{label.capitalize()} detected"
+    return f"Significant {label} detected"
+
 # Map technician-declared finding_categories onto KPI keys.
 _DECLARED_TO_KPI = {
     "blood": "blood",
@@ -198,16 +252,6 @@ def resolve_baseline(db: Session, instrument_type: str, tenant_id: str) -> dict[
     }
 
 
-def _severity(probability: float) -> str:
-    if probability >= 0.6:
-        return "high"
-    if probability >= 0.3:
-        return "medium"
-    if probability >= 0.1:
-        return "low"
-    return "none"
-
-
 def _risk_level(score: int) -> str:
     if score >= 85:
         return "low"
@@ -285,9 +329,11 @@ def analyze_inspection(
         kpi_summary[kpi] = present
         predicted_findings.append({
             "type": kpi,
+            "label": KPI_LABELS.get(kpi, kpi),
             "probability": probability,
             "confidence": confidence,
-            "severity": _severity(probability),
+            "severity": severity_from_probability(probability),
+            "status": status_from_probability(probability),
         })
 
     # ── Identification detection / match ────────────────────────────────────
@@ -324,21 +370,109 @@ def analyze_inspection(
     )
     score += id_matches * 2.0
     inspection_score = max(0, min(100, round(score)))
-    risk_level = _risk_level(inspection_score)
+
+    # ── Per-finding probability map for downstream logic ────────────────────
+    prob = {f["type"]: f["probability"] for f in predicted_findings}
+
+    # ── Critical KPI breaches drive risk + recommendation ───────────────────
+    critical_flags = [
+        kpi for kpi, thresh in _CRITICAL_THRESHOLDS.items()
+        if prob.get(kpi, 0.0) > thresh
+    ]
+    remove_flags = [k for k in critical_flags if k in _REMOVE_FROM_SERVICE]
+    reprocess_flags = [k for k in critical_flags if k in _REPROCESS]
+
+    if remove_flags:
+        risk_level = "critical"
+    elif critical_flags:
+        risk_level = "high"
+    else:
+        risk_level = _risk_level(inspection_score)
+
+    pass_fail = "FAIL" if critical_flags else "PASS"
+
+    # ── Findings summary (one line per key KPI) ─────────────────────────────
+    summary_kpis = ["blood", "bone", "tissue", "bioburden", "corrosion", "rust", "discoloration", "crack"]
+    findings_summary: list[str] = []
+    if not critical_flags:
+        findings_summary.append("No critical contamination detected")
+    for kpi in summary_kpis:
+        sev = severity_from_probability(prob.get(kpi, 0.0))
+        findings_summary.append(_finding_phrase(KPI_LABELS[kpi], sev))
 
     # ── Recommendation (no causation language) ──────────────────────────────
-    flagged = [k.replace("_", " ") for k, v in kpi_summary.items() if v]
-    if not flagged:
-        recommendation = "Accept inspection. No findings above threshold; routine processing recommended."
-    elif risk_level in ("high", "critical"):
+    if remove_flags:
+        names = ", ".join(KPI_LABELS[k] for k in remove_flags)
         recommendation = (
-            f"Quality review recommended. Possible {', '.join(flagged)} — "
-            "hold instrument for supervisor review before release."
+            f"Remove from service — possible {names} indicates a structural integrity concern. "
+            "Supervisor review required before any further use."
+        )
+    elif reprocess_flags:
+        names = ", ".join(KPI_LABELS[k] for k in reprocess_flags)
+        recommendation = (
+            f"Reprocess and re-inspect — possible {names} above the contamination threshold. "
+            "Supervisor review required before release."
+        )
+    elif critical_flags:
+        names = ", ".join(KPI_LABELS[k] for k in critical_flags)
+        recommendation = (
+            f"Supervisor review recommended — possible {names} above threshold. "
+            "Hold instrument until reviewed."
         )
     else:
-        recommendation = (
-            f"Accept inspection with supervisor review of {', '.join(flagged)} finding(s)."
+        recommendation = "Accept inspection. Continue routine processing."
+
+    # ── PASS/FAIL reason bullets ────────────────────────────────────────────
+    reason: list[str] = [
+        f"Manufacturer baseline matched at {round(baseline_match_score * 100)}%."
+        if resolution["baseline_source"] == "manufacturer"
+        else f"{BASELINE_LABELS.get(resolution['baseline_source'], 'Baseline')} matched at "
+             f"{round(baseline_match_score * 100)}%."
+    ]
+    for kpi in ["blood", "bone", "tissue", "corrosion", "crack"]:
+        sev = severity_from_probability(prob.get(kpi, 0.0))
+        reason.append(_finding_phrase(KPI_LABELS[kpi], sev) + ".")
+    if critical_flags:
+        reason.append(
+            "One or more findings exceeded the escalation threshold: "
+            + ", ".join(KPI_LABELS[k] for k in critical_flags) + "."
         )
+    else:
+        reason.append("All findings below escalation thresholds.")
+
+    # ── Overall confidence ──────────────────────────────────────────────────
+    confidences = [f["confidence"] for f in predicted_findings] or [0.8]
+    overall_conf = round(sum(confidences) / len(confidences), 2)
+    if overall_conf >= 0.85:
+        confidence_level = "High"
+    elif overall_conf >= 0.70:
+        confidence_level = "Medium"
+    else:
+        confidence_level = "Low"
+
+    # ── Explainability ──────────────────────────────────────────────────────
+    top_findings = sorted(predicted_findings, key=lambda f: f["probability"], reverse=True)[:3]
+    risk_drivers = (
+        [KPI_LABELS.get(k, k) for k in critical_flags]
+        if critical_flags
+        else ["No KPI above escalation threshold"]
+    )
+    explainability = {
+        "baseline_source": resolution["baseline_source"],
+        "baseline_match_score": baseline_match_score,
+        "highest_findings": [
+            {"type": f["type"], "label": KPI_LABELS.get(f["type"], f["type"]),
+             "probability": f["probability"], "severity": severity_from_probability(f["probability"])}
+            for f in top_findings
+        ],
+        "risk_drivers": risk_drivers,
+        "confidence_level": confidence_level,
+        "rationale": (
+            "Score derived from the approved baseline match, weighted KPI findings, and "
+            "identification matches. Risk and recommendation are driven by whether any KPI "
+            "exceeds its escalation threshold."
+        ),
+    }
 
     source = resolution["baseline_source"]
     return {
@@ -351,10 +485,17 @@ def analyze_inspection(
         "baseline_deviation_score": baseline_deviation_score,
         "inspection_score": inspection_score,
         "risk_level": risk_level,
+        "pass_fail": pass_fail,
         "predicted_findings": predicted_findings,
         "kpi_summary": kpi_summary,
         "identification": identification,
+        "findings_summary": findings_summary,
+        "confidence": overall_conf,
+        "confidence_level": confidence_level,
         "recommendation": recommendation,
+        "reason": reason,
+        "critical_flags": critical_flags,
+        "explainability": explainability,
         "human_review_required": True,
         "placeholder_scoring": True,
     }

--- a/backend/tests/test_analysis_panel_output.py
+++ b/backend/tests/test_analysis_panel_output.py
@@ -1,0 +1,121 @@
+"""Upgraded AI analysis output: summary, confidence, severity/status, pass/fail,
+critical-threshold escalation, and explainability."""
+from app.services.baseline_comparison_scoring_service import (
+    analyze_inspection,
+    severity_from_probability,
+    status_from_probability,
+)
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+
+SHA = "5e1f00d0" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == itype).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"panel-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+        )
+    finally:
+        db.close()
+
+
+# ── Threshold helpers ────────────────────────────────────────────────────────
+
+class TestThresholds:
+    def test_severity_rules(self):
+        assert severity_from_probability(0.05) == "none"
+        assert severity_from_probability(0.20) == "low"
+        assert severity_from_probability(0.45) == "moderate"
+        assert severity_from_probability(0.80) == "high"
+
+    def test_status_rules(self):
+        assert status_from_probability(0.05) == "clear"
+        assert status_from_probability(0.20) == "monitor"
+        assert status_from_probability(0.45) == "review"
+        assert status_from_probability(0.80) == "escalate"
+
+
+# ── Completed analysis shape ─────────────────────────────────────────────────
+
+class TestCompletedOutput:
+    def test_has_summary_and_confidence(self):
+        out = _analyze("scissors")
+        assert out["analysis_status"] == "completed"
+        # No "pending" placeholders in a completed analysis
+        assert out["findings_summary"], "findings_summary must be populated"
+        assert out["confidence"] is not None
+        assert out["confidence_level"] in ("High", "Medium", "Low")
+        assert out["pass_fail"] in ("PASS", "FAIL")
+
+    def test_kpi_findings_have_severity_and_status(self):
+        out = _analyze("forceps")
+        for f in out["predicted_findings"]:
+            assert f["severity"] in ("none", "low", "moderate", "high")
+            assert f["status"] in ("clear", "monitor", "review", "escalate")
+            assert "label" in f
+
+    def test_explainability_present(self):
+        out = _analyze("needle_holder")
+        ex = out["explainability"]
+        assert ex["baseline_source"] == "manufacturer"
+        assert ex["baseline_match_score"] == out["baseline_match_score"]
+        assert ex["highest_findings"]
+        assert ex["risk_drivers"]
+        assert ex["confidence_level"] == out["confidence_level"]
+
+    def test_clean_instrument_passes(self):
+        # No declared findings → low probabilities → PASS + accept recommendation
+        out = _analyze("retractor")
+        if not out["critical_flags"]:
+            assert out["pass_fail"] == "PASS"
+            assert "Accept inspection" in out["recommendation"]
+
+
+# ── Critical-threshold escalation ────────────────────────────────────────────
+
+class TestCriticalEscalation:
+    def test_declared_blood_triggers_reprocess(self):
+        # Declaring blood pushes its probability high (>0.30) → FAIL + reprocess
+        out = _analyze("scissors", declared=["blood"])
+        assert out["critical_flags"], "blood should breach critical threshold"
+        assert out["pass_fail"] == "FAIL"
+        assert out["risk_level"] in ("high", "critical")
+        assert "Reprocess" in out["recommendation"] or "Supervisor review" in out["recommendation"]
+
+    def test_declared_crack_removes_from_service(self):
+        out = _analyze("forceps", declared=["crack"])
+        assert "crack" in out["critical_flags"]
+        assert out["risk_level"] == "critical"
+        assert "Remove from service" in out["recommendation"]
+
+    def test_missing_baseline_still_supervisor_review(self):
+        itype = "clip_applier"
+        db = SessionLocal()
+        try:
+            db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == itype).delete()
+            db.commit()
+            out = analyze_inspection(
+                db, instrument_type=itype, tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA,
+            )
+        finally:
+            db.close()
+        assert out["analysis_status"] == "supervisor_review_required"
+        assert out["inspection_score"] is None

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -35,9 +35,20 @@ type FieldErrors = Partial<Record<keyof FormFields | "images", string>>;
 
 type PredictedFinding = {
   type: string;
+  label?: string;
   probability: number;
   confidence: number;
   severity: string;
+  status?: string;
+};
+
+type Explainability = {
+  baseline_source: string | null;
+  baseline_match_score: number | null;
+  highest_findings: { type: string; label: string; probability: number; severity: string }[];
+  risk_drivers: string[];
+  confidence_level: string;
+  rationale: string;
 };
 
 type Analysis = {
@@ -49,10 +60,17 @@ type Analysis = {
   baseline_deviation_score: number | null;
   inspection_score: number | null;
   risk_level: string | null;
+  pass_fail?: string;
   predicted_findings: PredictedFinding[];
   kpi_summary: Record<string, boolean>;
   identification: Record<string, boolean>;
+  findings_summary?: string[];
+  confidence?: number;
+  confidence_level?: string;
   recommendation: string;
+  reason?: string[];
+  critical_flags?: string[];
+  explainability?: Explainability;
   human_review_required: boolean;
   placeholder_scoring?: boolean;
 };
@@ -878,13 +896,15 @@ function AIPredictionPanel({
         {/* Prediction grid */}
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <PredictionField label="Predicted Findings" value={
-            prediction.detected_issue === "unknown" || prediction.detected_issue === ""
-              ? "Pending AI analysis"
-              : prediction.detected_issue.replace(/_/g, " ")
+            prediction.analysis?.analysis_status === "completed"
+              ? (prediction.analysis.critical_flags && prediction.analysis.critical_flags.length > 0
+                  ? prediction.analysis.critical_flags.map((c) => c.replace(/_/g, " ")).join(", ")
+                  : "No critical findings")
+              : "Pending AI analysis"
           } />
           <PredictionField label="Confidence" value={
-            prediction.confidence > 0
-              ? `${(prediction.confidence).toFixed(0)}%`
+            prediction.analysis?.analysis_status === "completed" && prediction.analysis.confidence != null
+              ? `${prediction.analysis.confidence_level ?? ""} (${Math.round((prediction.analysis.confidence) * 100)}%)`.trim()
               : "Pending"
           } />
           <div className="flex flex-col">
@@ -1004,6 +1024,7 @@ const KPI_DISPLAY: { key: string; label: string }[] = [
   { key: "tissue", label: "Tissue" },
   { key: "bioburden", label: "Bioburden" },
   { key: "debris", label: "Debris" },
+  { key: "other_organic_residue", label: "Other Organic Residue" },
   { key: "rust", label: "Rust" },
   { key: "discoloration", label: "Discoloration" },
   { key: "corrosion", label: "Corrosion" },
@@ -1012,6 +1033,34 @@ const KPI_DISPLAY: { key: string; label: string }[] = [
   { key: "insulation_damage", label: "Insulation Damage" },
   { key: "missing_component", label: "Missing Component" },
 ];
+
+// Display rules from probability (0–1). Mirrors the backend thresholds.
+function severityOf(p: number): string {
+  const pct = p * 100;
+  if (pct <= 10) return "None";
+  if (pct <= 30) return "Low";
+  if (pct <= 60) return "Moderate";
+  return "High";
+}
+function statusOf(p: number): string {
+  const pct = p * 100;
+  if (pct <= 10) return "Clear";
+  if (pct <= 30) return "Monitor";
+  if (pct <= 60) return "Review";
+  return "Escalate";
+}
+const STATUS_STYLE: Record<string, string> = {
+  Clear: "bg-emerald-100 text-emerald-800",
+  Monitor: "bg-amber-100 text-amber-800",
+  Review: "bg-orange-100 text-orange-800",
+  Escalate: "bg-red-100 text-red-800",
+};
+const SEVERITY_STYLE: Record<string, string> = {
+  None: "text-slate-500",
+  Low: "text-amber-600",
+  Moderate: "text-orange-600",
+  High: "text-red-600 font-semibold",
+};
 
 function AnalysisDetails({ analysis }: { analysis: Analysis }) {
   const score = analysis.inspection_score ?? 0;
@@ -1025,6 +1074,7 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
       ? `${analysis.baseline_source.replace(/_/g, " ")} baseline`
       : "—");
   const isFallback = analysis.baseline_role === "fallback";
+  const passFail = analysis.pass_fail ?? (analysis.critical_flags && analysis.critical_flags.length > 0 ? "FAIL" : "PASS");
 
   return (
     <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
@@ -1057,31 +1107,54 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
         <PredictionField label="Baseline Match" value={matchPct} />
       </div>
 
-      {/* KPI finding cards */}
+      {/* Findings summary */}
+      {analysis.findings_summary && analysis.findings_summary.length > 0 && (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Findings Summary</p>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-0.5 text-sm text-slate-700">
+            {analysis.findings_summary.map((s, i) => (
+              <li key={i} className="flex items-start gap-1.5">
+                <span className={s.startsWith("No ") ? "text-emerald-500" : "text-amber-500"}>•</span>
+                <span>{s}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* KPI finding cards: name · probability · severity · status */}
       <div>
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">KPI Findings</p>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
           {KPI_DISPLAY.map(({ key, label }) => {
-            const present = analysis.kpi_summary[key] === true;
             const finding = analysis.predicted_findings.find((f) => f.type === key);
+            const p = finding?.probability ?? 0;
+            const pct = Math.round(p * 100);
+            const severity = finding?.severity
+              ? finding.severity.charAt(0).toUpperCase() + finding.severity.slice(1)
+              : severityOf(p);
+            const status = finding?.status
+              ? finding.status.charAt(0).toUpperCase() + finding.status.slice(1)
+              : statusOf(p);
             return (
-              <div
-                key={key}
-                className={`flex items-center justify-between rounded-lg border px-3 py-2 text-sm ${
-                  present ? "border-red-300 bg-red-50" : "border-slate-200 bg-slate-50"
-                }`}
-              >
-                <span className="font-medium text-slate-700">{label}</span>
-                <span className="flex items-center gap-1.5">
-                  {finding && (
-                    <span className="text-xs text-slate-400">{Math.round(finding.probability * 100)}%</span>
-                  )}
-                  <span className={`inline-block h-2.5 w-2.5 rounded-full ${present ? "bg-red-500" : "bg-emerald-400"}`} />
-                </span>
+              <div key={key} className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-slate-700">{label}</span>
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLE[status] ?? "bg-slate-100 text-slate-600"}`}>
+                    {status}
+                  </span>
+                </div>
+                <div className="mt-1 flex items-center justify-between text-xs">
+                  <span className="text-slate-500">Probability <span className="font-semibold text-slate-700">{pct}%</span></span>
+                  <span className={SEVERITY_STYLE[severity] ?? "text-slate-500"}>Severity: {severity}</span>
+                </div>
               </div>
             );
           })}
         </div>
+        <p className="mt-1.5 text-xs text-slate-400">
+          Status: 0–10% Clear · 11–30% Monitor · 31–60% Review · 61%+ Escalate.
+        </p>
       </div>
 
       {/* Identification */}
@@ -1105,15 +1178,58 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
         </div>
       </div>
 
-      {/* Recommended action */}
-      <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1">Recommended Action</p>
-        <p className="text-sm text-slate-700">{analysis.recommendation}</p>
+      {/* Recommended action with PASS/FAIL + reasons */}
+      <div className={`rounded-lg border px-4 py-3 ${passFail === "PASS" ? "border-emerald-300 bg-emerald-50" : "border-red-300 bg-red-50"}`}>
+        <div className="flex items-center gap-2 mb-1">
+          <span className={`rounded px-2 py-0.5 text-xs font-bold ${passFail === "PASS" ? "bg-emerald-600 text-white" : "bg-red-600 text-white"}`}>
+            {passFail}
+          </span>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Recommended Action</p>
+        </div>
+        {analysis.reason && analysis.reason.length > 0 && (
+          <ul className="mb-2 ml-1 space-y-0.5 text-sm text-slate-700">
+            {analysis.reason.map((r, i) => (
+              <li key={i} className="flex items-start gap-1.5"><span className="text-slate-400">–</span><span>{r}</span></li>
+            ))}
+          </ul>
+        )}
+        <p className="text-sm font-medium text-slate-800">{analysis.recommendation}</p>
+      </div>
+
+      {/* Explainability */}
+      {analysis.explainability && (
+        <details className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+          <summary className="cursor-pointer text-sm font-semibold text-slate-700">
+            Why LumenAI scored this inspection this way
+          </summary>
+          <div className="mt-2 space-y-1.5 text-sm text-slate-600">
+            <p><span className="text-slate-500">Baseline source:</span> <span className="capitalize">{analysis.explainability.baseline_source ?? "—"}</span></p>
+            <p><span className="text-slate-500">Baseline match:</span> {analysis.explainability.baseline_match_score != null ? `${Math.round(analysis.explainability.baseline_match_score * 100)}%` : "—"}</p>
+            <div>
+              <span className="text-slate-500">Highest findings:</span>
+              <ul className="ml-3 mt-0.5 list-disc">
+                {analysis.explainability.highest_findings.map((f) => (
+                  <li key={f.type} className="capitalize">{f.label} — {Math.round(f.probability * 100)}% ({f.severity})</li>
+                ))}
+              </ul>
+            </div>
+            <p><span className="text-slate-500">Risk drivers:</span> {analysis.explainability.risk_drivers.join(", ")}</p>
+            <p><span className="text-slate-500">Confidence level:</span> {analysis.explainability.confidence_level}</p>
+            <p className="text-slate-500 italic">{analysis.explainability.rationale}</p>
+          </div>
+        </details>
+      )}
+
+      {/* Image evidence placeholder — never fake bounding boxes */}
+      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-500">
+        <p className="font-medium text-slate-600">Image evidence map not yet available.</p>
+        <p className="text-xs">A future release will highlight detected regions on the uploaded image.</p>
       </div>
 
       {analysis.placeholder_scoring && (
         <p className="text-xs text-slate-400 italic">
-          Scoring produced by deterministic baseline-comparison service (placeholder). Not production computer vision.
+          Scoring produced by deterministic baseline-comparison service (placeholder). Not production computer vision —
+          per-KPI probabilities are heuristic, not pixel-level detections.
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary

Upgrades the AI Analysis Results Panel so the output is clear, explainable, and clinically defensible for SPD managers, IP, and quality reviewers. Clinical logic lives in the backend (testable); the panel maps it.

## Backend (scoring service)
- Per-finding **severity** (None/Low/Moderate/High) and **status** (Clear/Monitor/Review/Escalate) from probability thresholds.
- **findings_summary** — e.g. "No blood detected", "Minor discoloration detected".
- Overall **confidence** + **confidence_level** (High/Medium/Low).
- **pass_fail** + **reason** bullets explaining the verdict.
- **Critical KPI thresholds** drive escalation: blood/bone/tissue/bioburden > 30%, rust/corrosion > 60%, crack/missing_component > 30% → risk **high/critical** and a **reprocess / supervisor-review / remove-from-service** recommendation.
- **explainability** block (baseline source & match, highest findings, risk drivers, confidence, rationale).

## Frontend (New Inspection result panel)
- Replaces **"Predicted Findings: Pending"** / **"Confidence: Pending"** with a real summary + confidence after a completed analysis.
- **KPI cards** now show **probability %, severity, and status** with a threshold legend.
- **Recommended Action** shows **PASS/FAIL** with reason bullets explaining why.
- **"Why LumenAI scored this inspection this way"** explainability section.
- **Image-evidence placeholder** ("map not yet available… future release") — no fake bounding boxes.

## Honesty note
Per-KPI probabilities are still from the deterministic placeholder (not pixel-level CV) and the panel says so. Real image detection + severity grading (e.g. rust degree) remains a separate build.

## Validation
- `npm --prefix frontend run build` → ✅ clean
- `python -m pytest tests -q` → ✅ **2133 passed, 2 skipped**
- `ruff check` → ✅ clean
- New tests: severity/status rules; completed output has summary/confidence/pass_fail (no "Pending"); KPI severity+status; explainability; declared blood → reprocess escalation; declared crack → remove from service; missing baseline → supervisor review.

## Files
- `backend/app/services/baseline_comparison_scoring_service.py`
- `backend/tests/test_analysis_panel_output.py`
- `frontend/src/pages/NewInspectionPage.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_