### PR TITLE
fix: register orphaned analytics router + case-insensitive login/bootstrap matching

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -633,6 +633,9 @@ app.include_router(knowledge_router)
 from app.routes.pilot_deployment import router as pilot_deployment_router
 app.include_router(pilot_deployment_router)
 
+from app.routes.analytics import router as analytics_router
+app.include_router(analytics_router, prefix=settings.API_PREFIX)
+
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 
 app.include_router(capa_predictive_risk_router)

--- a/backend/app/routers/auth_simple.py
+++ b/backend/app/routers/auth_simple.py
@@ -57,8 +57,13 @@ def _make_token(sub: str) -> str:
     return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
 
 def _verify_user(u: str, password: str) -> Optional[str]:
+    # Case-insensitive match — an email typed with different capitalization
+    # than it was stored with must still authenticate.
     with engine.begin() as conn:
-        row = conn.execute(text("SELECT username, password_hash FROM users WHERE username=:u"), {"u": u}).fetchone()
+        row = conn.execute(
+            text("SELECT username, password_hash FROM users WHERE LOWER(username)=LOWER(:u)"),
+            {"u": u.strip()},
+        ).fetchone()
         if not row:
             return None
         if not bcrypt.verify(password, row.password_hash):
@@ -74,11 +79,12 @@ def _user_role(username: str) -> str:
     'viewer'. The assignment table is the source of truth for roles granted via
     the User Management UI / bootstrap.
     """
+    normalized = username.strip()
     try:
         with engine.begin() as conn:
             row = conn.execute(
-                text("SELECT role FROM user_role_assignments WHERE username=:u"),
-                {"u": username},
+                text("SELECT role FROM user_role_assignments WHERE LOWER(username)=LOWER(:u)"),
+                {"u": normalized},
             ).fetchone()
             if row and row.role:
                 return row.role
@@ -87,7 +93,7 @@ def _user_role(username: str) -> str:
     try:
         with engine.begin() as conn:
             row = conn.execute(
-                text("SELECT role FROM users WHERE username=:u"), {"u": username}
+                text("SELECT role FROM users WHERE LOWER(username)=LOWER(:u)"), {"u": normalized}
             ).fetchone()
             if row and row.role:
                 return row.role

--- a/backend/app/routes/admin_users.py
+++ b/backend/app/routes/admin_users.py
@@ -28,9 +28,11 @@ ASSIGNABLE_ROLES = {"admin", "spd_manager", "supervisor", "operator", "viewer", 
 
 
 def _upsert_role(db: Session, username: str, role: str, assigned_by: str) -> UserRoleAssignment:
+    from sqlalchemy import func
+
     row = (
         db.query(UserRoleAssignment)
-        .filter(UserRoleAssignment.username == username)
+        .filter(func.lower(UserRoleAssignment.username) == username.strip().lower())
         .first()
     )
     now = datetime.now(timezone.utc)
@@ -82,11 +84,12 @@ def bootstrap_admin(
     if body.password:
         from datetime import datetime, timezone
         from passlib.hash import bcrypt
+        from sqlalchemy import func
         from app.models.admin_credential import AdminCredential
 
         cred = (
             db.query(AdminCredential)
-            .filter(AdminCredential.username == body.username)
+            .filter(func.lower(AdminCredential.username) == body.username.strip().lower())
             .first()
         )
         pw_hash = bcrypt.hash(body.password)

--- a/backend/app/routes/analytics.py
+++ b/backend/app/routes/analytics.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -6,6 +8,104 @@ from app.deps import get_db
 from app.db import models
 
 router = APIRouter(tags=["analytics"])
+
+_READ_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_FINDING_TYPES = ("blood", "bone", "tissue", "debris", "corrosion", "crack")
+
+
+@router.get("/analytics/kpi-summary")
+def kpi_summary(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Cross-page executive KPI summary, computed from real stored data.
+
+    Was previously called by ~15 frontend pages (dashboards, executive
+    consoles, notifications) with no backend route at all, always 404ing —
+    every caller already treats each field as optional and falls back to a
+    demo value, so nothing crashed, but no real number was ever shown.
+
+    Fields that aren't honestly computable yet (active-user counts, review
+    turnaround time, login frequency, adoption rate) are simply omitted
+    rather than fabricated.
+    """
+    from app.models.baseline_library import BaselineLibraryEntry
+    from app.services.capa_service import capa_summary
+
+    tenant_id = getattr(current_user, "tenant_id", None)
+    role = getattr(current_user, "role", "")
+
+    query = db.query(models.Inspection)
+    if role != "admin" and tenant_id:
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    rows = query.all()
+
+    total_inspections = len(rows)
+    now = datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+
+    def _created_at_aware(r) -> datetime | None:
+        # SQLite can hand back a naive datetime for a DateTime(timezone=True)
+        # column depending on driver/version — normalize before comparing so
+        # this never raises on an offset-naive vs. offset-aware mismatch.
+        if r.created_at is None:
+            return None
+        return r.created_at if r.created_at.tzinfo is not None else r.created_at.replace(tzinfo=timezone.utc)
+
+    inspections_this_week = sum(
+        1 for r in rows
+        if (ts := _created_at_aware(r)) is not None and ts >= week_ago
+    )
+
+    high_risk_findings = sum(1 for r in rows if r.risk_score >= 70)
+    open_findings = sum(1 for r in rows if r.status == "pending")
+    images_collected = sum(1 for r in rows if r.has_image)
+    high_risk_instruments = len({r.instrument_type for r in rows if r.risk_score >= 70})
+
+    finding_tally = dict.fromkeys(_FINDING_TYPES, 0)
+    for r in rows:
+        if r.detected_issue in finding_tally:
+            finding_tally[r.detected_issue] += 1
+
+    # Baseline library is platform-wide (no tenant_id column).
+    baselines = db.query(BaselineLibraryEntry).all()
+    total_baselines = len(baselines)
+    baselines_approved = sum(1 for b in baselines if b.approval_status == "approved")
+    baseline_coverage_pct = (
+        round(baselines_approved / total_baselines * 100, 1) if total_baselines else 0.0
+    )
+
+    capas = capa_summary()
+    total_users = db.query(models.User).count()
+
+    return {
+        "total_inspections": total_inspections,
+        "inspections_this_week": inspections_this_week,
+        "high_risk_findings": high_risk_findings,
+        "open_findings": open_findings,
+        "review_backlog": open_findings,
+        "images_collected": images_collected,
+        "high_risk_instruments": high_risk_instruments,
+        "blood_findings": finding_tally["blood"],
+        "bone_findings": finding_tally["bone"],
+        "tissue_findings": finding_tally["tissue"],
+        "debris_findings": finding_tally["debris"],
+        "corrosion_findings": finding_tally["corrosion"],
+        "crack_findings": finding_tally["crack"],
+        "total_baselines": total_baselines,
+        "baselines_approved": baselines_approved,
+        "baseline_coverage_pct": baseline_coverage_pct,
+        "total_capas": capas["total"],
+        "open_capas": capas["open"],
+        "completed_capas": capas["closed"],
+        "total_users": total_users,
+        "human_review_required": True,
+        "note": (
+            "Computed from real stored data. Fields not yet computable (active-user "
+            "counts, adoption rate, review turnaround time, login frequency) are "
+            "omitted rather than fabricated."
+        ),
+    }
 
 
 @router.get("/analytics/powerbi")

--- a/backend/app/routes/system.py
+++ b/backend/app/routes/system.py
@@ -50,9 +50,14 @@ async def login(request: Request):
 
     from app.routers.auth_simple import _verify_user, _make_token, _user_role
 
+    # Emails/usernames are matched case-insensitively — "Jane@Hospital.org" at
+    # bootstrap time must still work when typed "jane@hospital.org" at login.
+    username_normalized = username.strip().lower()
+
     # 1) Validate against the self-managed admin credential table (founder bootstrap).
     try:
         from passlib.hash import bcrypt
+        from sqlalchemy import func
         from app.db.session import SessionLocal
         from app.models.admin_credential import AdminCredential
 
@@ -60,14 +65,14 @@ async def login(request: Request):
         try:
             cred = (
                 db.query(AdminCredential)
-                .filter(AdminCredential.username == username)
+                .filter(func.lower(AdminCredential.username) == username_normalized)
                 .first()
             )
             if cred and bcrypt.verify(password, cred.password_hash):
                 return {
-                    "access_token": _make_token(username),
+                    "access_token": _make_token(cred.username),
                     "token_type": "bearer",
-                    "role": _user_role(username),
+                    "role": _user_role(cred.username),
                 }
         finally:
             db.close()

--- a/backend/tests/test_analytics_kpi_summary.py
+++ b/backend/tests/test_analytics_kpi_summary.py
@@ -1,0 +1,52 @@
+"""Regression test for a production bug: GET /api/analytics/kpi-summary and
+GET /api/analytics/powerbi both 404'd because app/routes/analytics.py's
+router was defined but never registered in main.py — ~15 frontend pages
+(dashboards, executive consoles, NotificationProvider) called
+/api/analytics/kpi-summary with no backend route at all.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+
+class TestAnalyticsRouterRegistered:
+    def test_kpi_summary_endpoint_exists(self):
+        r = client.get("/api/analytics/kpi-summary", headers=AUTH_ADMIN)
+        assert r.status_code == 200, r.text
+
+    def test_powerbi_endpoint_exists(self):
+        r = client.get("/api/analytics/powerbi", headers=AUTH_ADMIN)
+        assert r.status_code == 200, r.text
+
+
+class TestKpiSummaryShape:
+    def test_kpi_summary_has_expected_real_fields(self):
+        r = client.get("/api/analytics/kpi-summary", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "total_inspections", "inspections_this_week", "high_risk_findings",
+            "open_findings", "review_backlog", "images_collected",
+            "total_baselines", "baselines_approved", "baseline_coverage_pct",
+            "total_capas", "open_capas", "completed_capas", "total_users",
+            "human_review_required",
+        ):
+            assert key in body
+
+    def test_kpi_summary_readable_by_viewer(self):
+        r = client.get("/api/analytics/kpi-summary", headers=AUTH_VIEWER)
+        assert r.status_code == 200
+
+    def test_kpi_summary_no_fabricated_fields_present(self):
+        # Fields that aren't honestly computable yet must be absent, not
+        # fabricated with a fake value.
+        r = client.get("/api/analytics/kpi-summary", headers=AUTH_ADMIN)
+        body = r.json()
+        for key in ("active_users", "review_turnaround_hrs", "login_frequency_per_week", "adoption_rate_pct"):
+            assert key not in body

--- a/backend/tests/test_login_case_insensitive.py
+++ b/backend/tests/test_login_case_insensitive.py
@@ -1,0 +1,80 @@
+"""Regression test: bootstrap + login must match usernames/emails
+case-insensitively. Previously every lookup (AdminCredential, the legacy
+users table, user_role_assignments) did an exact-case string match, so an
+account bootstrapped as "Jane@Hospital.org" could not log in when typed as
+"jane@hospital.org" (or vice versa) — silently failing with a generic
+"Invalid credentials" that gave no hint the issue was casing.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.admin_credential import AdminCredential
+from app.models.user_role_assignment import UserRoleAssignment
+
+client = TestClient(app)
+
+
+def _clear(username: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(UserRoleAssignment).filter(UserRoleAssignment.username == username).delete()
+        db.query(AdminCredential).filter(AdminCredential.username == username).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestCaseInsensitiveLogin:
+    def test_login_with_different_case_than_bootstrap_succeeds(self, monkeypatch):
+        _clear("Founder@Lumen.AI")
+        monkeypatch.setenv("ADMIN_BOOTSTRAP_TOKEN", "s3cret")
+        boot = client.post(
+            "/api/admin/bootstrap",
+            json={"username": "Founder@Lumen.AI", "password": "NewPassword123"},
+            headers={"X-Bootstrap-Token": "s3cret"},
+        )
+        assert boot.status_code == 200, boot.text
+        assert boot.json()["login_password_set"] is True
+
+        # Log in with a different case than what was used at bootstrap.
+        login = client.post(
+            "/api/auth/login",
+            json={"email": "founder@lumen.ai", "password": "NewPassword123"},
+        )
+        assert login.status_code == 200, login.text
+        body = login.json()
+        assert body["access_token"]
+        assert body["role"] == "admin"
+
+    def test_bootstrap_twice_with_different_case_updates_same_row(self, monkeypatch):
+        _clear("Dup@Lumen.AI")
+        monkeypatch.setenv("ADMIN_BOOTSTRAP_TOKEN", "s3cret")
+        client.post(
+            "/api/admin/bootstrap",
+            json={"username": "Dup@Lumen.AI", "password": "FirstPassword123"},
+            headers={"X-Bootstrap-Token": "s3cret"},
+        )
+        client.post(
+            "/api/admin/bootstrap",
+            json={"username": "dup@lumen.ai", "password": "SecondPassword123"},
+            headers={"X-Bootstrap-Token": "s3cret"},
+        )
+
+        db = SessionLocal()
+        try:
+            rows = db.query(AdminCredential).filter(
+                AdminCredential.username.in_(["Dup@Lumen.AI", "dup@lumen.ai"])
+            ).all()
+            assert len(rows) == 1  # updated in place, not duplicated
+        finally:
+            db.close()
+
+        # The second (most recent) password is the one that works now.
+        login = client.post(
+            "/api/auth/login",
+            json={"email": "DUP@LUMEN.AI", "password": "SecondPassword123"},
+        )
+        assert login.status_code == 200, login.text

--- a/frontend/src/lib/notifications.tsx
+++ b/frontend/src/lib/notifications.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
 import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
 
 export type AlertSeverity = "critical" | "warning" | "info";
 
@@ -154,9 +155,15 @@ function generateAlerts(kpi: Record<string, number>, pwr: Record<string, number>
 }
 
 export function NotificationProvider({ children }: { children: React.ReactNode }) {
+  const { token } = useAuth();
   const [alerts, setAlerts] = useState<AppAlert[]>([]);
 
+  // NotificationProvider wraps the whole app, including the unauthenticated
+  // /login and /station routes — skip the fetch entirely when signed out
+  // instead of firing an Authorization: Bearer (empty) request that always
+  // 401s.
   const fetchAlerts = useCallback(async () => {
+    if (!token) return;
     try {
       const [kpiRes, pwrRes] = await Promise.allSettled([
         apiFetch("/api/analytics/kpi-summary", { raw: true }),
@@ -184,7 +191,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         { id: "demo-info", severity: "info", title: "47 inspections completed", detail: "3 more inspections needed to reach the 50-inspection go-live threshold.", route: "/go-live-center", routeLabel: "View Go-Live Center", ts: now - 1000 * 60 * 60 * 6, read: false },
       ]);
     }
-  }, []);
+  }, [token]);
 
   useEffect(() => {
     fetchAlerts();


### PR DESCRIPTION
## Summary
Cherry-picks two self-contained fixes from PR #70 onto `main`, isolated from that branch's unrelated pilot-validation architectural work:

1. **Analytics router registration** — `app/routes/analytics.py` defined a router (`GET /api/analytics/powerbi`) that was never registered in `main.py`; every call 404'd, including `~15` frontend pages/dashboards/`NotificationProvider` that all call `/api/analytics/kpi-summary`, a route that never existed at all. Adds the missing `app.include_router(...)` call and implements `kpi-summary` for real: total/weekly inspections, high-risk findings, per-type finding tallies, open findings, images collected, baseline coverage, and CAPA counts — all computed from stored data. Fields that aren't honestly computable yet (active users, review turnaround, login frequency, adoption rate) are omitted rather than fabricated.
2. **Case-insensitive username/email matching** — `AdminCredential` lookups (`/auth/login`), the legacy `users` table lookup (`_verify_user`), and `user_role_assignments` lookups (`_user_role`) all did exact-case string matching. An account bootstrapped with one capitalization couldn't log in with different casing — this failed silently with a generic "Invalid credentials."

## Why This Change
These fixes were built and validated on PR #70, but that branch also carries unrelated, unresolved pilot-validation architecture that conflicts with `main`. Rather than block these two safe, independent fixes on that reconciliation, this PR ports just the analytics + login-casing commits directly onto `main` so the live `/api/analytics/*` 404s and login-casing friction can be resolved now.

## Scope
**Included:**
- `backend/app/main.py` — register the analytics router.
- `backend/app/routes/analytics.py` — real `kpi-summary` implementation + naive/aware datetime fix.
- `backend/app/routers/auth_simple.py`, `backend/app/routes/admin_users.py`, `backend/app/routes/system.py` — case-insensitive lookups.
- `frontend/src/lib/notifications.tsx` — `NotificationProvider` now skips its analytics fetch entirely when signed out (was firing an unauthenticated request that always 401'd on `/login`). Resolved a merge conflict here by keeping `main`'s current `apiFetch`-based convention (from PR #71's fetch→apiFetch codemod) while preserving this token-gate fix, rather than reintroducing the raw-`fetch` approach PR #70 was written against.
- New tests: `test_analytics_kpi_summary.py`, `test_login_case_insensitive.py`.

**Excluded:**
- PR #70's pilot-validation architectural duplication (unrelated, deferred).
- PR #72's enterprise-auth real-JWT fix (already merged separately to `main`).

## Testing
- [x] Unit tests — new tests in both added files, cherry-picked cleanly
- [x] Full backend suite: `2342 passed` (362.16s)
- [x] `ruff check app tests` — all checks passed
- [x] `npm run build` — clean
- [ ] Manual verification (pending merge + redeploy to live Render service)
- [ ] Docker build
- [ ] API/worker runtime validation

## Risks
Low. Both changes are additive (a router registration, a new endpoint, and stricter-but-still-correct case folding on existing lookups) — nothing previously working is changed in behavior except that mismatched-case logins now succeed instead of failing.

## Rollback Plan
Revert this commit; both fixes are independent of any other in-flight work on `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011Fk9dzNXLSbHDHTsT5TCKL)_