### PR TITLE
Allow custom instrument types on baselines and inspections

### DIFF
--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import re
 from datetime import datetime, timezone
 from typing import List, Literal, Optional
 
@@ -37,10 +38,30 @@ def require_inspection_runner(current_user=Depends(get_current_user)):
     return current_user
 
 _ALLOWED_INSTRUMENT_TYPES = {
+    # Anatomy-aware families (match the instrument anatomy library).
+    "rigid_scope", "flexible_endoscope", "drill_bit", "kerrison_rongeur",
     "laparoscopic_grasper", "retractor", "scissors", "needle_holder",
     "forceps", "trocar", "electrosurgical", "suction_irrigation",
     "clip_applier", "stapler", "other",
 }
+
+# Custom instrument types (SPD sites carry instruments beyond the built-in list)
+# are accepted when they are well-formed slugs — lowercase alphanumerics and
+# underscores. This keeps data quality (no free-form garbage / injection) while
+# allowing new additions the built-in list does not yet cover.
+_INSTRUMENT_TYPE_SLUG = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+
+
+def _validate_instrument_type(v: str) -> str:
+    if v in _ALLOWED_INSTRUMENT_TYPES:
+        return v
+    if len(v) <= 50 and _INSTRUMENT_TYPE_SLUG.match(v):
+        return v
+    raise ValueError(
+        f"instrument_type '{v}' must be a known type "
+        f"({sorted(_ALLOWED_INSTRUMENT_TYPES)}) or a lowercase slug "
+        f"(letters, numbers, underscores; ≤50 chars)."
+    )
 _ALLOWED_MATERIAL_TYPES = {"stainless_steel", "titanium", "polymer", "tungsten_carbide", "other"}
 _ALLOWED_DETECTED_ISSUES = {
     "blood", "bone", "tissue", "debris", "corrosion",
@@ -90,9 +111,7 @@ class InspectionCreate(BaseModel):
     @field_validator("instrument_type")
     @classmethod
     def validate_instrument_type(cls, v: str) -> str:
-        if v not in _ALLOWED_INSTRUMENT_TYPES:
-            raise ValueError(f"instrument_type '{v}' not in approved list: {sorted(_ALLOWED_INSTRUMENT_TYPES)}")
-        return v
+        return _validate_instrument_type(v)
 
     @field_validator("material_type")
     @classmethod
@@ -140,9 +159,7 @@ class ManufacturerBaselineCreate(BaseModel):
     @field_validator("instrument_type")
     @classmethod
     def _validate_type(cls, v: str) -> str:
-        if v not in _ALLOWED_INSTRUMENT_TYPES:
-            raise ValueError(f"instrument_type '{v}' not in approved list: {sorted(_ALLOWED_INSTRUMENT_TYPES)}")
-        return v
+        return _validate_instrument_type(v)
 
     @field_validator("baseline_source")
     @classmethod

--- a/backend/tests/test_manufacturer_baseline_flow.py
+++ b/backend/tests/test_manufacturer_baseline_flow.py
@@ -61,12 +61,37 @@ class TestManufacturerBaselineCreation:
         }, headers=AUTH_VIEWER)
         assert resp.status_code == 403
 
-    def test_invalid_instrument_type_rejected(self):
+    def test_malformed_instrument_type_rejected(self):
+        # Free-form garbage (spaces/caps/symbols) is still rejected for data quality.
+        for bad in ["Not A Real Type!", "UPPER", "has space"]:
+            resp = client.post("/api/baselines/manufacturer", json={
+                "instrument_type": bad,
+                "manufacturer_name": "Acme",
+            }, headers=AUTH_ADMIN)
+            assert resp.status_code == 422, f"{bad!r} should be rejected"
+
+    def test_custom_slug_instrument_type_accepted(self):
+        # SPD sites carry instruments beyond the built-in list — a well-formed
+        # custom slug is accepted so techs can add new instrument types.
+        itype = "custom_ent_scope"
+        _clear(itype)
         resp = client.post("/api/baselines/manufacturer", json={
-            "instrument_type": "not_a_real_type",
+            "instrument_type": itype,
             "manufacturer_name": "Acme",
+            "image_sha256": SHA,
         }, headers=AUTH_ADMIN)
-        assert resp.status_code == 422
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["instrument_type"] == itype
+
+    def test_new_anatomy_families_accepted(self):
+        for itype in ("rigid_scope", "flexible_endoscope"):
+            _clear(itype)
+            resp = client.post("/api/baselines/manufacturer", json={
+                "instrument_type": itype,
+                "manufacturer_name": "Acme",
+                "image_sha256": SHA,
+            }, headers=AUTH_ADMIN)
+            assert resp.status_code == 201, resp.text
 
 
 class TestBaselineImageUploadAuth:

--- a/backend/tests/test_p14_pilot_ops.py
+++ b/backend/tests/test_p14_pilot_ops.py
@@ -51,7 +51,8 @@ class TestInspectionCreate:
         assert res.status_code == 422
 
     def test_invalid_instrument_type_rejected(self):
-        payload = {**VALID_INSPECTION, "instrument_type": "magic_wand"}
+        # Well-formed custom slugs are now allowed; free-form garbage is not.
+        payload = {**VALID_INSPECTION, "instrument_type": "Magic Wand!"}
         res = client.post("/api/inspections", json=payload, headers=VIEWER_HEADERS)
         assert res.status_code == 422
 

--- a/frontend/src/components/CreateManufacturerBaseline.tsx
+++ b/frontend/src/components/CreateManufacturerBaseline.tsx
@@ -4,6 +4,10 @@ import { useAuth, API_BASE } from "@/lib/auth";
 // Must match the inspection instrument types so a baseline lines up with the
 // instrument an inspection is run against.
 const INSTRUMENT_TYPES = [
+  { value: "rigid_scope", label: "Rigid Scope / Endoscope" },
+  { value: "flexible_endoscope", label: "Flexible Endoscope" },
+  { value: "drill_bit", label: "Drill Bit / Reamer / Burr" },
+  { value: "kerrison_rongeur", label: "Kerrison / Rongeur" },
   { value: "laparoscopic_grasper", label: "Laparoscopic Grasper" },
   { value: "scissors", label: "Scissors" },
   { value: "forceps", label: "Forceps" },
@@ -14,14 +18,26 @@ const INSTRUMENT_TYPES = [
   { value: "suction_irrigation", label: "Suction / Irrigation" },
   { value: "clip_applier", label: "Clip Applier" },
   { value: "stapler", label: "Stapler" },
-  { value: "other", label: "Other" },
+  { value: "other", label: "Other (type a new instrument type)" },
 ];
+
+// Normalize a free-text instrument type to the slug convention the rest of the
+// app uses (lowercase, underscores) so a custom baseline lines up with the
+// instrument type an inspection is run against.
+function slugifyType(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/tiff"];
 
 export default function CreateManufacturerBaseline({ onCreated }: { onCreated?: () => void }) {
   const { headers, role, logout } = useAuth();
   const [instrumentType, setInstrumentType] = useState("");
+  const [customType, setCustomType] = useState("");
   const [manufacturer, setManufacturer] = useState("");
   const [model, setModel] = useState("");
   const [image, setImage] = useState<File | null>(null);
@@ -35,6 +51,12 @@ export default function CreateManufacturerBaseline({ onCreated }: { onCreated?: 
     setBanner(null);
     if (!instrumentType || !manufacturer.trim() || !image) {
       setBanner({ type: "error", message: "Instrument type, manufacturer, and a baseline image are required." });
+      return;
+    }
+    // Resolve the effective instrument type: a custom entry when "Other" is chosen.
+    const effectiveType = instrumentType === "other" ? slugifyType(customType) : instrumentType;
+    if (instrumentType === "other" && !effectiveType) {
+      setBanner({ type: "error", message: "Enter the instrument type name for “Other”." });
       return;
     }
 
@@ -67,7 +89,7 @@ export default function CreateManufacturerBaseline({ onCreated }: { onCreated?: 
         method: "POST",
         headers: hdrs,
         body: JSON.stringify({
-          instrument_type: instrumentType,
+          instrument_type: effectiveType,
           manufacturer_name: manufacturer.trim(),
           model_name: model.trim(),
           image_sha256: sha,
@@ -95,6 +117,7 @@ export default function CreateManufacturerBaseline({ onCreated }: { onCreated?: 
         message: `Approved manufacturer baseline #${data.id} created for ${data.instrument_type.replace(/_/g, " ")}. Inspections of this instrument type will now be scored against it.`,
       });
       setInstrumentType("");
+      setCustomType("");
       setManufacturer("");
       setModel("");
       setImage(null);
@@ -140,6 +163,23 @@ export default function CreateManufacturerBaseline({ onCreated }: { onCreated?: 
                 <option key={t.value} value={t.value}>{t.label}</option>
               ))}
             </select>
+            {instrumentType === "other" && (
+              <div className="mt-2">
+                <input
+                  value={customType}
+                  onChange={(e) => setCustomType(e.target.value)}
+                  disabled={!canCreate}
+                  placeholder="Type the instrument type, e.g. Cystoscope"
+                  className="block w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+                />
+                {customType.trim() && (
+                  <p className="mt-1 text-xs text-slate-500">
+                    Will be saved as <code className="rounded bg-slate-100 px-1">{slugifyType(customType)}</code>.
+                    Use this same type when running inspections so they score against this baseline.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
           <div>
             <label className="block text-xs font-medium text-slate-700 mb-1">Manufacturer *</label>

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -129,6 +129,10 @@ type AIPrediction = {
 // ─── constants ────────────────────────────────────────────────────────────────
 
 const INSTRUMENT_TYPES = [
+  { value: "rigid_scope", label: "Rigid Scope / Endoscope" },
+  { value: "flexible_endoscope", label: "Flexible Endoscope" },
+  { value: "drill_bit", label: "Drill Bit / Reamer / Burr" },
+  { value: "kerrison_rongeur", label: "Kerrison / Rongeur" },
   { value: "laparoscopic_grasper", label: "Laparoscopic Grasper" },
   { value: "scissors", label: "Scissors" },
   { value: "forceps", label: "Forceps" },
@@ -139,8 +143,14 @@ const INSTRUMENT_TYPES = [
   { value: "suction_irrigation", label: "Suction / Irrigation" },
   { value: "clip_applier", label: "Clip Applier" },
   { value: "stapler", label: "Stapler" },
-  { value: "other", label: "Other" },
+  { value: "other", label: "Other (type a new instrument type)" },
 ];
+
+// Normalize a free-text instrument type to the app's slug convention so a
+// custom inspection lines up with a custom manufacturer baseline of the same type.
+function slugifyType(text: string): string {
+  return text.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
 
 const FINDING_CATEGORIES: { value: FindingCategory; label: string; tooltip: string }[] = [
   { value: "blood", label: "Blood", tooltip: "Visible blood residue in lumen or on instrument surface" },
@@ -215,6 +225,8 @@ export default function NewInspectionPage() {
   };
   const [form, setForm] = useState<FormFields>(initialForm);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  // "Other" lets the tech type an instrument type not in the built-in list.
+  const [customTypeMode, setCustomTypeMode] = useState(false);
   const [anatomyZones, setAnatomyZones] = useState<string[]>([]);
   const [inspectedZones, setInspectedZones] = useState<string[]>([]);
   const [inspectionImages, setInspectionImages] = useState<File[]>([]);
@@ -744,8 +756,20 @@ export default function NewInspectionPage() {
               <div>
                 <RequiredLabel label="Instrument Type" />
                 <select
-                  id="instrument_type" value={form.instrument_type}
-                  onChange={(e) => { setStr("instrument_type")(e); checkBaseline(e.target.value); }}
+                  id="instrument_type"
+                  value={customTypeMode ? "other" : form.instrument_type}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "other") {
+                      setCustomTypeMode(true);
+                      setForm((f) => ({ ...f, instrument_type: "" }));
+                      setNoBaselineWarning(false);
+                    } else {
+                      setCustomTypeMode(false);
+                      setForm((f) => ({ ...f, instrument_type: v }));
+                      checkBaseline(v);
+                    }
+                  }}
                   onBlur={onBlurRequired("instrument_type", "Instrument Type")}
                   className={inputCls}
                 >
@@ -754,6 +778,27 @@ export default function NewInspectionPage() {
                     <option key={t.value} value={t.value}>{t.label}</option>
                   ))}
                 </select>
+                {customTypeMode && (
+                  <div className="mt-2">
+                    <input
+                      type="text"
+                      placeholder="Type the instrument type, e.g. Cystoscope"
+                      value={form.instrument_type}
+                      onChange={(e) => {
+                        const slug = slugifyType(e.target.value);
+                        setForm((f) => ({ ...f, instrument_type: slug }));
+                        if (slug) checkBaseline(slug);
+                      }}
+                      className={inputCls}
+                    />
+                    {form.instrument_type && (
+                      <p className="mt-1 text-xs text-gray-500">
+                        Saved as <code className="rounded bg-gray-100 px-1">{form.instrument_type}</code>.
+                        Create a manufacturer baseline of this same type so inspections score against it.
+                      </p>
+                    )}
+                  </div>
+                )}
                 <FieldError message={fieldErrors.instrument_type} />
                 {noBaselineWarning && (
                   <p className="mt-1 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1">


### PR DESCRIPTION
## Summary

Technicians couldn't add instruments beyond the built-in dropdown: choosing **"Other"** gave no text field, the list lacked rigid/flexible scope, and the backend validator hard-rejected any unlisted type. This fixes all three.

## Frontend
- Added **Rigid Scope**, **Flexible Endoscope**, **Drill Bit**, and **Kerrison / Rongeur** to the instrument-type dropdowns on both the **Manufacturer Baseline** form and the **New Inspection** form (aligned with the anatomy families).
- Choosing **"Other"** now reveals a text input to type a new instrument type. The entry is normalized to the app's slug convention (`lowercase_with_underscores`) so a custom baseline and a custom inspection of the same type line up. The New Inspection flow drives anatomy + baseline lookup off the typed value and shows the saved slug.

## Backend
- Relaxed the `instrument_type` validator (shared by `InspectionCreate` and `ManufacturerBaselineCreate`) to accept **well-formed custom slugs** (lowercase alphanumerics/underscores, ≤50 chars) in addition to the known families, and added the anatomy families to the known set.
- Free-form garbage (spaces, capitals, symbols, oversized) is **still rejected** for data quality — this is a format check, not a removal of validation.

## Validation
- Backend: **2296 passed, 2 skipped** (new tests: custom slug accepted, new anatomy families accepted, malformed types still 422; updated two tests that previously relied on slug-like values being rejected).
- `npm run build` → clean · `ruff check` → clean.
- Headless: selecting "Other" reveals the custom input on New Inspection, no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_