### PR TITLE
Phase 17 — Model training pipeline & AI readiness scaffolding

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -115,6 +115,8 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.capture_device")        # register borescope capture-device registry
     importlib.import_module("app.models.supervisor_review")     # register supervisor AI-agreement feedback store
     importlib.import_module("app.models.instrument_knowledge")  # register instrument knowledge library
+    importlib.import_module("app.models.model_registry")        # register P17 model registry table
+    importlib.import_module("app.models.shadow_prediction")     # register P17 shadow-prediction table
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -555,6 +557,9 @@ app.include_router(instrument_intelligence_router, prefix=settings.API_PREFIX)
 
 from app.routes.instrument_intelligence_admin import router as instrument_intelligence_admin_router
 app.include_router(instrument_intelligence_admin_router, prefix=settings.API_PREFIX)
+
+from app.routes.model_pipeline import router as model_pipeline_router
+app.include_router(model_pipeline_router, prefix=settings.API_PREFIX)
 
 app.include_router(agent_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/models/model_registry.py
+++ b/backend/app/models/model_registry.py
@@ -1,0 +1,47 @@
+"""Phase 17 §5 — Model Registry.
+
+One row per trained model version: what it is, which dataset it came from, how it
+scored, its known limitations, and its approval status. This is the source of
+truth for the deployment gate — a recommendation may only be driven by a model
+whose registry stage permits it.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ModelRegistryEntry(Base):
+    __tablename__ = "model_registry"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    model_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    model_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    model_type: Mapped[str] = mapped_column(String(60), nullable=False, index=True)  # task key
+    dataset_version: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+
+    training_date: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    # not_started | training | trained | failed
+    training_status: Mapped[str] = mapped_column(String(30), default="not_started", nullable=False)
+
+    # JSON-encoded metrics + limitations (portable across SQLite/Postgres).
+    evaluation_metrics: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    known_limitations: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    # experimental | pilot | validated | deprecated
+    approval_status: Mapped[str] = mapped_column(
+        String(20), default="experimental", nullable=False, index=True
+    )
+    approved_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    release_notes: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/models/shadow_prediction.py
+++ b/backend/app/models/shadow_prediction.py
@@ -1,0 +1,45 @@
+"""Phase 17 §9 — Shadow-mode predictions.
+
+A shadow model runs silently: its prediction is stored but never shown as a
+clinical recommendation. Once a supervisor records the final human decision, the
+shadow prediction is compared to it — giving real, pre-deployment performance
+evidence without ever influencing care.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ShadowPrediction(Base):
+    __tablename__ = "shadow_predictions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    model_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    model_version: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    model_type: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+
+    # The silent prediction — stored, never surfaced as a clinical recommendation.
+    predicted_label: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    predicted_confidence: Mapped[str] = mapped_column(String(20), default="", nullable=False)
+    prediction_payload: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    # Filled in later when the human final decision is known (§9 comparison).
+    supervisor_final_label: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    agreed_with_human: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
+    # Always true for shadow rows — a hard invariant the API relies on.
+    shadow_mode: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/backend/app/routes/model_pipeline.py
+++ b/backend/app/routes/model_pipeline.py
@@ -1,0 +1,276 @@
+"""Phase 17 — Model Training Pipeline & AI Readiness API.
+
+Endpoints for the model lifecycle: task/gate discovery, dataset-split preview,
+training-run preparation, model-registry CRUD + human-in-the-loop promotion,
+and shadow-mode prediction capture/reconciliation. Nothing here can silently
+drive a clinical recommendation — the deployment gate is enforced server-side
+and models are never auto-promoted.
+"""
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.model_registry import ModelRegistryEntry
+from app.models.shadow_prediction import ShadowPrediction
+from app.services.ml import shadow_mode
+from app.services.ml.deployment_gates import (
+    APPROVAL_STAGES, GATE_CAPABILITIES, capabilities, evaluate_promotion,
+)
+from app.services.ml.model_tasks import MODEL_TASKS, SAFETY_CRITICAL_FINDINGS, is_valid_task
+from app.services.ml.training_pipeline import prepare_training_run
+
+router = APIRouter(tags=["model-pipeline"])
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+# ── Discovery ────────────────────────────────────────────────────────────────
+
+@router.get("/model-pipeline/tasks")
+def list_tasks(current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer"))):
+    """Model task definitions (label spaces) + safety-critical findings."""
+    return {
+        "tasks": {
+            k: {"name": v["name"], "labels": v["labels"], "safety_critical": v["safety_critical"]}
+            for k, v in MODEL_TASKS.items()
+        },
+        "safety_critical_findings": SAFETY_CRITICAL_FINDINGS,
+    }
+
+
+@router.get("/model-pipeline/deployment-gates")
+def list_gates(current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer"))):
+    """What each approval stage may do (§8)."""
+    return {"stages": APPROVAL_STAGES, "capabilities": GATE_CAPABILITIES}
+
+
+# ── Dataset split preview / training-run preparation ─────────────────────────
+
+class Sample(BaseModel):
+    id: str | int
+    inspection_id: int | None = None
+    instrument_serial: str | None = None
+    instrument_family: str | None = None
+    anatomy_zone: str | None = None
+    finding: str | None = None
+    severity: str | None = None
+    manufacturer: str | None = None
+    image_quality: str | None = None
+
+
+class PrepareRunIn(BaseModel):
+    task: str = Field(..., description="Model task key")
+    samples: list[Sample] = Field(default_factory=list)
+    seed: str = Field("lumenai-v1", max_length=64)
+    group_by_serial: bool = False
+
+
+@router.post("/model-pipeline/prepare-run")
+def prepare_run(
+    body: PrepareRunIn,
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Prepare a training run: validate task, split data, check leakage. Does not
+    train (no labeled dataset yet) — returns the run manifest honestly."""
+    if not is_valid_task(body.task):
+        raise HTTPException(status_code=422, detail=f"Unknown task '{body.task}'.")
+    samples = [s.model_dump() for s in body.samples]
+    run = prepare_training_run(body.task, samples, seed=body.seed, group_by_serial=body.group_by_serial)
+    # Drop the bulky raw assignment map from the API response; keep the summary.
+    run["split"] = {k: run["split"][k] for k in ("counts", "split_groups", "ratios", "stratified_by")}
+    return run
+
+
+# ── Model registry ───────────────────────────────────────────────────────────
+
+class RegisterModelIn(BaseModel):
+    model_id: str = Field(..., min_length=1, max_length=100)
+    model_version: str = Field(..., min_length=1, max_length=50)
+    model_type: str = Field(..., description="A model task key")
+    dataset_version: str = Field("", max_length=100)
+    known_limitations: str = Field("", max_length=4000)
+    release_notes: str = Field("", max_length=4000)
+
+
+@router.post("/model-pipeline/models", status_code=201)
+def register_model(
+    body: RegisterModelIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Register a new model version. Always starts as `experimental` — never
+    higher. Promotion is a separate, human-gated action."""
+    if not is_valid_task(body.model_type):
+        raise HTTPException(status_code=422, detail=f"Unknown model_type '{body.model_type}'.")
+    tenant_id = _tenant(current_user, request)
+    row = ModelRegistryEntry(
+        tenant_id=tenant_id,
+        model_id=body.model_id,
+        model_version=body.model_version,
+        model_type=body.model_type,
+        dataset_version=body.dataset_version,
+        training_status="not_started",
+        evaluation_metrics="{}",
+        known_limitations=body.known_limitations,
+        approval_status="experimental",  # hard default — never trust client
+        release_notes=body.release_notes,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id, actor_email=_actor(current_user),
+        actor_role=getattr(current_user, "role", ""), action_type="model_registered",
+        resource_type="model", resource_id=f"{row.model_id}:{row.model_version}",
+    )
+    return _model_view(row)
+
+
+@router.get("/model-pipeline/models")
+def list_models(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    tenant_id = _tenant(current_user, request)
+    rows = (
+        db.query(ModelRegistryEntry)
+        .filter(ModelRegistryEntry.tenant_id == tenant_id)
+        .order_by(ModelRegistryEntry.id.desc())
+        .all()
+    )
+    return {"count": len(rows), "models": [_model_view(r) for r in rows]}
+
+
+class PromoteIn(BaseModel):
+    target_stage: str = Field(..., description="pilot | validated | deprecated")
+    checklist: dict[str, bool] = Field(default_factory=dict)
+    sample_size: int = Field(0, ge=0)
+    release_notes: str = Field("", max_length=4000)
+
+
+@router.post("/model-pipeline/models/{model_db_id}/promote")
+def promote_model(
+    model_db_id: int,
+    body: PromoteIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Human-in-the-loop promotion. Refuses to advance until every requirement is
+    met; never auto-promotes. The approver is the authenticated user."""
+    tenant_id = _tenant(current_user, request)
+    row = (
+        db.query(ModelRegistryEntry)
+        .filter(ModelRegistryEntry.id == model_db_id, ModelRegistryEntry.tenant_id == tenant_id)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Model not found.")
+
+    decision = evaluate_promotion(
+        row.approval_status, body.target_stage,
+        checklist=body.checklist, sample_size=body.sample_size, approver=_actor(current_user),
+    )
+    if not decision["allowed"]:
+        # 409: the request is well-formed but requirements are unmet.
+        raise HTTPException(status_code=409, detail={"message": "Promotion blocked.", **decision})
+
+    row.approval_status = body.target_stage
+    row.approved_by = _actor(current_user)
+    if body.release_notes:
+        row.release_notes = body.release_notes
+    db.commit()
+    db.refresh(row)
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id, actor_email=_actor(current_user),
+        actor_role=getattr(current_user, "role", ""), action_type="model_promoted",
+        resource_type="model", resource_id=f"{row.model_id}:{row.model_version}->{body.target_stage}",
+    )
+    return {"promoted": True, "model": _model_view(row), "decision": decision}
+
+
+def _model_view(row: ModelRegistryEntry) -> dict:
+    caps = capabilities(row.approval_status)
+    return {
+        "id": row.id,
+        "model_id": row.model_id,
+        "model_version": row.model_version,
+        "model_type": row.model_type,
+        "dataset_version": row.dataset_version,
+        "training_status": row.training_status,
+        "evaluation_metrics": json.loads(row.evaluation_metrics or "{}"),
+        "known_limitations": row.known_limitations,
+        "approval_status": row.approval_status,
+        "approved_by": row.approved_by,
+        "release_notes": row.release_notes,
+        "capabilities": caps,
+        "human_review_required": True,
+    }
+
+
+# ── Shadow mode ──────────────────────────────────────────────────────────────
+
+class ShadowIn(BaseModel):
+    model_id: str = Field(..., min_length=1, max_length=100)
+    model_version: str = Field("", max_length=50)
+    model_type: str = Field("", max_length=60)
+    predicted_label: str = Field(..., max_length=100)
+    predicted_confidence: str = Field("", max_length=20)
+    inspection_id: int | None = None
+    payload: dict = Field(default_factory=dict)
+
+
+@router.post("/model-pipeline/shadow-predictions", status_code=201)
+def create_shadow_prediction(
+    body: ShadowIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Record a silent shadow prediction. The response deliberately does NOT
+    surface the predicted label as a clinical recommendation."""
+    tenant_id = _tenant(current_user, request)
+    # A registered experimental+ model may run shadow; a deprecated one may not.
+    reg = (
+        db.query(ModelRegistryEntry)
+        .filter(ModelRegistryEntry.tenant_id == tenant_id, ModelRegistryEntry.model_id == body.model_id)
+        .order_by(ModelRegistryEntry.id.desc())
+        .first()
+    )
+    if reg is not None and not capabilities(reg.approval_status)["can_run_shadow_mode"]:
+        raise HTTPException(status_code=409, detail=f"Model stage '{reg.approval_status}' cannot run shadow mode.")
+
+    row = shadow_mode.record_shadow_prediction(
+        db, tenant_id=tenant_id, model_id=body.model_id, model_version=body.model_version,
+        model_type=body.model_type, predicted_label=body.predicted_label,
+        predicted_confidence=body.predicted_confidence, inspection_id=body.inspection_id,
+        payload=body.payload,
+    )
+    return shadow_mode.public_view(row)
+
+
+@router.get("/model-pipeline/shadow-predictions/performance")
+def shadow_perf(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    tenant_id = _tenant(current_user, request)
+    rows = db.query(ShadowPrediction).filter(ShadowPrediction.tenant_id == tenant_id).all()
+    return shadow_mode.shadow_performance(rows)

--- a/backend/app/services/ml/__init__.py
+++ b/backend/app/services/ml/__init__.py
@@ -1,0 +1,10 @@
+"""Phase 17 — Model Training Pipeline & AI Readiness.
+
+Repeatable, honest scaffolding to train, evaluate, version, and *safely* deploy
+anatomy-aware AI models from validated inspection data. No fabricated metrics and
+no auto-promotion: models are experimental until a human validates them, and
+deployment gates enforce what each approval stage may actually do.
+
+Lifecycle: Data → Labels → Training → Evaluation → Registry → Shadow Mode →
+Pilot → Validation → Deployment.
+"""

--- a/backend/app/services/ml/dataset_split.py
+++ b/backend/app/services/ml/dataset_split.py
@@ -1,0 +1,133 @@
+"""Phase 17 §2 — Dataset split with leakage prevention + stratification.
+
+Deterministic 70/15/15 train/validation/test split that:
+  * groups samples so images from the same inspection (and baseline/inspection
+    pairs, and — if configured — the same instrument serial) never straddle the
+    split boundary;
+  * stratifies by a composite key (family/zone/finding/severity/manufacturer/
+    image-quality) so each split reflects the population.
+
+Pure-Python and deterministic (seeded hashing) — no numpy/sklearn dependency.
+"""
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+from typing import Any
+
+TRAIN, VAL, TEST = "train", "validation", "test"
+_DEFAULT_RATIOS = (0.70, 0.15, 0.15)
+
+
+def _group_key(sample: dict, group_by_serial: bool) -> str:
+    """Leakage-prevention grouping key. All samples sharing this key are kept in
+    the same split. inspection_id groups an inspection's images (and its
+    baseline/inspection pair); optionally the instrument serial groups an
+    instrument's whole history out of the validation/test sets."""
+    if group_by_serial and sample.get("instrument_serial"):
+        return f"serial:{sample['instrument_serial']}"
+    if sample.get("inspection_id") is not None:
+        return f"insp:{sample['inspection_id']}"
+    # Fall back to a per-sample group (its own id) — no grouping constraint.
+    return f"sample:{sample.get('id')}"
+
+
+def _stratum_key(sample: dict) -> str:
+    parts = [
+        sample.get("instrument_family", "unknown"),
+        sample.get("anatomy_zone", "unknown"),
+        sample.get("finding", "none"),
+        str(sample.get("severity", "none")),
+        sample.get("manufacturer", "unknown"),
+        sample.get("image_quality", "unknown"),
+    ]
+    return "|".join(str(p) for p in parts)
+
+
+def _bucket(group_key: str, seed: str) -> float:
+    """Stable [0,1) hash for a group, seeded for reproducibility."""
+    h = hashlib.sha256(f"{seed}:{group_key}".encode()).hexdigest()
+    return int(h[:8], 16) / 0xFFFFFFFF
+
+
+def split_dataset(
+    samples: list[dict],
+    ratios: tuple[float, float, float] = _DEFAULT_RATIOS,
+    seed: str = "lumenai-v1",
+    group_by_serial: bool = False,
+) -> dict[str, Any]:
+    """Split samples into train/validation/test.
+
+    Each sample is a dict with (all optional): id, inspection_id,
+    instrument_serial, instrument_family, anatomy_zone, finding, severity,
+    manufacturer, image_quality.
+
+    Returns assignments (id→split), the grouped sample ids per split, and the
+    realized per-stratum counts. Grouping is enforced first (no leakage), then
+    groups are distributed within each stratum by a seeded hash to approximate
+    the target ratios.
+    """
+    if abs(sum(ratios) - 1.0) > 1e-6:
+        raise ValueError(f"ratios must sum to 1.0, got {ratios}")
+    train_r, val_r, _test_r = ratios
+
+    # 1. Collect groups and the stratum each group belongs to (a group's stratum
+    #    is that of its first sample — grouping wins over stratification to
+    #    guarantee no leakage).
+    groups: dict[str, list[dict]] = defaultdict(list)
+    group_stratum: dict[str, str] = {}
+    for s in samples:
+        gk = _group_key(s, group_by_serial)
+        groups[gk].append(s)
+        group_stratum.setdefault(gk, _stratum_key(s))
+
+    # 2. Within each stratum, order groups by their seeded hash and slice by ratio
+    #    so every stratum contributes proportionally to all three splits.
+    by_stratum: dict[str, list[str]] = defaultdict(list)
+    for gk, stratum in group_stratum.items():
+        by_stratum[stratum].append(gk)
+
+    assignments: dict[Any, str] = {}
+    split_groups: dict[str, list[str]] = {TRAIN: [], VAL: [], TEST: []}
+    for stratum, gks in by_stratum.items():
+        ordered = sorted(gks, key=lambda g: _bucket(g, seed))
+        n = len(ordered)
+        n_train = round(n * train_r)
+        n_val = round(n * val_r)
+        for i, gk in enumerate(ordered):
+            if i < n_train:
+                split = TRAIN
+            elif i < n_train + n_val:
+                split = VAL
+            else:
+                split = TEST
+            split_groups[split].append(gk)
+            for s in groups[gk]:
+                assignments[s.get("id")] = split
+
+    counts = {k: sum(len(groups[g]) for g in v) for k, v in split_groups.items()}
+    return {
+        "assignments": assignments,
+        "split_groups": split_groups,
+        "counts": counts,
+        "total_samples": len(samples),
+        "total_groups": len(groups),
+        "ratios": {TRAIN: train_r, VAL: val_r, TEST: _test_r},
+        "group_by_serial": group_by_serial,
+        "seed": seed,
+        "stratified_by": [
+            "instrument_family", "anatomy_zone", "finding",
+            "severity", "manufacturer", "image_quality",
+        ],
+    }
+
+
+def has_no_group_leakage(result: dict) -> bool:
+    """True iff no group id appears in more than one split (leakage check)."""
+    seen: dict[str, str] = {}
+    for split, gks in result["split_groups"].items():
+        for gk in gks:
+            if gk in seen and seen[gk] != split:
+                return False
+            seen[gk] = split
+    return True

--- a/backend/app/services/ml/deployment_gates.py
+++ b/backend/app/services/ml/deployment_gates.py
@@ -1,0 +1,140 @@
+"""Phase 17 §7 & §8 — Deployment gates + human-in-the-loop promotion rules.
+
+Encodes what each approval stage may do and what a model must satisfy before a
+human may promote it. Models are NEVER auto-promoted: promotion always returns a
+requirement checklist and refuses to advance until a human confirms it.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Approval lifecycle (ordered).
+APPROVAL_STAGES = ["experimental", "pilot", "validated", "deprecated"]
+
+# Capabilities per stage (§8).
+GATE_CAPABILITIES: dict[str, dict[str, Any]] = {
+    "experimental": {
+        "can_drive_clinical_recommendation": False,
+        "can_run_shadow_mode": True,
+        "can_provide_advisory": False,
+        "requires_human_review_disclaimer": True,
+        "usable_for_new_inspection": False,
+        "description": "Shadow mode only. Cannot drive or advise a clinical recommendation.",
+    },
+    "pilot": {
+        "can_drive_clinical_recommendation": False,
+        "can_run_shadow_mode": True,
+        "can_provide_advisory": True,
+        "requires_human_review_disclaimer": True,
+        "usable_for_new_inspection": True,
+        "description": "Advisory only, with a visible human-review disclaimer. Cannot decide.",
+    },
+    "validated": {
+        "can_drive_clinical_recommendation": True,
+        "can_run_shadow_mode": True,
+        "can_provide_advisory": True,
+        "requires_human_review_disclaimer": True,
+        "usable_for_new_inspection": True,
+        "supervisor_override_allowed": True,
+        "description": "May support a workflow decision; supervisor override always allowed.",
+    },
+    "deprecated": {
+        "can_drive_clinical_recommendation": False,
+        "can_run_shadow_mode": False,
+        "can_provide_advisory": False,
+        "requires_human_review_disclaimer": True,
+        "usable_for_new_inspection": False,
+        "description": "Retired. Cannot be used for new inspections.",
+    },
+}
+
+
+def capabilities(stage: str) -> dict[str, Any]:
+    return dict(GATE_CAPABILITIES.get(stage, GATE_CAPABILITIES["experimental"]))
+
+
+def can_drive_clinical_recommendation(stage: str) -> bool:
+    return capabilities(stage)["can_drive_clinical_recommendation"]
+
+
+def requires_human_review_disclaimer(stage: str) -> bool:
+    return capabilities(stage)["requires_human_review_disclaimer"]
+
+
+def usable_for_new_inspection(stage: str) -> bool:
+    return capabilities(stage)["usable_for_new_inspection"]
+
+
+# Human-in-the-loop requirements to leave experimental (§7).
+_MIN_VALIDATION_SAMPLES = 200
+
+
+def promotion_requirements(target_stage: str) -> list[str]:
+    if target_stage == "pilot":
+        return [
+            "supervisor_validation",
+            "minimum_sample_size",
+            "false_negative_review",
+            "edge_case_review",
+            "limitations_documented",
+        ]
+    if target_stage == "validated":
+        return [
+            "supervisor_validation",
+            "minimum_sample_size",
+            "false_negative_review",
+            "edge_case_review",
+            "limitations_documented",
+            "shadow_mode_completed",
+            "safety_false_negative_within_threshold",
+        ]
+    return []
+
+
+def evaluate_promotion(
+    current_stage: str,
+    target_stage: str,
+    *,
+    checklist: dict[str, bool] | None = None,
+    sample_size: int = 0,
+    approver: str | None = None,
+) -> dict[str, Any]:
+    """Decide whether a *human-initiated* promotion may proceed.
+
+    Never auto-promotes: returns ``allowed`` plus the unmet requirements. The
+    caller (route) only writes the new stage when ``allowed`` is True and an
+    approver is recorded.
+    """
+    checklist = checklist or {}
+    if target_stage not in APPROVAL_STAGES:
+        return {"allowed": False, "reason": f"Unknown target stage '{target_stage}'."}
+
+    # Deprecation is always allowed (retiring a model is safe).
+    if target_stage == "deprecated":
+        return {"allowed": bool(approver), "unmet": [] if approver else ["approver_required"],
+                "requirements": [], "auto_promoted": False}
+
+    cur_i = APPROVAL_STAGES.index(current_stage) if current_stage in APPROVAL_STAGES else 0
+    tgt_i = APPROVAL_STAGES.index(target_stage)
+    if tgt_i <= cur_i:
+        return {"allowed": False, "reason": f"Cannot promote from {current_stage} to {target_stage}."}
+    if tgt_i > cur_i + 1:
+        return {"allowed": False,
+                "reason": "Promotion must advance one stage at a time (no skipping)."}
+
+    reqs = promotion_requirements(target_stage)
+    unmet = [r for r in reqs if not checklist.get(r, False)]
+    if "minimum_sample_size" in reqs and sample_size < _MIN_VALIDATION_SAMPLES:
+        if "minimum_sample_size" not in unmet:
+            unmet.append("minimum_sample_size")
+    if not approver:
+        unmet.append("approver_required")
+
+    return {
+        "allowed": len(unmet) == 0,
+        "requirements": reqs,
+        "unmet": unmet,
+        "minimum_sample_size": _MIN_VALIDATION_SAMPLES,
+        "auto_promoted": False,
+        "note": "Models are never auto-promoted; a human must satisfy every requirement.",
+    }

--- a/backend/app/services/ml/evaluation.py
+++ b/backend/app/services/ml/evaluation.py
@@ -1,0 +1,119 @@
+"""Phase 17 §6 — Evaluation metrics (pure Python, no sklearn).
+
+Computes accuracy, per-class precision/recall/F1, false-positive/negative rates,
+a confusion matrix, per-group breakdowns, and — most importantly — the
+safety-critical false-negative rates (missed blood/tissue/residue/crack/missing
+component). Nothing is fabricated: metrics are computed from provided
+(y_true, y_pred) pairs only.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from app.services.ml.model_tasks import SAFETY_CRITICAL_FINDINGS
+
+
+def _safe_div(n: float, d: float) -> float | None:
+    return round(n / d, 4) if d else None
+
+
+def confusion_matrix(y_true: list[str], y_pred: list[str], labels: list[str]) -> dict[str, dict[str, int]]:
+    m = {t: {p: 0 for p in labels} for t in labels}
+    for t, p in zip(y_true, y_pred):
+        if t in m and p in m[t]:
+            m[t][p] += 1
+    return m
+
+
+def _per_class(y_true: list[str], y_pred: list[str], labels: list[str]) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    total = len(y_true)
+    for label in labels:
+        tp = sum(1 for t, p in zip(y_true, y_pred) if t == label and p == label)
+        fp = sum(1 for t, p in zip(y_true, y_pred) if t != label and p == label)
+        fn = sum(1 for t, p in zip(y_true, y_pred) if t == label and p != label)
+        tn = total - tp - fp - fn
+        precision = _safe_div(tp, tp + fp)
+        recall = _safe_div(tp, tp + fn)
+        f1 = (
+            _safe_div(2 * precision * recall, precision + recall)
+            if precision is not None and recall is not None and (precision + recall)
+            else None
+        )
+        out[label] = {
+            "support": tp + fn,
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "false_positive_rate": _safe_div(fp, fp + tn),
+            "false_negative_rate": _safe_div(fn, fn + tp),
+        }
+    return out
+
+
+def evaluate(y_true: list[str], y_pred: list[str], labels: list[str],
+             groups: dict[str, list[str]] | None = None) -> dict[str, Any]:
+    """Full evaluation report.
+
+    ``groups`` optionally maps a breakdown name (e.g. 'instrument_family') to a
+    per-sample list of group values (same length as y_true); each is scored
+    with accuracy so performance can be read per family / zone / finding / severity.
+    """
+    if len(y_true) != len(y_pred):
+        raise ValueError("y_true and y_pred must be the same length")
+    n = len(y_true)
+    correct = sum(1 for t, p in zip(y_true, y_pred) if t == p)
+    per_class = _per_class(y_true, y_pred, labels)
+
+    # Macro averages over classes that have support.
+    supported = [c for c in per_class.values() if c["support"]]
+    def _macro(key: str) -> float | None:
+        vals = [c[key] for c in supported if c[key] is not None]
+        return round(sum(vals) / len(vals), 4) if vals else None
+
+    breakdowns: dict[str, dict] = {}
+    for name, group_vals in (groups or {}).items():
+        if len(group_vals) != n:
+            continue
+        by_group: dict[str, list[bool]] = defaultdict(list)
+        for g, t, p in zip(group_vals, y_true, y_pred):
+            by_group[g].append(t == p)
+        breakdowns[name] = {
+            g: {"n": len(hits), "accuracy": _safe_div(sum(hits), len(hits))}
+            for g, hits in by_group.items()
+        }
+
+    return {
+        "sample_count": n,
+        "accuracy": _safe_div(correct, n),
+        "macro_precision": _macro("precision"),
+        "macro_recall": _macro("recall"),
+        "macro_f1": _macro("f1"),
+        "per_class": per_class,
+        "confusion_matrix": confusion_matrix(y_true, y_pred, labels),
+        "performance_breakdowns": breakdowns,
+        "safety_metrics": safety_metrics(y_true, y_pred),
+    }
+
+
+def safety_metrics(y_true: list[str], y_pred: list[str]) -> dict[str, Any]:
+    """Critical false-negative rates: a missed contamination/defect is the most
+    dangerous error in SPD. FNR = missed / actual-present for each critical class."""
+    out: dict[str, Any] = {}
+    worst = 0.0
+    for finding in SAFETY_CRITICAL_FINDINGS:
+        present = sum(1 for t in y_true if t == finding)
+        missed = sum(1 for t, p in zip(y_true, y_pred) if t == finding and p != finding)
+        fnr = _safe_div(missed, present)
+        out[f"{finding.replace(' ', '_')}_false_negative_rate"] = fnr
+        if fnr is not None:
+            worst = max(worst, fnr)
+    out["worst_safety_false_negative_rate"] = worst if any(
+        v is not None for k, v in out.items()
+    ) else None
+    out["note"] = (
+        "False negatives on contamination/structural findings are the primary "
+        "safety risk; these gate promotion (see model_deployment_gates.md)."
+    )
+    return out

--- a/backend/app/services/ml/feature_store.py
+++ b/backend/app/services/ml/feature_store.py
@@ -1,0 +1,69 @@
+"""Phase 17 §4 — Baseline-comparison feature store (stubs).
+
+Defines the feature vector a future image model / baseline-diff will consume, and
+extracts what is *honestly* available today from the deterministic pilot scoring
+result. Real computer-vision features (color/texture/edge/corrosion/blur/lighting)
+are labeled as not-yet-computed rather than fabricated.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# The full feature schema (order is stable so it can back a real feature matrix).
+FEATURE_NAMES = [
+    "baseline_match_score",
+    "image_similarity_score",
+    "color_deviation",
+    "texture_deviation",
+    "edge_anomaly",
+    "corrosion_color_signature",
+    "dark_residue_signal",
+    "image_blur_score",
+    "lighting_quality_score",
+    "zone_coverage_score",
+]
+
+# Features that require real pixel-level CV — not computed in the pilot.
+_CV_FEATURES = {
+    "image_similarity_score", "color_deviation", "texture_deviation",
+    "edge_anomaly", "corrosion_color_signature", "dark_residue_signal",
+    "image_blur_score", "lighting_quality_score",
+}
+
+
+def extract_features(analysis_result: dict, coverage: dict | None = None) -> dict[str, Any]:
+    """Extract the feature vector for one inspection.
+
+    Available-now features come from the deterministic scoring result and the
+    coverage engine. CV features are returned as ``None`` with an ``available``
+    flag — the store records that they are pending a real vision model, never a
+    fabricated number.
+    """
+    coverage = coverage or analysis_result.get("inspection_coverage") or {}
+    values: dict[str, Any] = {name: None for name in FEATURE_NAMES}
+
+    values["baseline_match_score"] = analysis_result.get("baseline_match_score")
+    cov_pct = coverage.get("overall_coverage")
+    values["zone_coverage_score"] = cov_pct if isinstance(cov_pct, (int, float)) else None
+
+    available = {
+        name: (values[name] is not None) and (name not in _CV_FEATURES)
+        for name in FEATURE_NAMES
+    }
+    return {
+        "features": values,
+        "available": available,
+        "pending_cv_features": sorted(_CV_FEATURES),
+        "note": (
+            "CV features (color/texture/edge/corrosion/blur/lighting/similarity) "
+            "require a trained vision model; stored as null until then — not fabricated."
+        ),
+    }
+
+
+def feature_completeness(feature_record: dict) -> float:
+    """Fraction of the schema that is actually populated today (0..1)."""
+    avail = feature_record.get("available", {})
+    if not avail:
+        return 0.0
+    return round(sum(1 for v in avail.values() if v) / len(avail), 3)

--- a/backend/app/services/ml/model_tasks.py
+++ b/backend/app/services/ml/model_tasks.py
@@ -1,0 +1,79 @@
+"""Phase 17 §3 — Model task definitions.
+
+The label spaces for each anatomy-aware classifier LumenAI intends to train.
+Kept as data so training, evaluation, and the registry all agree on the classes.
+These mirror the instrument-anatomy library and the SPD scoring vocabulary.
+"""
+from __future__ import annotations
+
+# A. Instrument Family Classifier
+INSTRUMENT_FAMILY_LABELS = [
+    "rigid_scope", "flexible_endoscope", "drill_bit", "kerrison_rongeur",
+    "scissors", "needle_holder", "laparoscopic", "general_forceps", "unknown",
+]
+
+# B. Anatomy Zone Classifier
+ANATOMY_ZONE_LABELS = [
+    "o-ring area", "serration", "groove", "hinge", "box lock", "drill-bit flute",
+    "threaded region", "lumen", "scope port", "cutting edge", "insulation edge",
+    "handle seam", "unknown",
+]
+
+# C. Finding Classifier
+FINDING_LABELS = [
+    "blood", "bone", "tissue", "organic residue", "debris", "rust", "corrosion",
+    "discoloration", "crack", "pitting", "insulation damage", "missing component",
+    "wear", "none",
+]
+
+# D. Severity Classifier
+SEVERITY_LABELS = ["none", "trace", "minor", "moderate", "visible", "severe", "heavy"]
+
+# E. Clinical Disposition Classifier
+DISPOSITION_LABELS = ["pass", "monitor", "supervisor_review", "reprocess", "remove_from_service"]
+
+
+# Task registry: task_key → (human name, label space, whether safety-critical).
+MODEL_TASKS: dict[str, dict] = {
+    "instrument_family": {
+        "name": "Instrument Family Classifier",
+        "labels": INSTRUMENT_FAMILY_LABELS,
+        "safety_critical": False,
+    },
+    "anatomy_zone": {
+        "name": "Anatomy Zone Classifier",
+        "labels": ANATOMY_ZONE_LABELS,
+        "safety_critical": False,
+    },
+    "finding": {
+        "name": "Finding Classifier",
+        "labels": FINDING_LABELS,
+        "safety_critical": True,
+    },
+    "severity": {
+        "name": "Severity Classifier",
+        "labels": SEVERITY_LABELS,
+        "safety_critical": True,
+    },
+    "clinical_disposition": {
+        "name": "Clinical Disposition Classifier",
+        "labels": DISPOSITION_LABELS,
+        "safety_critical": True,
+    },
+}
+
+# Findings whose *false negatives* are the most dangerous (missed contamination or
+# structural failure). Tracked explicitly as safety metrics (§6).
+SAFETY_CRITICAL_FINDINGS = [
+    "blood", "tissue", "organic residue", "crack", "missing component",
+]
+
+
+def task_labels(task_key: str) -> list[str]:
+    if task_key not in MODEL_TASKS:
+        raise KeyError(f"Unknown model task '{task_key}'. Known: {sorted(MODEL_TASKS)}")
+    return list(MODEL_TASKS[task_key]["labels"])
+
+
+def is_valid_task(task_key: str) -> bool:
+    return task_key in MODEL_TASKS

--- a/backend/app/services/ml/shadow_mode.py
+++ b/backend/app/services/ml/shadow_mode.py
@@ -1,0 +1,80 @@
+"""Phase 17 §9 — Shadow-mode helpers.
+
+Record a silent prediction and later reconcile it against the human final
+decision. The invariant enforced here (and asserted by tests): a shadow
+prediction is stored WITHOUT any clinical recommendation ever being surfaced.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.shadow_prediction import ShadowPrediction
+
+
+def record_shadow_prediction(
+    db: Session,
+    *,
+    tenant_id: str,
+    model_id: str,
+    model_version: str,
+    model_type: str,
+    predicted_label: str,
+    predicted_confidence: str = "",
+    inspection_id: int | None = None,
+    payload: dict[str, Any] | None = None,
+) -> ShadowPrediction:
+    row = ShadowPrediction(
+        tenant_id=tenant_id,
+        model_id=model_id,
+        model_version=model_version,
+        model_type=model_type,
+        inspection_id=inspection_id,
+        predicted_label=predicted_label,
+        predicted_confidence=str(predicted_confidence),
+        prediction_payload=json.dumps(payload or {}),
+        shadow_mode=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def public_view(row: ShadowPrediction) -> dict[str, Any]:
+    """What a NON-privileged consumer may see: the fact a shadow ran, but never
+    the predicted clinical recommendation. This is the API contract that keeps a
+    shadow model from influencing care."""
+    return {
+        "id": row.id,
+        "model_id": row.model_id,
+        "model_type": row.model_type,
+        "shadow_mode": True,
+        "clinical_recommendation_shown": False,
+        "note": "A shadow model ran silently; its prediction is not shown as a recommendation.",
+    }
+
+
+def reconcile_with_human(db: Session, row: ShadowPrediction, final_label: str) -> ShadowPrediction:
+    """Attach the human final decision and compute agreement (§9 comparison)."""
+    row.supervisor_final_label = final_label
+    row.agreed_with_human = (row.predicted_label == final_label)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def shadow_performance(rows: list[ShadowPrediction]) -> dict[str, Any]:
+    """Aggregate agreement over reconciled shadow predictions — real evidence,
+    only counting rows that have a human final decision."""
+    reconciled = [r for r in rows if r.agreed_with_human is not None]
+    agreed = sum(1 for r in reconciled if r.agreed_with_human)
+    return {
+        "total_shadow_predictions": len(rows),
+        "reconciled": len(reconciled),
+        "agreed_with_human": agreed,
+        "agreement_rate": round(agreed / len(reconciled), 4) if reconciled else None,
+        "note": "Agreement measured only on shadow predictions reconciled against a human final decision.",
+    }

--- a/backend/app/services/ml/training_pipeline.py
+++ b/backend/app/services/ml/training_pipeline.py
@@ -1,0 +1,83 @@
+"""Phase 17 §1 — Training pipeline foundation.
+
+Orchestrates the repeatable path: image ingestion → label ingestion → dataset
+split → (train/val/test sets) → model-artifact output → evaluation report →
+registry entry. Training itself is a stub: with no labeled data yet, the pipeline
+prepares and validates everything around training and records a `not_started`
+registry entry rather than fabricating a trained model or metrics.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from app.services.ml.dataset_split import has_no_group_leakage, split_dataset
+from app.services.ml.model_tasks import MODEL_TASKS, is_valid_task, task_labels
+
+
+def dataset_version(samples: list[dict], seed: str) -> str:
+    """Deterministic dataset fingerprint so a registry entry pins its exact data."""
+    ids = sorted(str(s.get("id")) for s in samples)
+    digest = hashlib.sha256((seed + "|" + ",".join(ids)).encode()).hexdigest()[:12]
+    return f"ds-{len(samples)}-{digest}"
+
+
+def prepare_training_run(
+    task_key: str,
+    samples: list[dict],
+    *,
+    seed: str = "lumenai-v1",
+    group_by_serial: bool = False,
+) -> dict[str, Any]:
+    """Prepare (not execute) a training run: validate the task, split the data
+    with leakage checks, and assemble the run manifest a real trainer would use.
+
+    Honest: returns ``training_status: not_started`` and no metrics — there is no
+    labeled dataset to train on yet. Everything *around* training is real.
+    """
+    if not is_valid_task(task_key):
+        raise ValueError(f"Unknown model task '{task_key}'.")
+
+    split = split_dataset(samples, seed=seed, group_by_serial=group_by_serial)
+    leakage_free = has_no_group_leakage(split)
+    dsv = dataset_version(samples, seed)
+
+    return {
+        "task": task_key,
+        "task_name": MODEL_TASKS[task_key]["name"],
+        "labels": task_labels(task_key),
+        "safety_critical": MODEL_TASKS[task_key]["safety_critical"],
+        "dataset_version": dsv,
+        "split_counts": split["counts"],
+        "split": split,
+        "leakage_free": leakage_free,
+        "training_status": "not_started",
+        "prepared_at": datetime.now(timezone.utc).isoformat(),
+        "model_artifact": None,
+        "evaluation_report": None,
+        "note": (
+            "Pipeline prepared and split validated. Training is not executed — no "
+            "labeled dataset exists yet. No metrics are fabricated."
+        ),
+    }
+
+
+def build_registry_payload(run: dict, model_id: str, model_version: str,
+                           known_limitations: str = "") -> dict[str, Any]:
+    """Turn a prepared run into the fields for a ModelRegistryEntry (experimental)."""
+    return {
+        "model_id": model_id,
+        "model_version": model_version,
+        "model_type": run["task"],
+        "dataset_version": run["dataset_version"],
+        "training_date": "",
+        "training_status": run["training_status"],
+        "evaluation_metrics": json.dumps({}),
+        "known_limitations": known_limitations or (
+            "Untrained scaffold entry — no validated performance. Experimental; "
+            "shadow mode only until a human validates real metrics."
+        ),
+        "approval_status": "experimental",
+    }

--- a/backend/tests/test_model_pipeline_phase17.py
+++ b/backend/tests/test_model_pipeline_phase17.py
@@ -1,0 +1,184 @@
+"""Phase 17 — Model Training Pipeline & AI Readiness.
+
+Covers dataset-split leakage prevention, model registry, deployment gates
+(experimental cannot drive; pilot needs disclaimer; validated allows override;
+deprecated unusable), shadow mode (stores without showing a recommendation), and
+safety metrics (blood false-negative rate, anatomy-zone performance).
+"""
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.ml.dataset_split import split_dataset, has_no_group_leakage
+from app.services.ml.evaluation import evaluate, safety_metrics
+from app.services.ml.deployment_gates import (
+    capabilities, evaluate_promotion, usable_for_new_inspection,
+)
+from app.services.ml.training_pipeline import prepare_training_run
+
+client = TestClient(app)
+AUTH = {"Authorization": "Bearer dev-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+
+# ── Dataset split ─────────────────────────────────────────────────────────────
+
+def _samples(n_inspections=30, imgs=2):
+    out = []
+    for insp in range(1, n_inspections + 1):
+        fam = "rigid_scope" if insp % 2 else "drill_bit"
+        for k in range(imgs):
+            out.append({
+                "id": f"{insp}-{k}", "inspection_id": insp, "instrument_serial": f"S{insp}",
+                "instrument_family": fam, "anatomy_zone": "o-ring area", "finding": "blood",
+                "severity": "moderate", "manufacturer": "M", "image_quality": "good",
+            })
+    return out
+
+
+class TestDatasetSplit:
+    def test_split_preserves_inspection_grouping(self):
+        samples = _samples()
+        r = split_dataset(samples)
+        assert has_no_group_leakage(r)
+        # No inspection's images straddle two splits.
+        by_insp = {}
+        for s in samples:
+            by_insp.setdefault(s["inspection_id"], set()).add(r["assignments"][s["id"]])
+        assert all(len(v) == 1 for v in by_insp.values())
+
+    def test_split_ratios_roughly_70_15_15(self):
+        r = split_dataset(_samples(100, imgs=1))
+        total = r["total_samples"]
+        assert 0.6 <= r["counts"]["train"] / total <= 0.8
+        assert r["counts"]["train"] + r["counts"]["validation"] + r["counts"]["test"] == total
+
+    def test_prepare_run_is_not_started_and_leakage_free(self):
+        run = prepare_training_run("finding", _samples())
+        assert run["training_status"] == "not_started"
+        assert run["leakage_free"] is True
+        assert run["model_artifact"] is None  # nothing fabricated
+
+
+# ── Evaluation / safety metrics ───────────────────────────────────────────────
+
+class TestEvaluation:
+    def test_blood_false_negative_metric_tracked(self):
+        y_true = ["blood", "blood", "none", "tissue"]
+        y_pred = ["blood", "none", "none", "tissue"]  # one blood missed
+        m = safety_metrics(y_true, y_pred)
+        assert m["blood_false_negative_rate"] == 0.5
+        assert m["tissue_false_negative_rate"] == 0.0
+
+    def test_anatomy_zone_performance_calculated(self):
+        y_true = ["blood", "none", "blood", "none"]
+        y_pred = ["blood", "none", "none", "none"]
+        zones = ["o-ring area", "o-ring area", "hinge", "hinge"]
+        ev = evaluate(y_true, y_pred, ["blood", "none"], groups={"anatomy_zone": zones})
+        breakdown = ev["performance_breakdowns"]["anatomy_zone"]
+        assert breakdown["o-ring area"]["accuracy"] == 1.0
+        assert breakdown["hinge"]["accuracy"] == 0.5
+
+
+# ── Deployment gates (service level) ──────────────────────────────────────────
+
+class TestDeploymentGates:
+    def test_experimental_cannot_drive_recommendation(self):
+        assert capabilities("experimental")["can_drive_clinical_recommendation"] is False
+        assert capabilities("experimental")["can_run_shadow_mode"] is True
+
+    def test_pilot_requires_disclaimer_and_is_advisory_only(self):
+        caps = capabilities("pilot")
+        assert caps["requires_human_review_disclaimer"] is True
+        assert caps["can_provide_advisory"] is True
+        assert caps["can_drive_clinical_recommendation"] is False
+
+    def test_validated_allows_supervisor_override(self):
+        caps = capabilities("validated")
+        assert caps["can_drive_clinical_recommendation"] is True
+        assert caps["supervisor_override_allowed"] is True
+
+    def test_deprecated_not_usable_for_new_inspection(self):
+        assert usable_for_new_inspection("deprecated") is False
+
+    def test_no_auto_promotion_without_requirements(self):
+        blocked = evaluate_promotion("experimental", "pilot", approver="a")
+        assert blocked["allowed"] is False
+        assert "supervisor_validation" in blocked["unmet"]
+
+    def test_cannot_skip_stage(self):
+        assert evaluate_promotion("experimental", "validated", approver="a")["allowed"] is False
+
+
+# ── API: registry + promotion + shadow ────────────────────────────────────────
+
+class TestModelPipelineApi:
+    def _register(self, model_id="m-api-1", mtype="finding"):
+        return client.post("/api/model-pipeline/models", headers=AUTH, json={
+            "model_id": model_id, "model_version": "0.1", "model_type": mtype,
+        })
+
+    def test_registry_records_model_version(self):
+        r = self._register("m-registry")
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["model_version"] == "0.1"
+        assert body["approval_status"] == "experimental"  # never higher on create
+        assert body["capabilities"]["can_drive_clinical_recommendation"] is False
+
+    def test_experimental_model_cannot_drive_via_api(self):
+        r = self._register("m-exp")
+        assert r.json()["capabilities"]["can_drive_clinical_recommendation"] is False
+
+    def test_promotion_blocked_then_allowed_with_checklist(self):
+        mid = self._register("m-promote").json()["id"]
+        blocked = client.post(f"/api/model-pipeline/models/{mid}/promote", headers=AUTH,
+                              json={"target_stage": "pilot"})
+        assert blocked.status_code == 409
+        ok = client.post(f"/api/model-pipeline/models/{mid}/promote", headers=AUTH, json={
+            "target_stage": "pilot", "sample_size": 300,
+            "checklist": {
+                "supervisor_validation": True, "minimum_sample_size": True,
+                "false_negative_review": True, "edge_case_review": True,
+                "limitations_documented": True,
+            },
+        })
+        assert ok.status_code == 200, ok.text
+        assert ok.json()["model"]["approval_status"] == "pilot"
+        assert ok.json()["model"]["capabilities"]["requires_human_review_disclaimer"] is True
+
+    def test_shadow_mode_stores_without_showing_recommendation(self):
+        self._register("m-shadow")
+        s = client.post("/api/model-pipeline/shadow-predictions", headers=AUTH, json={
+            "model_id": "m-shadow", "predicted_label": "blood", "predicted_confidence": "0.9",
+        })
+        assert s.status_code == 201, s.text
+        body = s.json()
+        assert body["shadow_mode"] is True
+        assert body["clinical_recommendation_shown"] is False
+        assert "predicted_label" not in body  # the silent prediction is not surfaced
+
+    def test_deprecated_model_cannot_run_shadow(self):
+        # Register, deprecate, then a shadow prediction must be refused.
+        mid = self._register("m-dep").json()["id"]
+        dep = client.post(f"/api/model-pipeline/models/{mid}/promote", headers=AUTH,
+                          json={"target_stage": "deprecated"})
+        assert dep.status_code == 200, dep.text
+        s = client.post("/api/model-pipeline/shadow-predictions", headers=AUTH, json={
+            "model_id": "m-dep", "predicted_label": "blood",
+        })
+        assert s.status_code == 409
+
+    def test_viewer_cannot_register_model(self):
+        r = client.post("/api/model-pipeline/models", headers=AUTH_VIEWER, json={
+            "model_id": "m-viewer", "model_version": "0.1", "model_type": "finding",
+        })
+        assert r.status_code == 403
+
+    def test_tasks_and_gates_discovery(self):
+        t = client.get("/api/model-pipeline/tasks", headers=AUTH)
+        assert t.status_code == 200
+        assert "finding" in t.json()["tasks"]
+        assert "blood" in t.json()["safety_critical_findings"]
+        g = client.get("/api/model-pipeline/deployment-gates", headers=AUTH)
+        assert g.status_code == 200
+        assert set(g.json()["stages"]) == {"experimental", "pilot", "validated", "deprecated"}

--- a/docs/ai/model-deployment-gates.md
+++ b/docs/ai/model-deployment-gates.md
@@ -1,0 +1,46 @@
+# Model Deployment Gates (Phase 17)
+
+What each approval stage may do, and what a human must satisfy to advance a
+model. Source: `app.services.ml.deployment_gates`. Models are **never
+auto-promoted**.
+
+## Capabilities by stage
+
+| Stage | Drive clinical rec? | Advisory? | Shadow? | Usable for new inspection? | Disclaimer |
+|---|---|---|---|---|---|
+| **experimental** | ✗ | ✗ | ✓ | ✗ | required |
+| **pilot** | ✗ | ✓ | ✓ | ✓ | required |
+| **validated** | ✓ (override allowed) | ✓ | ✓ | ✓ | required |
+| **deprecated** | ✗ | ✗ | ✗ | ✗ | required |
+
+- **Experimental** — shadow mode only; cannot drive or advise a recommendation.
+- **Pilot** — advisory only, with a visible human-review disclaimer; cannot decide.
+- **Validated** — may support a workflow decision; **supervisor override always
+  allowed**.
+- **Deprecated** — retired; cannot be used for new inspections or shadow runs.
+
+## Human-in-the-loop promotion (§7)
+
+To leave **experimental → pilot**, all of:
+- `supervisor_validation`
+- `minimum_sample_size` (≥ 200 validation samples)
+- `false_negative_review`
+- `edge_case_review`
+- `limitations_documented`
+
+To reach **validated**, additionally:
+- `shadow_mode_completed`
+- `safety_false_negative_within_threshold`
+
+Rules enforced by `evaluate_promotion`:
+- Advance **one stage at a time** (no skipping experimental→validated).
+- Every requirement must be checked **and** an approver recorded, or the API
+  returns **409** with the unmet list.
+- Deprecation is always allowed (retiring a model is safe) but still records who
+  did it.
+
+## Why server-side
+
+The gate lives in the backend so a model's stage — not a client flag — decides
+whether it can influence a recommendation. A deprecated model is refused even for
+shadow runs.

--- a/docs/ai/model-registry.md
+++ b/docs/ai/model-registry.md
@@ -1,0 +1,33 @@
+# Model Registry (Phase 17)
+
+Source of truth for every trained model version and the gate that governs it.
+Table: `app.models.model_registry.ModelRegistryEntry`. API: `/api/model-pipeline/models`.
+
+## Fields
+
+| Field | Meaning |
+|---|---|
+| `model_id` | Stable identifier for a model line |
+| `model_version` | Version string within that line |
+| `model_type` | Task key (`finding`, `anatomy_zone`, …) |
+| `dataset_version` | Deterministic fingerprint of the training data |
+| `training_date` | When training completed (empty until real training) |
+| `training_status` | `not_started` \| `training` \| `trained` \| `failed` |
+| `evaluation_metrics` | JSON metrics (empty `{}` until a real evaluation) |
+| `known_limitations` | Free-text limitations (required before promotion) |
+| `approval_status` | `experimental` \| `pilot` \| `validated` \| `deprecated` |
+| `approved_by` | The human who promoted it |
+| `release_notes` | Change notes |
+
+## Rules
+
+- A model is **always created as `experimental`** — the API hard-defaults it and
+  never trusts a client-supplied status.
+- Every model view carries its stage `capabilities` and `human_review_required: true`.
+- Promotion is a separate, human-gated action (`/promote`) — see
+  `model-deployment-gates.md`.
+- Registration and promotion are audit-logged.
+
+## Tenancy
+
+Registry rows are tenant-scoped; a tenant only sees and promotes its own models.

--- a/docs/ai/model-training-pipeline.md
+++ b/docs/ai/model-training-pipeline.md
@@ -1,0 +1,64 @@
+# Model Training Pipeline (Phase 17)
+
+Repeatable path from validated inspection data to a *safely* deployed,
+anatomy-aware model. Training itself is not executed yet — there is no labeled
+dataset — so the pipeline prepares and validates everything around training and
+records an honest `not_started` registry entry. No metrics are fabricated.
+
+## Lifecycle
+
+```
+Data → Labels → Training → Evaluation → Registry → Shadow Mode → Pilot → Validation → Deployment
+```
+
+## Stages (code)
+
+| Step | Module |
+|---|---|
+| Image + label ingestion | `app.models.retained_image` (opt-in, EXIF-stripped) |
+| Dataset split (70/15/15) | `app.services.ml.dataset_split` |
+| Model task definitions | `app.services.ml.model_tasks` |
+| Feature store | `app.services.ml.feature_store` |
+| Training-run preparation | `app.services.ml.training_pipeline` |
+| Evaluation metrics | `app.services.ml.evaluation` |
+| Model registry | `app.models.model_registry` |
+| Deployment gates | `app.services.ml.deployment_gates` |
+| Shadow mode | `app.services.ml.shadow_mode`, `app.models.shadow_prediction` |
+
+## Model tasks
+
+- **Instrument Family Classifier** — rigid scope, flexible endoscope, drill bit,
+  Kerrison/rongeur, scissors, needle holder, laparoscopic, general forceps, unknown.
+- **Anatomy Zone Classifier** — o-ring area, serration, groove, hinge, box lock,
+  drill-bit flute, threaded region, lumen, scope port, cutting edge, insulation
+  edge, handle seam, unknown.
+- **Finding Classifier** — blood, bone, tissue, organic residue, debris, rust,
+  corrosion, discoloration, crack, pitting, insulation damage, missing component,
+  wear, none. *(safety-critical)*
+- **Severity Classifier** — none, trace, minor, moderate, visible, severe, heavy.
+  *(safety-critical)*
+- **Clinical Disposition Classifier** — pass, monitor, supervisor_review,
+  reprocess, remove_from_service. *(safety-critical)*
+
+## Dataset split
+
+70% train / 15% validation / 15% test, deterministic (seeded), stratified by
+instrument family, anatomy zone, finding, severity, manufacturer, and image
+quality. Leakage prevention groups all images from one inspection (and its
+baseline/inspection pair) into a single split; `group_by_serial` additionally
+keeps one instrument's whole history out of validation/test. See
+`inspection-coverage-rules.md` sibling doc `model-registry.md` for downstream.
+
+## Training data requirements
+
+Real training needs: labeled zones + findings + severities per image, sufficient
+per-class support (esp. the safety-critical findings), manufacturer/model
+diversity, and supervisor-validated ground truth (the `SupervisorReview`
+zone/family/finding corrections are the seed label set).
+
+## Honesty
+
+- No fabricated model, artifact, or metric until a real model is trained.
+- CV features (color/texture/edge/blur/lighting/similarity) are stored as null
+  until a vision model exists — see `feature_store.py`.
+- `human_review_required: true` on every model view.

--- a/docs/ai/safety-metrics.md
+++ b/docs/ai/safety-metrics.md
@@ -1,0 +1,42 @@
+# Safety Metrics (Phase 17)
+
+In SPD, the most dangerous model error is a **false negative** on contamination
+or structural failure — a missed hazard that reaches a patient. These metrics
+are tracked explicitly and gate promotion. Source: `app.services.ml.evaluation`.
+
+## Standard metrics
+
+Per task: accuracy, per-class precision / recall / F1, false-positive rate,
+false-negative rate, confusion matrix, and performance breakdowns by instrument
+family, anatomy zone, finding type, and severity. Plus supervisor agreement rate
+(from `SupervisorReview` + shadow reconciliation).
+
+## Safety-critical false-negative rates
+
+Tracked for the findings whose misses matter most:
+
+- **blood** false-negative rate
+- **tissue** false-negative rate
+- **organic residue** false-negative rate
+- **crack** false-negative rate
+- **missing component** false-negative rate
+
+`safety_metrics()` also reports `worst_safety_false_negative_rate` across these.
+
+FNR = (present but predicted otherwise) / (all actually present). A value of
+`0.0` means no hazards of that class were missed on the evaluation set; `null`
+means the class had no positive examples (not "safe" — just untested).
+
+## Gate
+
+`safety_false_negative_within_threshold` is a required checklist item for
+**validated** promotion. A model with an unreviewed or out-of-threshold safety
+FNR cannot support a workflow decision. Thresholds are set per deployment during
+the human `false_negative_review` step and recorded in the model's
+`known_limitations`.
+
+## Honesty
+
+Metrics are computed only from provided `(y_true, y_pred)` pairs — never
+simulated. Until a real model and labeled test set exist, these functions have
+nothing to score and the registry entry stays `experimental` with empty metrics.

--- a/docs/ai/shadow-mode-validation.md
+++ b/docs/ai/shadow-mode-validation.md
@@ -1,0 +1,29 @@
+# Shadow-Mode Validation (Phase 17)
+
+Measure a model's real performance **before** it can influence care. Source:
+`app.services.ml.shadow_mode`, `app.models.shadow_prediction`. API:
+`/api/model-pipeline/shadow-predictions`.
+
+## Behavior
+
+- The model runs **silently** on an inspection; its prediction is **stored**.
+- Users **never see** the shadow prediction as a clinical recommendation — the
+  API response exposes only that a shadow ran (`clinical_recommendation_shown:
+  false`) and omits the predicted label.
+- When the human final decision is recorded, the shadow prediction is
+  **reconciled** against it (`agreed_with_human`).
+- Aggregated agreement (`/shadow-predictions/performance`) is computed **only**
+  over reconciled rows — real evidence, never projected.
+
+## Invariant
+
+A `ShadowPrediction` row always has `shadow_mode = true`. The public view is the
+contract that keeps a shadow model from affecting a recommendation. Only
+`experimental`, `pilot`, and `validated` models may run shadow; a `deprecated`
+model is refused (409).
+
+## Promotion gate
+
+`shadow_mode_completed` is a required checklist item for **validated** promotion:
+a model must have demonstrated agreement in shadow before it can support a
+workflow decision.


### PR DESCRIPTION
## Summary

Moves LumenAI from structured training-data capture into a **repeatable, honest model lifecycle** — without weakening clinical safety.

`Data → Labels → Training → Evaluation → Registry → Shadow Mode → Pilot → Validation → Deployment`

Training is **not executed** (there's no labeled dataset yet) — everything *around* training is real, and **no metrics are fabricated**. Models are never auto-promoted, and deployment gates are enforced server-side.

## Services (`app/services/ml/`)
- **model_tasks** — label spaces for the 5 classifiers (instrument family, anatomy zone, finding, severity, clinical disposition) + safety-critical findings.
- **dataset_split** — deterministic 70/15/15 split, stratified by family/zone/finding/severity/manufacturer/image-quality, with **leakage prevention**: an inspection's images (and baseline/inspection pairs) never straddle splits; optional `group_by_serial` keeps an instrument's whole history out of val/test.
- **feature_store** — baseline-comparison feature schema; available-now features from the deterministic scorer, CV features stored `null` (not fabricated).
- **evaluation** — accuracy, per-class precision/recall/F1, FP/FN rates, confusion matrix, per-group breakdowns, and **safety-critical false-negative rates** (blood/tissue/organic residue/crack/missing component).
- **deployment_gates** — per-stage capabilities + human-in-the-loop promotion. Experimental = shadow only (no drive/advise); pilot = advisory + disclaimer; validated = may support a decision with supervisor override; deprecated = unusable. Never auto-promotes; enforces one-stage-at-a-time and a full requirement checklist (incl. ≥200 samples) with a recorded approver.
- **training_pipeline** — prepares/validates a run, returns `not_started` (honest).
- **shadow_mode** — record a silent prediction, reconcile against the human final decision, aggregate agreement over reconciled rows only.

## Models + API
- `ModelRegistryEntry` and `ShadowPrediction` tables (auto-created on startup).
- `/api/model-pipeline`: `tasks`, `deployment-gates`, `prepare-run`, `models` CRUD + human-gated `promote`, `shadow-predictions` + `performance`. Registration always starts **experimental** (server-hardened); shadow responses **never surface the predicted label** as a recommendation; deprecated models are refused for shadow.

## Docs
`model-training-pipeline.md`, `model-registry.md`, `model-deployment-gates.md`, `shadow-mode-validation.md`, `safety-metrics.md`.

## Validation
- **18 new tests** (split grouping/ratios, registry, gate rules, promotion blocked without checklist → 409, pilot disclaimer, validated override, shadow stores without showing recommendation, deprecated cannot shadow, blood FN metric, anatomy-zone performance, viewer cannot register).
- Backend: **2314 passed, 2 skipped**.
- `npm run build` → clean · `ruff check` → clean.

## Notes
Backend + docs only (no frontend runtime change). Honesty/safety preserved: no fabricated training/metrics, `human_review_required` on model views, no auto-promotion, server-side gate, no FDA claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KicJQSajkgoi93WsFKfuki)_