### PR TITLE
LumenAI Inspect v1.4 — Clinical Decision Support & SPD Mentor

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -117,6 +117,8 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.instrument_knowledge")  # register instrument knowledge library
     importlib.import_module("app.models.model_registry")        # register P17 model registry table
     importlib.import_module("app.models.shadow_prediction")     # register P17 shadow-prediction table
+    importlib.import_module("app.models.competency_event")       # register v1.4 technician competency events
+    importlib.import_module("app.models.mentor_coaching_review") # register v1.4 supervisor coaching reviews
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -126,7 +128,7 @@ async def lifespan(_app: FastAPI):
         from app.db.column_migrator import ensure_columns
         from app.models.inspection import Inspection
         from app.models.supervisor_review import SupervisorReview
-        ensure_columns(engine, Inspection)
+        ensure_columns(engine, Inspection)  # includes v1.4's `technician` column
         ensure_columns(engine, SupervisorReview)
     except Exception as _mig_e:
         import logging
@@ -598,6 +600,9 @@ app.include_router(agent_router, prefix=settings.API_PREFIX)
 app.include_router(stream_router, prefix=settings.API_PREFIX)
 
 app.include_router(vendor_analytics_router, prefix=settings.API_PREFIX)
+
+from app.routes.spd_mentor import router as spd_mentor_router
+app.include_router(spd_mentor_router, prefix=settings.API_PREFIX)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/models/competency_event.py
+++ b/backend/app/models/competency_event.py
@@ -1,0 +1,37 @@
+"""v1.4 — Technician competency tracking.
+
+A lightweight event log the SPD Mentor Engine's competency service reads to
+build per-technician summaries: findings reviewed, supervisor corrections,
+repeated errors, and education completed. Deliberately separate from
+SupervisorReview (the ML ground-truth label store) — this table tracks
+technician learning/competency, not model performance.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class CompetencyEvent(Base):
+    __tablename__ = "competency_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    technician: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    # finding_reviewed | supervisor_correction | repeated_error | education_completed
+    event_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    finding_type: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -77,3 +77,9 @@ class Inspection(Base):
     risk_level: Mapped[str | None] = mapped_column(String(20), nullable=True)
     recommended_action: Mapped[str | None] = mapped_column(String(500), nullable=True)
     overall_cleaning_assessment: Mapped[str | None] = mapped_column(String(80), nullable=True)
+
+    # v1.4 — the technician who submitted the inspection (request actor at
+    # creation time), so the SPD Mentor Engine's competency service can
+    # attribute findings-reviewed/supervisor-corrections to a real person
+    # instead of fabricating attribution. Nullable/blank for older rows.
+    technician: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/backend/app/models/mentor_coaching_review.py
+++ b/backend/app/models/mentor_coaching_review.py
@@ -1,0 +1,39 @@
+"""v1.4 — Supervisor Coaching Dashboard review store.
+
+Captures a supervisor's review of the SPD Mentor Engine's coaching output for
+an inspection — approve as-is, edit the recommendation, and/or add an
+educational comment. Deliberately separate from SupervisorReview (which
+captures AI-agreement for ML ground truth) — this table tracks coaching
+quality/effectiveness, not model performance.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class MentorCoachingReview(Base):
+    __tablename__ = "mentor_coaching_reviews"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    reviewer_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    reviewer_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    approved: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    edited_recommendation: Mapped[str] = mapped_column(String(1000), default="", nullable=False)
+    educational_comment: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -137,6 +137,20 @@ def submit_supervisor_review(
         inspection.override_reason = body.rationale.strip()
         inspection.override_by = _actor(current_user)
         inspection.override_at = datetime.now(timezone.utc)
+
+    # v1.4 — technician competency tracking, derived from this same review.
+    from app.services.competency_service import record_finding_reviewed, record_supervisor_correction
+
+    if inspection.technician:
+        record_finding_reviewed(
+            db, tenant_id=tenant_id, technician=inspection.technician, inspection_id=inspection_id,
+        )
+        if agreement != "agree" or body.override_action.strip():
+            record_supervisor_correction(
+                db, tenant_id=tenant_id, technician=inspection.technician,
+                finding_type=body.finding_type.strip(), inspection_id=inspection_id,
+            )
+
     db.commit()
     db.refresh(review)
 

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -107,6 +107,9 @@ class InspectionCreate(BaseModel):
     inspected_zones: Optional[List[str]] = Field(None)
     # Technician-declared finding categories (optional — AI determines findings)
     finding_categories: Optional[List[str]] = Field(None)
+    # v1.4 — SPD Mentor Engine Training Mode: explain every finding, anatomy,
+    # recommendation, and terminology in the returned analysis.
+    training_mode: bool = Field(False)
 
     @field_validator("instrument_type")
     @classmethod
@@ -387,6 +390,7 @@ async def create_inspection(
             keydot_id=body.keydot_id,
             decoder_backend=body.identifier_source or "declared",
             inspected_zones=body.inspected_zones,
+            training_mode=body.training_mode,
         )
         # Persist the SPD verdict regardless of completion state so history and
         # the dashboard show what the analysis concluded.
@@ -409,6 +413,8 @@ async def create_inspection(
         baseline_status = "not_applicable"
         risk_score_val = calculate_risk(detected_issue, conf_val)
         score_status = "scored"
+
+    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
 
     row = models.Inspection(
         file_name=body.file_name or "manual-entry",
@@ -439,12 +445,12 @@ async def create_inspection(
         risk_level=risk_level_val,
         recommended_action=recommended_action_val,
         overall_cleaning_assessment=cleaning_assessment_val,
+        technician=actor,
     )
     db.add(row)
     db.commit()
     db.refresh(row)
 
-    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
     log_audit_event(
         db,
         tenant_id=tenant_id,

--- a/backend/app/routes/spd_mentor.py
+++ b/backend/app/routes/spd_mentor.py
@@ -1,0 +1,232 @@
+"""v1.4 — SPD Mentor Engine API surface.
+
+- GET  /api/mentor/education                      — Educational Knowledge Library (all articles)
+- GET  /api/mentor/education/{finding_type}        — single article
+- POST /api/mentor/education/{finding_type}/complete — mark an article completed (competency tracking)
+- GET  /api/mentor/competency/{technician}         — technician competency summary
+- GET  /api/inspections/{inspection_id}/mentor     — re-derive the SPD Mentor payload for a past inspection
+- GET  /api/mentor/coaching-queue                  — Supervisor Coaching Dashboard: inspections awaiting review
+- POST /api/inspections/{inspection_id}/coaching-review — approve/edit/comment on the AI's coaching
+- GET  /api/mentor/coaching-effectiveness          — aggregate coaching-review stats
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.mentor_coaching_review import MentorCoachingReview
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.competency_service import competency_summary, record_education_completed
+from app.services.education_library import get_article, list_articles
+
+router = APIRouter(tags=["spd-mentor"])
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+# ── Educational Knowledge Library ────────────────────────────────────────────
+@router.get("/mentor/education")
+def get_education_library(
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    return {"articles": list_articles()}
+
+
+@router.get("/mentor/education/{finding_type}")
+def get_education_article(
+    finding_type: str,
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    article = get_article(finding_type)
+    if article is None:
+        raise HTTPException(status_code=404, detail=f"No education article for '{finding_type}'.")
+    return article
+
+
+@router.post("/mentor/education/{finding_type}/complete", status_code=201)
+def complete_education_article(
+    finding_type: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator")),
+):
+    article = get_article(finding_type)
+    if article is None:
+        raise HTTPException(status_code=404, detail=f"No education article for '{finding_type}'.")
+
+    technician = _actor(current_user)
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    record_education_completed(db, tenant_id=tenant_id, technician=technician, finding_type=finding_type)
+    db.commit()
+    return competency_summary(db, technician)
+
+
+# ── Competency Support ────────────────────────────────────────────────────────
+@router.get("/mentor/competency/{technician}")
+def get_competency_summary(
+    technician: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator")),
+):
+    role = getattr(current_user, "role", "viewer")
+    if role not in ("admin", "spd_manager") and _actor(current_user) != technician:
+        raise HTTPException(status_code=403, detail="You may only view your own competency summary.")
+    return competency_summary(db, technician)
+
+
+# ── Per-inspection mentor re-derivation (Training Mode viewer) ───────────────
+@router.get("/inspections/{inspection_id}/mentor")
+def get_inspection_mentor(
+    inspection_id: int,
+    request: Request,
+    training_mode: bool = False,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Re-derive the SPD Mentor payload for a previously-submitted inspection.
+
+    Mirrors the clinical-report.pdf endpoint's pattern: analysis is
+    deterministic from the stored inspection's identity, so re-running it
+    reproduces the same findings — this lets a technician revisit an
+    inspection with Training Mode on without re-uploading images.
+    """
+    tenant_id = getattr(current_user, "tenant_id", None)
+    query = db.query(models.Inspection).filter(models.Inspection.id == inspection_id)
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    row = query.first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    analysis = analyze_inspection(
+        db,
+        instrument_type=row.instrument_type,
+        tenant_id=row.tenant_id,
+        has_image=bool(row.has_image),
+        image_sha256=row.image_sha256,
+        instrument_barcode=row.instrument_barcode,
+        instrument_udi=row.instrument_udi,
+        training_mode=training_mode,
+    )
+    return analysis["clinical_decision"]["spd_mentor"]
+
+
+# ── Supervisor Coaching Dashboard ─────────────────────────────────────────────
+class CoachingReviewIn(BaseModel):
+    approved: bool = Field(True)
+    edited_recommendation: str = Field("", max_length=1000)
+    educational_comment: str = Field("", max_length=2000)
+
+
+@router.get("/mentor/coaching-queue")
+def get_coaching_queue(
+    request: Request,
+    limit: int = 25,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Recent inspections whose AI coaching has not yet been reviewed by a
+    supervisor, most recent first."""
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    query = db.query(models.Inspection).filter(models.Inspection.has_image.is_(True))
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    rows = query.order_by(models.Inspection.id.desc()).limit(max(1, min(limit, 100))).all()
+
+    reviewed_ids = {
+        r.inspection_id
+        for r in db.query(MentorCoachingReview.inspection_id)
+        .filter(MentorCoachingReview.inspection_id.in_([row.id for row in rows]))
+        .all()
+    } if rows else set()
+
+    return {
+        "queue": [
+            {
+                "inspection_id": row.id,
+                "instrument_type": row.instrument_type,
+                "technician": row.technician,
+                "risk_level": row.risk_level,
+                "recommended_action": row.recommended_action,
+                "coaching_reviewed": row.id in reviewed_ids,
+            }
+            for row in rows
+        ],
+    }
+
+
+@router.post("/inspections/{inspection_id}/coaching-review", status_code=201)
+def submit_coaching_review(
+    inspection_id: int,
+    body: CoachingReviewIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    inspection = db.query(models.Inspection).filter(models.Inspection.id == inspection_id).first()
+    if inspection is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+
+    review = MentorCoachingReview(
+        inspection_id=inspection_id,
+        tenant_id=tenant_id,
+        reviewer_name=_actor(current_user),
+        reviewer_role=getattr(current_user, "role", "spd_manager"),
+        approved=body.approved,
+        edited_recommendation=body.edited_recommendation.strip(),
+        educational_comment=body.educational_comment.strip(),
+    )
+    db.add(review)
+    db.commit()
+    db.refresh(review)
+
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id,
+        actor_email=_actor(current_user), actor_role=getattr(current_user, "role", "spd_manager"),
+        action_type="mentor_coaching_review", resource_type="inspection",
+        resource_id=str(inspection_id),
+    )
+    return {
+        "id": review.id,
+        "inspection_id": inspection_id,
+        "approved": review.approved,
+        "edited_recommendation": review.edited_recommendation,
+        "educational_comment": review.educational_comment,
+    }
+
+
+@router.get("/mentor/coaching-effectiveness")
+def get_coaching_effectiveness(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Aggregate stats on how often supervisors approve the AI's coaching
+    unchanged vs. edit or add educational comments — derived only from
+    recorded reviews, empty when there are none yet."""
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    query = db.query(MentorCoachingReview)
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(MentorCoachingReview.tenant_id == tenant_id)
+    reviews = query.all()
+
+    total = len(reviews)
+    approved_unchanged = sum(1 for r in reviews if r.approved and not r.edited_recommendation)
+    edited = sum(1 for r in reviews if r.edited_recommendation)
+    with_comment = sum(1 for r in reviews if r.educational_comment)
+
+    return {
+        "total_reviews": total,
+        "approved_unchanged": approved_unchanged,
+        "edited": edited,
+        "with_educational_comment": with_comment,
+        "approved_unchanged_pct": round(100 * approved_unchanged / total) if total else None,
+    }

--- a/backend/app/routes/spd_mentor.py
+++ b/backend/app/routes/spd_mentor.py
@@ -5,6 +5,7 @@
 - POST /api/mentor/education/{finding_type}/complete — mark an article completed (competency tracking)
 - GET  /api/mentor/competency/{technician}         — technician competency summary
 - GET  /api/inspections/{inspection_id}/mentor     — re-derive the SPD Mentor payload for a past inspection
+- POST /api/mentor/build                           — rebuild the SPD Mentor payload from an already-displayed result (no re-derivation)
 - GET  /api/mentor/coaching-queue                  — Supervisor Coaching Dashboard: inspections awaiting review
 - POST /api/inspections/{inspection_id}/coaching-review — approve/edit/comment on the AI's coaching
 - GET  /api/mentor/coaching-effectiveness          — aggregate coaching-review stats
@@ -96,6 +97,15 @@ def get_inspection_mentor(
     deterministic from the stored inspection's identity, so re-running it
     reproduces the same findings — this lets a technician revisit an
     inspection with Training Mode on without re-uploading images.
+
+    Caveat (shared with clinical-report.pdf): technician-declared finding
+    categories are not persisted on the Inspection row, so if the original
+    analysis was biased by a declared finding, this re-derivation can differ
+    from what was originally shown. The Training Mode toggle on a
+    just-submitted inspection uses POST /mentor/build instead, which
+    reconstructs the payload from the exact result already on screen — use
+    this endpoint only when that client-side result isn't available (e.g.
+    revisiting history later).
     """
     tenant_id = getattr(current_user, "tenant_id", None)
     query = db.query(models.Inspection).filter(models.Inspection.id == inspection_id)
@@ -116,6 +126,28 @@ def get_inspection_mentor(
         training_mode=training_mode,
     )
     return analysis["clinical_decision"]["spd_mentor"]
+
+
+class MentorBuildIn(BaseModel):
+    result: dict = Field(..., description="The raw analysis result already shown on screen.")
+    overall: str = Field(..., description="The clinical_decision.overall_result already shown on screen.")
+
+
+@router.post("/mentor/build")
+def build_mentor_from_client_result(
+    body: MentorBuildIn,
+    training_mode: bool = False,
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Rebuild the SPD Mentor payload for the exact result already displayed
+    client-side (from a just-submitted inspection). Purely a re-format of
+    data the caller already has — no DB re-derivation, so toggling Training
+    Mode can never change the findings or disposition being explained,
+    unlike GET /inspections/{id}/mentor's best-effort re-derivation.
+    """
+    from app.services.spd_mentor_engine import build_spd_mentor
+
+    return build_spd_mentor(body.result, body.overall, training_mode=training_mode)
 
 
 # ── Supervisor Coaching Dashboard ─────────────────────────────────────────────

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -851,10 +851,11 @@ def executive_summary(result: dict, overall_result: str) -> list[str]:
     return [ln for ln in lines if ln]
 
 
-def build_clinical_decision(result: dict) -> dict:
+def build_clinical_decision(result: dict, training_mode: bool = False) -> dict:
     """Assemble the full Explainable-AI Clinical Decision Support payload
     (Phases 13.1–13.11) from an already-computed analysis result."""
     from app.services.clinical_mentor import build_mentor  # lazy: avoid cycle
+    from app.services.spd_mentor_engine import build_spd_mentor  # lazy: avoid cycle
 
     findings = {x["type"]: x for x in result.get("predicted_findings", [])}
     overall = _overall_result(result)
@@ -951,6 +952,9 @@ def build_clinical_decision(result: dict) -> dict:
         # Phase 14 — Clinical Mentor: interpretation, why-this-matters, expanded
         # actions, standards guidance, learning mode, risk separation, mentor.
         **build_mentor(result, overall),
+        # v1.4 — SPD Mentor Engine: corrective action chains, anatomy coaching,
+        # confidence coaching, clinical decision summary, education cards.
+        "spd_mentor": build_spd_mentor(result, overall, training_mode=training_mode),
     }
 
 
@@ -967,6 +971,7 @@ def analyze_inspection(
     keydot_id: Optional[str] = None,
     decoder_backend: str = "declared",
     inspected_zones: Optional[list[str]] = None,
+    training_mode: bool = False,
 ) -> dict[str, Any]:
     """Run the deterministic baseline-comparison analysis.
 
@@ -984,8 +989,12 @@ def analyze_inspection(
 
     # ── Governance gate: no approved baseline → no final score ──────────────
     if not resolution["baseline_found"]:
+        from app.services.instrument_anatomy import get_anatomy
+
         no_baseline = {
             "analysis_status": "supervisor_review_required",
+            "instrument_type": instrument_type,
+            "instrument_anatomy": get_anatomy(instrument_type),
             "baseline_source": None,
             "baseline_version": None,
             "baseline_comparison_label": None,
@@ -1015,7 +1024,7 @@ def analyze_inspection(
             "human_review_required": True,
             "placeholder_scoring": True,
         }
-        no_baseline["clinical_decision"] = build_clinical_decision(no_baseline)
+        no_baseline["clinical_decision"] = build_clinical_decision(no_baseline, training_mode=training_mode)
         return no_baseline
 
     seed = _seed_from(image_sha256, f"{instrument_type}:{instrument_barcode or ''}")
@@ -1308,6 +1317,7 @@ def analyze_inspection(
 
     result = {
         "analysis_status": "completed",
+        "instrument_type": instrument_type,
         "baseline_source": source,
         "baseline_role": _baseline_role(source),
         "baseline_comparison_label": _baseline_comparison_label(source),
@@ -1350,5 +1360,5 @@ def analyze_inspection(
         "production_validated": False,
     }
     # Phase 13: Explainable Clinical Decision Support payload.
-    result["clinical_decision"] = build_clinical_decision(result)
+    result["clinical_decision"] = build_clinical_decision(result, training_mode=training_mode)
     return result

--- a/backend/app/services/clinical_mentor.py
+++ b/backend/app/services/clinical_mentor.py
@@ -154,6 +154,17 @@ FINDING_EDUCATION: dict[str, dict] = {
         "spd_response": "Remove from service; complete assembly or replace.",
         "supervisor_tips": "Verify against the tray content list and instrument photo.",
     },
+    "wear": {
+        "why_it_matters": (
+            "Wear is a gradual loss of material or sharpness that can reduce instrument "
+            "performance and, if progressive, lead to functional failure."
+        ),
+        "definition": "Gradual surface or edge degradation from repeated use and reprocessing cycles.",
+        "typical_causes": "Normal use over the instrument's service life, repeated sterilization cycles, or mechanical stress.",
+        "clinical_significance": "Worn cutting edges or jaw inserts can compromise instrument function even without contamination.",
+        "spd_response": "Monitor minor wear; evaluate for repair or retirement if function is affected.",
+        "supervisor_tips": "Compare against the instrument's inspection history to judge whether wear is progressive.",
+    },
 }
 
 # ── Expanded next-action checklists (Phase 14.3) ─────────────────────────────

--- a/backend/app/services/competency_service.py
+++ b/backend/app/services/competency_service.py
@@ -1,0 +1,128 @@
+"""v1.4 — Technician competency support.
+
+Records competency events (findings reviewed, supervisor corrections, repeated
+errors, education completed) and builds per-technician competency summaries.
+Repeated-error detection and training progress are both derived only from
+events actually recorded — nothing is fabricated for technicians with no
+recorded activity.
+"""
+from __future__ import annotations
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.competency_event import CompetencyEvent
+
+# A finding-type correction recorded this many times (or more) for the same
+# technician is flagged as a repeated error.
+_REPEATED_ERROR_THRESHOLD = 2
+
+
+def _record(db: Session, *, tenant_id: str, technician: str, event_type: str,
+            finding_type: str = "", inspection_id: int | None = None) -> CompetencyEvent:
+    event = CompetencyEvent(
+        tenant_id=tenant_id,
+        technician=technician,
+        event_type=event_type,
+        finding_type=finding_type,
+        inspection_id=inspection_id,
+    )
+    db.add(event)
+    return event
+
+
+def record_finding_reviewed(db: Session, *, tenant_id: str, technician: str, inspection_id: int) -> None:
+    """A supervisor reviewed one of this technician's inspections."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="finding_reviewed", inspection_id=inspection_id)
+
+
+def record_supervisor_correction(db: Session, *, tenant_id: str, technician: str,
+                                  finding_type: str, inspection_id: int) -> None:
+    """A supervisor disagreed with, partially agreed with, or overrode the AI
+    on one of this technician's inspections. Also detects and logs a repeated
+    error when the same technician has been corrected on the same finding
+    type before."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="supervisor_correction", finding_type=finding_type,
+            inspection_id=inspection_id)
+
+    if not finding_type:
+        return
+    prior_corrections = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(
+            CompetencyEvent.technician == technician,
+            CompetencyEvent.event_type == "supervisor_correction",
+            CompetencyEvent.finding_type == finding_type,
+        )
+        .scalar()
+        or 0
+    )
+    if prior_corrections >= _REPEATED_ERROR_THRESHOLD:
+        _record(db, tenant_id=tenant_id, technician=technician,
+                event_type="repeated_error", finding_type=finding_type,
+                inspection_id=inspection_id)
+
+
+def record_education_completed(db: Session, *, tenant_id: str, technician: str, finding_type: str) -> None:
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="education_completed", finding_type=finding_type)
+
+
+def _count(db: Session, technician: str, event_type: str) -> int:
+    return (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == event_type)
+        .scalar()
+        or 0
+    )
+
+
+def competency_summary(db: Session, technician: str) -> dict:
+    """Per-technician competency summary derived entirely from recorded
+    competency events — an empty summary for a technician with no recorded
+    activity, never a fabricated score."""
+    findings_reviewed = _count(db, technician, "finding_reviewed")
+    supervisor_corrections = _count(db, technician, "supervisor_correction")
+
+    repeated_error_rows = (
+        db.query(CompetencyEvent.finding_type, func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == "repeated_error")
+        .group_by(CompetencyEvent.finding_type)
+        .all()
+    )
+    repeated_errors = {finding_type: count for finding_type, count in repeated_error_rows}
+
+    education_rows = (
+        db.query(CompetencyEvent.finding_type)
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == "education_completed")
+        .distinct()
+        .all()
+    )
+    education_completed = sorted(row[0] for row in education_rows if row[0])
+
+    # Training progress: a simple, honest ratio — corrections resolved without
+    # becoming a repeated error, out of all recorded activity. None (not 0)
+    # when there is no activity to score yet.
+    total_activity = findings_reviewed + supervisor_corrections
+    training_progress_pct = (
+        round(100 * (1 - (sum(repeated_errors.values()) / supervisor_corrections)))
+        if supervisor_corrections else None
+    )
+
+    return {
+        "technician": technician,
+        "findings_reviewed": findings_reviewed,
+        "supervisor_corrections": supervisor_corrections,
+        "repeated_errors": repeated_errors,
+        "education_completed": education_completed,
+        "training_progress_pct": training_progress_pct,
+        "has_activity": total_activity > 0,
+    }

--- a/backend/app/services/education_library.py
+++ b/backend/app/services/education_library.py
@@ -1,0 +1,81 @@
+"""v1.4 — Educational Knowledge Library.
+
+Structured SPD education articles for the twelve contamination/condition
+categories LumenAI recognizes. Each article is built from the same source of
+truth already used by the AI Mentor (clinical_mentor.FINDING_EDUCATION) and
+the instrument anatomy library (instrument_anatomy.py) — nothing here is
+duplicated content, it is reshaped into a browsable reference.
+"""
+from __future__ import annotations
+
+from app.services.baseline_comparison_scoring_service import KPI_LABELS
+from app.services.clinical_mentor import FINDING_EDUCATION
+from app.services.instrument_anatomy import INSTRUMENT_ANATOMY
+from app.services.spd_mentor_engine import IFU_REFERENCE_NOTE, corrective_action_chain
+
+# The twelve categories the v1.4 spec enumerates, in spec order. Internal keys
+# match clinical_mentor.FINDING_EDUCATION / KPI_LABELS.
+CATEGORIES: list[str] = [
+    "blood", "bone", "tissue", "other_organic_residue", "debris",
+    "rust", "corrosion", "crack", "wear", "pitting",
+    "missing_component", "insulation_damage",
+]
+
+# instrument_anatomy.py's per-zone contamination_risks/condition_risks lists
+# are the same default vocabulary on every zone (no per-zone override is ever
+# supplied), so they cannot distinguish "typical" locations for one finding
+# type from another. Instead, derive typical locations from what the zone data
+# *does* differentiate: contamination/organic findings collect in zones the
+# codebase already marks as high-retention; structural/condition findings
+# concentrate in zones with high/critical inherent risk. Insulation damage is
+# tied to the one zone actually named for it.
+_CONTAMINATION_FINDINGS = {"blood", "bone", "tissue", "other_organic_residue", "debris"}
+
+
+def _typical_anatomy_locations(finding_type: str) -> list[str]:
+    """Zone names, across all instrument families, that are typical retention/
+    risk sites for this finding type — derived from each zone's own risk
+    classification in instrument_anatomy.py."""
+    zones: set[str] = set()
+    if finding_type == "insulation_damage":
+        target = {"insulation edge"}
+    else:
+        target = None
+
+    for defn in INSTRUMENT_ANATOMY.values():
+        for zone in defn["zones"]:
+            name = zone["zone_name"]
+            if target is not None:
+                if name in target:
+                    zones.add(name)
+                continue
+            if finding_type in _CONTAMINATION_FINDINGS:
+                if zone["retention_risk"] == "high":
+                    zones.add(name)
+            else:
+                if zone["zone_risk_level"] in ("high", "critical"):
+                    zones.add(name)
+    return sorted(zones)
+
+
+def get_article(finding_type: str) -> dict | None:
+    """Full knowledge-library article for one finding type."""
+    edu = FINDING_EDUCATION.get(finding_type)
+    if not edu:
+        return None
+    return {
+        "finding": KPI_LABELS.get(finding_type, finding_type),
+        "finding_type": finding_type,
+        "definition": edu["definition"],
+        "clinical_importance": edu["clinical_significance"],
+        "typical_anatomy_locations": _typical_anatomy_locations(finding_type),
+        "inspection_tips": edu["supervisor_tips"],
+        "cleaning_considerations": edu["typical_causes"],
+        "corrective_actions": corrective_action_chain(finding_type),
+        "reference": IFU_REFERENCE_NOTE,
+    }
+
+
+def list_articles() -> list[dict]:
+    """All twelve knowledge-library articles, spec order."""
+    return [a for a in (get_article(k) for k in CATEGORIES) if a is not None]

--- a/backend/app/services/spd_mentor_engine.py
+++ b/backend/app/services/spd_mentor_engine.py
@@ -1,0 +1,313 @@
+"""v1.4 — SPD Mentor Engine.
+
+Turns an inspection analysis into an active SPD educator: structured corrective
+action chains per finding, anatomy-aware coaching tied to the instrument's
+actual high-retention zones, confidence coaching when image quality or
+coverage is incomplete, a concise clinical decision summary, and (in Training
+Mode) expanded explanations of every finding, the anatomy involved, the
+recommendation, and SPD terminology.
+
+This module composes existing Phase 13/14/15 infrastructure
+(clinical_mentor.py, instrument_anatomy.py, instrument_zones.py,
+inspection_coverage.py) rather than duplicating it — it never replaces
+supervisor judgment, and every statement is derived from the actual analysis
+result, not fabricated.
+"""
+from __future__ import annotations
+
+from app.services.clinical_mentor import (
+    FINDING_EDUCATION,
+    NEXT_ACTIONS,
+    STANDARDS_GUIDANCE,
+    learning_content,
+)
+from app.services.baseline_comparison_scoring_service import KPI_LABELS
+
+MENTOR_DISCLAIMER = (
+    "This guidance is AI-generated educational support. It does not replace "
+    "supervisor judgment or the manufacturer's Instructions For Use (IFU)."
+)
+
+IFU_REFERENCE_NOTE = "AAMI ST79 (institution-specific implementation may vary)."
+
+# ── Corrective action chains (Deliverable 2) ─────────────────────────────────
+# Ordered, structured step-by-step recommendations per finding type. Derived
+# from accepted SPD practice — supervisor verification is the final step for
+# every contamination finding; structural findings escalate to remove-from-
+# service rather than reprocessing.
+CORRECTIVE_ACTION_CHAINS: dict[str, list[str]] = {
+    "blood": [
+        "Reclean the instrument.",
+        "Brush serrations manually.",
+        "Flush the lumen.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "tissue": [
+        "Reclean the instrument.",
+        "Brush affected surfaces manually.",
+        "Flush any lumens or channels.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "other_organic_residue": [
+        "Reclean the instrument.",
+        "Consider extended enzymatic contact time or a biofilm-directed protocol.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "bone": [
+        "Reclean the instrument.",
+        "Flush and brush cannulated channels with the correct-diameter brush.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "debris": [
+        "Reclean the instrument.",
+        "Identify and remove the particulate source.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "rust": [
+        "Remove from service.",
+        "Evaluate for repair.",
+        "Inspect surrounding anatomy.",
+        "Document corrosion.",
+    ],
+    "corrosion": [
+        "Remove from service.",
+        "Evaluate for repair.",
+        "Inspect surrounding anatomy.",
+        "Document corrosion.",
+    ],
+    "pitting": [
+        "Remove from service for evaluation if extensive.",
+        "Inspect surrounding anatomy.",
+        "Document the finding.",
+        "Monitor at future inspections if minor.",
+    ],
+    "crack": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Repair evaluation.",
+    ],
+    "insulation_damage": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Test insulation integrity.",
+        "Repair or replace evaluation.",
+    ],
+    "missing_component": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Verify against the tray content list and instrument photo.",
+        "Complete assembly or replace.",
+    ],
+    "wear": [
+        "Document and monitor.",
+        "Compare against prior inspections.",
+        "Escalate to supervisor if progressive.",
+    ],
+    "discoloration": [
+        "Document and monitor.",
+        "Investigate if progressive or paired with corrosion.",
+    ],
+}
+
+
+def corrective_action_chain(finding_type: str) -> list[str]:
+    """Ordered corrective-action steps for a single finding type."""
+    return CORRECTIVE_ACTION_CHAINS.get(finding_type, ["Supervisor review recommended."])
+
+
+def corrective_actions_for_result(result: dict) -> list[dict]:
+    """Structured corrective-action recommendation per actionable finding."""
+    out = []
+    for f in result.get("predicted_findings", []):
+        if f["severity_index"] < 1:
+            continue
+        finding_type = f["type"]
+        out.append({
+            "finding": KPI_LABELS.get(finding_type, finding_type),
+            "steps": corrective_action_chain(finding_type),
+        })
+    return out
+
+
+# ── Anatomy-aware coaching (Deliverable 3) ───────────────────────────────────
+# Canned coaching phrasing for instrument families with well-known SPD lore.
+# Falls back to a generated sentence from the instrument's own anatomy zones
+# for families without a specific canned phrase — never fabricated per-family
+# detail beyond what instrument_anatomy.py already defines.
+_FAMILY_COACHING_PHRASES: dict[str, list[str]] = {
+    "kerrison_rongeur": [
+        "Kerrison jaw serrations are high-retention anatomy zones.",
+        "Open the box lock and actuate the hinge during inspection — soil hides in the pivot.",
+    ],
+    "rigid_scope": [
+        "Rigid scope O-ring regions frequently retain organic material.",
+        "Inspect the working channel and seal closely; these are high-retention zones.",
+    ],
+    "drill_bit": [
+        "Drill-bit flutes require careful brushing.",
+        "Threaded regions between the flutes are a common site for retained residue.",
+    ],
+    "needle_holder": [
+        "Needle-holder box locks should be opened during inspection.",
+        "Jaw inserts and serrations are high-retention anatomy zones.",
+    ],
+}
+
+
+def anatomy_coaching(result: dict) -> list[str]:
+    """Anatomy-aware coaching sentences for the instrument being inspected."""
+    anatomy = result.get("instrument_anatomy") or {}
+    family = anatomy.get("family", "default")
+    messages = list(_FAMILY_COACHING_PHRASES.get(family, []))
+
+    if not messages:
+        category = anatomy.get("category", "instrument")
+        for zone in anatomy.get("zones", []):
+            if zone.get("retention_risk") == "high" or zone.get("zone_name") in anatomy.get("high_risk_zones", []):
+                messages.append(
+                    f"{category.capitalize()} {zone['zone_name']} is a high-retention anatomy zone."
+                )
+    return messages
+
+
+def _zone_description(zone_name: str) -> str:
+    from app.services.instrument_zones import ZONE_INFO
+
+    info = ZONE_INFO.get(zone_name.lower())
+    if info and info.get("reason"):
+        return info["reason"]
+    return f"{zone_name.capitalize()} — inspect closely per the instrument's anatomy profile."
+
+
+# ── AI confidence coaching (Deliverable 7) ───────────────────────────────────
+_LOW_CONFIDENCE_THRESHOLD = 0.7
+_LOW_COVERAGE_THRESHOLD = 75
+
+
+def confidence_coaching(result: dict) -> dict | None:
+    """Coaching for the technician when confidence is limited by image
+    quality or incomplete inspection coverage. Returns None when confidence
+    and coverage are both adequate — nothing to coach."""
+    confidence = result.get("confidence")
+    coverage = result.get("inspection_coverage") or {}
+    coverage_pct = coverage.get("overall_coverage")
+    coverage_assessed = coverage.get("assessed", False)
+
+    low_confidence = confidence is not None and confidence < _LOW_CONFIDENCE_THRESHOLD
+    low_coverage = coverage_assessed and coverage_pct is not None and coverage_pct < _LOW_COVERAGE_THRESHOLD
+    not_assessed = not coverage_assessed
+
+    if not (low_confidence or low_coverage or not_assessed):
+        return None
+
+    suggestions: list[str] = []
+    if not_assessed or low_coverage:
+        suggestions.append("Capture additional images.")
+        suggestions.append("Capture missing anatomy zones.")
+    if low_confidence:
+        suggestions.append("Improve lighting.")
+    suggestions.append("Request supervisor review.")
+
+    return {
+        "message": (
+            "Confidence is limited because image quality and inspection "
+            "coverage are incomplete."
+        ),
+        "suggestions": suggestions,
+    }
+
+
+# ── Clinical decision summary (Deliverable 8, concise form) ──────────────────
+def clinical_decision_summary(result: dict, overall: str) -> dict:
+    coverage = result.get("inspection_coverage") or {}
+    supervisor_review = "Recommended" if overall in {
+        "SUPERVISOR REVIEW", "REPROCESS", "REMOVE FROM SERVICE",
+    } else "Not required"
+
+    return {
+        "instrument": result.get("instrument_type") or "Unknown instrument",
+        "inspection_coverage": coverage.get("overall_coverage"),
+        "findings": result.get("findings_summary") or "No actionable findings detected.",
+        "risk": result.get("risk_level"),
+        "recommendation": result.get("recommended_action"),
+        "supervisor_review": supervisor_review,
+    }
+
+
+# ── SPD education cards (Deliverable 4) ──────────────────────────────────────
+def education_card(finding_type: str) -> dict | None:
+    edu = FINDING_EDUCATION.get(finding_type)
+    if not edu:
+        return None
+    return {
+        "finding": KPI_LABELS.get(finding_type, finding_type),
+        "clinical_significance": edu["clinical_significance"],
+        "recommended_practice": edu["spd_response"],
+        "reference": IFU_REFERENCE_NOTE,
+    }
+
+
+def education_cards_for_result(result: dict) -> list[dict]:
+    out = []
+    for f in result.get("predicted_findings", []):
+        if f["severity_index"] < 1:
+            continue
+        card = education_card(f["type"])
+        if card:
+            out.append(card)
+    return out
+
+
+# ── Training Mode (Deliverable 6) ────────────────────────────────────────────
+TERMINOLOGY: dict[str, str] = {
+    "baseline match": "How closely the instrument's current condition matches its approved reference (baseline) image or record.",
+    "retention zone": "An anatomy region — such as a serration, lumen, box lock, or hinge — where soil is mechanically difficult to remove and easy to miss visually.",
+    "IFU": "Instructions For Use — the manufacturer's official reprocessing and inspection instructions for a specific device.",
+    "disposition": "The recommended next step for an instrument after inspection (e.g. PASS, REPROCESS, REMOVE FROM SERVICE).",
+    "coverage": "The percentage of an instrument's required high-risk anatomy zones that were actually photographed/inspected.",
+    "supervisor review": "A second, qualified review of an instrument before it is released, required whenever cleanliness or condition is uncertain.",
+}
+
+
+def training_mode_explanations(result: dict, overall: str) -> dict:
+    """Expanded, always-explain content for onboarding/competency building:
+    every finding, the anatomy involved, the recommendation, and terminology."""
+    anatomy = result.get("instrument_anatomy") or {}
+    return {
+        "every_finding": learning_content(result),
+        "anatomy_explained": [
+            {"zone": zone_name, "explanation": _zone_description(zone_name)}
+            for zone_name in anatomy.get("zone_names", [])
+        ],
+        "recommendation_explained": {
+            "disposition": overall,
+            "next_actions": NEXT_ACTIONS.get(overall, []),
+            "standards_guidance": STANDARDS_GUIDANCE.get(overall, ""),
+        },
+        "terminology": [
+            {"term": term, "definition": definition}
+            for term, definition in TERMINOLOGY.items()
+        ],
+    }
+
+
+# ── Assembly ──────────────────────────────────────────────────────────────
+def build_spd_mentor(result: dict, overall: str, *, training_mode: bool = False) -> dict:
+    """Assemble the full v1.4 SPD Mentor payload."""
+    payload = {
+        "disclaimer": MENTOR_DISCLAIMER,
+        "corrective_actions": corrective_actions_for_result(result),
+        "anatomy_coaching": anatomy_coaching(result),
+        "confidence_coaching": confidence_coaching(result),
+        "clinical_decision_summary": clinical_decision_summary(result, overall),
+        "education_cards": education_cards_for_result(result),
+        "training_mode": training_mode,
+    }
+    if training_mode:
+        payload["expanded_explanations"] = training_mode_explanations(result, overall)
+    return payload

--- a/backend/app/services/spd_mentor_engine.py
+++ b/backend/app/services/spd_mentor_engine.py
@@ -181,7 +181,7 @@ def _zone_description(zone_name: str) -> str:
     info = ZONE_INFO.get(zone_name.lower())
     if info and info.get("reason"):
         return info["reason"]
-    return f"{zone_name.capitalize()} — inspect closely per the instrument's anatomy profile."
+    return "Inspect closely per the instrument's anatomy profile."
 
 
 # ── AI confidence coaching (Deliverable 7) ───────────────────────────────────
@@ -223,6 +223,17 @@ def confidence_coaching(result: dict) -> dict | None:
 
 
 # ── Clinical decision summary (Deliverable 8, concise form) ──────────────────
+def _findings_sentence(result: dict) -> str:
+    """findings_summary is a list of per-KPI phrases (e.g. "Blood detected",
+    "No bone detected") — collapse to a single sentence naming only what was
+    actually found, not an exhaustive negative checklist."""
+    phrases = result.get("findings_summary") or []
+    positive = [p for p in phrases if not p.startswith("No ")]
+    if not positive:
+        return "No actionable findings detected."
+    return "; ".join(positive) + "."
+
+
 def clinical_decision_summary(result: dict, overall: str) -> dict:
     coverage = result.get("inspection_coverage") or {}
     supervisor_review = "Recommended" if overall in {
@@ -232,7 +243,7 @@ def clinical_decision_summary(result: dict, overall: str) -> dict:
     return {
         "instrument": result.get("instrument_type") or "Unknown instrument",
         "inspection_coverage": coverage.get("overall_coverage"),
-        "findings": result.get("findings_summary") or "No actionable findings detected.",
+        "findings": _findings_sentence(result),
         "risk": result.get("risk_level"),
         "recommendation": result.get("recommended_action"),
         "supervisor_review": supervisor_review,

--- a/backend/tests/test_spd_mentor_engine.py
+++ b/backend/tests/test_spd_mentor_engine.py
@@ -1,0 +1,290 @@
+"""v1.4 — SPD Mentor Engine: corrective actions, anatomy coaching, confidence
+coaching, training mode, education library, and competency support."""
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.education_library import get_article, list_articles
+from app.services.spd_mentor_engine import (
+    confidence_coaching,
+    corrective_action_chain,
+    education_card,
+)
+from app.main import app
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"sme-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None, training_mode=False):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+            training_mode=training_mode,
+        )
+    finally:
+        db.close()
+
+
+class TestCorrectiveActionRecommendations:
+    def test_blood_recommendation_generated(self):
+        cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        blood = next((a for a in actions if a["finding"] == "blood"), None)
+        assert blood is not None
+        assert blood["steps"] == corrective_action_chain("blood")
+        assert "Supervisor verification." in blood["steps"]
+
+    def test_rust_generates_repair_remove_recommendation(self):
+        # "rust" is not a declarable category in the scoring engine (only its
+        # sibling "corrosion" is) — assert the chain directly, as the education
+        # card/library tests already do for other pure-function lookups.
+        steps = corrective_action_chain("rust")
+        assert "Remove from service." in steps
+        assert "Evaluate for repair." in steps
+
+    def test_corrosion_recommendation_generated(self):
+        cd = _analyze("scissors", declared=["corrosion"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        corrosion = next((a for a in actions if a["finding"] == "corrosion"), None)
+        assert corrosion is not None
+        assert "Remove from service." in corrosion["steps"]
+        assert "Evaluate for repair." in corrosion["steps"]
+
+    def test_crack_generates_remove_from_service_recommendation(self):
+        cd = _analyze("forceps", declared=["crack"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        crack = next((a for a in actions if a["finding"] == "crack"), None)
+        assert crack is not None
+        assert crack["steps"][0] == "Remove from service immediately."
+        assert "Notify supervisor." in crack["steps"]
+
+
+class TestAnatomyAwareCoaching:
+    def test_kerrison_serrations_coaching(self):
+        cd = _analyze("kerrison_rongeur")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("Kerrison jaw serrations are high-retention anatomy zones." == c for c in coaching)
+
+    def test_rigid_scope_oring_coaching(self):
+        cd = _analyze("rigid_scope")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("O-ring" in c for c in coaching)
+
+    def test_drill_bit_flutes_coaching(self):
+        cd = _analyze("drill_bit")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("flutes" in c.lower() for c in coaching)
+
+    def test_needle_holder_box_lock_coaching(self):
+        cd = _analyze("needle_holder")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("box lock" in c.lower() for c in coaching)
+
+
+class TestConfidenceCoaching:
+    def test_low_confidence_coaching_displayed(self):
+        result = {
+            "confidence": 0.5,
+            "inspection_coverage": {"assessed": True, "overall_coverage": 40},
+        }
+        coaching = confidence_coaching(result)
+        assert coaching is not None
+        assert "incomplete" in coaching["message"].lower()
+        assert "Request supervisor review." in coaching["suggestions"]
+
+    def test_high_confidence_full_coverage_no_coaching(self):
+        result = {
+            "confidence": 0.95,
+            "inspection_coverage": {"assessed": True, "overall_coverage": 100},
+        }
+        assert confidence_coaching(result) is None
+
+    def test_coverage_not_assessed_triggers_coaching(self):
+        result = {"confidence": 0.9, "inspection_coverage": {"assessed": False}}
+        coaching = confidence_coaching(result)
+        assert coaching is not None
+        assert "Capture additional images." in coaching["suggestions"]
+
+
+class TestTrainingMode:
+    def test_training_mode_expands_explanations(self):
+        cd_off = _analyze("scissors", declared=["blood"], training_mode=False)["clinical_decision"]
+        cd_on = _analyze("scissors", declared=["blood"], training_mode=True)["clinical_decision"]
+
+        assert "expanded_explanations" not in cd_off["spd_mentor"]
+        assert cd_off["spd_mentor"]["training_mode"] is False
+
+        mentor_on = cd_on["spd_mentor"]
+        assert mentor_on["training_mode"] is True
+        expanded = mentor_on["expanded_explanations"]
+        assert expanded["every_finding"]
+        assert expanded["anatomy_explained"]
+        assert expanded["recommendation_explained"]["disposition"]
+        assert any(t["term"] == "IFU" for t in expanded["terminology"])
+
+
+class TestEducationCards:
+    def test_education_card_rendered_correctly(self):
+        card = education_card("blood")
+        assert card["finding"] == "blood"
+        assert card["clinical_significance"]
+        assert card["recommended_practice"]
+        assert "AAMI ST79" in card["reference"]
+
+    def test_clinical_decision_includes_education_cards(self):
+        cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
+        cards = cd["spd_mentor"]["education_cards"]
+        assert any(c["finding"] == "blood" for c in cards)
+
+
+class TestEducationLibrary:
+    def test_library_has_all_twelve_categories(self):
+        articles = list_articles()
+        assert len(articles) == 12
+
+    def test_article_fields_present(self):
+        article = get_article("rust")
+        for field in (
+            "definition", "clinical_importance", "typical_anatomy_locations",
+            "inspection_tips", "cleaning_considerations", "corrective_actions", "reference",
+        ):
+            assert article[field], f"missing/empty {field}"
+
+    def test_unknown_finding_type_returns_none(self):
+        assert get_article("not_a_real_finding") is None
+
+
+class TestMentorDisclaimer:
+    def test_disclaimer_never_replaces_supervisor_judgment(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        assert "does not replace" in cd["spd_mentor"]["disclaimer"].lower()
+
+
+class TestSupervisorCoachingDashboard:
+    def _create(self, itype):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_coaching_queue_lists_inspection(self):
+        iid = self._create("scissors")
+        r = client.get("/api/mentor/coaching-queue", headers=AUTH_MGR)
+        assert r.status_code == 200
+        ids = [row["inspection_id"] for row in r.json()["queue"]]
+        assert iid in ids
+
+    def test_submit_coaching_review(self):
+        iid = self._create("forceps")
+        r = client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True, "educational_comment": "Good catch on the box lock."},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["educational_comment"] == "Good catch on the box lock."
+
+    def test_operator_cannot_submit_coaching_review(self):
+        iid = self._create("forceps")
+        r = client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True}, headers=AUTH_OPERATOR,
+        )
+        assert r.status_code == 403
+
+    def test_coaching_effectiveness_reflects_reviews(self):
+        iid = self._create("needle_holder")
+        client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True}, headers=AUTH_MGR,
+        )
+        r = client.get("/api/mentor/coaching-effectiveness", headers=AUTH_MGR)
+        assert r.status_code == 200
+        assert r.json()["total_reviews"] >= 1
+
+
+class TestCompetencySupport:
+    def _create_as_operator(self, itype):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_competency_summary_updates_after_supervisor_review(self):
+        iid = self._create_as_operator("scissors")
+
+        before = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_MGR)
+        assert before.status_code == 200
+        before_reviewed = before.json()["findings_reviewed"]
+        before_corrections = before.json()["supervisor_corrections"]
+
+        r = client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={
+                "agreement": "disagree",
+                "rationale": "Debris still present in hinge.",
+                "finding_type": "debris",
+            },
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+
+        after = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_MGR)
+        assert after.status_code == 200
+        assert after.json()["findings_reviewed"] == before_reviewed + 1
+        assert after.json()["supervisor_corrections"] == before_corrections + 1
+
+    def test_operator_can_view_own_summary_only(self):
+        r = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        r2 = client.get("/api/mentor/competency/spd_manager@local.dev", headers=AUTH_OPERATOR)
+        assert r2.status_code == 403
+
+    def test_education_completion_recorded(self):
+        r = client.post("/api/mentor/education/blood/complete", headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        assert "blood" in r.json()["education_completed"]
+
+
+class TestInspectionMentorEndpoint:
+    def test_rederive_mentor_for_past_inspection(self):
+        _baseline("scissors")
+        r = client.post("/api/inspections", json={
+            "instrument_type": "scissors", "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        iid = r.json()["id"]
+
+        r = client.get(f"/api/inspections/{iid}/mentor?training_mode=true", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert r.json()["training_mode"] is True
+        assert "expanded_explanations" in r.json()

--- a/docs/mentor/anatomy-aware-coaching.md
+++ b/docs/mentor/anatomy-aware-coaching.md
@@ -1,0 +1,37 @@
+# Anatomy-Aware Coaching (v1.4)
+
+## What it does
+`spd_mentor_engine.anatomy_coaching(result)` returns technician-facing
+coaching sentences tied to the instrument's actual anatomy profile
+(`result.instrument_anatomy`, from the Phase 15 Instrument Anatomy Library) —
+never generic filler.
+
+## Canned phrasing for well-known SPD lore
+A small set of instrument families have specific, widely-recognized SPD
+coaching phrases (`_FAMILY_COACHING_PHRASES`):
+
+- **Kerrison rongeur**: "Kerrison jaw serrations are high-retention anatomy
+  zones." / "Open the box lock and actuate the hinge during inspection — soil
+  hides in the pivot."
+- **Rigid scope**: "Rigid scope O-ring regions frequently retain organic
+  material." / "Inspect the working channel and seal closely; these are
+  high-retention zones."
+- **Drill bit**: "Drill-bit flutes require careful brushing." / "Threaded
+  regions between the flutes are a common site for retained residue."
+- **Needle holder**: "Needle-holder box locks should be opened during
+  inspection." / "Jaw inserts and serrations are high-retention anatomy
+  zones."
+
+## Generated fallback
+For every other instrument family (laparoscopic, general forceps, scissors,
+flexible endoscope, and anything unclassified), coaching sentences are
+generated from the instrument's own zone data: any zone with
+`retention_risk == "high"` (or listed in `high_risk_zones`) produces
+`"{category} {zone_name} is a high-retention anatomy zone."` — always derived
+from the actual anatomy profile, never invented per-instrument detail.
+
+## Zone descriptions (Training Mode)
+When Training Mode is on, every anatomy zone for the instrument gets an
+explanation via `_zone_description()`, which reuses
+`instrument_zones.ZONE_INFO`'s per-zone reason (falling back to a generic
+retention-risk sentence for zones without a specific entry).

--- a/docs/mentor/clinical-decision-support.md
+++ b/docs/mentor/clinical-decision-support.md
@@ -1,0 +1,51 @@
+# Clinical Decision Support — v1.4 additions
+
+## Clinical Decision Summary
+`spd_mentor.clinical_decision_summary` gives the concise, plain-language
+summary a supervisor scans first:
+
+```
+{
+  "instrument": "Rigid Scope",
+  "inspection_coverage": 95,
+  "findings": "Blood indicators detected within the O-ring region.",
+  "risk": "High",
+  "recommendation": "Reclean and repeat inspection before packaging.",
+  "supervisor_review": "Recommended"
+}
+```
+
+`supervisor_review` is `"Recommended"` whenever the overall disposition is
+`SUPERVISOR REVIEW`, `REPROCESS`, or `REMOVE FROM SERVICE`, and `"Not
+required"` for `PASS`/`MONITOR` — derived from the same disposition already
+computed by the Phase 13 Explainable AI Clinical Decision Support payload, not
+a separate judgment.
+
+## Corrective Action Recommendations
+`spd_mentor.corrective_actions` gives one structured, ordered step chain per
+actionable finding (severity index ≥ 1), e.g.:
+
+- **Blood** → Reclean → Brush serrations manually → Flush the lumen → Repeat
+  visual inspection → Supervisor verification.
+- **Rust / Corrosion** → Remove from service → Evaluate for repair → Inspect
+  surrounding anatomy → Document corrosion.
+- **Crack** → Remove from service immediately → Notify supervisor → Repair
+  evaluation.
+
+Full chains for all twelve categories live in
+`spd_mentor_engine.CORRECTIVE_ACTION_CHAINS` and are reused by the Educational
+Knowledge Library so the two never drift apart.
+
+## AI Confidence Coaching
+`spd_mentor.confidence_coaching` returns `null` when confidence and coverage
+are both adequate. Otherwise:
+
+```
+{
+  "message": "Confidence is limited because image quality and inspection coverage are incomplete.",
+  "suggestions": ["Capture additional images.", "Capture missing anatomy zones.", "Improve lighting.", "Request supervisor review."]
+}
+```
+
+Triggered when confidence < 70%, required-zone coverage < 75%, or zones were
+never tagged at all (`inspection_coverage.assessed == false`).

--- a/docs/mentor/competency-support.md
+++ b/docs/mentor/competency-support.md
@@ -1,0 +1,50 @@
+# Competency Support (v1.4)
+
+## What it tracks
+`backend/app/models/competency_event.py` is an append-only event log; each row
+is one of:
+
+- `finding_reviewed` — a supervisor reviewed one of this technician's
+  inspections.
+- `supervisor_correction` — the supervisor disagreed, partially agreed, or
+  overrode the AI on that inspection, tagged with the `finding_type` involved.
+- `repeated_error` — the same technician has now been corrected on the same
+  `finding_type` at least twice; logged automatically alongside the
+  correction that crosses the threshold.
+- `education_completed` — the technician marked a knowledge-library article
+  as read (`POST /api/mentor/education/{finding_type}/complete`).
+
+## Where it's recorded
+`app/routes/ai_clinical_review.py`'s existing `POST
+/inspections/{id}/supervisor-review` endpoint (the ML ground-truth capture
+path) also calls `competency_service.record_finding_reviewed` /
+`record_supervisor_correction` in the same transaction — competency tracking
+piggybacks on a review that was already happening, rather than requiring a
+second workflow.
+
+## Technician attribution
+`Inspection.technician` (added in v1.4, nullable) is set from the request
+actor at creation time (`POST /api/inspections`). Older inspections created
+before this field existed have `technician = null` and are simply excluded
+from competency aggregation — never backfilled with a guess.
+
+## Summary shape
+`GET /api/mentor/competency/{technician}`:
+```
+{
+  "technician": "jane@hospital.org",
+  "findings_reviewed": 12,
+  "supervisor_corrections": 3,
+  "repeated_errors": {"blood": 2},
+  "education_completed": ["blood", "crack"],
+  "training_progress_pct": 33,
+  "has_activity": true
+}
+```
+`training_progress_pct` is `null` (not `0`) when there have been no supervisor
+corrections yet — there is nothing to score, and the engine never fabricates
+a number for a technician with no recorded activity.
+
+## Access control
+A technician may only view their own summary; `admin`/`spd_manager` may view
+anyone's.

--- a/docs/mentor/education-library.md
+++ b/docs/mentor/education-library.md
@@ -1,0 +1,48 @@
+# Educational Knowledge Library (v1.4)
+
+## What it does
+`backend/app/services/education_library.py` exposes a structured knowledge
+article for each of the twelve contamination/condition categories LumenAI
+recognizes: Blood, Bone, Tissue, Organic residue, Debris, Rust, Corrosion,
+Cracks, Wear, Pitting, Missing component, Insulation damage.
+
+Nothing here is duplicated content — every article is reshaped from the same
+source of truth the AI Mentor already uses
+(`clinical_mentor.FINDING_EDUCATION`) plus the corrective-action chains from
+`spd_mentor_engine.py`, so the library and the live coaching can never drift
+apart.
+
+## Article shape
+```
+{
+  "finding": "crack",
+  "finding_type": "crack",
+  "definition": "...",
+  "clinical_importance": "...",
+  "typical_anatomy_locations": ["box lock", "hinge", "jaw", ...],
+  "inspection_tips": "...",
+  "cleaning_considerations": "...",
+  "corrective_actions": ["Remove from service immediately.", ...],
+  "reference": "AAMI ST79 (institution-specific implementation may vary)."
+}
+```
+
+## Typical anatomy locations
+`instrument_anatomy.py`'s per-zone `contamination_risks`/`condition_risks`
+lists are the same default vocabulary on every zone (no instrument family
+customizes them), so they cannot distinguish "typical" locations for one
+finding from another. Instead, `_typical_anatomy_locations()` derives them
+honestly from what the anatomy data *does* differentiate:
+
+- **Contamination findings** (blood, bone, tissue, organic residue, debris):
+  zones marked `retention_risk == "high"` across every instrument family.
+- **Structural/condition findings** (rust, corrosion, pitting, crack, wear,
+  missing component): zones with `zone_risk_level` of `high` or `critical`.
+- **Insulation damage**: the one zone actually named for it (`insulation
+  edge`), rather than the broad structural set.
+
+## API
+- `GET /api/mentor/education` — all twelve articles.
+- `GET /api/mentor/education/{finding_type}` — one article, 404 if unknown.
+- `POST /api/mentor/education/{finding_type}/complete` — mark an article
+  completed for the current user (feeds Competency Support).

--- a/docs/mentor/spd-mentor-engine.md
+++ b/docs/mentor/spd-mentor-engine.md
@@ -1,0 +1,44 @@
+# SPD Mentor Engine (v1.4)
+
+## What it does
+Turns an inspection analysis into active SPD education: interprets findings,
+explains contamination/damage/anatomy risk, suggests structured corrective
+action, and references SPD best practice — without ever replacing supervisor
+judgment.
+
+Implemented in `backend/app/services/spd_mentor_engine.py`, composed on top of
+the existing Phase 13/14/15 infrastructure (`clinical_mentor.py`,
+`instrument_anatomy.py`, `instrument_zones.py`, `inspection_coverage.py`)
+rather than duplicating it.
+
+## Where it runs
+`build_spd_mentor(result, overall, training_mode=False)` is called from
+`build_clinical_decision()` in `baseline_comparison_scoring_service.py` and
+attached to every analysis under `clinical_decision.spd_mentor`. It can also be
+re-derived for a past inspection via `GET /api/inspections/{id}/mentor`.
+
+## Payload shape
+```
+spd_mentor: {
+  disclaimer: str,
+  corrective_actions: [{finding, steps: [...]}],
+  anatomy_coaching: [str, ...],
+  confidence_coaching: {message, suggestions} | null,
+  clinical_decision_summary: {instrument, inspection_coverage, findings, risk, recommendation, supervisor_review},
+  education_cards: [{finding, clinical_significance, recommended_practice, reference}],
+  training_mode: bool,
+  expanded_explanations?: {...}   # only when training_mode is true
+}
+```
+
+## Disclaimer
+Every payload carries `MENTOR_DISCLAIMER`: this guidance is AI-generated
+educational support and does not replace supervisor judgment or the
+manufacturer's IFU. It is never omitted.
+
+## Never claims
+Consistent with project-wide governance rules, the engine never claims
+causation or regulatory clearance — corrective-action language is imperative
+("Reclean the instrument") but the overall recommendation stays advisory
+("Supervisor review: Recommended"), and every actionable output remains
+subject to `human_review_required: true` on the parent analysis.

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -150,9 +150,16 @@ function Stars({ n }: { n: number }) {
 export default function ClinicalDecisionPanel({
   cd,
   inspectionId,
+  rawResult,
 }: {
   cd: ClinicalDecision;
   inspectionId?: number;
+  /** The raw analysis result already shown on screen (from a just-submitted
+   * inspection). When present, Training Mode is toggled by rebuilding the
+   * mentor payload from this exact data (POST /mentor/build) instead of
+   * re-deriving from the database — so toggling it can never change which
+   * findings or disposition are being explained. */
+  rawResult?: Record<string, unknown>;
 }) {
   const { headers, role } = useAuth();
   const [pdfBusy, setPdfBusy] = useState(false);
@@ -163,14 +170,18 @@ export default function ClinicalDecisionPanel({
   const canReview = role === "admin" || role === "spd_manager";
 
   async function toggleTrainingMode() {
-    if (!inspectionId) return;
     const next = !(mentor?.training_mode ?? false);
     setTrainingBusy(true);
     try {
-      const updated = await apiFetch<SpdMentor>(
-        `/api/inspections/${inspectionId}/mentor?training_mode=${next}`
-      );
-      setMentor(updated);
+      const updated = rawResult
+        ? await apiFetch<SpdMentor>(`/api/mentor/build?training_mode=${next}`, {
+            method: "POST",
+            body: { result: rawResult, overall: cd.overall_result },
+          })
+        : inspectionId
+          ? await apiFetch<SpdMentor>(`/api/inspections/${inspectionId}/mentor?training_mode=${next}`)
+          : undefined;
+      if (updated) setMentor(updated);
     } finally {
       setTrainingBusy(false);
     }
@@ -275,7 +286,7 @@ export default function ClinicalDecisionPanel({
         <div className="rounded-lg border border-indigo-200 bg-indigo-50/50 p-4 space-y-3">
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">SPD Mentor</p>
-            {inspectionId && (
+            {(rawResult || inspectionId) && (
               <button
                 onClick={toggleTrainingMode}
                 disabled={trainingBusy}

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -51,6 +51,27 @@ type ClinicalDecision = {
     standard_practice: string; what_should_happen_next: string[];
     where_was_it_detected?: string; why_this_zone_is_high_risk?: string; verify_manually?: string;
   };
+  // v1.4 — SPD Mentor Engine
+  spd_mentor?: SpdMentor;
+};
+
+type SpdMentor = {
+  disclaimer: string;
+  corrective_actions: { finding: string; steps: string[] }[];
+  anatomy_coaching: string[];
+  confidence_coaching: { message: string; suggestions: string[] } | null;
+  clinical_decision_summary: {
+    instrument: string; inspection_coverage: number | null; findings: string;
+    risk: string | null; recommendation: string | null; supervisor_review: string;
+  };
+  education_cards: { finding: string; clinical_significance: string; recommended_practice: string; reference: string }[];
+  training_mode: boolean;
+  expanded_explanations?: {
+    every_finding: Record<string, unknown>[];
+    anatomy_explained: { zone: string; explanation: string }[];
+    recommendation_explained: { disposition: string; next_actions: string[]; standards_guidance: string };
+    terminology: { term: string; definition: string }[];
+  };
 };
 
 const RISK_BADGE: Record<string, string> = {
@@ -136,8 +157,24 @@ export default function ClinicalDecisionPanel({
   const { headers, role } = useAuth();
   const [pdfBusy, setPdfBusy] = useState(false);
   const [learning, setLearning] = useState(false);
+  const [mentor, setMentor] = useState<SpdMentor | undefined>(cd.spd_mentor);
+  const [trainingBusy, setTrainingBusy] = useState(false);
   const result = cd.overall_result;
   const canReview = role === "admin" || role === "spd_manager";
+
+  async function toggleTrainingMode() {
+    if (!inspectionId) return;
+    const next = !(mentor?.training_mode ?? false);
+    setTrainingBusy(true);
+    try {
+      const updated = await apiFetch<SpdMentor>(
+        `/api/inspections/${inspectionId}/mentor?training_mode=${next}`
+      );
+      setMentor(updated);
+    } finally {
+      setTrainingBusy(false);
+    }
+  }
 
   async function downloadPdf() {
     if (!inspectionId) return;
@@ -230,6 +267,102 @@ export default function ClinicalDecisionPanel({
             <p><span className="font-semibold text-slate-900">Standard practice:</span> {cd.ai_mentor.standard_practice}</p>
             <p><span className="font-semibold text-slate-900">What should happen next:</span> {cd.ai_mentor.what_should_happen_next.join("; ")}</p>
           </div>
+        </div>
+      )}
+
+      {/* v1.4 — SPD Mentor Engine */}
+      {mentor && (
+        <div className="rounded-lg border border-indigo-200 bg-indigo-50/50 p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">SPD Mentor</p>
+            {inspectionId && (
+              <button
+                onClick={toggleTrainingMode}
+                disabled={trainingBusy}
+                className="text-xs font-medium text-indigo-700 underline disabled:opacity-50"
+              >
+                {trainingBusy ? "Loading…" : mentor.training_mode ? "Training Mode: On" : "Training Mode: Off"}
+              </button>
+            )}
+          </div>
+
+          {/* Clinical Decision Summary */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-sm">
+            <div><div className="text-xs text-slate-500">Instrument</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.instrument}</div></div>
+            <div><div className="text-xs text-slate-500">Coverage</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.inspection_coverage ?? "—"}%</div></div>
+            <div><div className="text-xs text-slate-500">Supervisor Review</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.supervisor_review}</div></div>
+          </div>
+          <p className="text-sm text-slate-700">{mentor.clinical_decision_summary.findings}</p>
+
+          {/* Corrective Action Recommendations */}
+          {mentor.corrective_actions.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-slate-600 mb-1">Corrective Action</p>
+              {mentor.corrective_actions.map((a, i) => (
+                <p key={i} className="text-sm text-slate-700">
+                  <span className="font-medium capitalize">{a.finding}:</span> {a.steps.join(" → ")}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {/* Anatomy-Aware Coaching */}
+          {mentor.anatomy_coaching.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-slate-600 mb-1">Anatomy Coaching</p>
+              <ul className="space-y-0.5 text-sm text-slate-700">
+                {mentor.anatomy_coaching.map((c, i) => <li key={i}>• {c}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {/* AI Confidence Coaching */}
+          {mentor.confidence_coaching && (
+            <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2">
+              <p className="text-sm font-medium text-amber-800">{mentor.confidence_coaching.message}</p>
+              <ul className="mt-1 text-sm text-amber-700">
+                {mentor.confidence_coaching.suggestions.map((s, i) => <li key={i}>• {s}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {/* SPD Education Cards */}
+          {mentor.education_cards.length > 0 && (
+            <div className="space-y-1.5">
+              {mentor.education_cards.map((c, i) => (
+                <div key={i} className="rounded border border-slate-200 bg-white px-3 py-2">
+                  <p className="text-sm font-semibold capitalize text-slate-800">{c.finding}</p>
+                  <p className="text-sm text-slate-600">{c.clinical_significance}</p>
+                  <p className="text-sm text-slate-600"><span className="text-slate-500">Recommended practice:</span> {c.recommended_practice}</p>
+                  <p className="text-xs text-slate-400">{c.reference}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Training Mode expanded explanations */}
+          {mentor.training_mode && mentor.expanded_explanations && (
+            <div className="rounded border border-indigo-300 bg-white px-3 py-2 space-y-2">
+              <p className="text-xs font-semibold text-indigo-700">Terminology</p>
+              <ul className="text-sm text-slate-700 space-y-0.5">
+                {mentor.expanded_explanations.terminology.map((t, i) => (
+                  <li key={i}><span className="font-medium">{t.term}:</span> {t.definition}</li>
+                ))}
+              </ul>
+              {mentor.expanded_explanations.anatomy_explained.length > 0 && (
+                <>
+                  <p className="text-xs font-semibold text-indigo-700">Anatomy Explained</p>
+                  <ul className="text-sm text-slate-700 space-y-0.5">
+                    {mentor.expanded_explanations.anatomy_explained.map((z, i) => (
+                      <li key={i}><span className="font-medium capitalize">{z.zone}:</span> {z.explanation}</li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          )}
+
+          <p className="text-xs text-slate-400 italic">{mentor.disclaimer}</p>
         </div>
       )}
 

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -103,6 +103,8 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/capa", label: "CAPA", icon: ShieldCheck },
       { to: "/audit-evidence", label: "Audit Evidence", icon: FileText, roles: [...ELEVATED_ROLES, "auditor"] },
       { to: "/enterprise", label: "Enterprise Quality", icon: Building2, roles: ELEVATED_ROLES },
+      { to: "/education-library", label: "SPD Education Library", icon: BookOpen },
+      { to: "/coaching-dashboard", label: "Supervisor Coaching", icon: ClipboardCheck, roles: ELEVATED_ROLES },
     ],
   },
   {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -100,6 +100,8 @@ const ImageQualityPage = lazy(() => import("./pages/ImageQualityPage"));
 const GoLiveCenterPage = lazy(() => import("./pages/GoLiveCenterPage"));
 const ImplementationTrackerPage = lazy(() => import("./pages/ImplementationTrackerPage"));
 const TrainingCompliancePage = lazy(() => import("./pages/TrainingCompliancePage"));
+const EducationLibraryPage = lazy(() => import("./pages/EducationLibraryPage"));
+const SupervisorCoachingDashboard = lazy(() => import("./pages/SupervisorCoachingDashboard"));
 const BaselineReadinessPage = lazy(() => import("./pages/BaselineReadinessPage"));
 const InspectionReadinessPage = lazy(() => import("./pages/InspectionReadinessPage"));
 const ExecutiveAdoptionPage = lazy(() => import("./pages/ExecutiveAdoptionPage"));
@@ -387,6 +389,8 @@ function App() {
                       <Route path="/go-live-center" element={<Page name="GoLiveCenter"><GoLiveCenterPage /></Page>} />
                       <Route path="/implementation-tracker" element={<Page name="ImplementationTracker"><ImplementationTrackerPage /></Page>} />
                       <Route path="/training-compliance" element={<Page name="TrainingCompliance"><TrainingCompliancePage /></Page>} />
+                      <Route path="/education-library" element={<Page name="EducationLibrary"><EducationLibraryPage /></Page>} />
+                      <Route path="/coaching-dashboard" element={<Page name="CoachingDashboard"><RequireRole allowed={ELEVATED_ROLES}><SupervisorCoachingDashboard /></RequireRole></Page>} />
                       <Route path="/baseline-readiness" element={<Page name="BaselineReadiness"><BaselineReadinessPage /></Page>} />
                       <Route path="/inspection-readiness" element={<Page name="InspectionReadiness"><InspectionReadinessPage /></Page>} />
                       <Route path="/executive-adoption" element={<Page name="ExecutiveAdoption"><ExecutiveAdoptionPage /></Page>} />

--- a/frontend/src/pages/EducationLibraryPage.tsx
+++ b/frontend/src/pages/EducationLibraryPage.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from "react";
+import { BookOpen } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface Article {
+  finding: string;
+  finding_type: string;
+  definition: string;
+  clinical_importance: string;
+  typical_anatomy_locations: string[];
+  inspection_tips: string;
+  cleaning_considerations: string;
+  corrective_actions: string[];
+  reference: string;
+}
+
+export default function EducationLibraryPage() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await apiFetch<{ articles: Article[] }>("/api/mentor/education");
+        setArticles(data.articles);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return <div className="p-6 text-sm text-slate-500">Loading education library…</div>;
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-4">
+      <div className="flex items-center gap-2">
+        <BookOpen className="h-6 w-6 text-indigo-600" />
+        <h1 className="text-xl font-bold text-slate-900">SPD Education Library</h1>
+      </div>
+      <p className="text-sm text-slate-500">
+        Structured reference for every contamination and condition category LumenAI recognizes —
+        definition, clinical importance, typical anatomy locations, inspection tips, cleaning
+        considerations, and corrective actions.
+      </p>
+
+      <div className="space-y-2">
+        {articles.map((a) => (
+          <div key={a.finding_type} className="rounded-lg border border-slate-200 bg-white">
+            <button
+              onClick={() => setOpen(open === a.finding_type ? null : a.finding_type)}
+              className="w-full flex items-center justify-between px-4 py-3 text-left"
+            >
+              <span className="font-semibold capitalize text-slate-800">{a.finding.replace(/_/g, " ")}</span>
+              <span className="text-xs text-slate-400">{open === a.finding_type ? "Hide" : "View"}</span>
+            </button>
+            {open === a.finding_type && (
+              <div className="px-4 pb-4 space-y-2 text-sm text-slate-700">
+                <p><span className="font-medium text-slate-500">Definition:</span> {a.definition}</p>
+                <p><span className="font-medium text-slate-500">Clinical importance:</span> {a.clinical_importance}</p>
+                <p><span className="font-medium text-slate-500">Typical anatomy locations:</span> {a.typical_anatomy_locations.join(", ")}</p>
+                <p><span className="font-medium text-slate-500">Inspection tips:</span> {a.inspection_tips}</p>
+                <p><span className="font-medium text-slate-500">Cleaning considerations:</span> {a.cleaning_considerations}</p>
+                <div>
+                  <span className="font-medium text-slate-500">Corrective actions:</span>
+                  <ul className="mt-1 space-y-0.5">
+                    {a.corrective_actions.map((s, i) => <li key={i}>• {s}</li>)}
+                  </ul>
+                </div>
+                <p className="text-xs text-slate-400">{a.reference}</p>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -1077,7 +1077,11 @@ function AIPredictionPanel({
 
         {/* Phase 13 — Explainable Clinical Decision Support (primary view) */}
         {prediction.analysis?.clinical_decision && (
-          <ClinicalDecisionPanel cd={prediction.analysis.clinical_decision} inspectionId={prediction.id} />
+          <ClinicalDecisionPanel
+            cd={prediction.analysis.clinical_decision}
+            inspectionId={prediction.id}
+            rawResult={prediction.analysis}
+          />
         )}
 
         {/* Phase 15 — Instrument Intelligence: coverage, risk map, guidance */}

--- a/frontend/src/pages/SupervisorCoachingDashboard.tsx
+++ b/frontend/src/pages/SupervisorCoachingDashboard.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect, useCallback } from "react";
+import { ClipboardCheck } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface QueueItem {
+  inspection_id: number;
+  instrument_type: string;
+  technician: string | null;
+  risk_level: string | null;
+  recommended_action: string | null;
+  coaching_reviewed: boolean;
+}
+
+interface Effectiveness {
+  total_reviews: number;
+  approved_unchanged: number;
+  edited: number;
+  with_educational_comment: number;
+  approved_unchanged_pct: number | null;
+}
+
+export default function SupervisorCoachingDashboard() {
+  const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [effectiveness, setEffectiveness] = useState<Effectiveness | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [comment, setComment] = useState<Record<number, string>>({});
+  const [busy, setBusy] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [q, e] = await Promise.all([
+        apiFetch<{ queue: QueueItem[] }>("/api/mentor/coaching-queue"),
+        apiFetch<Effectiveness>("/api/mentor/coaching-effectiveness"),
+      ]);
+      setQueue(q.queue);
+      setEffectiveness(e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function review(inspectionId: number, approved: boolean) {
+    setBusy(inspectionId);
+    try {
+      await apiFetch(`/api/inspections/${inspectionId}/coaching-review`, {
+        method: "POST",
+        body: { approved, educational_comment: comment[inspectionId] ?? "" },
+      });
+      await load();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (loading) {
+    return <div className="p-6 text-sm text-slate-500">Loading coaching dashboard…</div>;
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-4">
+      <div className="flex items-center gap-2">
+        <ClipboardCheck className="h-6 w-6 text-indigo-600" />
+        <h1 className="text-xl font-bold text-slate-900">Supervisor Coaching Dashboard</h1>
+      </div>
+      <p className="text-sm text-slate-500">
+        Review the AI Mentor's coaching on recent inspections — approve it, or add an educational
+        comment for the technician.
+      </p>
+
+      {effectiveness && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 rounded-lg border border-slate-200 bg-white p-4">
+          <div><div className="text-xs text-slate-500">Total reviews</div><div className="text-xl font-bold text-slate-900">{effectiveness.total_reviews}</div></div>
+          <div><div className="text-xs text-slate-500">Approved unchanged</div><div className="text-xl font-bold text-emerald-700">{effectiveness.approved_unchanged}</div></div>
+          <div><div className="text-xs text-slate-500">Edited</div><div className="text-xl font-bold text-amber-700">{effectiveness.edited}</div></div>
+          <div><div className="text-xs text-slate-500">With comment</div><div className="text-xl font-bold text-slate-900">{effectiveness.with_educational_comment}</div></div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {queue.map((item) => (
+          <div key={item.inspection_id} className="rounded-lg border border-slate-200 bg-white p-4 space-y-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="text-sm">
+                <span className="font-semibold capitalize text-slate-800">{item.instrument_type}</span>
+                <span className="text-slate-400"> · #{item.inspection_id}</span>
+                {item.technician && <span className="text-slate-500"> · {item.technician}</span>}
+              </div>
+              <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${item.coaching_reviewed ? "bg-emerald-100 text-emerald-800" : "bg-amber-100 text-amber-800"}`}>
+                {item.coaching_reviewed ? "Reviewed" : "Awaiting review"}
+              </span>
+            </div>
+            <p className="text-sm text-slate-600">{item.recommended_action ?? "—"}</p>
+            <input
+              type="text"
+              placeholder="Add an educational comment for the technician…"
+              value={comment[item.inspection_id] ?? ""}
+              onChange={(e) => setComment((c) => ({ ...c, [item.inspection_id]: e.target.value }))}
+              className="w-full rounded border border-slate-300 px-2 py-1 text-sm"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={() => review(item.inspection_id, true)}
+                disabled={busy === item.inspection_id}
+                className="rounded bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => review(item.inspection_id, false)}
+                disabled={busy === item.inspection_id}
+                className="rounded bg-slate-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+              >
+                Flag for edit
+              </button>
+            </div>
+          </div>
+        ))}
+        {queue.length === 0 && <p className="text-sm text-slate-400">No inspections in the coaching queue.</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Transforms LumenAI from an inspection application into an intelligent SPD mentor. After every AI inspection, the platform now answers: what was found, why it matters, what SPD principles apply, what should happen next, and (in Training Mode) the underlying terminology and anatomy — while never replacing supervisor judgment.

Built as an **integration layer on top of the existing Phase 13/14/15 infrastructure** (`clinical_mentor.py`, `instrument_anatomy.py`, `instrument_zones.py`, `inspection_coverage.py`) rather than duplicating it — this codebase already had a substantial Explainable AI Clinical Decision Support system; v1.4 extends it with the specific deliverables below.

## Scope

**1. SPD Mentor Engine** (`backend/app/services/spd_mentor_engine.py`)
Interprets findings, explains contamination/damage/anatomy risk, suggests corrective action, references SPD best practice — carries a disclaimer on every payload that it does not replace supervisor judgment or the manufacturer's IFU.

**2. Corrective Action Recommendations**
Structured, ordered step chains per finding type (Blood → Reclean → Brush serrations manually → Flush lumen → Repeat visual inspection → Supervisor verification; Rust/Corrosion → Remove from service → Evaluate for repair → Inspect surrounding anatomy → Document; Crack → Remove from service immediately → Notify supervisor → Repair evaluation), covering all 12 categories.

**3. Anatomy-Aware Coaching**
Coaching sentences derived from each instrument's real anatomy profile, with canned phrasing matching well-known SPD lore (Kerrison serrations, rigid scope O-rings, drill-bit flutes, needle-holder box locks) and a generated fallback for every other family from the anatomy data itself.

**4. Educational Knowledge Library** (`backend/app/services/education_library.py`)
Structured articles for all 12 categories — definition, clinical importance, typical anatomy locations, inspection tips, cleaning considerations, corrective actions — reshaped from the same source of truth the AI Mentor uses, so they can't drift apart. Typical anatomy locations are derived from each zone's actual risk classification (not a fabricated per-finding list).

**5. Training Mode**
A `training_mode` flag (request param or toggle) expands every finding, anatomy zone, recommendation, and SPD terminology into full explanations — reuses existing Phase 14 learning-mode content rather than re-deriving it.

**6. Competency Support**
New `competency_events` log + `competency_service.py` tracks findings reviewed, supervisor corrections, repeated errors, and education completed per technician — fed automatically by the existing supervisor-review endpoint. `Inspection` gains a nullable `technician` field (the request actor at creation time); older inspections without it are excluded from aggregation rather than backfilled with a guess.

**7. AI Confidence Coaching**
When confidence < 70% or required-zone coverage < 75% (or zones were never tagged), technicians see why and what to do about it (capture more images, improve lighting, capture missing zones, request supervisor review).

**8. Clinical Decision Summary**
Concise instrument / coverage / findings / risk / recommendation / supervisor-review card, derived from the same disposition logic as the existing Phase 13 payload.

**9. Supervisor Coaching Dashboard**
New `mentor_coaching_reviews` table + API + frontend page — supervisors approve, edit, or add educational comments on the AI's coaching, and see aggregate coaching-effectiveness stats. Deliberately separate from the existing ML-ground-truth `supervisor-review` endpoint (different purpose: coaching quality, not model performance).

**10. Documentation** — `docs/mentor/{spd-mentor-engine,clinical-decision-support,anatomy-aware-coaching,education-library,competency-support}.md`

**11. Tests** — `backend/tests/test_spd_mentor_engine.py`, 26 new tests covering every bullet in the spec's test list.

**12. Frontend** — `ClinicalDecisionPanel` gains an SPD Mentor card with a Training Mode toggle; new `EducationLibraryPage` and `SupervisorCoachingDashboard` pages, wired into navigation.

## New API surface
- `GET /api/mentor/education`, `GET /api/mentor/education/{finding_type}`, `POST /api/mentor/education/{finding_type}/complete`
- `GET /api/mentor/competency/{technician}`
- `GET /api/inspections/{id}/mentor?training_mode=` (re-derives mentor content for a past inspection, mirroring the existing `clinical-report.pdf` pattern)
- `GET /api/mentor/coaching-queue`, `POST /api/inspections/{id}/coaching-review`, `GET /api/mentor/coaching-effectiveness`

## Testing
- [x] Unit tests — 26 new tests in `test_spd_mentor_engine.py`
- [x] Full backend suite: `2359 passed, 2 skipped` (was 2333/2 before this branch)
- [x] `ruff check app tests` — all checks passed
- [x] `npm run build` — clean
- [ ] Manual verification (pending merge + redeploy)
- [ ] Docker build
- [ ] API/worker runtime validation

## Risks
Additive throughout: one new nullable column on `Inspection` (back-filled via the existing `ensure_columns` migrator), two brand-new tables, one new router, and a new `spd_mentor` key nested inside the existing `clinical_decision` payload — nothing existing is renamed, removed, or changed in shape.

## Rollback Plan
Revert this commit. The new `technician` column and tables are additive and safe to leave in place even if the feature is rolled back.


---
_Generated by [Claude Code](https://claude.ai/code/session_011Fk9dzNXLSbHDHTsT5TCKL)_