### PR TITLE
Fix New Inspection page crash (temporal-dead-zone on form read)

### DIFF
--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -207,9 +207,21 @@ export default function NewInspectionPage() {
   const navigate = useNavigate();
   // Operators / SPD managers / admins can run inspections; viewers are read-only.
   const canRunInspection = role === "operator" || role === "spd_manager" || role === "admin";
+  const VIEWER_READONLY_MESSAGE =
+    "Viewer access is read-only. Ask an admin to assign Operator or SPD Manager access to run inspections.";
+  const ROLE_LABELS: Record<string, string> = {
+    admin: "Admin", spd_manager: "SPD Manager", supervisor: "Supervisor",
+    operator: "Operator", viewer: "Viewer", vendor_user: "Vendor",
+  };
+  const [form, setForm] = useState<FormFields>(initialForm);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [anatomyZones, setAnatomyZones] = useState<string[]>([]);
+  const [inspectedZones, setInspectedZones] = useState<string[]>([]);
+  const [inspectionImages, setInspectionImages] = useState<File[]>([]);
 
   // Phase 15 — load the instrument's anatomy zones so the tech can tag which
-  // zones were inspected (feeds the coverage engine).
+  // zones were inspected (feeds the coverage engine). Declared AFTER the state
+  // it depends on (avoids a temporal-dead-zone crash on the `form` read).
   useEffect(() => {
     const type = form.instrument_type.trim();
     if (!type) { setAnatomyZones([]); return; }
@@ -224,17 +236,6 @@ export default function NewInspectionPage() {
     }, 400);
     return () => { cancelled = true; clearTimeout(t); };
   }, [form.instrument_type, headers]);
-  const VIEWER_READONLY_MESSAGE =
-    "Viewer access is read-only. Ask an admin to assign Operator or SPD Manager access to run inspections.";
-  const ROLE_LABELS: Record<string, string> = {
-    admin: "Admin", spd_manager: "SPD Manager", supervisor: "Supervisor",
-    operator: "Operator", viewer: "Viewer", vendor_user: "Vendor",
-  };
-  const [form, setForm] = useState<FormFields>(initialForm);
-  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
-  const [anatomyZones, setAnatomyZones] = useState<string[]>([]);
-  const [inspectedZones, setInspectedZones] = useState<string[]>([]);
-  const [inspectionImages, setInspectionImages] = useState<File[]>([]);
   const [borescopeImages, setBorescopeImages] = useState<File[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [banner, setBanner] = useState<{ type: "success" | "error"; message: string } | null>(null);


### PR DESCRIPTION
## Summary

The New Inspection page crashed to the error boundary with **"Cannot access 'p' before initialization"**.

**Cause:** the Phase 15 anatomy-loading `useEffect` was placed **above** `const [form] = useState(...)`, so its dependency array `[form.instrument_type, headers]` read `form` at render time — before it was initialized (temporal dead zone).

**Fix:** move the effect below the state declarations it depends on.

**Why CI missed it:** this is a runtime render error, not a compile/type error — build, typecheck, and pytest all passed while the page crashed on mount. Verified the fix by driving `/inspection/new` headless: the form mounts with no page error and no error boundary.

## Validation
- `npm run build` → clean
- Headless render of `/inspection/new` → mounts, no runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_