### PR TITLE
Complete Zone Assignment Engine contract (zone_confidence + pilot label)

### DIFF
--- a/backend/app/services/instrument_zones.py
+++ b/backend/app/services/instrument_zones.py
@@ -162,8 +162,32 @@ def zone_for_finding(instrument_type: str, finding_type: str) -> str:
     return contam_zone if finding_type in _CONTAMINATION else cond_zone
 
 
-def zone_fields(instrument_type: str, finding_type: str) -> dict[str, str]:
-    """instrument_zone / zone_risk / zone_reason / recommended_manual_check."""
+def _zone_confidence(instrument_type: str, zone: str) -> float:
+    """Honest confidence for a *pilot* (non-CV) zone assignment.
+
+    This is NOT vision-derived certainty — it reflects how specifically the
+    instrument type resolved to a zone. A recognized instrument mapped to a
+    named high-retention zone is more trustworthy than the generic fallback.
+    Deliberately capped well below 1.0 because no pixel-level localization
+    occurred.
+    """
+    if zone in (_DEFAULT_CONTAM_ZONE, _DEFAULT_CONDITION_ZONE):
+        return 0.35  # generic fallback — instrument did not map to a named zone
+    name = (instrument_type or "").lower()
+    matched = any(
+        any(k in name for k in keywords) for keywords, _c, _cond in _INSTRUMENT_ZONE_RULES
+    )
+    return 0.7 if matched else 0.5
+
+
+def zone_fields(instrument_type: str, finding_type: str) -> dict:
+    """Pilot zone-assignment output for a finding: probable instrument_zone,
+    zone_confidence, zone_reason, recommended_manual_check + the zone's risk.
+
+    ``assignment_method`` is fixed to ``pilot_zone_assignment`` — this is
+    deterministic pilot logic from the instrument type/tagged views, NOT computer
+    vision segmentation.
+    """
     zone = zone_for_finding(instrument_type, finding_type)
     info = ZONE_INFO.get(zone, ZONE_INFO["unspecified region"])
     return {
@@ -171,6 +195,8 @@ def zone_fields(instrument_type: str, finding_type: str) -> dict[str, str]:
         "zone_risk": info["risk"],
         "zone_reason": info["reason"],
         "recommended_manual_check": info["manual_check"],
+        "zone_confidence": _zone_confidence(instrument_type, zone),
+        "assignment_method": "pilot_zone_assignment",
     }
 
 

--- a/backend/tests/test_instrument_architecture_preservation.py
+++ b/backend/tests/test_instrument_architecture_preservation.py
@@ -146,6 +146,19 @@ class TestZoneAwareScoring:
             assert "instrument_zone" in f
             assert "zone_risk" in f
 
+    def test_zone_assignment_is_labeled_pilot_with_confidence(self):
+        # Section 4 contract: probable zone + confidence + reason + manual check,
+        # honestly labeled as pilot (non-CV) assignment.
+        zf = zone_fields("orthopedic drill", "bone")
+        assert zf["assignment_method"] == "pilot_zone_assignment"
+        assert 0.0 < zf["zone_confidence"] <= 0.7  # capped — not CV certainty
+        assert zf["zone_reason"] and zf["recommended_manual_check"]
+
+    def test_named_zone_more_confident_than_generic_fallback(self):
+        named = zone_fields("orthopedic drill", "bone")          # → drill-bit flute
+        generic = zone_fields("mystery gadget", "blood")          # → unspecified region
+        assert named["zone_confidence"] > generic["zone_confidence"]
+
 
 # ── Coverage ──────────────────────────────────────────────────────────────────
 

--- a/docs/ai/zone-assignment-engine.md
+++ b/docs/ai/zone-assignment-engine.md
@@ -19,9 +19,12 @@ Inputs (pilot):
 
 Output per finding:
 - `instrument_zone`
-- `zone_risk`
+- `zone_confidence` — honest pilot confidence (capped ≤ 0.7; **not** CV certainty):
+  0.7 when the instrument mapped to a named zone, 0.5 when recognized but
+  unmatched, 0.35 for the generic fallback zone
 - `zone_reason`
 - `recommended_manual_check`
+- `assignment_method` — fixed to `pilot_zone_assignment`
 
 ## This is NOT computer vision
 


### PR DESCRIPTION
## Summary

The instrument-anatomy architecture patch (**PR #64**, merged) already delivered instrument-family differentiation (incl. flexible vs rigid scope), the anatomy profile service, inspection coverage, zone-aware scoring, anatomy-specific AI mentor wording, supervisor family feedback, documentation, and tests — plus the intake zone-view checklist.

Re-auditing against the spec's **§4 Zone Assignment Engine** surfaced one part not yet delivered: the per-finding output was missing an explicit **`zone_confidence`** and the internal **`pilot_zone_assignment`** label. This PR closes that gap.

## Changes
- `zone_fields(...)` now emits:
  - **`zone_confidence`** — honest pilot confidence, capped ≤ 0.7 (**not** CV certainty): `0.7` when the instrument maps to a named zone, `0.5` when recognized but unmatched, `0.35` for the generic fallback zone.
  - **`assignment_method: "pilot_zone_assignment"`** — so downstream consumers and audits can see this is deterministic pilot logic, not computer-vision segmentation.
- Findings already thread `zone_fields`, so the new fields flow into the per-finding payload automatically.
- Docs (`zone-assignment-engine.md`) and tests updated.

## Validation
- Backend: **2294 passed, 2 skipped**.
- `npm run build` → clean · `ruff check` → clean.

## Notes
Everything else in the spec is already on `main` from #64. Honesty preserved: pilot (non-CV) confidence, explicit label, `human_review_required`, no FDA claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_