### PR TITLE
Phase 15: Instrument Intelligence Engine (anatomy-aware AI) + explainability fix

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -114,6 +114,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.retained_image")        # register opt-in training-image store + labels
     importlib.import_module("app.models.capture_device")        # register borescope capture-device registry
     importlib.import_module("app.models.supervisor_review")     # register supervisor AI-agreement feedback store
+    importlib.import_module("app.models.instrument_knowledge")  # register instrument knowledge library
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -551,6 +552,9 @@ app.include_router(ai_clinical_review_router, prefix=settings.API_PREFIX)
 
 from app.routes.instrument_intelligence import router as instrument_intelligence_router
 app.include_router(instrument_intelligence_router, prefix=settings.API_PREFIX)
+
+from app.routes.instrument_intelligence_admin import router as instrument_intelligence_admin_router
+app.include_router(instrument_intelligence_admin_router, prefix=settings.API_PREFIX)
 
 app.include_router(agent_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/models/instrument_knowledge.py
+++ b/backend/app/models/instrument_knowledge.py
@@ -1,0 +1,43 @@
+"""Phase 15 §10 — Instrument Knowledge Library (extensible, multi-manufacturer).
+
+Foundation for manufacturer/model-specific instrument knowledge: anatomy zones,
+high-risk zones, known failure modes, maintenance interval, and repair/
+replacement criteria. Deliberately NOT hardcoded to one manufacturer — entries
+are data rows keyed by manufacturer + model + family.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class InstrumentKnowledge(Base):
+    __tablename__ = "instrument_knowledge"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    manufacturer: Mapped[str] = mapped_column(String(255), default="", nullable=False, index=True)
+    model: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    ifu_reference: Mapped[str] = mapped_column(String(500), default="", nullable=False)
+
+    # JSON-encoded lists (kept as text for portability across SQLite/Postgres).
+    anatomy_zones: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    high_risk_zones: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    known_failure_modes: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    maintenance_interval: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    repair_criteria: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    replacement_criteria: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/models/supervisor_review.py
+++ b/backend/app/models/supervisor_review.py
@@ -52,4 +52,5 @@ class SupervisorReview(Base):
     zone_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     corrected_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False)
     corrected_severity: Mapped[str] = mapped_column(String(30), default="", nullable=False)
+    corrected_recommendation: Mapped[str] = mapped_column(String(50), default="", nullable=False)
     final_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -40,6 +40,7 @@ class SupervisorReviewIn(BaseModel):
     zone_correct: bool | None = None
     corrected_zone: str = Field("", max_length=60)
     corrected_severity: str = Field("", max_length=30)
+    corrected_recommendation: str = Field("", max_length=50)
     final_disposition: str = Field("", max_length=50)
 
 
@@ -92,6 +93,7 @@ def submit_supervisor_review(
         zone_correct=body.zone_correct,
         corrected_zone=body.corrected_zone.strip(),
         corrected_severity=body.corrected_severity.strip(),
+        corrected_recommendation=body.corrected_recommendation.strip(),
         final_disposition=body.final_disposition.strip(),
     )
     db.add(review)

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -82,6 +82,8 @@ class InspectionCreate(BaseModel):
     keydot_id: Optional[str] = Field(None, max_length=255)
     # How identifiers were obtained: "pyzbar" (decoded) or "declared" (typed).
     identifier_source: Optional[str] = Field(None, max_length=20)
+    # Zones the technician captured/inspected (anatomy-aware coverage engine).
+    inspected_zones: Optional[List[str]] = Field(None)
     # Technician-declared finding categories (optional — AI determines findings)
     finding_categories: Optional[List[str]] = Field(None)
 
@@ -367,6 +369,7 @@ async def create_inspection(
             instrument_udi=body.instrument_udi,
             keydot_id=body.keydot_id,
             decoder_backend=body.identifier_source or "declared",
+            inspected_zones=body.inspected_zones,
         )
         # Persist the SPD verdict regardless of completion state so history and
         # the dashboard show what the analysis concluded.

--- a/backend/app/routes/instrument_intelligence_admin.py
+++ b/backend/app/routes/instrument_intelligence_admin.py
@@ -1,0 +1,150 @@
+"""Phase 15 — anatomy library read, knowledge library CRUD, executive analytics.
+
+- GET  /api/instrument-anatomy/{instrument_type} — resolved anatomy definition.
+- POST /api/instrument-knowledge — register a manufacturer/model knowledge entry.
+- GET  /api/instrument-knowledge — list entries.
+- GET  /api/analytics/zone-intelligence — executive zone/coverage analytics
+  computed from real data (stubs return zero/empty until data exists; nothing
+  fabricated).
+"""
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.instrument_knowledge import InstrumentKnowledge
+from app.models.supervisor_review import SupervisorReview
+from app.services.instrument_anatomy import get_anatomy
+
+router = APIRouter(tags=["instrument-intelligence"])
+
+
+@router.get("/instrument-anatomy/{instrument_type}")
+def instrument_anatomy(
+    instrument_type: str,
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Resolved anatomy definition (zones, high-risk zones, required images…)."""
+    return get_anatomy(instrument_type)
+
+
+class KnowledgeIn(BaseModel):
+    manufacturer: str = Field("", max_length=255)
+    model: str = Field("", max_length=255)
+    instrument_family: str = Field("", max_length=100)
+    ifu_reference: str = Field("", max_length=500)
+    anatomy_zones: list[str] = Field(default_factory=list)
+    high_risk_zones: list[str] = Field(default_factory=list)
+    known_failure_modes: list[str] = Field(default_factory=list)
+    maintenance_interval: str = Field("", max_length=255)
+    repair_criteria: str = Field("", max_length=2000)
+    replacement_criteria: str = Field("", max_length=2000)
+
+
+@router.post("/instrument-knowledge", status_code=201)
+def create_knowledge(
+    body: KnowledgeIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    row = InstrumentKnowledge(
+        tenant_id=tenant_id,
+        manufacturer=body.manufacturer, model=body.model,
+        instrument_family=body.instrument_family, ifu_reference=body.ifu_reference,
+        anatomy_zones=json.dumps(body.anatomy_zones),
+        high_risk_zones=json.dumps(body.high_risk_zones),
+        known_failure_modes=json.dumps(body.known_failure_modes),
+        maintenance_interval=body.maintenance_interval,
+        repair_criteria=body.repair_criteria,
+        replacement_criteria=body.replacement_criteria,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id, "manufacturer": row.manufacturer, "model": row.model}
+
+
+@router.get("/instrument-knowledge")
+def list_knowledge(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    rows = (
+        db.query(InstrumentKnowledge)
+        .filter(InstrumentKnowledge.tenant_id == tenant_id)
+        .order_by(InstrumentKnowledge.id.desc())
+        .all()
+    )
+    return {
+        "count": len(rows),
+        "entries": [
+            {
+                "id": r.id, "manufacturer": r.manufacturer, "model": r.model,
+                "instrument_family": r.instrument_family, "ifu_reference": r.ifu_reference,
+                "anatomy_zones": json.loads(r.anatomy_zones or "[]"),
+                "high_risk_zones": json.loads(r.high_risk_zones or "[]"),
+                "known_failure_modes": json.loads(r.known_failure_modes or "[]"),
+                "maintenance_interval": r.maintenance_interval,
+                "repair_criteria": r.repair_criteria,
+                "replacement_criteria": r.replacement_criteria,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.get("/analytics/zone-intelligence")
+def zone_intelligence(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Executive zone/coverage analytics — computed from real data only.
+
+    Metrics that require per-zone finding history (contamination/corrosion rate
+    by zone) are surfaced as empty until that data is captured, rather than
+    fabricated. Supervisor override-by-zone is computed from real reviews.
+    """
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    inspections = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id)
+    total = inspections.filter(models.Inspection.has_image.is_(True)).count()
+
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    override_by_zone: dict[str, int] = {}
+    corrected_zone_counts: dict[str, int] = {}
+    for r in reviews:
+        if r.override_action:
+            z = r.corrected_zone or "unspecified"
+            override_by_zone[z] = override_by_zone.get(z, 0) + 1
+        if r.corrected_zone:
+            corrected_zone_counts[r.corrected_zone] = corrected_zone_counts.get(r.corrected_zone, 0) + 1
+
+    return {
+        "total_ai_inspections": total,
+        # Require per-zone finding capture (future) — not fabricated.
+        "most_common_contamination_zones": [],
+        "most_frequently_missed_zones": [],
+        "highest_risk_instrument_families": [],
+        "contamination_rate_by_zone": {},
+        "corrosion_rate_by_zone": {},
+        "average_inspection_coverage": None,
+        "average_images_per_inspection": None,
+        # Computed from real supervisor reviews:
+        "supervisor_override_by_zone": override_by_zone,
+        "supervisor_corrected_zone_counts": corrected_zone_counts,
+        "note": (
+            "Zone/coverage rates require per-zone finding history (captured going "
+            "forward); shown empty rather than fabricated. Override-by-zone is real."
+        ),
+    }

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -252,6 +252,25 @@ def spd_risk_impact(tier: str) -> str:
     return _SPD_IMPACT_LABEL.get(tier, "Review")
 
 
+def _finding_action(kpi: str, spd_tier: str) -> str:
+    """Per-finding recommended action from its SPD tier.
+
+    Structural criticals → Remove from service; contamination criticals →
+    Reprocess; high → Supervisor review; low → Monitor; none → Clear.
+    """
+    if spd_tier == "critical":
+        return "Remove from service" if kpi in _STRUCTURAL_KPIS_ACTION else "Reprocess"
+    if spd_tier == "high":
+        return "Supervisor review"
+    if spd_tier == "low":
+        return "Monitor"
+    return "Clear"
+
+
+# Structural KPIs whose critical breach means the item leaves service.
+_STRUCTURAL_KPIS_ACTION = {"crack", "missing_component", "insulation_damage"}
+
+
 # Per-KPI risk weight — how much a positive finding deducts from the score.
 # Contamination (blood/bioburden/tissue/organic), cracks, and missing components
 # deduct far more aggressively than cosmetic discoloration / wear.
@@ -947,6 +966,7 @@ def analyze_inspection(
     instrument_udi: Optional[str] = None,
     keydot_id: Optional[str] = None,
     decoder_backend: str = "declared",
+    inspected_zones: Optional[list[str]] = None,
 ) -> dict[str, Any]:
     """Run the deterministic baseline-comparison analysis.
 
@@ -1037,6 +1057,9 @@ def analyze_inspection(
         # Instrument-zone taxonomy: where this finding is likely to hide, its
         # retention risk, and the recommended manual check for that zone.
         finding.update(zone_fields(instrument_type, kpi))
+        # Per-finding recommended action (Reprocess / Remove / Supervisor review /
+        # Monitor / Clear) from its SPD tier + structural vs contamination.
+        finding["recommended_action"] = _finding_action(kpi, spd_tier)
         predicted_findings.append(finding)
 
     # ── Identification detection / match (real decode-vs-baseline) ──────────
@@ -1248,6 +1271,21 @@ def analyze_inspection(
         }
         for f in predicted_findings
     }
+    # Phase 15 — anatomy-aware coverage, missing-image guidance, risk map.
+    from app.services.instrument_anatomy import get_anatomy
+    from app.services.inspection_coverage import (
+        build_risk_map, compute_coverage, missing_image_guidance,
+    )
+    anatomy = get_anatomy(instrument_type)
+    coverage = compute_coverage(instrument_type, inspected_zones)
+    guidance = missing_image_guidance(instrument_type, inspected_zones)
+    # Map detected findings onto their assigned zone for the risk map.
+    findings_by_zone: dict[str, list[str]] = {}
+    for f in predicted_findings:
+        if f["severity_index"] >= 2:
+            findings_by_zone.setdefault(f["instrument_zone"], []).append(f["label"])
+    risk_map = build_risk_map(instrument_type, findings_by_zone, inspected_zones)
+
     cleaning_assessment = overall_cleaning_assessment(findings_by_kpi)
     action = recommended_action(findings_by_kpi, baseline_match_score)
     explanation = scoring_explanation(findings_by_kpi, baseline_match_score, source)
@@ -1296,6 +1334,11 @@ def analyze_inspection(
         "scoring_explanation": explanation,
         "spd_critical_drivers": spd_critical,
         "spd_high_drivers": spd_high,
+        # Phase 15 — anatomy-aware intelligence.
+        "instrument_anatomy": anatomy,
+        "inspection_coverage": coverage,
+        "missing_image_guidance": guidance,
+        "risk_map": risk_map,
         "reason": reason,
         "critical_flags": critical_flags,
         "score_adjustments": score_adjustments,

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -471,22 +471,42 @@ def recommended_action(findings_by_kpi: dict[str, dict], baseline_match_score: f
         f = findings_by_kpi.get(kpi)
         return f if f and f["severity_index"] >= 1 else None
 
-    # REPROCESS / REMOVE FROM SERVICE
-    reprocess = []
-    for kpi in ("blood", "tissue", "other_organic_residue", "crack",
-                "missing_component", "insulation_damage"):
-        f = present(kpi)
-        if f and (kpi != "blood" or f["severity_index"] >= 2):
-            reprocess.append(KPI_LABELS[kpi])
-    for kpi in ("corrosion",):
-        f = present(kpi)
-        if f and f["severity_index"] >= 3:  # severe corrosion
-            reprocess.append("severe corrosion")
-    if reprocess:
+    def contamination_actionable(kpi: str) -> dict | None:
+        """Moderate+ anywhere, OR trace+ in a high-retention zone (zone-aware)."""
+        f = findings_by_kpi.get(kpi)
+        if not f:
+            return None
+        idx = f["severity_index"]
+        if idx >= 2 or (idx >= 1 and is_high_retention(f.get("instrument_zone", ""))):
+            return f
+        return None
+
+    # REMOVE FROM SERVICE — structural defects (moderate+), severe corrosion.
+    remove = []
+    for kpi in ("crack", "missing_component", "insulation_damage"):
+        f = findings_by_kpi.get(kpi)
+        if f and f["severity_index"] >= 2:
+            remove.append(KPI_LABELS[kpi])
+    corr = findings_by_kpi.get("corrosion")
+    if corr and corr["severity_index"] >= 3:
+        remove.append("severe corrosion")
+    if remove:
         return (
-            "Reprocess / remove from service — "
-            + ", ".join(sorted(set(reprocess)))
+            "Remove from service — " + ", ".join(sorted(set(remove)))
             + ". Supervisor review required before any further use."
+        )
+
+    # REPROCESS — residual contamination (zone-aware).
+    reprocess = [
+        KPI_LABELS[kpi]
+        for kpi in ("blood", "tissue", "other_organic_residue", "debris", "bone")
+        if contamination_actionable(kpi)
+    ]
+    if reprocess:
+        drivers = ", ".join(sorted(set(reprocess)))
+        return (
+            f"Reprocess — {drivers}. Return the instrument for complete cleaning "
+            "and re-inspect before release."
         )
 
     # SUPERVISOR REVIEW

--- a/backend/app/services/clinical_mentor.py
+++ b/backend/app/services/clinical_mentor.py
@@ -361,9 +361,26 @@ def ai_mentor(result: dict, overall: str) -> dict:
     )
     conf = result.get("confidence_level")
     conf_pct = round((result.get("confidence") or 0) * 100)
+
+    # Zone-specific reasoning (Phase 15 §8): where + why the zone is high-risk.
+    findings_by_kpi = {f["type"]: f for f in result.get("predicted_findings", [])}
+    where_detected = ""
+    why_zone_high_risk = ""
+    verify_manually = ""
+    if primary:
+        pf = findings_by_kpi.get(primary, {})
+        zone = pf.get("instrument_zone")
+        if zone and zone not in ("unspecified region", "surface discoloration area"):
+            where_detected = f"In the {zone}."
+            why_zone_high_risk = pf.get("zone_reason", "")
+            verify_manually = pf.get("recommended_manual_check", "")
+
     return {
         "what_was_detected": what,
+        "where_was_it_detected": where_detected or "No specific high-risk zone implicated.",
         "why_it_matters": why,
+        "why_this_zone_is_high_risk": why_zone_high_risk,
+        "verify_manually": verify_manually,
         "how_confident": f"{conf or 'n/a'} ({conf_pct}%)" if result.get("confidence") is not None else "n/a",
         "standard_practice": STANDARDS_GUIDANCE.get(overall, ""),
         "what_should_happen_next": NEXT_ACTIONS.get(overall, []),

--- a/backend/app/services/clinical_mentor.py
+++ b/backend/app/services/clinical_mentor.py
@@ -217,8 +217,22 @@ def _sev(result: dict, kpi: str) -> int:
 
 
 def _present_findings(result: dict) -> list[str]:
-    """KPIs at a clinically actionable (moderate+, idx>=2) level."""
-    return [f["type"] for f in result.get("predicted_findings", []) if f["severity_index"] >= 2]
+    """Clinically actionable findings: moderate+ (idx>=2) anywhere, OR trace+
+    contamination (idx>=1) in a HIGH-retention zone — so that anything which
+    escalates the disposition is also surfaced in the explanation."""
+    from app.services.instrument_zones import is_high_retention
+    out = []
+    for f in result.get("predicted_findings", []):
+        idx = f["severity_index"]
+        if idx >= 2:
+            out.append(f["type"])
+        elif (idx >= 1 and f["type"] in _CONTAMINATION_TYPES
+              and is_high_retention(f.get("instrument_zone", ""))):
+            out.append(f["type"])
+    return out
+
+
+_CONTAMINATION_TYPES = {"blood", "tissue", "other_organic_residue", "debris", "bone"}
 
 
 def _band(level: str) -> str:

--- a/backend/app/services/inspection_coverage.py
+++ b/backend/app/services/inspection_coverage.py
@@ -1,0 +1,118 @@
+"""Phase 15 — Inspection Coverage Engine, missing-image guidance, risk maps.
+
+Given the anatomy of an instrument and the zones the technician actually
+captured/inspected, compute a coverage score, quality band, missing required
+zones, still-needed image guidance, and a per-zone risk map.
+
+`inspected_zones` are technician-tagged/selected zones (a checklist) — not
+CV-detected (that is a future release). The engine is deterministic and honest.
+"""
+from __future__ import annotations
+
+from app.services.instrument_anatomy import get_anatomy
+
+
+def _norm(z: str) -> str:
+    return (z or "").strip().lower()
+
+
+def _quality(pct: int, missing_required: int) -> str:
+    if missing_required == 0 and pct >= 95:
+        return "complete"
+    if missing_required == 0 or pct >= 80:
+        return "acceptable"
+    if pct >= 50:
+        return "incomplete"
+    return "insufficient"
+
+
+def compute_coverage(instrument_type: str, inspected_zones: list[str] | None) -> dict:
+    """Coverage against the instrument's required high-risk zones.
+
+    When ``inspected_zones`` is None the technician did not tag zones, so coverage
+    is reported as ``not_assessed`` (rather than an alarming 0%). An explicit
+    (possibly empty) list is assessed normally.
+    """
+    anatomy = get_anatomy(instrument_type)
+    required = anatomy["required_images"]
+    if inspected_zones is None:
+        return {
+            "assessed": False,
+            "overall_coverage": None,
+            "required_zones": required,
+            "inspected": [],
+            "inspected_required": [],
+            "missing": required,
+            "quality": "not_assessed",
+            "message": "Zones were not tagged for this inspection — coverage not assessed.",
+            "min_images": anatomy["min_images"],
+        }
+    inspected = inspected_zones
+    inspected_norm = {_norm(z) for z in inspected}
+
+    inspected_required = [z for z in required if _norm(z) in inspected_norm]
+    missing_required = [z for z in required if _norm(z) not in inspected_norm]
+
+    pct = round(100 * len(inspected_required) / len(required)) if required else 100
+    quality = _quality(pct, len(missing_required))
+
+    message = None
+    if missing_required:
+        message = "Inspection incomplete. Upload additional images for required high-risk zones."
+
+    return {
+        "assessed": True,
+        "overall_coverage": pct,
+        "required_zones": required,
+        "inspected": [z for z in anatomy["zone_names"] if _norm(z) in inspected_norm],
+        "inspected_required": inspected_required,
+        "missing": missing_required,
+        "quality": quality,
+        "message": message,
+        "min_images": anatomy["min_images"],
+    }
+
+
+def missing_image_guidance(instrument_type: str, inspected_zones: list[str] | None) -> list[str]:
+    """'Still needed before final decision' view list for missing required zones.
+    Empty when zones were not tagged (avoid nagging on untagged inspections)."""
+    if inspected_zones is None:
+        return []
+    anatomy = get_anatomy(instrument_type)
+    inspected_norm = {_norm(z) for z in inspected_zones}
+    guidance = []
+    for zone in anatomy["required_images"]:
+        if _norm(zone) not in inspected_norm:
+            guidance.append(f"Close-up image of {zone}")
+    return guidance
+
+
+def build_risk_map(instrument_type: str, findings_by_zone: dict[str, list[str]] | None,
+                   inspected_zones: list[str] | None) -> list[dict]:
+    """Per-zone risk map: zone · required? · inspected? · findings? · zone risk ·
+    recommended manual check (text/card form; visual overlays are a future CV
+    release — nothing fabricated)."""
+    from app.services.instrument_zones import ZONE_INFO
+
+    anatomy = get_anatomy(instrument_type)
+    required_norm = {_norm(z) for z in anatomy["required_images"]}
+    inspected_norm = {_norm(z) for z in (inspected_zones or [])}
+    findings_by_zone = findings_by_zone or {}
+
+    rows = []
+    for z in anatomy["zones"]:
+        name = z["zone_name"]
+        info = ZONE_INFO.get(name.lower(), {})
+        rows.append({
+            "zone": name,
+            "zone_category": z["zone_category"],
+            "zone_risk": z["zone_risk_level"],
+            "retention_risk": z["retention_risk"],
+            "required": _norm(name) in required_norm,
+            "inspected": _norm(name) in inspected_norm,
+            "findings": findings_by_zone.get(name, []),
+            "recommended_manual_check": info.get(
+                "manual_check", "Inspect this zone and re-clean if residue is confirmed."
+            ),
+        })
+    return rows

--- a/backend/app/services/instrument_anatomy.py
+++ b/backend/app/services/instrument_anatomy.py
@@ -1,0 +1,211 @@
+"""Phase 15 — Instrument Anatomy Library.
+
+Extensible, data-driven definitions of instrument anatomy so LumenAI reasons the
+way SPD professionals inspect: by anatomy, high-risk zone, retention area, and
+required image coverage.
+
+Each instrument definition lists its anatomy zones (with per-zone risk +
+retention + typical contamination/condition risks), the high-risk subset, the
+images required for a complete inspection, recommended image angles, minimum
+image count, and recommended manual inspection steps.
+
+This is structured knowledge, not pixel-level detection — a future CV model that
+localizes zones drops into the same schema.
+"""
+from __future__ import annotations
+
+from app.services.instrument_zones import HIGH_RETENTION_ZONES
+
+# Standard contamination / condition risk vocabularies (per zone).
+_CONTAM = ["blood", "bone", "tissue", "organic residue", "debris"]
+_COND = ["rust", "corrosion", "pitting", "crack", "discoloration", "insulation damage", "missing component", "wear"]
+
+
+def _zone(name: str, category: str, risk: str, retention: str,
+          contamination: list[str] | None = None,
+          condition: list[str] | None = None) -> dict:
+    return {
+        "zone_name": name,
+        "zone_category": category,
+        "zone_risk_level": risk,          # low / medium / high / critical
+        "retention_risk": retention,      # low / medium / high
+        "contamination_risks": contamination if contamination is not None else _CONTAM,
+        "condition_risks": condition if condition is not None else _COND,
+    }
+
+
+# ── Instrument anatomy definitions ───────────────────────────────────────────
+# Keyed by canonical instrument family. `match` keywords resolve free-text
+# instrument_type onto a family. Extend by adding entries — no manufacturer is
+# hardcoded.
+INSTRUMENT_ANATOMY: dict[str, dict] = {
+    "rigid_scope": {
+        "category": "rigid endoscope",
+        "match": ["rigid scope", "scope", "endoscope", "arthroscope", "cystoscope", "laparoscope camera", "hysteroscope", "ureteroscope"],
+        "zones": [
+            _zone("distal tip", "lumen_scope", "high", "high"),
+            _zone("lens edge", "lumen_scope", "medium", "medium"),
+            _zone("o-ring area", "lumen_scope", "high", "high"),
+            _zone("light post", "lumen_scope", "medium", "medium"),
+            _zone("eyepiece", "handle_external", "low", "low"),
+            _zone("working channel", "lumen_scope", "critical", "high"),
+            _zone("sheath connection", "lumen_scope", "high", "high"),
+            _zone("seal", "lumen_scope", "high", "high"),
+        ],
+        "required_images": ["distal tip", "o-ring area", "light post", "lens edge", "working channel"],
+        "recommended_image_angles": ["distal end-on", "side profile", "port-on"],
+        "min_images": 3,
+        "manual_steps": [
+            "Flush and brush the working channel; borescope if available.",
+            "Inspect the o-ring/seal for soil and wear.",
+            "Check the distal tip and lens edge under magnification.",
+        ],
+    },
+    "drill_bit": {
+        "category": "rotary orthopedic",
+        "match": ["drill", "bit", "reamer", "burr"],
+        "zones": [
+            _zone("tip", "rotary_orthopedic", "high", "high"),
+            _zone("flutes", "rotary_orthopedic", "critical", "high"),
+            _zone("threaded region", "rotary_orthopedic", "high", "high"),
+            _zone("cutting edge", "rotary_orthopedic", "high", "medium"),
+            _zone("shank", "handle_external", "low", "low"),
+            _zone("hub", "mechanical", "medium", "medium"),
+        ],
+        "required_images": ["flutes", "threaded region", "tip", "hub"],
+        "recommended_image_angles": ["flute close-up", "tip end-on", "shank/hub"],
+        "min_images": 3,
+        "manual_steps": [
+            "Brush the flutes and threaded region; confirm no residue between spirals.",
+            "Inspect the cutting tip for wear and residue.",
+        ],
+    },
+    "kerrison_rongeur": {
+        "category": "orthopedic biter",
+        "match": ["kerrison", "rongeur", "punch", "biter"],
+        "zones": [
+            _zone("jaw", "cutting_working_surface", "high", "high"),
+            _zone("serrations", "cutting_working_surface", "high", "high"),
+            _zone("box lock", "mechanical", "high", "high"),
+            _zone("hinge", "mechanical", "high", "high"),
+            _zone("spring", "mechanical", "medium", "medium"),
+            _zone("ratchet", "mechanical", "high", "high"),
+            _zone("handle", "handle_external", "low", "low"),
+        ],
+        "required_images": ["jaw", "serrations", "box lock", "hinge", "spring", "ratchet"],
+        "recommended_image_angles": ["jaw close-up", "box lock", "hinge/spring"],
+        "min_images": 3,
+        "manual_steps": [
+            "Open the box lock and brush the pivot; actuate the hinge.",
+            "Brush the jaw serrations and spring channel.",
+        ],
+    },
+    "scissors": {
+        "category": "cutting",
+        "match": ["scissor", "shear"],
+        "zones": [
+            _zone("tip", "cutting_working_surface", "medium", "medium"),
+            _zone("blade", "cutting_working_surface", "medium", "medium"),
+            _zone("cutting edge", "cutting_working_surface", "medium", "medium"),
+            _zone("serration", "cutting_working_surface", "high", "high"),
+            _zone("box lock", "mechanical", "high", "high"),
+            _zone("handle", "handle_external", "low", "low"),
+        ],
+        "required_images": ["blade", "cutting edge", "box lock"],
+        "recommended_image_angles": ["blade side", "box lock", "tip close-up"],
+        "min_images": 2,
+        "manual_steps": [
+            "Inspect the cutting edge and tip; brush any serrations.",
+            "Open and brush the box lock.",
+        ],
+    },
+    "needle_holder": {
+        "category": "grasping",
+        "match": ["needle holder", "needle_holder", "needle-holder"],
+        "zones": [
+            _zone("jaw inserts", "cutting_working_surface", "high", "high"),
+            _zone("serrations", "cutting_working_surface", "high", "high"),
+            _zone("box lock", "mechanical", "high", "high"),
+            _zone("ratchet", "mechanical", "high", "high"),
+            _zone("tungsten carbide inserts", "cutting_working_surface", "medium", "medium"),
+            _zone("handle", "handle_external", "low", "low"),
+        ],
+        "required_images": ["jaw inserts", "serrations", "box lock", "ratchet"],
+        "recommended_image_angles": ["jaw close-up", "box lock", "ratchet"],
+        "min_images": 2,
+        "manual_steps": [
+            "Brush the jaw inserts and serrations.",
+            "Open the box lock and brush the ratchet teeth.",
+        ],
+    },
+    "laparoscopic": {
+        "category": "MIS / laparoscopic",
+        "match": ["laparoscop", "grasper", "maryland", "dissector", "bipolar", "monopolar", "trocar", "cannula"],
+        "zones": [
+            _zone("distal jaws", "cutting_working_surface", "high", "high"),
+            _zone("hinge", "mechanical", "high", "high"),
+            _zone("insulation edge", "handle_external", "critical", "high"),
+            _zone("shaft", "handle_external", "medium", "medium"),
+            _zone("handle seam", "handle_external", "high", "high"),
+            _zone("rotation knob", "mechanical", "medium", "medium"),
+            _zone("lumen/cannulated channel", "lumen_scope", "critical", "high"),
+        ],
+        "required_images": ["distal jaws", "insulation edge", "shaft", "handle seam", "rotation knob"],
+        "recommended_image_angles": ["distal jaws", "insulation length", "handle seam"],
+        "min_images": 3,
+        "manual_steps": [
+            "Flush the lumen/cannulated channel if present.",
+            "Inspect the full insulation length for breaches; test integrity.",
+            "Brush the distal jaws and handle seam.",
+        ],
+    },
+    "default": {
+        "category": "general instrument",
+        "match": [],
+        "zones": [
+            _zone("working surface", "cutting_working_surface", "medium", "medium"),
+            _zone("hinge/joint", "mechanical", "high", "high"),
+            _zone("box lock", "mechanical", "high", "high"),
+            _zone("handle", "handle_external", "low", "low"),
+        ],
+        "required_images": ["working surface", "hinge/joint"],
+        "recommended_image_angles": ["overall", "working surface", "joint close-up"],
+        "min_images": 1,
+        "manual_steps": [
+            "Inspect the working surface and any hinge/box lock.",
+        ],
+    },
+}
+
+
+def resolve_family(instrument_type: str) -> str:
+    """Resolve free-text instrument_type onto an anatomy family key."""
+    name = (instrument_type or "").lower()
+    for family, defn in INSTRUMENT_ANATOMY.items():
+        if family == "default":
+            continue
+        if any(k in name for k in defn["match"]):
+            return family
+    return "default"
+
+
+def get_anatomy(instrument_type: str) -> dict:
+    """Full anatomy definition for an instrument type."""
+    family = resolve_family(instrument_type)
+    defn = INSTRUMENT_ANATOMY[family]
+    zones = defn["zones"]
+    return {
+        "family": family,
+        "category": defn["category"],
+        "zones": zones,
+        "zone_names": [z["zone_name"] for z in zones],
+        "high_risk_zones": [
+            z["zone_name"] for z in zones
+            if z["zone_risk_level"] in ("high", "critical") or z["retention_risk"] == "high"
+            or z["zone_name"] in HIGH_RETENTION_ZONES
+        ],
+        "required_images": defn["required_images"],
+        "recommended_image_angles": defn["recommended_image_angles"],
+        "min_images": defn["min_images"],
+        "manual_steps": defn["manual_steps"],
+    }

--- a/backend/tests/test_instrument_intelligence_phase15.py
+++ b/backend/tests/test_instrument_intelligence_phase15.py
@@ -1,0 +1,150 @@
+"""Phase 15 — Instrument Intelligence Engine: anatomy, coverage, risk map,
+missing-image guidance, knowledge library, analytics."""
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.instrument_anatomy import get_anatomy, resolve_family
+from app.services.inspection_coverage import (
+    compute_coverage, missing_image_guidance, build_risk_map,
+)
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"p15-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None, inspected_zones=None):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+            inspected_zones=inspected_zones,
+        )
+    finally:
+        db.close()
+
+
+class TestAnatomyLibrary:
+    def test_rigid_scope_includes_oring(self):
+        a = get_anatomy("rigid scope")
+        assert "o-ring area" in a["zone_names"]
+        assert "working channel" in a["zone_names"]
+
+    def test_drill_bit_includes_flutes_and_threads(self):
+        a = get_anatomy("orthopedic drill")
+        assert "flutes" in a["zone_names"]
+        assert "threaded region" in a["zone_names"]
+
+    def test_kerrison_includes_serration_box_lock_hinge(self):
+        a = get_anatomy("kerrison rongeur")
+        for z in ("serrations", "box lock", "hinge"):
+            assert z in a["zone_names"]
+
+    def test_laparoscopic_includes_insulation_and_lumen(self):
+        a = get_anatomy("laparoscopic grasper")
+        assert "insulation edge" in a["zone_names"]
+        assert any("lumen" in z for z in a["zone_names"])
+
+    def test_default_family_for_unknown(self):
+        assert resolve_family("mystery tool") == "default"
+
+
+class TestCoverageEngine:
+    def test_complete_coverage(self):
+        req = get_anatomy("kerrison")["required_images"]
+        cov = compute_coverage("kerrison", req)
+        assert cov["overall_coverage"] == 100
+        assert cov["missing"] == []
+        assert cov["quality"] == "complete"
+
+    def test_missing_zone_lowers_coverage(self):
+        req = get_anatomy("kerrison")["required_images"]
+        cov = compute_coverage("kerrison", req[:-2])  # drop two required
+        assert cov["overall_coverage"] < 100
+        assert cov["missing"]
+        assert cov["message"] and "incomplete" in cov["message"].lower()
+
+    def test_missing_image_guidance(self):
+        g = missing_image_guidance("rigid scope", ["distal tip"])
+        assert any("o-ring area" in item for item in g)
+
+    def test_risk_map_rows(self):
+        rmap = build_risk_map("kerrison", {"serrations": ["blood"]}, ["serrations"])
+        row = next(r for r in rmap if r["zone"] == "serrations")
+        assert row["inspected"] is True
+        assert row["findings"] == ["blood"]
+        assert row["recommended_manual_check"]
+
+
+class TestAnalyzeIntegration:
+    def test_analysis_carries_anatomy_and_coverage(self):
+        out = _analyze("kerrison", inspected_zones=["serrations", "box lock"])
+        assert "instrument_anatomy" in out
+        assert "inspection_coverage" in out
+        assert "risk_map" in out
+        assert "missing_image_guidance" in out
+        assert out["inspection_coverage"]["overall_coverage"] <= 100
+
+    def test_findings_have_recommended_action(self):
+        out = _analyze("serrated forceps")
+        for f in out["predicted_findings"]:
+            assert f["recommended_action"] in (
+                "Clear", "Monitor", "Supervisor review", "Reprocess", "Remove from service"
+            )
+
+    def test_mentor_has_zone_reasoning(self):
+        out = _analyze("orthopedic drill", declared=["debris"])
+        mentor = out["clinical_decision"]["ai_mentor"]
+        assert "where_was_it_detected" in mentor
+        assert "why_this_zone_is_high_risk" in mentor
+
+
+class TestKnowledgeAndAnalytics:
+    def test_register_and_list_knowledge(self):
+        r = client.post("/api/instrument-knowledge", json={
+            "manufacturer": "Acme", "model": "RS-100", "instrument_family": "rigid_scope",
+            "ifu_reference": "IFU-RS-100", "anatomy_zones": ["distal tip", "o-ring area"],
+            "high_risk_zones": ["o-ring area"], "known_failure_modes": ["seal wear"],
+            "maintenance_interval": "annual", "repair_criteria": "seal leak",
+            "replacement_criteria": "cracked sheath",
+        }, headers=AUTH_ADMIN)
+        assert r.status_code == 201, r.text
+        lst = client.get("/api/instrument-knowledge", headers=AUTH_ADMIN).json()
+        assert any(e["manufacturer"] == "Acme" for e in lst["entries"])
+
+    def test_operator_cannot_register_knowledge(self):
+        r = client.post("/api/instrument-knowledge", json={"manufacturer": "X"}, headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+    def test_anatomy_endpoint(self):
+        r = client.get("/api/instrument-anatomy/rigid%20scope", headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        assert "o-ring area" in r.json()["zone_names"]
+
+    def test_zone_analytics_no_fabrication(self):
+        r = client.get("/api/analytics/zone-intelligence", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["contamination_rate_by_zone"] == {}  # not fabricated
+        assert "supervisor_override_by_zone" in body

--- a/backend/tests/test_instrument_zones.py
+++ b/backend/tests/test_instrument_zones.py
@@ -112,6 +112,35 @@ class TestZoneEscalation:
         assert _overall_result(r) in ("PASS", "MONITOR")
 
 
+class TestZoneEscalationExplained:
+    """Regression: a zone-escalated disposition must be explained by the
+    reasoning (no 'REPROCESS' while the mentor says 'no actionable findings')."""
+
+    def test_zone_escalated_finding_is_surfaced(self):
+        from app.services.clinical_mentor import _present_findings, ai_mentor
+        r = {
+            "analysis_status": "completed", "confidence": 0.85,
+            "confidence_level": "High", "baseline_match_score": 0.93,
+            "predicted_findings": [
+                {"type": "other_organic_residue", "severity_index": 1, "instrument_zone": "hinge"},
+            ],
+            "identification": {},
+        }
+        assert "other_organic_residue" in _present_findings(r)
+        m = ai_mentor(r, "REPROCESS")
+        assert m["what_was_detected"] != ["No actionable findings detected."]
+
+    def test_no_phantom_crack_in_recommendation(self):
+        from app.services.baseline_comparison_scoring_service import recommended_action
+        findings = {
+            "crack": {"severity_index": 1, "instrument_zone": "cutting edge"},
+            "other_organic_residue": {"severity_index": 1, "instrument_zone": "hinge"},
+        }
+        txt = recommended_action(findings, 0.93).lower()
+        assert "crack" not in txt  # an 11% cosmetic-wear crack is not a driver
+        assert "organic residue" in txt  # the zone-escalated contamination is
+
+
 class TestZoneReasoning:
     def test_interpretation_includes_zone_language(self):
         out = _analyze("serrated forceps", declared=["blood"])

--- a/docs/ai/inspection-coverage-engine.md
+++ b/docs/ai/inspection-coverage-engine.md
@@ -1,0 +1,27 @@
+# Inspection Coverage Engine (Phase 15)
+
+## What it does
+Given an instrument's anatomy and the zones the technician captured/inspected,
+computes an **Inspection Coverage Score**, a quality band, the missing required
+zones, and "still needed" image guidance.
+
+## Inputs
+- `instrument_type` → resolves to an anatomy family with `required_images`.
+- `inspected_zones` — technician-tagged zones (a checklist). Not CV-detected today.
+
+## Output
+- `overall_coverage` (% of required zones inspected)
+- `inspected`, `inspected_required`, `missing`
+- `quality`: complete / acceptable / incomplete / insufficient
+- `message` when required zones are missing:
+  "Inspection incomplete. Upload additional images for required high-risk zones."
+- Missing-image guidance: "Close-up image of {zone}" per missing required zone.
+
+## Required zones (configurable by instrument type)
+Defined per family in the Instrument Anatomy Library `required_images`. Extend or
+override per manufacturer/model via the Instrument Knowledge Library.
+
+## Risk map
+Per-zone: zone · required? · inspected? · findings? · zone risk · recommended
+manual check. Text/card form today; SVG/overlay/heatmap are a future CV release
+(nothing fabricated).

--- a/docs/ai/instrument-intelligence-engine.md
+++ b/docs/ai/instrument-intelligence-engine.md
@@ -1,0 +1,35 @@
+# Instrument Intelligence Engine (Phase 15)
+
+**Status:** Draft for review
+**Purpose:** Make LumenAI understand surgical instruments the way SPD professionals
+inspect them — by anatomy, high-risk zone, retention area, required image coverage,
+and clinical consequence — rather than reporting only "blood detected."
+
+> ⚠️ Advisory pilot. Zone assignment and coverage are deterministic heuristics
+> (instrument type + technician-tagged zones), not pixel-level CV. No FDA/
+> diagnostic claims; `human_review_required` stays true.
+
+## Components
+- **Instrument Anatomy Library** (`app/services/instrument_anatomy.py`) — per-family
+  anatomy zones, high-risk zones, required images, recommended angles, min images,
+  manual steps. Extensible; no manufacturer hardcoded.
+- **Zone risk model** (`app/services/instrument_zones.py`) — per-zone risk level,
+  retention risk, contamination/condition risks, high-retention set.
+- **Zone-aware output schema** — every finding carries `instrument_zone`,
+  `zone_risk`, `zone_reason`, `recommended_manual_check`, `recommended_action`.
+- **Zone-aware escalation** — contamination in a high-retention zone escalates more
+  aggressively than the same signal on a flat surface (see
+  `docs/ai/instrument-zone-taxonomy.md`).
+- **Inspection Coverage Engine** (`app/services/inspection_coverage.py`) — coverage
+  score, quality band, missing required zones, missing-image guidance, risk map.
+- **AI Inspection Mentor** — zone-specific reasoning (what / where / why the zone is
+  high risk / what to verify manually / what next).
+- **Instrument Knowledge Library** (`instrument_knowledge` table) — manufacturer/
+  model/family, IFU reference, anatomy + high-risk zones, failure modes, maintenance
+  interval, repair/replacement criteria.
+- **Executive analytics** — `GET /api/analytics/zone-intelligence` (real override-by-
+  zone; zone-rate metrics surfaced empty until per-zone history exists — not faked).
+
+## Future
+SVG anatomy maps, clickable zones, image overlays, heatmaps, and segmentation masks
+are a future CV release. The engine never fabricates visual evidence today.

--- a/docs/ai/instrument-zone-taxonomy.md
+++ b/docs/ai/instrument-zone-taxonomy.md
@@ -1,0 +1,37 @@
+# Instrument Zone Taxonomy (Phase 15)
+
+## Zone categories
+- **Cutting / working surface:** serrations, grooves, teeth, jaws, cutting edge
+- **Rotary / orthopedic:** drill-bit flute, threaded region, cutting channel, burr surface
+- **Lumen / scope:** lumen opening, inner channel, o-ring area, rigid scope port, lens edge, sheath connection
+- **Mechanical:** hinge, box lock, joint, ratchet, spring area
+- **Handle / external:** handle seam, insulation edge, outer sheath, surface discoloration area
+- **Unknown:** unspecified region, image quality insufficient
+
+## Zone risk model (per zone)
+`zone_name · zone_category · zone_risk_level (low/medium/high/critical) ·
+retention_risk (low/medium/high) · contamination_risks[] · condition_risks[]`
+
+## High-retention zones (escalate contamination)
+grooves, serrations, threaded regions, drill-bit flutes, o-ring areas, rigid scope
+ports, lumens, cannulated channels, box locks, hinges, joints, ratchets, handle
+seams, insulation edges, crevices.
+
+## Escalation rules
+- Blood 35% on a flat surface → Review.
+- Blood 35% in serrations / groove / lumen / o-ring / threaded region / flute /
+  box lock / hinge → High risk → Reprocess.
+- Debris in a drill-bit flute → High risk → Reprocess / supervisor review.
+- Organic residue in an o-ring area → High risk → Supervisor review.
+- Crack in a working surface → Remove from service.
+- Insulation damage on a laparoscopic instrument → Remove from service.
+
+Anything that escalates the disposition is also surfaced in the explanation.
+
+## Instrument-specific zone examples
+- **Rigid scope:** distal tip, lens edge, o-ring area, light post, eyepiece, working channel, sheath connection, seal.
+- **Drill bit:** tip, flutes, threaded region, cutting edge, shank, hub.
+- **Kerrison / rongeur:** jaw, serrations, box lock, hinge, spring, ratchet, handle.
+- **Scissors:** tip, blade, cutting edge, serration, box lock, handle.
+- **Needle holder:** jaw inserts, serrations, box lock, ratchet, tungsten carbide inserts, handle.
+- **Laparoscopic:** distal jaws, hinge, insulation edge, shaft, handle seam, rotation knob, lumen/cannulated channel.

--- a/docs/ai/zone-aware-training-plan.md
+++ b/docs/ai/zone-aware-training-plan.md
@@ -1,0 +1,42 @@
+# Zone-Aware Training Plan (Phase 15)
+
+**Status:** Draft for review
+
+## Dataset fields (per image)
+instrument_type · instrument_family · finding_type · severity · zone_type ·
+zone_risk · retention_risk · image_angle · lighting_quality ·
+supervisor_confirmed_zone · corrected_zone · corrected_severity ·
+corrected_recommendation · recommended_cleaning_response · source · consent.
+
+## Instrument coverage (examples required)
+drill bits, rigid scopes, cannulated instruments, serrated forceps, laparoscopic
+instruments, hinged instruments, box-lock instruments, insulated instruments —
+with clean/known-good examples per zone.
+
+## Labeling rules
+- Multi-label per image; each finding tagged with its **zone**, severity, and the
+  recommended cleaning response.
+- Region annotation (box/mask) on the zone once CV localization is trained.
+- Critical findings (blood/crack/missing component) get two-reviewer adjudication;
+  only `gold` labels enter validation/test.
+- Uncertain zone → `unspecified region` / `image quality insufficient`.
+
+## Supervisor validation workflow
+Supervisor review captures: AI finding correct? · AI zone correct? · corrected
+zone · corrected severity · corrected recommendation · final disposition ·
+rationale. Stored in `supervisor_reviews` as labeled training data and the primary
+source of per-zone ground truth and FP/FN signal.
+
+## Model evaluation
+Per-zone precision/recall (did the model name the right zone?) alongside finding-
+type metrics; critical-zone recall reported separately; shadow-mode only until
+per-zone thresholds are met.
+
+## Future heatmap / bounding-box roadmap
+SVG anatomy maps → clickable zones → image overlays → heatmaps → segmentation
+masks. Not fabricated in the pilot.
+
+## PHI avoidance & image rights
+Instrument-only imagery; EXIF stripped; de-identified filenames; opt-in retention
+with recorded consent. Web images for research/prototyping only, tagged
+`source=web`, excluded from validation/test, never treated as ground truth.

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -48,6 +48,7 @@ type ClinicalDecision = {
   ai_mentor?: {
     what_was_detected: string[]; why_it_matters: string; how_confident: string;
     standard_practice: string; what_should_happen_next: string[];
+    where_was_it_detected?: string; why_this_zone_is_high_risk?: string; verify_manually?: string;
   };
 };
 
@@ -214,7 +215,16 @@ export default function ClinicalDecisionPanel({
           <p className="text-xs font-semibold uppercase tracking-wide text-blue-700 mb-2">AI Mentor</p>
           <div className="space-y-1.5 text-sm text-slate-700">
             <p><span className="font-semibold text-slate-900">What was detected:</span> {cd.ai_mentor.what_was_detected.join(", ")}</p>
+            {cd.ai_mentor.where_was_it_detected && (
+              <p><span className="font-semibold text-slate-900">Where:</span> {cd.ai_mentor.where_was_it_detected}</p>
+            )}
+            {cd.ai_mentor.why_this_zone_is_high_risk && (
+              <p><span className="font-semibold text-slate-900">Why this zone is high-risk:</span> {cd.ai_mentor.why_this_zone_is_high_risk}</p>
+            )}
             <p><span className="font-semibold text-slate-900">Why it matters:</span> {cd.ai_mentor.why_it_matters}</p>
+            {cd.ai_mentor.verify_manually && (
+              <p><span className="font-semibold text-slate-900">Verify manually:</span> {cd.ai_mentor.verify_manually}</p>
+            )}
             <p><span className="font-semibold text-slate-900">How confident:</span> {cd.ai_mentor.how_confident}</p>
             <p><span className="font-semibold text-slate-900">Standard practice:</span> {cd.ai_mentor.standard_practice}</p>
             <p><span className="font-semibold text-slate-900">What should happen next:</span> {cd.ai_mentor.what_should_happen_next.join("; ")}</p>

--- a/frontend/src/components/InstrumentIntelligencePanel.tsx
+++ b/frontend/src/components/InstrumentIntelligencePanel.tsx
@@ -1,0 +1,131 @@
+/**
+ * Phase 15 — Instrument Intelligence: coverage score, missing-image guidance,
+ * and a text/card instrument risk map. Reads the anatomy-aware fields the
+ * analysis now returns. No fabricated visual overlays.
+ */
+type Coverage = {
+  assessed?: boolean;
+  overall_coverage: number | null;
+  required_zones: string[];
+  inspected: string[];
+  missing: string[];
+  quality: string;
+  message: string | null;
+};
+type RiskRow = {
+  zone: string; zone_category: string; zone_risk: string; retention_risk: string;
+  required: boolean; inspected: boolean; findings: string[]; recommended_manual_check: string;
+};
+export type InstrumentIntel = {
+  instrument_anatomy?: { family: string; category: string; high_risk_zones: string[]; recommended_image_angles: string[]; min_images: number };
+  inspection_coverage?: Coverage;
+  missing_image_guidance?: string[];
+  risk_map?: RiskRow[];
+};
+
+const QUALITY_STYLE: Record<string, string> = {
+  complete: "bg-emerald-100 text-emerald-800",
+  acceptable: "bg-amber-100 text-amber-800",
+  incomplete: "bg-orange-100 text-orange-800",
+  insufficient: "bg-red-100 text-red-800",
+  not_assessed: "bg-slate-100 text-slate-500",
+};
+const ZONE_RISK_STYLE: Record<string, string> = {
+  low: "text-slate-500", medium: "text-amber-600", high: "text-orange-600", critical: "text-red-600 font-semibold",
+};
+
+export default function InstrumentIntelligencePanel({ intel }: { intel: InstrumentIntel }) {
+  const cov = intel.inspection_coverage;
+  const rmap = intel.risk_map ?? [];
+  const guidance = intel.missing_image_guidance ?? [];
+  if (!cov && rmap.length === 0) return null;
+
+  return (
+    <div className="space-y-4">
+      {/* Inspection Coverage */}
+      {cov && (
+        <div className="rounded-lg border border-slate-200 bg-white p-4">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Inspection Coverage</p>
+            <span className={`rounded-full px-2 py-0.5 text-xs font-bold capitalize ${QUALITY_STYLE[cov.quality] ?? "bg-slate-100"}`}>{cov.quality}</span>
+          </div>
+          {cov.assessed === false || cov.overall_coverage == null ? (
+            <p className="text-sm text-slate-500">{cov.message ?? "Coverage not assessed — tag inspected zones to enable."}</p>
+          ) : (
+            <div className="flex items-center gap-3">
+              <div className="text-2xl font-bold text-slate-900">{cov.overall_coverage}%</div>
+              <div className="flex-1 h-2 rounded-full bg-slate-100 overflow-hidden">
+                <div className={`h-full ${cov.overall_coverage >= 80 ? "bg-emerald-500" : cov.overall_coverage >= 50 ? "bg-amber-500" : "bg-red-500"}`} style={{ width: `${cov.overall_coverage}%` }} />
+              </div>
+            </div>
+          )}
+          {cov.assessed !== false && (
+            <>
+              <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+                <div>
+                  <div className="text-xs text-slate-500 mb-0.5">Inspected</div>
+                  <div className="flex flex-wrap gap-1">
+                    {cov.inspected.length ? cov.inspected.map((z) => <span key={z} className="rounded-full bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700 capitalize">{z}</span>) : <span className="text-xs text-slate-400">none tagged</span>}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-slate-500 mb-0.5">Missing (required)</div>
+                  <div className="flex flex-wrap gap-1">
+                    {cov.missing.length ? cov.missing.map((z) => <span key={z} className="rounded-full bg-red-50 px-2 py-0.5 text-xs text-red-700 capitalize">{z}</span>) : <span className="text-xs text-emerald-600">all required zones covered</span>}
+                  </div>
+                </div>
+              </div>
+              {cov.message && <p className="mt-2 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">{cov.message}</p>}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Missing image guidance */}
+      {guidance.length > 0 && (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Still needed before final decision</p>
+          <ul className="space-y-0.5 text-sm text-slate-700">
+            {guidance.map((g, i) => <li key={i} className="flex items-start gap-1.5"><span className="text-amber-500">•</span><span>{g}</span></li>)}
+          </ul>
+        </div>
+      )}
+
+      {/* Instrument risk map */}
+      {rmap.length > 0 && (
+        <div className="rounded-lg border border-slate-200 bg-white p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">
+            Instrument Risk Map {intel.instrument_anatomy && <span className="normal-case text-slate-400">· {intel.instrument_anatomy.category}</span>}
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-left text-slate-400">
+                  <th className="py-1 pr-3 font-medium">Zone</th>
+                  <th className="py-1 px-2 font-medium">Zone Risk</th>
+                  <th className="py-1 px-2 font-medium">Required</th>
+                  <th className="py-1 px-2 font-medium">Inspected</th>
+                  <th className="py-1 px-2 font-medium">Findings</th>
+                  <th className="py-1 px-2 font-medium">Manual check</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rmap.map((r) => (
+                  <tr key={r.zone} className="border-t border-slate-100 align-top">
+                    <td className="py-1 pr-3 font-medium capitalize text-slate-700">{r.zone}</td>
+                    <td className={`py-1 px-2 capitalize ${ZONE_RISK_STYLE[r.zone_risk] ?? ""}`}>{r.zone_risk}</td>
+                    <td className="py-1 px-2">{r.required ? "Yes" : "—"}</td>
+                    <td className="py-1 px-2">{r.inspected ? <span className="text-emerald-600">Yes</span> : <span className="text-slate-400">No</span>}</td>
+                    <td className="py-1 px-2 capitalize">{r.findings.length ? r.findings.join(", ") : "—"}</td>
+                    <td className="py-1 px-2 text-slate-500">{r.recommended_manual_check}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-2 text-xs text-slate-400">Text/card risk map. Visual anatomy maps, clickable zones, and heatmaps are a future computer-vision release (not fabricated).</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -1,7 +1,8 @@
-import { ChangeEvent, FormEvent, useCallback, useRef, useState } from "react";
+import { ChangeEvent, FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth, API_BASE } from "@/lib/auth";
 import ClinicalDecisionPanel from "@/components/ClinicalDecisionPanel";
+import InstrumentIntelligencePanel, { InstrumentIntel } from "@/components/InstrumentIntelligencePanel";
 import { FormSection } from "@/components/ui/FormSection";
 import { RequiredLabel, FieldError } from "@/components/ui/RequiredField";
 import { StatusBanner } from "@/components/ui/StatusBanner";
@@ -47,6 +48,7 @@ type PredictedFinding = {
   zone_risk?: string;
   zone_reason?: string;
   recommended_manual_check?: string;
+  recommended_action?: string;
 };
 
 type SeverityByKpi = Record<
@@ -104,6 +106,11 @@ type Analysis = {
   production_validated?: boolean;
   // Phase 13 — Explainable Clinical Decision Support payload.
   clinical_decision?: Parameters<typeof ClinicalDecisionPanel>[0]["cd"];
+  // Phase 15 — anatomy-aware intelligence (coverage, risk map, guidance).
+  instrument_anatomy?: InstrumentIntel["instrument_anatomy"];
+  inspection_coverage?: InstrumentIntel["inspection_coverage"];
+  missing_image_guidance?: InstrumentIntel["missing_image_guidance"];
+  risk_map?: InstrumentIntel["risk_map"];
 };
 
 type AIPrediction = {
@@ -200,6 +207,23 @@ export default function NewInspectionPage() {
   const navigate = useNavigate();
   // Operators / SPD managers / admins can run inspections; viewers are read-only.
   const canRunInspection = role === "operator" || role === "spd_manager" || role === "admin";
+
+  // Phase 15 — load the instrument's anatomy zones so the tech can tag which
+  // zones were inspected (feeds the coverage engine).
+  useEffect(() => {
+    const type = form.instrument_type.trim();
+    if (!type) { setAnatomyZones([]); return; }
+    let cancelled = false;
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/instrument-anatomy/${encodeURIComponent(type)}`, { headers: headers() });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setAnatomyZones(Array.isArray(data.zone_names) ? data.zone_names : []);
+      } catch { /* non-fatal */ }
+    }, 400);
+    return () => { cancelled = true; clearTimeout(t); };
+  }, [form.instrument_type, headers]);
   const VIEWER_READONLY_MESSAGE =
     "Viewer access is read-only. Ask an admin to assign Operator or SPD Manager access to run inspections.";
   const ROLE_LABELS: Record<string, string> = {
@@ -208,6 +232,8 @@ export default function NewInspectionPage() {
   };
   const [form, setForm] = useState<FormFields>(initialForm);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [anatomyZones, setAnatomyZones] = useState<string[]>([]);
+  const [inspectedZones, setInspectedZones] = useState<string[]>([]);
   const [inspectionImages, setInspectionImages] = useState<File[]>([]);
   const [borescopeImages, setBorescopeImages] = useState<File[]>([]);
   const [submitting, setSubmitting] = useState(false);
@@ -412,6 +438,7 @@ export default function NewInspectionPage() {
         instrument_udi: udiFinal,
         keydot_id: form.keydot_id || undefined,
         identifier_source: identifierSource,
+        inspected_zones: inspectedZones.length ? inspectedZones : undefined,
         file_name: allImages[0]?.name || "inspection_image",
         has_image: true,
         image_sha256: imageSha256,
@@ -502,6 +529,7 @@ export default function NewInspectionPage() {
     setForm({ ...initialForm, inspection_date: nowDatetimeLocal() });
     setInspectionImages([]);
     setBorescopeImages([]);
+    setInspectedZones([]);
     setFieldErrors({});
     setBanner(null);
     setPrediction(null);
@@ -815,6 +843,33 @@ export default function NewInspectionPage() {
               />
             </div>
             <p className="text-xs text-gray-500">Max 10 MB per file. Only SHA-256 hash is stored — raw images are not retained.</p>
+
+            {/* Phase 15 — zones inspected (feeds the coverage engine) */}
+            {anatomyZones.length > 0 && (
+              <div className="mt-3">
+                <label className="block text-sm font-medium text-gray-700">
+                  Zones inspected <span className="text-slate-400 font-normal">(tag which zones your images cover)</span>
+                </label>
+                <div className="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-2">
+                  {anatomyZones.map((z) => (
+                    <label key={z} className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer capitalize">
+                      <input
+                        type="checkbox"
+                        checked={inspectedZones.includes(z)}
+                        disabled={!canRunInspection}
+                        onChange={(e) =>
+                          setInspectedZones((prev) =>
+                            e.target.checked ? [...prev, z] : prev.filter((x) => x !== z),
+                          )
+                        }
+                      />
+                      {z}
+                    </label>
+                  ))}
+                </div>
+                <p className="mt-1 text-xs text-slate-400">Drives the Inspection Coverage score and missing-image guidance.</p>
+              </div>
+            )}
           </FormSection>
 
           {/* Section 5 — Manual Observations (always optional) */}
@@ -977,6 +1032,11 @@ function AIPredictionPanel({
         {/* Phase 13 — Explainable Clinical Decision Support (primary view) */}
         {prediction.analysis?.clinical_decision && (
           <ClinicalDecisionPanel cd={prediction.analysis.clinical_decision} inspectionId={prediction.id} />
+        )}
+
+        {/* Phase 15 — Instrument Intelligence: coverage, risk map, guidance */}
+        {prediction.analysis && (
+          <InstrumentIntelligencePanel intel={prediction.analysis as InstrumentIntel} />
         )}
 
         {/* Detailed KPI breakdown (retained below the clinical summary) */}
@@ -1205,6 +1265,9 @@ function AnalysisDetails({ analysis }: { analysis: Analysis }) {
                     {finding.zone_reason && <p className="mt-0.5 text-slate-500">{finding.zone_reason}</p>}
                     {finding.recommended_manual_check && (
                       <p className="mt-0.5 text-slate-600"><span className="text-slate-400">Manual check:</span> {finding.recommended_manual_check}</p>
+                    )}
+                    {finding.recommended_action && finding.recommended_action !== "Clear" && (
+                      <p className="mt-0.5 text-slate-700"><span className="text-slate-400">Action:</span> <span className="font-medium">{finding.recommended_action}</span></p>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Summary

### Phase 15 — Instrument Intelligence Engine (anatomy-aware)
LumenAI now reasons by **anatomy, high-risk zone, retention area, and required image coverage**.
- **Instrument Anatomy Library** — per-family zones + high-risk zones + required images + angles + min images + manual steps (rigid scope, drill bit, kerrison/rongeur, scissors, needle holder, laparoscopic + default). Extensible; no manufacturer hardcoded.
- **Inspection Coverage Engine** — coverage score, quality band (complete/acceptable/incomplete/insufficient), missing required zones, missing-image guidance, per-zone **risk map**. Untagged inspections report `not_assessed` (no false 0%).
- **Zone-aware output schema** — each finding adds `recommended_action`.
- **AI Mentor zone reasoning** — where detected · why the zone is high-risk · verify manually.
- **Instrument Knowledge Library** — `instrument_knowledge` table + routes (manufacturer/model/family, IFU, anatomy, failure modes, maintenance, repair/replacement criteria).
- **Executive zone analytics** — `/api/analytics/zone-intelligence` (real override-by-zone; zone-rate metrics empty until per-zone history exists — not fabricated).
- **Supervisor feedback** — `corrected_recommendation` added.
- **Frontend** — Instrument Intelligence panel (coverage, guidance, risk map); AI Mentor where/why-zone/verify; per-finding action on KPI cards; "Zones inspected" checklist on the New Inspection form.
- **Docs** — 4 files under `docs/ai/`.

Reuses Phase 14 zone taxonomy/escalation/supervisor-zone-feedback.

### Also: explainability fix
Faint contamination that zone-escalates the disposition is now surfaced in the AI Mentor/interpretation, and the recommendation only names real moderate+ structural drivers (no phantom 11% crack).

## Validation
- `npm run build` → clean · `pytest tests -q` → **2274 passed, 2 skipped** · ruff clean
- New: `test_instrument_intelligence_phase15.py` + zone-escalation regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)