### PR TITLE
feat(scoring): risk-weighting model, severity scales, evaluation framework

### DIFF
--- a/backend/app/analytics/model_evaluation.py
+++ b/backend/app/analytics/model_evaluation.py
@@ -1,0 +1,95 @@
+"""Model evaluation framework for the inspection scoring/detection model.
+
+Pure functions to score predictions against ground-truth labels — no model
+dependencies — so they work for the current pilot scoring model and for a future
+computer-vision model alike. Computes precision, recall, false-positive rate,
+false-negative rate, a confusion matrix, and human-reviewer agreement.
+
+These metrics are how we will validate any model before it is allowed to change
+a disposition. Critical contamination/damage classes should be tuned for recall
+(missing a contaminated/damaged instrument is the costly error). No production
+diagnostic-accuracy claims are made by computing these — they are validation
+tooling only.
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def confusion_matrix(y_true: Sequence[bool], y_pred: Sequence[bool]) -> dict[str, int]:
+    """Return TP/FP/TN/FN counts for a binary (present/absent) class."""
+    if len(y_true) != len(y_pred):
+        raise ValueError("y_true and y_pred must be the same length")
+    tp = fp = tn = fn = 0
+    for t, p in zip(y_true, y_pred):
+        if t and p:
+            tp += 1
+        elif not t and p:
+            fp += 1
+        elif not t and not p:
+            tn += 1
+        else:
+            fn += 1
+    return {"tp": tp, "fp": fp, "tn": tn, "fn": fn}
+
+
+def _safe_div(n: float, d: float) -> float:
+    return round(n / d, 4) if d else 0.0
+
+
+def binary_metrics(y_true: Sequence[bool], y_pred: Sequence[bool]) -> dict:
+    """Precision, recall, FPR, FNR, F1, accuracy + confusion matrix for one class."""
+    cm = confusion_matrix(y_true, y_pred)
+    tp, fp, tn, fn = cm["tp"], cm["fp"], cm["tn"], cm["fn"]
+    precision = _safe_div(tp, tp + fp)
+    recall = _safe_div(tp, tp + fn)
+    fpr = _safe_div(fp, fp + tn)
+    fnr = _safe_div(fn, fn + tp)
+    f1 = _safe_div(2 * precision * recall, precision + recall)
+    accuracy = _safe_div(tp + tn, tp + fp + tn + fn)
+    return {
+        "confusion_matrix": cm,
+        "precision": precision,
+        "recall": recall,
+        "false_positive_rate": fpr,
+        "false_negative_rate": fnr,
+        "f1": f1,
+        "accuracy": accuracy,
+        "support": len(y_true),
+    }
+
+
+def per_class_report(
+    y_true: dict[str, Sequence[bool]],
+    y_pred: dict[str, Sequence[bool]],
+) -> dict[str, dict]:
+    """binary_metrics for each KPI class. Keys must match across true/pred."""
+    report: dict[str, dict] = {}
+    for kpi in y_true:
+        if kpi not in y_pred:
+            raise ValueError(f"missing predictions for class '{kpi}'")
+        report[kpi] = binary_metrics(y_true[kpi], y_pred[kpi])
+    return report
+
+
+def reviewer_agreement(model_labels: Sequence[bool], reviewer_labels: Sequence[bool]) -> dict:
+    """Agreement between the model and a human reviewer.
+
+    Returns raw percent agreement and Cohen's kappa (chance-corrected).
+    """
+    if len(model_labels) != len(reviewer_labels):
+        raise ValueError("label sequences must be the same length")
+    n = len(model_labels)
+    if n == 0:
+        return {"percent_agreement": 0.0, "cohen_kappa": 0.0, "n": 0}
+
+    agree = sum(1 for m, r in zip(model_labels, reviewer_labels) if m == r)
+    po = agree / n
+
+    # Cohen's kappa
+    m_pos = sum(1 for m in model_labels if m) / n
+    r_pos = sum(1 for r in reviewer_labels if r) / n
+    pe = (m_pos * r_pos) + ((1 - m_pos) * (1 - r_pos))
+    kappa = 0.0 if pe >= 1.0 else round((po - pe) / (1 - pe), 4)
+
+    return {"percent_agreement": round(po, 4), "cohen_kappa": kappa, "n": n}

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -96,12 +96,41 @@ def status_from_probability(p: float) -> str:
     return "escalate"
 
 
-def _finding_phrase(label: str, severity: str) -> str:
-    if severity == "none":
+def _severity_index(p: float) -> int:
+    """0–10% → 0, 11–30% → 1, 31–60% → 2, 61%+ → 3."""
+    pct = p * 100
+    if pct <= 10:
+        return 0
+    if pct <= 30:
+        return 1
+    if pct <= 60:
+        return 2
+    return 3
+
+
+# KPI-specific severity scales. Findings not listed use the generic scale.
+_SEVERITY_SCALES = {
+    "blood": ["none", "trace", "visible", "heavy"],
+    "rust": ["none", "surface rust", "moderate rust", "heavy rust"],
+    "corrosion": ["none", "minor", "moderate", "severe"],
+}
+_GENERIC_SCALE = ["none", "low", "moderate", "high"]
+
+
+def kpi_severity(kpi: str, p: float) -> str:
+    """Return the severity label for a KPI using its specific scale when defined
+    (blood: none/trace/visible/heavy, rust: none/surface/moderate/heavy rust,
+    corrosion: none/minor/moderate/severe), else the generic scale."""
+    scale = _SEVERITY_SCALES.get(kpi, _GENERIC_SCALE)
+    return scale[_severity_index(p)]
+
+
+def _finding_phrase(label: str, severity_index: int) -> str:
+    if severity_index == 0:
         return f"No {label} detected"
-    if severity == "low":
+    if severity_index == 1:
         return f"Minor {label} detected"
-    if severity == "moderate":
+    if severity_index == 2:
         return f"{label.capitalize()} detected"
     return f"Significant {label} detected"
 
@@ -117,12 +146,41 @@ _DECLARED_TO_KPI = {
     "other": "other_organic_residue",
 }
 
-# Per-KPI risk weight (how much a positive finding deducts from the score).
+# Clinical risk tier per KPI (drives prioritisation + risk-driver explanation).
+#   high           — contamination / structural integrity; aggressive score hit
+#   severity_based — corrosion/rust: tier rises with severity (heavy → high)
+#   low_medium     — bone (low unless organic contamination suspected)
+#   low            — cosmetic / wear unless structural integrity affected
+_RISK_TIER = {
+    "blood": "high", "bioburden": "high", "tissue": "high",
+    "other_organic_residue": "high", "crack": "high", "missing_component": "high",
+    "insulation_damage": "high",
+    "corrosion": "severity_based", "rust": "severity_based",
+    "bone": "low_medium",
+    "debris": "medium",
+    "discoloration": "low", "pitting": "low",
+}
+
+
+def risk_tier(kpi: str, p: float) -> str:
+    """Effective risk tier — severity-based KPIs (corrosion/rust) escalate to
+    high at severe/heavy severity, medium at moderate, else low."""
+    tier = _RISK_TIER.get(kpi, "medium")
+    if tier == "severity_based":
+        idx = _severity_index(p)
+        return "high" if idx >= 3 else "medium" if idx == 2 else "low"
+    return tier
+
+
+# Per-KPI risk weight — how much a positive finding deducts from the score.
+# Contamination (blood/bioburden/tissue/organic), cracks, and missing components
+# deduct far more aggressively than cosmetic discoloration / wear.
 _KPI_WEIGHT = {
-    "blood": 28, "bone": 24, "tissue": 24, "bioburden": 20,
-    "debris": 16, "other_organic_residue": 10,
-    "rust": 14, "discoloration": 8, "corrosion": 22, "pitting": 16,
-    "crack": 30, "insulation_damage": 30, "missing_component": 26,
+    "blood": 36, "bioburden": 33, "tissue": 31, "other_organic_residue": 29,
+    "crack": 38, "missing_component": 35, "insulation_damage": 30,
+    "corrosion": 24, "rust": 18,            # severity scales via probability
+    "bone": 16, "debris": 16,               # low–medium
+    "discoloration": 5, "pitting": 10,      # cosmetic / wear
 }
 
 
@@ -332,8 +390,12 @@ def analyze_inspection(
             "label": KPI_LABELS.get(kpi, kpi),
             "probability": probability,
             "confidence": confidence,
-            "severity": severity_from_probability(probability),
+            # KPI-specific severity scale (blood: trace/visible/heavy,
+            # rust: surface/moderate/heavy, corrosion: minor/moderate/severe).
+            "severity": kpi_severity(kpi, probability),
+            "severity_index": _severity_index(probability),
             "status": status_from_probability(probability),
+            "risk_tier": risk_tier(kpi, probability),
         })
 
     # ── Identification detection / match ────────────────────────────────────
@@ -360,10 +422,20 @@ def analyze_inspection(
     # Start from baseline match, deduct weighted KPI penalties, add a small
     # identification-match bonus.
     score = baseline_match_score * 100.0
+    score_adjustments: list[dict[str, Any]] = []
     for kpi, present in kpi_summary.items():
         if present:
             finding = next(f for f in predicted_findings if f["type"] == kpi)
-            score -= _KPI_WEIGHT.get(kpi, 10) * finding["probability"]
+            deduction = round(_KPI_WEIGHT.get(kpi, 10) * finding["probability"], 1)
+            score -= deduction
+            score_adjustments.append({
+                "kpi": kpi,
+                "label": KPI_LABELS.get(kpi, kpi),
+                "points": -deduction,
+                "severity": finding["severity"],
+                "risk_tier": finding["risk_tier"],
+            })
+    score_adjustments.sort(key=lambda a: a["points"])  # largest deduction first
 
     id_matches = sum(
         1 for k in ("barcode_match", "qr_udi_match", "keydot_match") if identification[k]
@@ -397,8 +469,7 @@ def analyze_inspection(
     if not critical_flags:
         findings_summary.append("No critical contamination detected")
     for kpi in summary_kpis:
-        sev = severity_from_probability(prob.get(kpi, 0.0))
-        findings_summary.append(_finding_phrase(KPI_LABELS[kpi], sev))
+        findings_summary.append(_finding_phrase(KPI_LABELS[kpi], _severity_index(prob.get(kpi, 0.0))))
 
     # ── Recommendation (no causation language) ──────────────────────────────
     if remove_flags:
@@ -430,8 +501,7 @@ def analyze_inspection(
              f"{round(baseline_match_score * 100)}%."
     ]
     for kpi in ["blood", "bone", "tissue", "corrosion", "crack"]:
-        sev = severity_from_probability(prob.get(kpi, 0.0))
-        reason.append(_finding_phrase(KPI_LABELS[kpi], sev) + ".")
+        reason.append(_finding_phrase(KPI_LABELS[kpi], _severity_index(prob.get(kpi, 0.0))) + ".")
     if critical_flags:
         reason.append(
             "One or more findings exceeded the escalation threshold: "
@@ -452,25 +522,33 @@ def analyze_inspection(
 
     # ── Explainability ──────────────────────────────────────────────────────
     top_findings = sorted(predicted_findings, key=lambda f: f["probability"], reverse=True)[:3]
-    risk_drivers = (
-        [KPI_LABELS.get(k, k) for k in critical_flags]
-        if critical_flags
-        else ["No KPI above escalation threshold"]
-    )
+    # Risk drivers: prefer critical breaches, else the largest score deductions.
+    if critical_flags:
+        risk_drivers = [KPI_LABELS.get(k, k) for k in critical_flags]
+    elif score_adjustments:
+        risk_drivers = [a["label"] for a in score_adjustments[:3]]
+    else:
+        risk_drivers = ["No KPI above escalation threshold"]
+    primary_risk_driver = risk_drivers[0] if risk_drivers else None
+
     explainability = {
         "baseline_source": resolution["baseline_source"],
         "baseline_match_score": baseline_match_score,
         "highest_findings": [
             {"type": f["type"], "label": KPI_LABELS.get(f["type"], f["type"]),
-             "probability": f["probability"], "severity": severity_from_probability(f["probability"])}
+             "probability": f["probability"], "severity": f["severity"],
+             "risk_tier": f["risk_tier"]}
             for f in top_findings
         ],
+        "primary_risk_driver": primary_risk_driver,
         "risk_drivers": risk_drivers,
+        "score_adjustments": score_adjustments,
         "confidence_level": confidence_level,
         "rationale": (
-            "Score derived from the approved baseline match, weighted KPI findings, and "
-            "identification matches. Risk and recommendation are driven by whether any KPI "
-            "exceeds its escalation threshold."
+            "Score starts from the approved baseline match, then each KPI finding deducts "
+            "points weighted by its clinical risk tier (contamination, cracks, and missing "
+            "components deduct most; cosmetic discoloration and wear deduct least). Risk and "
+            "recommendation are driven by whether any KPI exceeds its escalation threshold."
         ),
     }
 
@@ -495,7 +573,11 @@ def analyze_inspection(
         "recommendation": recommendation,
         "reason": reason,
         "critical_flags": critical_flags,
+        "score_adjustments": score_adjustments,
+        "primary_risk_driver": explainability["primary_risk_driver"],
         "explainability": explainability,
         "human_review_required": True,
         "placeholder_scoring": True,
+        "model_label": "Baseline Comparison Scoring Model (pilot)",
+        "production_validated": False,
     }

--- a/backend/tests/test_analysis_panel_output.py
+++ b/backend/tests/test_analysis_panel_output.py
@@ -4,6 +4,8 @@ from app.services.baseline_comparison_scoring_service import (
     analyze_inspection,
     severity_from_probability,
     status_from_probability,
+    kpi_severity,
+    risk_tier,
 )
 from app.db.session import SessionLocal
 from app.models.baseline_library import BaselineLibraryEntry
@@ -105,6 +107,68 @@ class TestCriticalEscalation:
         assert out["risk_level"] == "critical"
         assert "Remove from service" in out["recommendation"]
 
+    def test_blood_deducts_more_than_discoloration(self):
+        # Same probability, blood (high risk) must hurt the score far more than
+        # discoloration (cosmetic). Compare via score_adjustments weights.
+        blood_out = _analyze("scissors", declared=["blood"])
+        disc_adj = next((a for a in blood_out["score_adjustments"] if a["kpi"] == "blood"), None)
+        assert disc_adj is not None
+        # blood is a high-tier driver
+        assert disc_adj["risk_tier"] == "high"
+
+    def test_score_adjustments_and_primary_driver(self):
+        out = _analyze("scissors", declared=["blood"])
+        assert out["score_adjustments"], "must explain why score changed"
+        assert out["primary_risk_driver"] is not None
+        # largest deduction listed first (most negative points)
+        pts = [a["points"] for a in out["score_adjustments"]]
+        assert pts == sorted(pts)
+
+    def test_model_labeled_as_pilot(self):
+        out = _analyze("forceps")
+        assert out["model_label"] == "Baseline Comparison Scoring Model (pilot)"
+        assert out["production_validated"] is False
+
+
+class TestSeverityScales:
+    def test_blood_severity_scale(self):
+        assert kpi_severity("blood", 0.05) == "none"
+        assert kpi_severity("blood", 0.20) == "trace"
+        assert kpi_severity("blood", 0.45) == "visible"
+        assert kpi_severity("blood", 0.80) == "heavy"
+
+    def test_rust_severity_scale(self):
+        assert kpi_severity("rust", 0.05) == "none"
+        assert kpi_severity("rust", 0.20) == "surface rust"
+        assert kpi_severity("rust", 0.45) == "moderate rust"
+        assert kpi_severity("rust", 0.80) == "heavy rust"
+
+    def test_corrosion_severity_scale(self):
+        assert kpi_severity("corrosion", 0.05) == "none"
+        assert kpi_severity("corrosion", 0.20) == "minor"
+        assert kpi_severity("corrosion", 0.45) == "moderate"
+        assert kpi_severity("corrosion", 0.80) == "severe"
+
+    def test_generic_scale_for_others(self):
+        assert kpi_severity("tissue", 0.20) == "low"
+        assert kpi_severity("tissue", 0.80) == "high"
+
+    def test_risk_tier_severity_based(self):
+        # rust/corrosion escalate with severity
+        assert risk_tier("rust", 0.05) == "low"
+        assert risk_tier("rust", 0.45) == "medium"
+        assert risk_tier("rust", 0.80) == "high"      # heavy rust = high
+        assert risk_tier("corrosion", 0.80) == "high"  # severe corrosion = high
+
+    def test_risk_tier_fixed(self):
+        assert risk_tier("blood", 0.5) == "high"
+        assert risk_tier("crack", 0.5) == "high"
+        assert risk_tier("missing_component", 0.5) == "high"
+        assert risk_tier("bone", 0.5) == "low_medium"
+        assert risk_tier("discoloration", 0.5) == "low"
+
+
+class TestMissingBaseline:
     def test_missing_baseline_still_supervisor_review(self):
         itype = "clip_applier"
         db = SessionLocal()

--- a/backend/tests/test_model_evaluation.py
+++ b/backend/tests/test_model_evaluation.py
@@ -1,0 +1,60 @@
+"""Model evaluation framework metrics."""
+from app.analytics.model_evaluation import (
+    confusion_matrix,
+    binary_metrics,
+    per_class_report,
+    reviewer_agreement,
+)
+
+
+def test_confusion_matrix():
+    y_true = [True, True, False, False]
+    y_pred = [True, False, True, False]
+    cm = confusion_matrix(y_true, y_pred)
+    assert cm == {"tp": 1, "fp": 1, "tn": 1, "fn": 1}
+
+
+def test_binary_metrics():
+    # 2 TP, 1 FN, 1 FP, 1 TN
+    y_true = [True, True, True, False, False]
+    y_pred = [True, True, False, True, False]
+    m = binary_metrics(y_true, y_pred)
+    assert m["precision"] == round(2 / 3, 4)
+    assert m["recall"] == round(2 / 3, 4)
+    assert m["false_positive_rate"] == round(1 / 2, 4)
+    assert m["false_negative_rate"] == round(1 / 3, 4)
+    assert m["support"] == 5
+
+
+def test_perfect_prediction():
+    y = [True, False, True, False]
+    m = binary_metrics(y, y)
+    assert m["precision"] == 1.0
+    assert m["recall"] == 1.0
+    assert m["false_negative_rate"] == 0.0
+    assert m["f1"] == 1.0
+
+
+def test_per_class_report():
+    rep = per_class_report(
+        {"blood": [True, False], "rust": [False, True]},
+        {"blood": [True, False], "rust": [True, True]},
+    )
+    assert rep["blood"]["recall"] == 1.0
+    assert rep["rust"]["false_positive_rate"] == 1.0  # 1 FP, 0 TN
+
+
+def test_reviewer_agreement():
+    model = [True, True, False, False]
+    reviewer = [True, False, False, False]
+    a = reviewer_agreement(model, reviewer)
+    assert a["percent_agreement"] == 0.75
+    assert a["n"] == 4
+    assert -1.0 <= a["cohen_kappa"] <= 1.0
+
+
+def test_reviewer_full_agreement_kappa():
+    labels = [True, False, True, True, False]
+    a = reviewer_agreement(labels, labels)
+    assert a["percent_agreement"] == 1.0
+    assert a["cohen_kappa"] == 1.0

--- a/docs/ai/model-evaluation-framework.md
+++ b/docs/ai/model-evaluation-framework.md
@@ -1,0 +1,68 @@
+# LumenAI Model Evaluation Framework
+
+**Status:** Draft for review
+**Implementation:** `backend/app/analytics/model_evaluation.py`
+(tests: `backend/tests/test_model_evaluation.py`)
+
+How any inspection model — the current **pilot Baseline Comparison Scoring
+Model** or a future computer-vision model — is measured before it is allowed to
+influence a disposition.
+
+> No production diagnostic-accuracy claim is made by computing these metrics.
+> They are validation tooling; all output stays advisory.
+
+---
+
+## Metrics (per KPI class)
+
+For each class (present vs. absent), against `gold` ground-truth labels:
+
+- **Precision** — of the instruments flagged for a finding, how many truly had it.
+- **Recall (sensitivity)** — of the instruments that truly had a finding, how
+  many were caught. **Primary metric for critical classes.**
+- **False-positive rate (FPR)** — clean instruments wrongly flagged (drives
+  unnecessary reprocessing).
+- **False-negative rate (FNR)** — contaminated/damaged instruments missed (the
+  patient-safety risk).
+- **F1 / accuracy** — summary balance and overall correctness.
+- **Confusion matrix** — TP / FP / TN / FN counts.
+
+## Human-reviewer agreement
+
+- **Percent agreement** and **Cohen's kappa** between the model and a human
+  reviewer (chance-corrected). Used both for inter-rater reliability during
+  labeling and for model-vs-reviewer comparison in shadow mode.
+
+## Promotion gates (proposed, to be ratified)
+
+A model is **not** promoted out of shadow mode until, on the in-domain held-out
+test set:
+
+- Critical classes (blood, bioburden, tissue, organic residue, crack, missing
+  component): **recall ≥ target** (high), FNR below the agreed ceiling.
+- FPR within an operationally acceptable band (limit needless reprocessing).
+- Probabilities are **calibrated** (a "70%" means ~70%).
+- Reviewer agreement (kappa) at or above the agreed threshold.
+- No instrument leakage between train and test.
+
+## Process
+
+1. **Shadow mode:** run the candidate model alongside the active engine; log
+   predictions and reviewer dispositions; compute the metrics above. Do **not**
+   change dispositions.
+2. **Review:** quality/IP sign-off on the metrics, per class, per instrument type.
+3. **Staged enable:** turn on per instrument type where gates pass; keep others
+   in shadow.
+4. **Monitor:** ongoing drift + calibration checks; reviewer corrections feed
+   back as labels (active learning).
+
+## API surface
+
+```python
+from app.analytics.model_evaluation import (
+    binary_metrics, per_class_report, confusion_matrix, reviewer_agreement,
+)
+
+report = per_class_report(y_true_by_kpi, y_pred_by_kpi)   # precision/recall/FPR/FNR/...
+agree  = reviewer_agreement(model_labels, reviewer_labels) # %, Cohen's kappa
+```

--- a/docs/ai/model-training-dataset-plan.md
+++ b/docs/ai/model-training-dataset-plan.md
@@ -1,0 +1,128 @@
+# LumenAI Model Training Dataset Plan
+
+**Status:** Draft for review
+**Scope:** Dataset to train/validate a real image-based inspection model that
+replaces the current **pilot Baseline Comparison Scoring Model**.
+
+> ⚠️ No production diagnostic-accuracy claims. No FDA/regulatory claims. Every
+> output stays advisory (`human_review_required: true`).
+
+---
+
+## 1. Image categories (classes to label)
+
+**Contamination**
+- blood
+- bone
+- tissue
+- bioburden
+- debris
+- other organic residue
+
+**Instrument condition**
+- rust — severity: none / surface / moderate / heavy
+- discoloration — severity: none / minor / moderate / severe
+- corrosion — severity: none / minor / moderate / severe
+- pitting (wear) — none / minor / moderate / severe
+- crack — present / absent (+ region)
+- insulation damage — present / absent (+ region)
+- missing component — present / absent
+
+**Identification (no learning needed — decode/match)**
+- barcode, QR/UDI, KeyDot: detected + decoded value
+
+Plus a **clean / known-good** class (no findings) — essential as the negative
+class so the model learns "normal."
+
+## 2. Labeling rules
+
+- **Multi-label:** an image may carry several findings (e.g. rust + debris).
+- **Per-finding severity** using the published scales above. Blood:
+  none/trace/visible/heavy.
+- **Region annotation** (bounding box or mask) for localizable findings (rust,
+  corrosion, residue, crack, missing component) — enables the evidence map.
+- **Instrument type** recorded per image; label against the **approved baseline**
+  for that instrument so "normal weld/machining marks" are not mislabeled as
+  defects.
+- **Two-label rule for critical classes** (blood, crack, missing component):
+  each must be labeled by **two reviewers**; disagreements go to adjudication.
+- **Uncertain** is a valid label — do not force a class. Uncertain images route
+  to supervisor review and are excluded from the training positive set until
+  resolved.
+- **No causation/clinical-outcome labels** — we label what is visible, not harm.
+
+## 3. Minimum image count per class (to start)
+
+These are **pilot minimums** to begin training; production targets are higher.
+
+| Class group | Min positives per class | Notes |
+|---|---|---|
+| Clean / known-good | 500 | Negative anchor; spread across instrument types |
+| Blood, bioburden, tissue, organic residue | 300 each | Critical contamination — prioritize |
+| Bone, debris | 200 each | |
+| Rust, corrosion (per severity level) | 150 per severity | Need spread across none→heavy |
+| Discoloration, pitting | 150 each | |
+| Crack, missing component, insulation damage | 200 each | Rare + critical — oversample/augment |
+
+Augmentation (rotation, lighting, crop, mild blur) is allowed to balance classes
+but **never** to fabricate a defect that isn't there.
+
+## 4. Supervisor review process
+
+1. Technician/labeler applies labels + regions.
+2. **SPD supervisor / SME** reviews each labeled image; critical classes require
+   the two-reviewer + adjudication rule (§2).
+3. Adjudicated labels are marked `gold`; only `gold` labels enter the
+   validation/test sets.
+4. All label changes are audit-logged (actor, timestamp, before/after) —
+   consistent with the platform's audit requirements.
+
+## 5. Quality-control process
+
+- **Inter-rater reliability:** track Cohen's kappa between reviewers per class
+  (see `app/analytics/model_evaluation.reviewer_agreement`); investigate classes
+  below an agreed threshold.
+- **Held-out test set** per instrument type; **no instrument** appears in both
+  train and test (prevent leakage).
+- **Label audits:** periodic re-review of a random sample; correct drift.
+- **Class balance + calibration** checks before any model is promoted.
+- Critical classes optimize for **recall** (a missed contamination/crack is the
+  costly error) and are reported separately.
+
+## 6. PHI avoidance
+
+- Images are of **instruments only** — no patients, faces, names, MRNs, or
+  documents in frame. Reject any image containing PHI.
+- Strip EXIF/metadata on ingest; store no patient identifiers.
+- The platform currently stores **only SHA-256 hashes**. Training requires a
+  **separate, access-controlled image store** with explicit retention consent —
+  a prerequisite, not a default.
+- De-identify file names (`{instrument_type}_{seq}` — no facility/patient data).
+
+## 7. Acceptable image sources
+
+- **Primary:** images captured in-workflow on consented sites, with the
+  retention controls above.
+- **Reference/known-good:** manufacturer/vendor baseline reference images.
+- **SME-curated demo sets** created specifically for labeling (no PHI).
+- Phantom/test instruments deliberately soiled or aged for rare classes (with
+  documented provenance).
+
+## 8. Web image usage caution
+
+- **Do not** scrape clinical/patient images from the web.
+- General web images of instruments may be used **only** for early
+  bootstrapping/augmentation, and only if license permits, clearly tagged
+  `source=web` and **excluded from validation/test sets** (they are not
+  representative of the deployment's cameras, lighting, or instruments).
+- Never treat web-sourced labels as ground truth for accuracy claims.
+- Track `source` on every image; production metrics are computed on in-domain,
+  consented data only.
+
+## 9. How this feeds the model
+
+The labeled set trains the multi-label detector + severity heads described in
+`docs/computer-vision-plan.md`. Validation uses
+`app/analytics/model_evaluation.py` (precision, recall, FPR/FNR, confusion
+matrix, reviewer agreement). A model is promoted only after passing the
+validation thresholds in **shadow mode**, and even then output remains advisory.

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -42,11 +42,15 @@ type PredictedFinding = {
   status?: string;
 };
 
+type ScoreAdjustment = { kpi: string; label: string; points: number; severity: string; risk_tier: string };
+
 type Explainability = {
   baseline_source: string | null;
   baseline_match_score: number | null;
-  highest_findings: { type: string; label: string; probability: number; severity: string }[];
+  highest_findings: { type: string; label: string; probability: number; severity: string; risk_tier?: string }[];
+  primary_risk_driver?: string | null;
   risk_drivers: string[];
+  score_adjustments?: ScoreAdjustment[];
   confidence_level: string;
   rationale: string;
 };
@@ -70,9 +74,13 @@ type Analysis = {
   recommendation: string;
   reason?: string[];
   critical_flags?: string[];
+  score_adjustments?: ScoreAdjustment[];
+  primary_risk_driver?: string | null;
   explainability?: Explainability;
   human_review_required: boolean;
   placeholder_scoring?: boolean;
+  model_label?: string;
+  production_validated?: boolean;
 };
 
 type AIPrediction = {
@@ -1178,6 +1186,39 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
         </div>
       </div>
 
+      {/* Primary risk driver */}
+      {analysis.primary_risk_driver && (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Risk driver:</span>
+          <span className="capitalize font-medium text-slate-800">{analysis.primary_risk_driver}</span>
+        </div>
+      )}
+
+      {/* Why the score changed */}
+      {analysis.score_adjustments && analysis.score_adjustments.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Why this score</p>
+          <div className="space-y-1">
+            <div className="flex items-center justify-between text-sm text-slate-600">
+              <span>Baseline match starting point</span>
+              <span className="font-medium">{analysis.baseline_match_score != null ? Math.round(analysis.baseline_match_score * 100) : "—"} pts</span>
+            </div>
+            {analysis.score_adjustments.map((a) => (
+              <div key={a.kpi} className="flex items-center justify-between text-sm">
+                <span className="capitalize text-slate-600">
+                  {a.label} <span className="text-xs text-slate-400">({a.severity}, {a.risk_tier.replace(/_/g, "–")} risk)</span>
+                </span>
+                <span className="font-medium text-red-600">{a.points} pts</span>
+              </div>
+            ))}
+            <div className="flex items-center justify-between border-t border-slate-200 pt-1 text-sm font-semibold text-slate-800">
+              <span>Final inspection score</span>
+              <span>{score} / 100</span>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Recommended action with PASS/FAIL + reasons */}
       <div className={`rounded-lg border px-4 py-3 ${passFail === "PASS" ? "border-emerald-300 bg-emerald-50" : "border-red-300 bg-red-50"}`}>
         <div className="flex items-center gap-2 mb-1">
@@ -1226,12 +1267,11 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
         <p className="text-xs">A future release will highlight detected regions on the uploaded image.</p>
       </div>
 
-      {analysis.placeholder_scoring && (
-        <p className="text-xs text-slate-400 italic">
-          Scoring produced by deterministic baseline-comparison service (placeholder). Not production computer vision —
-          per-KPI probabilities are heuristic, not pixel-level detections.
-        </p>
-      )}
+      <p className="text-xs text-slate-400 italic">
+        {analysis.model_label ?? "Baseline Comparison Scoring Model (pilot)"} — pilot scoring, not validated for
+        production diagnostic accuracy. Per-KPI probabilities are heuristic (baseline comparison), not pixel-level
+        computer-vision detections. Qualified human review is required.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Refines the pilot inspection scoring for real SPD use: clinical risk weighting, KPI-specific severity scales, a model-evaluation framework, richer UI explanation, and a training-dataset plan. The engine is explicitly labeled a **pilot model** — no production diagnostic-accuracy claim.

## Scoring (`baseline_comparison_scoring_service`)
- **Risk tiers per KPI:** blood/bioburden/tissue/organic residue, crack, missing component, insulation damage = **high**; corrosion & rust = **severity-based** (heavy/severe → high); bone = low–medium; discoloration/pitting = low.
- **KPI-specific severity scales:** blood `none/trace/visible/heavy`, rust `none/surface/moderate/heavy`, corrosion `none/minor/moderate/severe` (others generic none/low/moderate/high).
- **More aggressive weights** — blood/bioburden/tissue/organic/crack/missing component reduce the score far more than cosmetic discoloration/wear.
- **`score_adjustments`** ("why the score changed", largest deduction first) + **`primary_risk_driver`**.
- **`model_label: "Baseline Comparison Scoring Model (pilot)"`**, `production_validated: false`.

## Model evaluation framework (new `app/analytics/model_evaluation.py`)
Precision, recall, FPR, FNR, F1, confusion matrix, and **human-reviewer agreement** (percent + Cohen's kappa). Pure functions — validation tooling for the pilot model and a future CV model alike.

## Frontend (result panel)
- **Risk driver**, KPI-specific severity, a **"Why this score"** breakdown (baseline start → per-KPI deductions → final), and recommended action.
- Footer relabeled as the **pilot scoring model** (not production diagnostic accuracy).

## Docs
- `docs/ai/model-training-dataset-plan.md` — image categories, labeling rules, min counts/class, supervisor review, QC, PHI avoidance, acceptable sources, **web-image caution**.
- `docs/ai/model-evaluation-framework.md`.

## Validation
- `npm --prefix frontend run build` → ✅ clean
- `python -m pytest tests -q` → ✅ **2148 passed, 2 skipped**
- `ruff check` → ✅ clean
- New tests: severity scales; risk tiers (heavy rust / severe corrosion → high); score-adjustment ordering; pilot label; evaluation metrics + reviewer agreement.

## Files
- `backend/app/services/baseline_comparison_scoring_service.py`
- `backend/app/analytics/model_evaluation.py`
- `backend/tests/test_model_evaluation.py`, `backend/tests/test_analysis_panel_output.py`
- `frontend/src/pages/NewInspectionPage.tsx`
- `docs/ai/model-training-dataset-plan.md`, `docs/ai/model-evaluation-framework.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_