### PR TITLE
Instrument high-risk zone detection + Full-KPI-detail cleanup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -122,7 +122,9 @@ async def lifespan(_app: FastAPI):
     try:
         from app.db.column_migrator import ensure_columns
         from app.models.inspection import Inspection
+        from app.models.supervisor_review import SupervisorReview
         ensure_columns(engine, Inspection)
+        ensure_columns(engine, SupervisorReview)
     except Exception as _mig_e:
         import logging
         logging.getLogger(__name__).warning("Column back-fill skipped: %s", _mig_e)

--- a/backend/app/models/supervisor_review.py
+++ b/backend/app/models/supervisor_review.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -46,3 +46,10 @@ class SupervisorReview(Base):
     # Snapshot of what the AI said, for training-data provenance.
     ai_recommendation: Mapped[str] = mapped_column(String(50), default="", nullable=False)
     ai_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Zone-aware feedback (instrument high-risk zone detection) — labeled data.
+    finding_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    zone_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    corrected_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False)
+    corrected_severity: Mapped[str] = mapped_column(String(30), default="", nullable=False)
+    final_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -35,6 +35,12 @@ class SupervisorReviewIn(BaseModel):
     agreement: str = Field(..., description="agree | partially_agree | disagree")
     rationale: str = Field("", max_length=2000)
     override_action: str = Field("", max_length=50)
+    # Zone-aware feedback → labeled training data.
+    finding_correct: bool | None = None
+    zone_correct: bool | None = None
+    corrected_zone: str = Field("", max_length=60)
+    corrected_severity: str = Field("", max_length=30)
+    final_disposition: str = Field("", max_length=50)
 
 
 @router.post("/inspections/{inspection_id}/supervisor-review", status_code=201)
@@ -82,6 +88,11 @@ def submit_supervisor_review(
         override_action=body.override_action.strip(),
         ai_recommendation=inspection.recommended_action or "",
         ai_score=(100 - inspection.risk_score) if inspection.score_status == "scored" else None,
+        finding_correct=body.finding_correct,
+        zone_correct=body.zone_correct,
+        corrected_zone=body.corrected_zone.strip(),
+        corrected_severity=body.corrected_severity.strip(),
+        final_disposition=body.final_disposition.strip(),
     )
     db.add(review)
 

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -26,6 +26,8 @@ from typing import Any, Optional
 
 from sqlalchemy.orm import Session
 
+from app.services.instrument_zones import is_high_retention, zone_fields
+
 # Baseline resolution order — most authoritative first.
 BASELINE_PRIORITY = ["manufacturer", "vendor", "hospital"]
 
@@ -589,6 +591,15 @@ def _overall_result(result: dict) -> str:
     # Residual contamination → return for cleaning/reprocessing (moderate+).
     if any(idx(k) >= 2 for k in ("blood", "tissue", "other_organic_residue", "debris", "bone")):
         return "REPROCESS"
+    # Zone-aware escalation: contamination in a HIGH-retention zone (serrations,
+    # box locks, lumens, drill-bit flutes, o-ring areas, hinges …) is treated
+    # more aggressively than the same probability on a flat surface — even a
+    # trace signal there warrants reprocessing.
+    for f in result.get("predicted_findings", []):
+        if (f["type"] in ("blood", "tissue", "other_organic_residue", "debris", "bone")
+                and f["severity_index"] >= 1
+                and is_high_retention(f.get("instrument_zone", ""))):
+            return "REPROCESS"
     # Condition change / baseline concern → supervisor review.
     moderate_condition = idx("corrosion") == 2 or idx("rust") == 2
     mismatch = result.get("identification", {}).get("identification_status") == "mismatch"
@@ -987,7 +998,7 @@ def analyze_inspection(
         present = probability >= 0.5
         kpi_summary[kpi] = present
         spd_tier = spd_risk_tier(kpi, probability)
-        predicted_findings.append({
+        finding = {
             "type": kpi,
             "label": KPI_LABELS.get(kpi, kpi),
             "probability": probability,
@@ -1002,7 +1013,11 @@ def analyze_inspection(
             # SPD operational weighting surfaced to the panel.
             "spd_risk": spd_tier,
             "spd_risk_impact": spd_risk_impact(spd_tier),
-        })
+        }
+        # Instrument-zone taxonomy: where this finding is likely to hide, its
+        # retention risk, and the recommended manual check for that zone.
+        finding.update(zone_fields(instrument_type, kpi))
+        predicted_findings.append(finding)
 
     # ── Identification detection / match (real decode-vs-baseline) ──────────
     # Values may be decoded from the image (pyzbar) or technician-declared; the

--- a/backend/app/services/clinical_mentor.py
+++ b/backend/app/services/clinical_mentor.py
@@ -260,9 +260,19 @@ def detailed_interpretation(result: dict, overall: str) -> list[str]:
         ]
     present = _present_findings(result)
     match = result.get("baseline_match_score")
+    findings_by_kpi = {f["type"]: f for f in result.get("predicted_findings", [])}
     lines: list[str] = []
     if match is not None:
         lines.append(f"The instrument matched its approved baseline at {round(match * 100)}%.")
+
+    def _zone_phrase(kpi: str) -> str:
+        f = findings_by_kpi.get(kpi, {})
+        zone = f.get("instrument_zone")
+        if not zone or zone in ("unspecified region", "surface discoloration area"):
+            return ""
+        from app.services.instrument_zones import is_high_retention
+        tag = ", a high-retention zone" if is_high_retention(zone) else ""
+        return f" in the {zone} region{tag}"
 
     structural = [k for k in present if k in _STRUCTURAL_KPIS or (k == "corrosion" and _sev(result, k) >= 3)]
     contamination = [k for k in present if k in CLEANING_KPIS]
@@ -270,7 +280,7 @@ def detailed_interpretation(result: dict, overall: str) -> list[str]:
     if structural:
         primary = structural[0]
         edu = FINDING_EDUCATION.get(primary, {})
-        lines.append(f"A structural finding consistent with {KPI_LABELS.get(primary, primary)} was detected.")
+        lines.append(f"A structural finding consistent with {KPI_LABELS.get(primary, primary)} was detected{_zone_phrase(primary)}.")
         if not contamination:
             lines.append("Although contamination was not detected, the structural integrity of the instrument may be compromised.")
         if edu.get("clinical_significance"):
@@ -279,7 +289,7 @@ def detailed_interpretation(result: dict, overall: str) -> list[str]:
     elif contamination:
         primary = contamination[0]
         edu = FINDING_EDUCATION.get(primary, {})
-        lines.append(f"A contamination indicator ({KPI_LABELS.get(primary, primary)}) was detected.")
+        lines.append(f"{KPI_LABELS.get(primary, primary).capitalize()} indicators were detected{_zone_phrase(primary)}.")
         if edu.get("clinical_significance"):
             lines.append(edu["clinical_significance"])
         lines.append("The instrument should be returned for cleaning and re-inspected before release.")

--- a/backend/app/services/instrument_zones.py
+++ b/backend/app/services/instrument_zones.py
@@ -1,0 +1,158 @@
+"""Instrument-zone taxonomy + zone-aware retention logic.
+
+SPD reality: contamination and damage hide in specific instrument zones
+(serrations, box locks, lumens, drill-bit flutes, o-ring areas, hinges …).
+This module maps an instrument to its likely zones, marks high-retention zones,
+and supplies the reason + recommended manual check per zone.
+
+The zone is assigned deterministically from the instrument type — this is the
+same placeholder-grade heuristic as the rest of the pilot scoring engine, NOT
+pixel-level localization. A future CV release will localize the actual region.
+"""
+from __future__ import annotations
+
+# ── Zone taxonomy (Deliverable 1) ────────────────────────────────────────────
+ZONE_TAXONOMY: dict[str, list[str]] = {
+    "cutting_working_surface": ["serrations", "grooves", "teeth", "jaws", "cutting edge"],
+    "rotary_orthopedic": ["drill-bit flute", "threaded region", "cutting channel", "burr surface"],
+    "lumen_scope": ["lumen opening", "inner channel", "o-ring area", "rigid scope port", "lens edge", "sheath connection"],
+    "mechanical": ["hinge", "box lock", "joint", "ratchet", "spring area"],
+    "handle_external": ["handle seam", "insulation edge", "outer sheath", "surface discoloration area"],
+    "unknown": ["unspecified region", "image quality insufficient"],
+}
+
+# Zones where residual soil is hard to remove — escalate contamination here.
+HIGH_RETENTION_ZONES: set[str] = {
+    "serrations", "grooves", "teeth", "cutting edge",
+    "drill-bit flute", "threaded region", "cutting channel", "burr surface",
+    "lumen opening", "inner channel", "o-ring area", "rigid scope port",
+    "hinge", "box lock", "joint", "ratchet",
+    "insulation edge",
+}
+
+# Per-zone reason + recommended manual check + inherent zone risk.
+ZONE_INFO: dict[str, dict[str, str]] = {
+    "serrations": {
+        "risk": "high",
+        "reason": "Serrations can retain blood and tissue after manual cleaning.",
+        "manual_check": "Inspect and brush the serrated surface; repeat cleaning if residue is confirmed.",
+    },
+    "grooves": {
+        "risk": "high",
+        "reason": "Grooves trap organic residue that surface cleaning may miss.",
+        "manual_check": "Brush the grooves under magnification and re-inspect.",
+    },
+    "box lock": {
+        "risk": "high",
+        "reason": "Box locks are enclosed pivot points where soil commonly persists.",
+        "manual_check": "Open the box lock, brush the pivot, and re-inspect.",
+    },
+    "hinge": {
+        "risk": "high",
+        "reason": "Hinges are protected pivot areas prone to retained soil.",
+        "manual_check": "Actuate and brush the hinge; verify it is clean and moves freely.",
+    },
+    "drill-bit flute": {
+        "risk": "high",
+        "reason": "Flutes and threaded regions of drill bits are high-retention zones.",
+        "manual_check": "Brush the flutes/threads; confirm no residue in the channels.",
+    },
+    "threaded region": {
+        "risk": "high",
+        "reason": "Threaded regions retain residue between the threads.",
+        "manual_check": "Brush and flush the threads; re-inspect under magnification.",
+    },
+    "lumen opening": {
+        "risk": "high",
+        "reason": "Lumens and inner channels are classic retention points requiring focused inspection.",
+        "manual_check": "Flush and brush the lumen; borescope the channel if available.",
+    },
+    "inner channel": {
+        "risk": "high",
+        "reason": "Inner channels can hold residue that outer cleaning cannot reach.",
+        "manual_check": "Flush and brush the channel; re-inspect the lumen.",
+    },
+    "o-ring area": {
+        "risk": "high",
+        "reason": "Residue near the o-ring/port area is a common retention point requiring focused inspection.",
+        "manual_check": "Inspect around the o-ring/port; clean and re-seat as indicated.",
+    },
+    "rigid scope port": {
+        "risk": "high",
+        "reason": "Scope ports collect residue at connection points.",
+        "manual_check": "Clean the port and sheath connection; re-inspect.",
+    },
+    "ratchet": {
+        "risk": "high",
+        "reason": "Ratchet teeth trap soil between the engagement surfaces.",
+        "manual_check": "Brush the ratchet through its range; re-inspect.",
+    },
+    "insulation edge": {
+        "risk": "high",
+        "reason": "Insulation edges can harbor soil and signal insulation wear on electrosurgical items.",
+        "manual_check": "Inspect the insulation edge for soil and breaches; test insulation integrity.",
+    },
+    "cutting edge": {
+        "risk": "medium",
+        "reason": "Cutting edges accumulate residue along the working surface.",
+        "manual_check": "Wipe/brush the cutting edge and re-inspect.",
+    },
+    "surface discoloration area": {
+        "risk": "low",
+        "reason": "Open surfaces are lower-retention; cosmetic changes here are usually not clinically significant.",
+        "manual_check": "Wipe the surface; monitor for progression at the next inspection.",
+    },
+    "unspecified region": {
+        "risk": "low",
+        "reason": "No specific high-retention zone identified for this instrument.",
+        "manual_check": "Perform a standard visual re-inspection.",
+    },
+}
+
+# ── Instrument → zone rules ──────────────────────────────────────────────────
+# (keyword substrings, contamination_zone, condition_zone). First match wins.
+_INSTRUMENT_ZONE_RULES: list[tuple[tuple[str, ...], str, str]] = [
+    (("drill", "reamer", "burr", "bit"), "drill-bit flute", "threaded region"),
+    (("scope", "endoscope", "arthroscope", "cystoscope", "laparoscop", "ureteroscope"), "o-ring area", "lens edge"),
+    (("cannula", "cannulated", "suction", "trocar", "lumen"), "inner channel", "outer sheath"),
+    (("forcep", "clamp", "hemostat", "kocher", "needle_holder", "needle holder", "grasper"), "serrations", "box lock"),
+    (("scissor", "shear"), "hinge", "cutting edge"),
+    (("rongeur", "kerrison", "punch", "biter"), "box lock", "jaws"),
+    (("bipolar", "monopolar", "electro", "cautery", "insulat"), "insulation edge", "insulation edge"),
+]
+_DEFAULT_CONTAM_ZONE = "unspecified region"
+_DEFAULT_CONDITION_ZONE = "surface discoloration area"
+
+# Findings treated as contamination (routed to the retention zone).
+_CONTAMINATION = {"blood", "tissue", "other_organic_residue", "debris", "bone", "bioburden"}
+
+
+def resolve_zones(instrument_type: str) -> tuple[str, str]:
+    """Return (contamination_zone, condition_zone) for an instrument type."""
+    name = (instrument_type or "").lower()
+    for keywords, contam, cond in _INSTRUMENT_ZONE_RULES:
+        if any(k in name for k in keywords):
+            return contam, cond
+    return _DEFAULT_CONTAM_ZONE, _DEFAULT_CONDITION_ZONE
+
+
+def zone_for_finding(instrument_type: str, finding_type: str) -> str:
+    """Deterministic zone for a finding on a given instrument."""
+    contam_zone, cond_zone = resolve_zones(instrument_type)
+    return contam_zone if finding_type in _CONTAMINATION else cond_zone
+
+
+def zone_fields(instrument_type: str, finding_type: str) -> dict[str, str]:
+    """instrument_zone / zone_risk / zone_reason / recommended_manual_check."""
+    zone = zone_for_finding(instrument_type, finding_type)
+    info = ZONE_INFO.get(zone, ZONE_INFO["unspecified region"])
+    return {
+        "instrument_zone": zone,
+        "zone_risk": info["risk"],
+        "zone_reason": info["reason"],
+        "recommended_manual_check": info["manual_check"],
+    }
+
+
+def is_high_retention(zone: str) -> bool:
+    return zone in HIGH_RETENTION_ZONES

--- a/backend/tests/test_ai_clinical_review.py
+++ b/backend/tests/test_ai_clinical_review.py
@@ -180,3 +180,36 @@ class TestSupervisorReviewAPI:
     def test_performance_summary_operator_blocked(self):
         r = client.get("/api/model-performance/ai-summary", headers=AUTH_OPERATOR)
         assert r.status_code == 403
+
+    def test_supervisor_can_correct_zone(self):
+        iid = self._create("scissors")
+        r = client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={
+                "agreement": "partially_agree",
+                "rationale": "Blood was actually in the hinge, not the tip.",
+                "finding_correct": True,
+                "zone_correct": False,
+                "corrected_zone": "hinge",
+                "corrected_severity": "visible",
+                "final_disposition": "reprocess",
+            },
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+        # The corrected zone is persisted as labeled training data.
+        from app.db.session import SessionLocal
+        from app.models.supervisor_review import SupervisorReview
+        db = SessionLocal()
+        try:
+            row = (
+                db.query(SupervisorReview)
+                .filter(SupervisorReview.inspection_id == iid)
+                .order_by(SupervisorReview.id.desc())
+                .first()
+            )
+            assert row.corrected_zone == "hinge"
+            assert row.zone_correct is False
+            assert row.final_disposition == "reprocess"
+        finally:
+            db.close()

--- a/backend/tests/test_instrument_zones.py
+++ b/backend/tests/test_instrument_zones.py
@@ -1,0 +1,120 @@
+"""Instrument-specific high-risk zone detection."""
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import analyze_inspection, _overall_result
+from app.services.instrument_zones import (
+    resolve_zones,
+    zone_for_finding,
+    zone_fields,
+    is_high_retention,
+    ZONE_TAXONOMY,
+)
+
+SHA = "a1b2c3d4" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"z-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+        )
+    finally:
+        db.close()
+
+
+class TestTaxonomy:
+    def test_taxonomy_categories(self):
+        for cat in ("cutting_working_surface", "rotary_orthopedic", "lumen_scope",
+                    "mechanical", "handle_external", "unknown"):
+            assert cat in ZONE_TAXONOMY
+
+    def test_instrument_zone_mapping(self):
+        assert resolve_zones("serrated forceps")[0] == "serrations"
+        assert resolve_zones("orthopedic drill")[0] == "drill-bit flute"
+        assert resolve_zones("rigid scope")[0] == "o-ring area"
+        assert resolve_zones("cannulated shaver")[0] == "inner channel"
+        # Unknown instrument → non-retention default.
+        assert resolve_zones("mystery tool")[0] == "unspecified region"
+
+    def test_zone_fields_shape(self):
+        zf = zone_fields("serrated forceps", "blood")
+        assert zf["instrument_zone"] == "serrations"
+        assert zf["zone_risk"] == "high"
+        assert "retain blood" in zf["zone_reason"].lower() or zf["zone_reason"]
+        assert zf["recommended_manual_check"]
+
+    def test_contamination_routes_to_retention_zone(self):
+        assert zone_for_finding("orthopedic drill", "debris") == "drill-bit flute"
+        assert is_high_retention("drill-bit flute")
+        assert not is_high_retention("unspecified region")
+
+
+class TestSchema:
+    def test_findings_carry_zone_fields(self):
+        out = _analyze("serrated forceps")
+        for f in out["predicted_findings"]:
+            for key in ("instrument_zone", "zone_risk", "zone_reason", "recommended_manual_check"):
+                assert key in f
+
+
+class TestZoneEscalation:
+    def test_blood_in_serration_escalates(self):
+        # Trace-level blood forced on a serrated instrument → REPROCESS (zone).
+        out = _analyze("serrated forceps", declared=["blood"])
+        cd = out["clinical_decision"]
+        assert cd["overall_result"] in ("REPROCESS", "REMOVE FROM SERVICE")
+        blood = next(f for f in out["predicted_findings"] if f["type"] == "blood")
+        assert blood["instrument_zone"] == "serrations"
+
+    def test_debris_in_drill_flute_escalates(self):
+        out = _analyze("orthopedic drill", declared=["debris"])
+        assert out["clinical_decision"]["overall_result"] in ("REPROCESS", "REMOVE FROM SERVICE")
+
+    def test_residue_in_oring_escalates_direct(self):
+        # Direct rule check: trace organic residue in a high-retention zone -> REPROCESS.
+        r = {
+            "analysis_status": "completed", "baseline_match_score": 0.92,
+            "predicted_findings": [
+                {"type": "other_organic_residue", "severity_index": 1, "instrument_zone": "o-ring area"},
+            ],
+            "identification": {},
+        }
+        assert _overall_result(r) == "REPROCESS"
+
+    def test_flat_cosmetic_does_not_escalate(self):
+        # Trace contamination on a NON-retention (flat) zone stays low.
+        r = {
+            "analysis_status": "completed", "baseline_match_score": 0.92,
+            "predicted_findings": [
+                {"type": "blood", "severity_index": 1, "instrument_zone": "unspecified region"},
+                {"type": "discoloration", "severity_index": 1, "instrument_zone": "surface discoloration area"},
+            ],
+            "identification": {},
+        }
+        assert _overall_result(r) in ("PASS", "MONITOR")
+
+
+class TestZoneReasoning:
+    def test_interpretation_includes_zone_language(self):
+        out = _analyze("serrated forceps", declared=["blood"])
+        text = " ".join(out["clinical_decision"]["clinical_interpretation"]).lower()
+        assert "serrations" in text
+        assert "high-retention zone" in text

--- a/docs/ai/instrument-zone-detection-training-plan.md
+++ b/docs/ai/instrument-zone-detection-training-plan.md
@@ -1,0 +1,89 @@
+# Instrument Zone Detection — Training Dataset Plan
+
+**Status:** Draft for review
+**Purpose:** Train the model to localize *where* on an instrument contamination or
+damage is likely to hide — not just *what* was detected — so explanations name
+the actual high-retention zone (serrations, box lock, lumen, drill-bit flute,
+o-ring area, hinge, …) and disposition escalates accordingly.
+
+> ⚠️ Advisory pilot. The current zone assignment is a deterministic heuristic
+> from instrument type, not pixel-level localization. No FDA/diagnostic claims;
+> `human_review_required` remains true.
+
+---
+
+## 1. Labels captured per image
+
+- **instrument_type** (e.g. serrated forceps, orthopedic drill, rigid scope)
+- **finding_type** (blood, tissue, bone, debris, organic residue, rust, corrosion, discoloration, pitting, crack, insulation damage, missing component)
+- **severity** (per published scales)
+- **zone_type** (from the zone taxonomy)
+- **zone_risk** (high / medium / low)
+- **image_angle** (e.g. jaw-on, side, distal, port-on)
+- **lighting_quality** (good / acceptable / poor)
+- **supervisor_confirmed_zone** (adjudicated ground-truth zone)
+- **recommended_cleaning_response** (zone-specific manual check)
+
+## 2. Zone taxonomy (label set)
+
+- **Cutting / working surface:** serrations, grooves, teeth, jaws, cutting edge
+- **Rotary / orthopedic:** drill-bit flute, threaded region, cutting channel, burr surface
+- **Lumen / scope:** lumen opening, inner channel, o-ring area, rigid scope port, lens edge, sheath connection
+- **Mechanical:** hinge, box lock, joint, ratchet, spring area
+- **Handle / external:** handle seam, insulation edge, outer sheath, surface discoloration area
+- **Unknown:** unspecified region, image quality insufficient
+
+High-retention zones (escalate contamination): serrations, grooves, teeth,
+cutting edge, drill-bit flute, threaded region, cutting channel, burr surface,
+lumen opening, inner channel, o-ring area, rigid scope port, hinge, box lock,
+joint, ratchet, insulation edge.
+
+## 3. Instrument coverage (examples required)
+
+Collect labeled examples across:
+- **Drill bits / reamers / burrs** — flutes, threaded regions
+- **Rigid scopes** — o-ring/port, lumen, lens edge
+- **Cannulated instruments** — inner channel, lumen opening
+- **Serrated forceps / graspers** — serrations, box lock
+- **Laparoscopic instruments** — insulation edge, jaws, shaft lumen
+- **Hinged instruments (scissors)** — hinge, cutting edge
+- **Box-lock instruments (hemostats, needle holders)** — box lock, serrations
+- **Insulated electrosurgical instruments** — insulation edge
+
+Include clean/known-good examples of each zone so the model learns normal
+machining/weld appearance per zone.
+
+## 4. Labeling rules
+
+- Multi-label per image; each finding tagged with its **zone** and severity.
+- Region annotation (box/mask) on the zone once CV localization is trained.
+- **Zone is adjudicated** for critical findings (blood/crack/missing component)
+  by two reviewers; disagreements resolved before promotion to `gold`.
+- Uncertain zone → `unspecified region` / `image quality insufficient`; excluded
+  from the positive zone set until resolved.
+- No PHI in frame; EXIF stripped; de-identified filenames.
+
+## 5. Supervisor validation (feedback loop)
+
+The supervisor review captures, per inspection:
+- **AI finding correct?** (finding_correct)
+- **AI zone correct?** (zone_correct)
+- **Corrected zone** (corrected_zone)
+- **Corrected severity** (corrected_severity)
+- **Final disposition** (final_disposition)
+
+These are stored (`supervisor_reviews`) as labeled training data — the primary
+source of zone ground truth and of false-positive/false-negative zone signal.
+
+## 6. Model evaluation
+
+- Per-zone precision/recall (did the model name the right zone?) alongside the
+  existing finding-type metrics (`app/analytics/model_evaluation.py`).
+- Critical-zone recall (lumen, serrations, box lock, flute) reported separately.
+- Shadow-mode only until per-zone thresholds are met; output stays advisory.
+
+## 7. Governance / rights
+
+- Retention is opt-in with recorded consent; instrument-only imagery.
+- Web images (research/prototyping only) tagged `source=web`, excluded from
+  validation/test, never treated as ground truth.

--- a/frontend/src/components/SupervisorNotes.tsx
+++ b/frontend/src/components/SupervisorNotes.tsx
@@ -23,6 +23,8 @@ export default function SupervisorNotes({
   const [agreement, setAgreement] = useState("agree");
   const [rationale, setRationale] = useState("");
   const [override, setOverride] = useState("");
+  const [zoneCorrect, setZoneCorrect] = useState<boolean | null>(null);
+  const [correctedZone, setCorrectedZone] = useState("");
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const [busy, setBusy] = useState(false);
   const commentRequired = agreement !== "agree" || !!override.trim();
@@ -39,7 +41,13 @@ export default function SupervisorNotes({
       const res = await fetch(`${API_BASE}/api/inspections/${inspectionId}/supervisor-review`, {
         method: "POST",
         headers: headers(),
-        body: JSON.stringify({ agreement, rationale: rationale.trim(), override_action: override.trim() }),
+        body: JSON.stringify({
+          agreement,
+          rationale: rationale.trim(),
+          override_action: override.trim(),
+          zone_correct: zoneCorrect,
+          corrected_zone: correctedZone.trim(),
+        }),
       });
       if (res.status === 403) { setMsg({ ok: false, text: "Supervisor access (admin/SPD manager) required." }); return; }
       if (!res.ok) {
@@ -87,6 +95,20 @@ export default function SupervisorNotes({
         placeholder="Override action (optional, e.g. reprocess / remove)"
         className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
       />
+      {/* Zone-aware feedback → labeled training data */}
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+        <span className="text-slate-500">AI zone correct?</span>
+        <button onClick={() => setZoneCorrect(true)} className={`rounded-full px-2 py-0.5 border ${zoneCorrect === true ? "bg-emerald-600 text-white border-emerald-600" : "border-slate-300 text-slate-600"}`}>Yes</button>
+        <button onClick={() => setZoneCorrect(false)} className={`rounded-full px-2 py-0.5 border ${zoneCorrect === false ? "bg-red-600 text-white border-red-600" : "border-slate-300 text-slate-600"}`}>No</button>
+        {zoneCorrect === false && (
+          <input
+            value={correctedZone}
+            onChange={(e) => setCorrectedZone(e.target.value)}
+            placeholder="Corrected zone (e.g. hinge, box lock)"
+            className="flex-1 min-w-[10rem] rounded-lg border border-slate-300 px-2 py-1"
+          />
+        )}
+      </div>
       <div className="mt-2 flex items-center gap-3">
         <button onClick={submit} disabled={busy} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
           {busy ? "Saving…" : "Submit review"}

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -1068,13 +1068,6 @@ function PredictionField({ label, value }: { label: string; value: string }) {
 
 // ─── sub-component: full AI analysis output ──────────────────────────────────
 
-const RISK_LEVEL_STYLE: Record<string, string> = {
-  low: "bg-emerald-100 text-emerald-800",
-  medium: "bg-amber-200 text-amber-900",
-  high: "bg-orange-500 text-white",
-  critical: "bg-red-600 text-white",
-};
-
 // KPI cards the analysis panel always surfaces (contamination + condition).
 const KPI_DISPLAY: { key: string; label: string }[] = [
   { key: "blood", label: "Blood" },
@@ -1125,12 +1118,6 @@ const SPD_IMPACT_STYLE: Record<string, string> = {
   Review: "bg-orange-100 text-orange-800",
   Reprocess: "bg-red-100 text-red-800",
 };
-const CLEANING_STYLE: Record<string, string> = {
-  Clean: "border-emerald-300 bg-emerald-50 text-emerald-900",
-  "Residual contamination suspected": "border-amber-300 bg-amber-50 text-amber-900",
-  "Cleaning failure": "border-red-300 bg-red-50 text-red-900",
-  "Supervisor review required": "border-orange-300 bg-orange-50 text-orange-900",
-};
 const ID_STATUS_STYLE: Record<string, string> = {
   verified: "bg-emerald-100 text-emerald-800",
   mismatch: "bg-red-100 text-red-800",
@@ -1145,19 +1132,17 @@ const ID_STATUS_LABEL: Record<string, string> = {
 };
 
 function AnalysisDetails({ analysis }: { analysis: Analysis }) {
-  const score = analysis.inspection_score ?? 0;
-  const risk = analysis.risk_level ?? "unknown";
-  const matchPct = analysis.baseline_match_score != null
-    ? `${Math.round(analysis.baseline_match_score * 100)}%`
-    : "—";
-
   const comparisonLabel = analysis.baseline_comparison_label
     ?? (analysis.baseline_source
       ? `${analysis.baseline_source.replace(/_/g, " ")} baseline`
       : "—");
   const isFallback = analysis.baseline_role === "fallback";
-  const passFail = analysis.pass_fail ?? (analysis.critical_flags && analysis.critical_flags.length > 0 ? "FAIL" : "PASS");
 
+  // NOTE: the score, risk, cleaning, reasoning, recommendation, evidence, and
+  // executive-summary sections now live in ClinicalDecisionPanel (the primary
+  // view). This block is the collapsible "Full KPI detail" — raw per-KPI
+  // findings + identification only, to avoid duplicating (and diverging from)
+  // the clinical decision above.
   return (
     <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
       {/* Which baseline was used for the comparison */}
@@ -1172,37 +1157,6 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
           </span>
         )}
       </div>
-
-      {/* Score + risk + baseline headline */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        <div className="flex flex-col">
-          <span className="text-xs text-slate-500 font-medium">Inspection Score</span>
-          <span className="mt-1 text-2xl font-bold text-slate-900">{score}<span className="text-sm text-slate-400"> / 100</span></span>
-        </div>
-        <div className="flex flex-col">
-          <span className="text-xs text-slate-500 font-medium">Risk Level</span>
-          <span className={`mt-1 inline-flex w-fit items-center rounded-full px-2.5 py-1 text-sm font-bold capitalize ${RISK_LEVEL_STYLE[risk] ?? "bg-slate-200 text-slate-700"}`}>
-            {risk}
-          </span>
-        </div>
-        <PredictionField label="Baseline Source" value={analysis.baseline_source?.replace(/_/g, " ") ?? "—"} />
-        <PredictionField label="Baseline Match" value={matchPct} />
-      </div>
-
-      {/* Findings summary */}
-      {analysis.findings_summary && analysis.findings_summary.length > 0 && (
-        <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Findings Summary</p>
-          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-0.5 text-sm text-slate-700">
-            {analysis.findings_summary.map((s, i) => (
-              <li key={i} className="flex items-start gap-1.5">
-                <span className={s.startsWith("No ") ? "text-emerald-500" : "text-amber-500"}>•</span>
-                <span>{s}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
 
       {/* KPI finding cards: name · probability · severity · status */}
       <div>
@@ -1243,29 +1197,6 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
         </p>
       </div>
 
-      {/* Overall Cleaning Assessment (replaces standalone bioburden KPI) */}
-      {analysis.overall_cleaning_assessment && (
-        <div className={`rounded-lg border px-4 py-3 ${CLEANING_STYLE[analysis.overall_cleaning_assessment] ?? "border-slate-200 bg-slate-50 text-slate-800"}`}>
-          <p className="text-xs font-semibold uppercase tracking-wide opacity-70 mb-0.5">Overall Cleaning Assessment</p>
-          <p className="text-sm font-semibold">{analysis.overall_cleaning_assessment}</p>
-          <p className="mt-0.5 text-xs opacity-70">
-            Derived from blood, bone, tissue, organic residue and debris — not a standalone bioburden score.
-          </p>
-        </div>
-      )}
-
-      {/* Top risk drivers */}
-      {analysis.top_risk_drivers && analysis.top_risk_drivers.length > 0 && (
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Top Risk Drivers</p>
-          <div className="flex flex-wrap gap-1.5">
-            {analysis.top_risk_drivers.map((d, i) => (
-              <span key={i} className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium capitalize text-slate-700">{d}</span>
-            ))}
-          </div>
-        </div>
-      )}
-
       {/* Identification — real decode-vs-baseline verification */}
       <div>
         <div className="mb-2 flex items-center gap-2">
@@ -1302,110 +1233,6 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
         </div>
       </div>
 
-      {/* Primary risk driver */}
-      {analysis.primary_risk_driver && (
-        <div className="flex items-center gap-2 text-sm">
-          <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Risk driver:</span>
-          <span className="capitalize font-medium text-slate-800">{analysis.primary_risk_driver}</span>
-        </div>
-      )}
-
-      {/* Why the score changed */}
-      {analysis.score_adjustments && analysis.score_adjustments.length > 0 && (
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Why this score</p>
-          <div className="space-y-1">
-            <div className="flex items-center justify-between text-sm text-slate-600">
-              <span>Baseline match starting point</span>
-              <span className="font-medium">{analysis.baseline_match_score != null ? Math.round(analysis.baseline_match_score * 100) : "—"} pts</span>
-            </div>
-            {analysis.score_adjustments.map((a) => (
-              <div key={a.kpi} className="flex items-center justify-between text-sm">
-                <span className="capitalize text-slate-600">
-                  {a.label} <span className="text-xs text-slate-400">({a.severity}, {a.risk_tier.replace(/_/g, "–")} risk)</span>
-                </span>
-                <span className="font-medium text-red-600">{a.points} pts</span>
-              </div>
-            ))}
-            <div className="flex items-center justify-between border-t border-slate-200 pt-1 text-sm font-semibold text-slate-800">
-              <span>Final inspection score</span>
-              <span>{score} / 100</span>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Recommended action with PASS/FAIL + reasons */}
-      <div className={`rounded-lg border px-4 py-3 ${passFail === "PASS" ? "border-emerald-300 bg-emerald-50" : "border-red-300 bg-red-50"}`}>
-        <div className="flex items-center gap-2 mb-1">
-          <span className={`rounded px-2 py-0.5 text-xs font-bold ${passFail === "PASS" ? "bg-emerald-600 text-white" : "bg-red-600 text-white"}`}>
-            {passFail}
-          </span>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Recommended Action</p>
-        </div>
-        {analysis.reason && analysis.reason.length > 0 && (
-          <ul className="mb-2 ml-1 space-y-0.5 text-sm text-slate-700">
-            {analysis.reason.map((r, i) => (
-              <li key={i} className="flex items-start gap-1.5"><span className="text-slate-400">–</span><span>{r}</span></li>
-            ))}
-          </ul>
-        )}
-        {analysis.recommended_action && (
-          <p className="text-sm font-semibold text-slate-900">{analysis.recommended_action}</p>
-        )}
-        <p className="text-sm text-slate-700">{analysis.recommendation}</p>
-      </div>
-
-      {/* Why the score changed — plain-language explanation */}
-      {analysis.scoring_explanation && analysis.scoring_explanation.length > 0 && (
-        <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Reason Score Changed</p>
-          <ul className="space-y-0.5 text-sm text-slate-700">
-            {analysis.scoring_explanation.map((line, i) => (
-              <li key={i} className="flex items-start gap-1.5">
-                <span className={line.startsWith("No ") ? "text-emerald-500" : "text-amber-500"}>•</span>
-                <span>{line}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {/* Explainability */}
-      {analysis.explainability && (
-        <details className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-          <summary className="cursor-pointer text-sm font-semibold text-slate-700">
-            Why LumenAI scored this inspection this way
-          </summary>
-          <div className="mt-2 space-y-1.5 text-sm text-slate-600">
-            <p><span className="text-slate-500">Baseline source:</span> <span className="capitalize">{analysis.explainability.baseline_source ?? "—"}</span></p>
-            <p><span className="text-slate-500">Baseline match:</span> {analysis.explainability.baseline_match_score != null ? `${Math.round(analysis.explainability.baseline_match_score * 100)}%` : "—"}</p>
-            <div>
-              <span className="text-slate-500">Highest findings:</span>
-              <ul className="ml-3 mt-0.5 list-disc">
-                {analysis.explainability.highest_findings.map((f) => (
-                  <li key={f.type} className="capitalize">{f.label} — {Math.round(f.probability * 100)}% ({f.severity})</li>
-                ))}
-              </ul>
-            </div>
-            <p><span className="text-slate-500">Risk drivers:</span> {analysis.explainability.risk_drivers.join(", ")}</p>
-            <p><span className="text-slate-500">Confidence level:</span> {analysis.explainability.confidence_level}</p>
-            <p className="text-slate-500 italic">{analysis.explainability.rationale}</p>
-          </div>
-        </details>
-      )}
-
-      {/* Image evidence placeholder — never fake bounding boxes */}
-      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-500">
-        <p className="font-medium text-slate-600">Image evidence map not yet available.</p>
-        <p className="text-xs">A future release will highlight detected regions on the uploaded image.</p>
-      </div>
-
-      <p className="text-xs text-slate-400 italic">
-        {analysis.model_label ?? "Baseline Comparison Scoring Model (pilot)"} — pilot scoring, not validated for
-        production diagnostic accuracy. Per-KPI probabilities are heuristic (baseline comparison), not pixel-level
-        computer-vision detections. Qualified human review is required.
-      </p>
     </div>
   );
 }

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -43,6 +43,10 @@ type PredictedFinding = {
   status?: string;
   spd_risk?: string;
   spd_risk_impact?: string;
+  instrument_zone?: string;
+  zone_risk?: string;
+  zone_reason?: string;
+  recommended_manual_check?: string;
 };
 
 type SeverityByKpi = Record<
@@ -1188,6 +1192,22 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
                 <div className="mt-0.5 text-xs text-slate-400">
                   SPD Risk Impact: <span className="font-medium text-slate-600">{impact}</span>
                 </div>
+                {finding?.instrument_zone && finding.instrument_zone !== "unspecified region" && (
+                  <div className="mt-1 border-t border-slate-100 pt-1 text-xs">
+                    <div className="flex items-center justify-between">
+                      <span className="text-slate-500">Zone: <span className="font-medium capitalize text-slate-700">{finding.instrument_zone}</span></span>
+                      <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-semibold ${
+                        finding.zone_risk === "high" ? "bg-red-100 text-red-700"
+                          : finding.zone_risk === "medium" ? "bg-amber-100 text-amber-700"
+                          : "bg-slate-100 text-slate-500"
+                      }`}>Zone Risk: {finding.zone_risk}</span>
+                    </div>
+                    {finding.zone_reason && <p className="mt-0.5 text-slate-500">{finding.zone_reason}</p>}
+                    {finding.recommended_manual_check && (
+                      <p className="mt-0.5 text-slate-600"><span className="text-slate-400">Manual check:</span> {finding.recommended_manual_check}</p>
+                    )}
+                  </div>
+                )}
               </div>
             );
           })}


### PR DESCRIPTION
## Summary

### Instrument-specific high-risk zone detection
Identifies *where* on an instrument contamination/damage is likely to hide, not just *what*.
- **Zone taxonomy** (`instrument_zones.py`): cutting/rotary/lumen/mechanical/handle/unknown + high-retention zone set; instrument→zone rules (drill→flute, scope→o-ring, forceps→serrations, cannula→inner channel, scissors→hinge, electro→insulation edge).
- **Schema**: every finding now carries `instrument_zone`, `zone_risk`, `zone_reason`, `recommended_manual_check`.
- **Zone-aware escalation**: contamination (even trace) in a HIGH-retention zone → REPROCESS; the same signal on a flat/unspecified zone does **not** escalate (preserves the earlier noise fix).
- **Zone-aware reasoning**: "… detected in the serrations region, a high-retention zone."
- **Supervisor feedback** extended: `finding_correct`, `zone_correct`, `corrected_zone`, `corrected_severity`, `final_disposition` (labeled training data; columns back-filled on startup).
- **Frontend**: KPI cards show Zone / Zone Risk / why-this-zone-matters / recommended manual check; Supervisor Notes captures "AI zone correct?" + corrected zone.
- **Docs**: `docs/ai/instrument-zone-detection-training-plan.md`.

### Cleanup (single source of truth)
Trimmed the "Full KPI detail" collapsible to raw per-KPI cards + identification only — removed the score/risk/recommendation/reasoning/evidence blocks now owned by the Clinical Decision panel (which also fixes the old "PASS vs MONITOR" wording divergence).

## Validation
- `npm run build` → clean
- `pytest tests -q` → **2256 passed, 2 skipped**
- ruff → clean
- New: `test_instrument_zones.py` (taxonomy/schema/escalation/reasoning) + supervisor zone-correction test

🤖 Generated with [Claude Code](https://claude.com/claude-code)