### PR TITLE
Preserve instrument→anatomy→zone→clinical architecture in AI analysis

### DIFF
--- a/backend/app/models/supervisor_review.py
+++ b/backend/app/models/supervisor_review.py
@@ -50,6 +50,10 @@ class SupervisorReview(Base):
     # Zone-aware feedback (instrument high-risk zone detection) — labeled data.
     finding_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     zone_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    # Anatomy-family feedback (architecture step 9) — labeled data for the future
+    # instrument-classification model.
+    instrument_family_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    corrected_instrument_family: Mapped[str] = mapped_column(String(60), default="", nullable=False)
     corrected_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False)
     corrected_severity: Mapped[str] = mapped_column(String(30), default="", nullable=False)
     corrected_recommendation: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -38,6 +38,9 @@ class SupervisorReviewIn(BaseModel):
     # Zone-aware feedback → labeled training data.
     finding_correct: bool | None = None
     zone_correct: bool | None = None
+    # Anatomy-family feedback → labeled training data for instrument classification.
+    instrument_family_correct: bool | None = None
+    corrected_instrument_family: str = Field("", max_length=60)
     corrected_zone: str = Field("", max_length=60)
     corrected_severity: str = Field("", max_length=30)
     corrected_recommendation: str = Field("", max_length=50)
@@ -91,6 +94,8 @@ def submit_supervisor_review(
         ai_score=(100 - inspection.risk_score) if inspection.score_status == "scored" else None,
         finding_correct=body.finding_correct,
         zone_correct=body.zone_correct,
+        instrument_family_correct=body.instrument_family_correct,
+        corrected_instrument_family=body.corrected_instrument_family.strip(),
         corrected_zone=body.corrected_zone.strip(),
         corrected_severity=body.corrected_severity.strip(),
         corrected_recommendation=body.corrected_recommendation.strip(),

--- a/backend/app/routes/instrument_intelligence_admin.py
+++ b/backend/app/routes/instrument_intelligence_admin.py
@@ -21,7 +21,7 @@ from app.deps import get_db
 from app.enterprise_auth import get_request_tenant_id
 from app.models.instrument_knowledge import InstrumentKnowledge
 from app.models.supervisor_review import SupervisorReview
-from app.services.instrument_anatomy import get_anatomy
+from app.services.instrument_anatomy import anatomy_profile
 
 router = APIRouter(tags=["instrument-intelligence"])
 
@@ -29,10 +29,15 @@ router = APIRouter(tags=["instrument-intelligence"])
 @router.get("/instrument-anatomy/{instrument_type}")
 def instrument_anatomy(
     instrument_type: str,
+    manufacturer: str | None = None,
+    model: str | None = None,
+    instrument_name: str | None = None,
     current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
 ):
-    """Resolved anatomy definition (zones, high-risk zones, required images…)."""
-    return get_anatomy(instrument_type)
+    """Anatomy Profile Service — resolved profile (family, zones, high-risk zones,
+    required image views, per-zone descriptions/risks, manual-check steps). Falls
+    back to a generic SPD profile with a supervisor-review warning when unknown."""
+    return anatomy_profile(instrument_type, manufacturer, model, instrument_name)
 
 
 class KnowledgeIn(BaseModel):

--- a/backend/app/services/instrument_anatomy.py
+++ b/backend/app/services/instrument_anatomy.py
@@ -39,6 +39,35 @@ def _zone(name: str, category: str, risk: str, retention: str,
 # instrument_type onto a family. Extend by adding entries — no manufacturer is
 # hardcoded.
 INSTRUMENT_ANATOMY: dict[str, dict] = {
+    # Flexible endoscopes are declared BEFORE rigid scopes so their specific
+    # keywords resolve first (a rigid scope's generic "scope"/"endoscope" match
+    # would otherwise swallow them).
+    "flexible_endoscope": {
+        "category": "flexible endoscope",
+        "match": [
+            "flexible", "flex scope", "colonoscope", "gastroscope", "bronchoscope",
+            "duodenoscope", "enteroscope", "sigmoidoscope", "choledochoscope",
+            "flexible ureteroscope", "flexible cystoscope",
+        ],
+        "zones": [
+            _zone("distal end", "lumen_scope", "critical", "high"),
+            _zone("bending section", "lumen_scope", "high", "high"),
+            _zone("insertion tube", "handle_external", "medium", "medium"),
+            _zone("suction channel", "lumen_scope", "critical", "high"),
+            _zone("biopsy channel", "lumen_scope", "critical", "high"),
+            _zone("air/water nozzle", "lumen_scope", "high", "high"),
+            _zone("light guide lens", "lumen_scope", "medium", "medium"),
+            _zone("control body", "handle_external", "low", "low"),
+        ],
+        "required_images": ["distal end", "biopsy channel", "suction channel", "bending section", "control body"],
+        "recommended_image_angles": ["distal end-on", "channel opening", "bending section", "control body"],
+        "min_images": 4,
+        "manual_steps": [
+            "Flush and brush the biopsy and suction channels; leak-test the endoscope.",
+            "Borescope the internal channels if available — retained soil hides inside pathways.",
+            "Inspect the distal end, air/water nozzle, and bending section closely.",
+        ],
+    },
     "rigid_scope": {
         "category": "rigid endoscope",
         "match": ["rigid scope", "scope", "endoscope", "arthroscope", "cystoscope", "laparoscope camera", "hysteroscope", "ureteroscope"],
@@ -159,6 +188,25 @@ INSTRUMENT_ANATOMY: dict[str, dict] = {
             "Brush the distal jaws and handle seam.",
         ],
     },
+    "general_forceps": {
+        "category": "grasping / clamping",
+        "match": ["forcep", "hemostat", "clamp", "kocher", "mosquito", "kelly", "allis", "babcock", "tissue forcep"],
+        "zones": [
+            _zone("jaws", "cutting_working_surface", "high", "high"),
+            _zone("serrations", "cutting_working_surface", "high", "high"),
+            _zone("box lock", "mechanical", "high", "high"),
+            _zone("hinge", "mechanical", "high", "high"),
+            _zone("ratchet", "mechanical", "high", "high"),
+            _zone("handle", "handle_external", "low", "low"),
+        ],
+        "required_images": ["jaws", "serrations", "box lock", "hinge"],
+        "recommended_image_angles": ["jaw close-up", "box lock", "hinge/ratchet"],
+        "min_images": 2,
+        "manual_steps": [
+            "Open the box lock and brush the pivot; actuate the hinge and ratchet.",
+            "Brush the jaw serrations and re-inspect under magnification.",
+        ],
+    },
     "default": {
         "category": "general instrument",
         "match": [],
@@ -208,4 +256,63 @@ def get_anatomy(instrument_type: str) -> dict:
         "recommended_image_angles": defn["recommended_image_angles"],
         "min_images": defn["min_images"],
         "manual_steps": defn["manual_steps"],
+    }
+
+
+def _zone_description(z: dict) -> str:
+    """Human-readable, honest one-liner per zone (from the zone's risk profile)."""
+    from app.services.instrument_zones import ZONE_INFO
+
+    info = ZONE_INFO.get(z["zone_name"].lower())
+    if info and info.get("reason"):
+        return info["reason"]
+    retention = z["retention_risk"]
+    if retention == "high":
+        return f"{z['zone_name'].capitalize()} is a high-retention zone where residual soil can persist after cleaning."
+    return f"{z['zone_name'].capitalize()} ({z['zone_category'].replace('_', ' ')}); {z['zone_risk_level']} inherent risk."
+
+
+def anatomy_profile(
+    instrument_type: str,
+    manufacturer: str | None = None,
+    model: str | None = None,
+    instrument_name: str | None = None,
+) -> dict:
+    """Architecture step 2 — the Anatomy Profile Service.
+
+    Given an instrument's type (and optionally name/manufacturer/model), return
+    the full anatomy profile the AI pipeline reasons over: family, anatomy zones,
+    required zones, high-risk zones, per-zone descriptions, contamination/condition
+    risks, recommended image views, and manual-check steps.
+
+    When the instrument cannot be classified the family resolves to ``unknown``
+    and a generic high-risk SPD profile is returned with a supervisor-review
+    warning — nothing is fabricated as a specific match.
+    """
+    # Consider every available identity hint when resolving the family.
+    hint = " ".join(x for x in (instrument_type, instrument_name, model, manufacturer) if x)
+    family = resolve_family(hint or (instrument_type or ""))
+    profile_found = family != "default"
+    defn = INSTRUMENT_ANATOMY[family]
+    zones = defn["zones"]
+    base = get_anatomy(hint or (instrument_type or ""))
+
+    return {
+        **base,
+        # `family` is a real family key when matched, else the honest "unknown".
+        "instrument_family": family if profile_found else "unknown",
+        "profile_found": profile_found,
+        "manufacturer": manufacturer or "",
+        "model": model or "",
+        "anatomy_zones": base["zone_names"],
+        "required_zones": defn["required_images"],
+        "recommended_image_views": defn["required_images"],
+        "zone_descriptions": {z["zone_name"]: _zone_description(z) for z in zones},
+        "contamination_risks": {z["zone_name"]: z["contamination_risks"] for z in zones},
+        "condition_risks": {z["zone_name"]: z["condition_risks"] for z in zones},
+        "manual_check_steps": defn["manual_steps"],
+        "warning": (
+            None if profile_found else
+            "Instrument anatomy profile not found. Supervisor review recommended."
+        ),
     }

--- a/backend/app/services/instrument_zones.py
+++ b/backend/app/services/instrument_zones.py
@@ -26,6 +26,7 @@ HIGH_RETENTION_ZONES: set[str] = {
     "serrations", "grooves", "teeth", "cutting edge",
     "drill-bit flute", "threaded region", "cutting channel", "burr surface",
     "lumen opening", "inner channel", "o-ring area", "rigid scope port",
+    "biopsy channel", "suction channel", "air/water nozzle",
     "hinge", "box lock", "joint", "ratchet",
     "insulation edge",
 }
@@ -72,6 +73,21 @@ ZONE_INFO: dict[str, dict[str, str]] = {
         "reason": "Inner channels can hold residue that outer cleaning cannot reach.",
         "manual_check": "Flush and brush the channel; re-inspect the lumen.",
     },
+    "biopsy channel": {
+        "risk": "high",
+        "reason": "Flexible endoscope channels require focused inspection because retained soil may remain inside internal pathways.",
+        "manual_check": "Flush and brush the biopsy channel end-to-end; borescope the channel if available.",
+    },
+    "suction channel": {
+        "risk": "high",
+        "reason": "Suction channels of flexible endoscopes retain soil deep in the internal pathway, out of reach of surface cleaning.",
+        "manual_check": "Flush and brush the suction channel; verify flow and re-inspect.",
+    },
+    "air/water nozzle": {
+        "risk": "high",
+        "reason": "Air/water nozzles are narrow ports that trap residue and biofilm.",
+        "manual_check": "Flush the air/water channel and clean the nozzle; confirm patency.",
+    },
     "o-ring area": {
         "risk": "high",
         "reason": "Residue near the o-ring/port area is a common retention point requiring focused inspection.",
@@ -113,6 +129,10 @@ ZONE_INFO: dict[str, dict[str, str]] = {
 # (keyword substrings, contamination_zone, condition_zone). First match wins.
 _INSTRUMENT_ZONE_RULES: list[tuple[tuple[str, ...], str, str]] = [
     (("drill", "reamer", "burr", "bit"), "drill-bit flute", "threaded region"),
+    # Flexible endoscopes route contamination to their internal channels — checked
+    # before the generic rigid-scope rule so they are not mis-zoned to the o-ring.
+    (("flexible", "colonoscope", "gastroscope", "bronchoscope", "duodenoscope",
+      "enteroscope", "sigmoidoscope", "choledochoscope"), "biopsy channel", "lens edge"),
     (("scope", "endoscope", "arthroscope", "cystoscope", "laparoscop", "ureteroscope"), "o-ring area", "lens edge"),
     (("cannula", "cannulated", "suction", "trocar", "lumen"), "inner channel", "outer sheath"),
     (("forcep", "clamp", "hemostat", "kocher", "needle_holder", "needle holder", "grasper"), "serrations", "box lock"),

--- a/backend/tests/test_instrument_architecture_preservation.py
+++ b/backend/tests/test_instrument_architecture_preservation.py
@@ -1,0 +1,234 @@
+"""Instrument architecture preservation patch — anatomy-aware classification,
+distinct rigid vs flexible endoscope profiles, zone-weighted scoring, anatomy
+profile service, coverage, anatomy-specific mentor wording, and supervisor
+anatomy-family feedback.
+"""
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.instrument_anatomy import (
+    anatomy_profile, get_anatomy, resolve_family,
+)
+from app.services.inspection_coverage import compute_coverage
+from app.services.instrument_zones import zone_fields, is_high_retention
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+SHA = "beadfeed" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"arch-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, inspected_zones=None):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, inspected_zones=inspected_zones,
+        )
+    finally:
+        db.close()
+
+
+# ── Classification / family differentiation ──────────────────────────────────
+
+class TestClassification:
+    def test_rigid_scope_uses_oring_profile(self):
+        a = get_anatomy("rigid scope")
+        assert resolve_family("rigid scope") == "rigid_scope"
+        assert "o-ring area" in a["zone_names"]
+
+    def test_flexible_endoscope_classified_separately_from_rigid(self):
+        assert resolve_family("flexible colonoscope") == "flexible_endoscope"
+        assert resolve_family("gastroscope") == "flexible_endoscope"
+        assert resolve_family("rigid scope") == "rigid_scope"
+        a = get_anatomy("flexible bronchoscope")
+        assert "biopsy channel" in a["zone_names"]
+        assert "suction channel" in a["zone_names"]
+        # Flexible endoscope must NOT be reasoned about as an o-ring rigid scope.
+        assert "o-ring area" not in a["zone_names"]
+
+    def test_drill_bit_flute_threaded_profile(self):
+        assert resolve_family("orthopedic drill bit") == "drill_bit"
+        a = get_anatomy("drill bit")
+        assert "flutes" in a["zone_names"]
+        assert "threaded region" in a["zone_names"]
+
+    def test_kerrison_serration_box_lock_profile(self):
+        assert resolve_family("kerrison rongeur") == "kerrison_rongeur"
+        a = get_anatomy("kerrison")
+        for z in ("serrations", "box lock", "hinge"):
+            assert z in a["zone_names"]
+
+    def test_general_forceps_family(self):
+        assert resolve_family("kelly forceps") == "general_forceps"
+
+    def test_unknown_instrument_uses_generic_profile_with_warning(self):
+        p = anatomy_profile("widget-9000")
+        assert p["instrument_family"] == "unknown"
+        assert p["profile_found"] is False
+        assert p["warning"] and "Supervisor review" in p["warning"]
+        # Generic SPD zones are still provided.
+        assert p["anatomy_zones"]
+
+
+# ── Anatomy profile service ───────────────────────────────────────────────────
+
+class TestAnatomyProfileService:
+    def test_profile_returns_expected_shape(self):
+        p = anatomy_profile("rigid scope", manufacturer="Acme", model="RS-1")
+        for key in (
+            "instrument_family", "anatomy_zones", "required_zones",
+            "high_risk_zones", "zone_descriptions", "contamination_risks",
+            "condition_risks", "recommended_image_views", "manual_check_steps",
+        ):
+            assert key in p
+        assert p["manufacturer"] == "Acme"
+        assert p["model"] == "RS-1"
+        assert p["warning"] is None
+
+    def test_manufacturer_model_hints_help_classification(self):
+        # Type is vague but the model name identifies a flexible scope.
+        p = anatomy_profile("endoscopic device", model="flexible gastroscope")
+        assert p["instrument_family"] == "flexible_endoscope"
+
+    def test_profile_endpoint(self):
+        r = client.get("/api/instrument-anatomy/flexible%20colonoscope", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["instrument_family"] == "flexible_endoscope"
+        assert "biopsy channel" in body["anatomy_zones"]
+
+
+# ── Zone assignment / zone-aware scoring ──────────────────────────────────────
+
+class TestZoneAwareScoring:
+    def test_flexible_endoscope_routes_to_channel_not_oring(self):
+        assert zone_fields("flexible gastroscope", "blood")["instrument_zone"] == "biopsy channel"
+        assert zone_fields("rigid scope", "blood")["instrument_zone"] == "o-ring area"
+
+    def test_blood_in_hinge_is_high_retention(self):
+        zf = zone_fields("curved scissors", "blood")
+        assert zf["instrument_zone"] == "hinge"
+        assert is_high_retention(zf["instrument_zone"])
+        assert zf["zone_risk"] == "high"
+
+    def test_bone_in_drill_flute_is_high_retention(self):
+        zf = zone_fields("orthopedic drill", "bone")
+        assert zf["instrument_zone"] == "drill-bit flute"
+        assert is_high_retention(zf["instrument_zone"])
+
+    def test_residue_in_oring_area_is_high_retention(self):
+        zf = zone_fields("rigid scope", "other_organic_residue")
+        assert zf["instrument_zone"] == "o-ring area"
+        assert is_high_retention(zf["instrument_zone"])
+
+    def test_findings_carry_zone_fields(self):
+        result = _analyze("flexible colonoscope")
+        for f in result["predicted_findings"]:
+            assert "instrument_zone" in f
+            assert "zone_risk" in f
+
+
+# ── Coverage ──────────────────────────────────────────────────────────────────
+
+class TestCoverage:
+    def test_missing_required_zone_lowers_coverage(self):
+        cov = compute_coverage("kerrison rongeur", ["jaw"])
+        assert cov["assessed"] is True
+        assert cov["missing"]
+        assert cov["overall_coverage"] < 100
+
+    def test_complete_zone_set_improves_coverage(self):
+        anatomy = get_anatomy("kerrison rongeur")
+        cov = compute_coverage("kerrison rongeur", anatomy["required_images"])
+        assert cov["overall_coverage"] == 100
+        assert cov["quality"] in ("complete", "acceptable")
+
+
+# ── Anatomy-specific mentor wording ───────────────────────────────────────────
+
+class TestMentorAnatomyLanguage:
+    def test_mentor_uses_flexible_channel_language(self):
+        # Force a contamination finding so the mentor speaks to the zone.
+        result = _analyze("flexible gastroscope")
+        # Inject a channel contamination finding and re-derive the mentor payload.
+        from app.services.clinical_mentor import ai_mentor
+        result["predicted_findings"] = [{
+            "type": "blood", "severity_index": 3, "instrument_zone": "biopsy channel",
+            "zone_reason": zone_fields("flexible gastroscope", "blood")["zone_reason"],
+            "recommended_manual_check": "Flush and brush the biopsy channel end-to-end.",
+        }]
+        m = ai_mentor(result, "REPROCESS")
+        assert "biopsy channel" in m["where_was_it_detected"]
+        assert "channel" in m["why_this_zone_is_high_risk"].lower()
+
+
+# ── Supervisor anatomy-family feedback ────────────────────────────────────────
+
+class TestSupervisorAnatomyFeedback:
+    def test_supervisor_can_correct_instrument_family_and_zone(self):
+        # Create an inspection to review.
+        _baseline("rigid scope")
+        db = SessionLocal()
+        try:
+            from app.db import models
+            insp = models.Inspection(
+                tenant_id="default-tenant", file_name="f.jpg", instrument_type="rigid scope",
+                risk_score=20, score_status="scored", has_image=True, image_sha256=SHA,
+                recommended_action="MONITOR",
+            )
+            db.add(insp)
+            db.commit()
+            db.refresh(insp)
+            iid = insp.id
+        finally:
+            db.close()
+
+        r = client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            headers=AUTH_ADMIN,
+            json={
+                "agreement": "disagree",
+                "rationale": "This is actually a flexible endoscope, residue is in the biopsy channel.",
+                "instrument_family_correct": False,
+                "corrected_instrument_family": "flexible endoscope",
+                "zone_correct": False,
+                "corrected_zone": "biopsy channel",
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        # Verify it persisted as labeled data.
+        db = SessionLocal()
+        try:
+            from app.models.supervisor_review import SupervisorReview
+            row = (
+                db.query(SupervisorReview)
+                .filter(SupervisorReview.inspection_id == iid)
+                .order_by(SupervisorReview.id.desc())
+                .first()
+            )
+            assert row is not None
+            assert row.instrument_family_correct is False
+            assert row.corrected_instrument_family == "flexible endoscope"
+            assert row.corrected_zone == "biopsy channel"
+        finally:
+            db.close()

--- a/docs/ai/inspection-coverage-rules.md
+++ b/docs/ai/inspection-coverage-rules.md
@@ -1,0 +1,47 @@
+# Inspection Coverage Rules
+
+Source of truth: `backend/app/services/inspection_coverage.py`
+(`compute_coverage`, `missing_image_guidance`, `build_risk_map`).
+
+## What it computes
+
+For an instrument family and the technician-tagged inspected zones:
+
+- `required_zones` (total) — from the anatomy profile's `required_images`
+- `inspected_required` — required zones that were tagged
+- `missing` — required high-risk zones not yet captured
+- `overall_coverage` — % of required zones captured
+- `quality` / coverage status:
+  - **complete** — no missing required zones and ≥95%
+  - **acceptable** — no missing required zones, or ≥80%
+  - **incomplete** — ≥50%
+  - **insufficient** — <50%
+  - **not_assessed** — zones were not tagged (reported honestly, not as 0%)
+
+## Missing-zone guidance
+
+When required high-risk zones are missing, the UI shows:
+
+> "Inspection coverage incomplete. Upload images for: [missing zones]."
+
+`missing_image_guidance` returns a "Close-up image of {zone}" line per missing
+required zone. It is empty when zones were not tagged (no nagging on untagged
+inspections).
+
+## Not a submission gate
+
+Coverage is advisory. It does **not** block submission unless an organization
+explicitly configures a hard gate. This keeps the pilot usable while still
+surfacing incomplete inspections for supervisor attention.
+
+## not_assessed vs 0%
+
+When `inspected_zones` is `None` (the technician did not tag zones), coverage is
+`not_assessed` with `overall_coverage: null` — deliberately **not** an alarming
+0%. An explicit (possibly empty) list is assessed normally.
+
+## Risk map
+
+`build_risk_map` emits a per-zone row (zone · required? · inspected? · findings ·
+zone risk · recommended manual check) — a text/card map. Visual anatomy overlays
+and heatmaps are a future CV release and are not fabricated.

--- a/docs/ai/instrument-anatomy-profiles.md
+++ b/docs/ai/instrument-anatomy-profiles.md
@@ -1,0 +1,47 @@
+# Instrument Anatomy Profiles
+
+Source of truth: `backend/app/services/instrument_anatomy.py`
+(`INSTRUMENT_ANATOMY`, `resolve_family`, `get_anatomy`, `anatomy_profile`).
+
+The Anatomy Profile Service takes an instrument's identity hints
+(`instrument_type`, optional `instrument_name`, `manufacturer`, `model`) and
+returns:
+
+- `instrument_family` (or `unknown`)
+- `anatomy_zones` / `zone_names`
+- `required_zones` / `recommended_image_views`
+- `high_risk_zones`
+- `zone_descriptions` (per-zone honest one-liner)
+- `contamination_risks` / `condition_risks` (per zone)
+- `manual_check_steps`
+- `warning` — set when the family is `unknown`
+
+## Families and their zones
+
+| Family | High-risk / retention zones |
+|---|---|
+| **rigid_scope** | distal tip, lens edge, **o-ring area**, light post, working channel, sheath connection, seal |
+| **flexible_endoscope** | distal end, bending section, **suction channel**, **biopsy channel**, air/water nozzle, light guide lens |
+| **drill_bit** | tip, **flutes**, **threaded region**, cutting edge, hub |
+| **kerrison_rongeur** | jaw, **serrations**, **box lock**, hinge, spring, ratchet |
+| **scissors** | tip, blade, cutting edge, serration, box lock |
+| **needle_holder** | jaw inserts, serrations, box lock, ratchet |
+| **laparoscopic** | distal jaws, hinge, **insulation edge**, shaft, handle seam, lumen/cannulated channel |
+| **general_forceps** | jaws, serrations, box lock, hinge, ratchet |
+| **unknown** | working surface, hinge/joint, box lock (generic SPD profile) + warning |
+
+## Rigid vs flexible endoscope
+
+The two are deliberately distinct. Flexible endoscopes are declared *before*
+rigid scopes so their keywords (`colonoscope`, `gastroscope`, `bronchoscope`,
+`duodenoscope`, `flexible …`) resolve first; a rigid scope's generic
+`scope`/`endoscope` match would otherwise swallow them. A rigid scope reasons
+about the **o-ring area / lens edge / sheath connection**; a flexible endoscope
+reasons about **internal channels (biopsy, suction) / distal end / bending
+section**.
+
+## Extending
+
+Add a family by inserting an entry into `INSTRUMENT_ANATOMY` with `match`
+keywords and `_zone(...)` definitions. No manufacturer is hardcoded; per-site
+manufacturer/model knowledge is layered via the `InstrumentKnowledge` table.

--- a/docs/ai/lumenai-instrument-intelligence-architecture.md
+++ b/docs/ai/lumenai-instrument-intelligence-architecture.md
@@ -1,0 +1,63 @@
+# LumenAI Instrument Intelligence Architecture
+
+LumenAI reasons the way an experienced SPD educator does: from the instrument,
+to its anatomy, to the specific high-retention zone, to the finding, to a
+zone-weighted risk, to a clinical decision, and finally to a plain-language
+mentor explanation. This document is the canonical description of that
+architecture and must be preserved by all AI analysis changes.
+
+## The preserved sequence
+
+Every AI analysis follows this pipeline. Do not bypass it.
+
+```
+1. Identify instrument type          (inspection intake / decoded identifier)
+2. Load instrument anatomy profile   (instrument_anatomy.anatomy_profile)
+3. Determine required inspection zones (anatomy.required_zones)
+4. Analyze uploaded image / metadata (baseline_comparison_scoring_service)
+5. Assign findings to anatomy zones  (instrument_zones.zone_fields — pilot)
+6. Apply zone-specific SPD risk rules (zone risk + retention escalation)
+7. Generate clinical decision        (build_clinical_decision / _overall_result)
+8. Generate AI mentor explanation    (clinical_mentor.build_mentor)
+9. Store supervisor feedback         (SupervisorReview — labeled training data)
+```
+
+```
+Instrument ─▶ Anatomy ─▶ Zone ─▶ Finding ─▶ Risk ─▶ Clinical Decision ─▶ Mentor
+     │            │         │                 │
+ resolve_     get_anatomy  zone_fields   zone_risk +      build_clinical_decision
+ family()     / anatomy_   (pilot_zone_  retention        + build_mentor()
+              profile()    assignment)   escalation
+```
+
+## Instrument families
+
+Each family carries its own anatomy profile (zones, high-risk subset, required
+image views, manual-check steps). Supported families:
+
+- `rigid_scope` — rigid endoscope
+- `flexible_endoscope` — flexible endoscope (distinct from rigid scope)
+- `drill_bit` — rotary orthopedic
+- `kerrison_rongeur` — orthopedic biter
+- `scissors` — cutting
+- `needle_holder` — grasping
+- `laparoscopic` — MIS / laparoscopic
+- `general_forceps` — grasping / clamping
+- `default` → reported as `unknown` — generic high-risk SPD profile + warning
+
+## Honesty guarantees
+
+- Zone assignment is **pilot logic** (`pilot_zone_assignment`), not pixel-level
+  CV segmentation. It is deterministic from instrument type + tagged views.
+- No fabricated heatmaps, overlays, or metrics.
+- `human_review_required: true` on all correlation/decision outputs.
+- Unknown instruments never masquerade as a specific match — they resolve to
+  `unknown` with a supervisor-review warning.
+- No FDA clearance or regulatory-approval claims.
+
+## Future true-CV roadmap
+
+The schema is CV-ready: a trained zone-localization model drops into
+`zone_fields`/`build_risk_map` without changing the pipeline. Supervisor
+zone/family corrections (§9) are captured today as the labeled dataset for that
+future model. See `zone-assignment-engine.md` for the migration path.

--- a/docs/ai/zone-assignment-engine.md
+++ b/docs/ai/zone-assignment-engine.md
@@ -1,0 +1,56 @@
+# Zone Assignment Engine (pilot)
+
+Source of truth: `backend/app/services/instrument_zones.py`
+(`resolve_zones`, `zone_for_finding`, `zone_fields`, `ZONE_INFO`,
+`HIGH_RETENTION_ZONES`).
+
+## What it is
+
+Given an instrument family and a finding, the engine assigns a probable
+**instrument zone**, its **risk**, a **reason**, and a **recommended manual
+check**. Contamination findings route to the instrument's high-retention
+contamination zone; condition findings route to the condition zone.
+
+Inputs (pilot):
+- instrument family / type
+- tagged inspected zones (checklist) when available
+- filename / view hints when available
+- baseline metadata
+
+Output per finding:
+- `instrument_zone`
+- `zone_risk`
+- `zone_reason`
+- `recommended_manual_check`
+
+## This is NOT computer vision
+
+The assignment is **`pilot_zone_assignment`** — deterministic from instrument
+type, not pixel-level localization. It is honestly labeled as such throughout
+the code and UI. We do not pretend a region was visually segmented.
+
+Example resolutions:
+
+| Instrument | Contamination zone | Condition zone |
+|---|---|---|
+| drill bit | drill-bit flute | threaded region |
+| flexible endoscope | biopsy channel | lens edge |
+| rigid scope | o-ring area | lens edge |
+| forceps / needle holder | serrations | box lock |
+| scissors | hinge | cutting edge |
+| kerrison / rongeur | box lock | jaws |
+
+## Retention escalation
+
+Findings in `HIGH_RETENTION_ZONES` (serrations, box lock, hinge, flutes,
+channels, o-ring area, insulation edge, …) escalate contamination risk relative
+to the same finding on a flat external surface — because residual soil is harder
+to remove there.
+
+## Future true-CV migration
+
+A trained segmentation model replaces `resolve_zones` with per-pixel zone
+localization while keeping the same output schema. Supervisor zone corrections
+(`SupervisorReview.zone_correct` / `corrected_zone`) accumulate as the labeled
+dataset. Until then, the tagged-view checklist supplies ground-truth zone
+context.

--- a/frontend/src/components/SupervisorNotes.tsx
+++ b/frontend/src/components/SupervisorNotes.tsx
@@ -25,6 +25,8 @@ export default function SupervisorNotes({
   const [override, setOverride] = useState("");
   const [zoneCorrect, setZoneCorrect] = useState<boolean | null>(null);
   const [correctedZone, setCorrectedZone] = useState("");
+  const [familyCorrect, setFamilyCorrect] = useState<boolean | null>(null);
+  const [correctedFamily, setCorrectedFamily] = useState("");
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const [busy, setBusy] = useState(false);
   const commentRequired = agreement !== "agree" || !!override.trim();
@@ -47,6 +49,8 @@ export default function SupervisorNotes({
           override_action: override.trim(),
           zone_correct: zoneCorrect,
           corrected_zone: correctedZone.trim(),
+          instrument_family_correct: familyCorrect,
+          corrected_instrument_family: correctedFamily.trim(),
         }),
       });
       if (res.status === 403) { setMsg({ ok: false, text: "Supervisor access (admin/SPD manager) required." }); return; }
@@ -95,6 +99,20 @@ export default function SupervisorNotes({
         placeholder="Override action (optional, e.g. reprocess / remove)"
         className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
       />
+      {/* Anatomy-family feedback → labeled training data */}
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+        <span className="text-slate-500">AI instrument family correct?</span>
+        <button onClick={() => setFamilyCorrect(true)} className={`rounded-full px-2 py-0.5 border ${familyCorrect === true ? "bg-emerald-600 text-white border-emerald-600" : "border-slate-300 text-slate-600"}`}>Yes</button>
+        <button onClick={() => setFamilyCorrect(false)} className={`rounded-full px-2 py-0.5 border ${familyCorrect === false ? "bg-red-600 text-white border-red-600" : "border-slate-300 text-slate-600"}`}>No</button>
+        {familyCorrect === false && (
+          <input
+            value={correctedFamily}
+            onChange={(e) => setCorrectedFamily(e.target.value)}
+            placeholder="Corrected family (e.g. flexible endoscope, drill bit)"
+            className="flex-1 min-w-[10rem] rounded-lg border border-slate-300 px-2 py-1"
+          />
+        )}
+      </div>
       {/* Zone-aware feedback → labeled training data */}
       <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
         <span className="text-slate-500">AI zone correct?</span>


### PR DESCRIPTION
## Summary

Make the AI analysis engine reason by **instrument anatomy** rather than a generic heuristic, while **preserving** the established pipeline:

`Instrument → Anatomy → Zone → Finding → Risk → Clinical Decision → Mentor`

The biggest behavioral change: **flexible endoscopes are now distinct from rigid scopes** — they reason about internal channels (biopsy/suction), not the o-ring area.

## Instrument classification
- New **`flexible_endoscope`** family (distal end, bending section, biopsy/suction channels, air/water nozzle, light guide lens, control body), declared *before* `rigid_scope` so its keywords resolve first.
- New **`general_forceps`** family.
- Unknown instruments resolve to **`unknown`** with a *"Instrument anatomy profile not found. Supervisor review recommended."* warning — they never masquerade as a specific match.

## Anatomy Profile Service
- `anatomy_profile(instrument_type, manufacturer, model, instrument_name)` returns family, anatomy zones, required/recommended image views, high-risk zones, per-zone descriptions, contamination/condition risks, and manual-check steps.
- `/api/instrument-anatomy/{type}` now serves this profile (accepts optional `manufacturer`/`model`/`instrument_name` hints) and preserves the existing `zone_names` contract the UI depends on.

## Zone assignment / zone-aware scoring
- Flexible-endoscope contamination routes to the **biopsy channel** (not the o-ring), with channel-specific reasons/manual checks.
- Biopsy/suction channels and air/water nozzle added to the high-retention set so residue there escalates risk.
- Zone assignment remains honest **pilot logic** (`pilot_zone_assignment`) — not CV segmentation.

## Supervisor feedback (labeled training data)
- Capture **instrument-family correctness + corrected family** alongside the existing zone correction (model column, review API, Supervisor Notes UI). Columns back-filled on startup via the existing column migrator.

## Docs
`lumenai-instrument-intelligence-architecture.md`, `instrument-anatomy-profiles.md`, `zone-assignment-engine.md`, `inspection-coverage-rules.md`.

## Validation
- Backend: **2292 passed, 2 skipped** (new `test_instrument_architecture_preservation.py` covers rigid-vs-flexible classification, drill-bit/Kerrison/forceps profiles, unknown→generic+warning, profile-service shape + manufacturer/model hinting, zone retention escalation, coverage, anatomy-specific mentor wording, supervisor family correction).
- `npm run build` → clean · `ruff check app` → clean.
- Headless: `/inspection/new` mounts with no page errors; anatomy `zone_names` contract preserved.

## Notes
Honesty constraints preserved: pilot zone assignment (not fabricated CV), `human_review_required`, no FDA/regulatory claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_