### PR TITLE
LumenAI Inspect v1.5 — Quality Intelligence & Continuous Improvement

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -117,6 +117,8 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.instrument_knowledge")  # register instrument knowledge library
     importlib.import_module("app.models.model_registry")        # register P17 model registry table
     importlib.import_module("app.models.shadow_prediction")     # register P17 shadow-prediction table
+    importlib.import_module("app.models.competency_event")       # register v1.4 technician competency events
+    importlib.import_module("app.models.mentor_coaching_review") # register v1.4 supervisor coaching reviews
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -126,7 +128,7 @@ async def lifespan(_app: FastAPI):
         from app.db.column_migrator import ensure_columns
         from app.models.inspection import Inspection
         from app.models.supervisor_review import SupervisorReview
-        ensure_columns(engine, Inspection)
+        ensure_columns(engine, Inspection)  # includes v1.4's `technician` column
         ensure_columns(engine, SupervisorReview)
     except Exception as _mig_e:
         import logging
@@ -598,6 +600,9 @@ app.include_router(agent_router, prefix=settings.API_PREFIX)
 app.include_router(stream_router, prefix=settings.API_PREFIX)
 
 app.include_router(vendor_analytics_router, prefix=settings.API_PREFIX)
+
+from app.routes.spd_mentor import router as spd_mentor_router
+app.include_router(spd_mentor_router, prefix=settings.API_PREFIX)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -119,6 +119,9 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.shadow_prediction")     # register P17 shadow-prediction table
     importlib.import_module("app.models.competency_event")       # register v1.4 technician competency events
     importlib.import_module("app.models.mentor_coaching_review") # register v1.4 supervisor coaching reviews
+    importlib.import_module("app.models.inspection_finding")      # register v1.5 per-finding detection log
+    importlib.import_module("app.models.root_cause")              # register v1.5 root-cause assignments
+    importlib.import_module("app.models.continuous_improvement")  # register v1.5 improvement tracker
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -603,6 +606,9 @@ app.include_router(vendor_analytics_router, prefix=settings.API_PREFIX)
 
 from app.routes.spd_mentor import router as spd_mentor_router
 app.include_router(spd_mentor_router, prefix=settings.API_PREFIX)
+
+from app.routes.quality_dashboard import router as quality_dashboard_router
+app.include_router(quality_dashboard_router)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/models/competency_event.py
+++ b/backend/app/models/competency_event.py
@@ -1,0 +1,37 @@
+"""v1.4 — Technician competency tracking.
+
+A lightweight event log the SPD Mentor Engine's competency service reads to
+build per-technician summaries: findings reviewed, supervisor corrections,
+repeated errors, and education completed. Deliberately separate from
+SupervisorReview (the ML ground-truth label store) — this table tracks
+technician learning/competency, not model performance.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class CompetencyEvent(Base):
+    __tablename__ = "competency_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    technician: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    # finding_reviewed | supervisor_correction | repeated_error | education_completed
+    event_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    finding_type: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/models/continuous_improvement.py
+++ b/backend/app/models/continuous_improvement.py
@@ -1,0 +1,45 @@
+"""v1.5 — Continuous Improvement Tracker.
+
+Tracks named quality initiatives (e.g. "retrain on Kerrison box-lock
+brushing") from proposal through completion. `actual_impact` is filled in by
+a human once observed — never computed/inferred automatically, since a
+before/after quality delta requires human judgment about what changed and
+why, not just a raw metric diff.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Date, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+INITIATIVE_STATUSES: list[str] = ["proposed", "in_progress", "completed", "abandoned"]
+
+
+class ContinuousImprovementInitiative(Base):
+    __tablename__ = "continuous_improvement_initiatives"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    initiative: Mapped[str] = mapped_column(String(500), nullable=False)
+    owner: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    target_date: Mapped[Date | None] = mapped_column(Date, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default="proposed", nullable=False, index=True)
+    expected_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    actual_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -77,3 +77,9 @@ class Inspection(Base):
     risk_level: Mapped[str | None] = mapped_column(String(20), nullable=True)
     recommended_action: Mapped[str | None] = mapped_column(String(500), nullable=True)
     overall_cleaning_assessment: Mapped[str | None] = mapped_column(String(80), nullable=True)
+
+    # v1.4 — the technician who submitted the inspection (request actor at
+    # creation time), so the SPD Mentor Engine's competency service can
+    # attribute findings-reviewed/supervisor-corrections to a real person
+    # instead of fabricating attribution. Nullable/blank for older rows.
+    technician: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -83,3 +83,21 @@ class Inspection(Base):
     # attribute findings-reviewed/supervisor-corrections to a real person
     # instead of fabricating attribution. Nullable/blank for older rows.
     technician: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # v1.5 — Quality Intelligence. `disposition` is the one of
+    # PASS/MONITOR/SUPERVISOR REVIEW/REPROCESS/REMOVE FROM SERVICE computed at
+    # analysis time (clinical_decision.overall_result) — persisted so pass
+    # rate/reclean rate/remove-from-service rate can be reported later without
+    # re-deriving analysis. `coverage_pct`/`coverage_quality` are the
+    # Inspection Coverage Engine's result at submission time, persisted for
+    # the same reason (coverage compliance reporting). All nullable/blank for
+    # older rows or inspections with no image.
+    disposition: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    coverage_pct: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    coverage_quality: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    # v1.5 — the AI-computed analysis confidence (0-1), distinct from the
+    # pre-existing `confidence` column above (a client-supplied manual-entry
+    # field for the no-image path). Persisted so "AI Confidence Trend" can be
+    # reported without re-deriving analysis.
+    ai_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/backend/app/models/inspection_finding.py
+++ b/backend/app/models/inspection_finding.py
@@ -1,0 +1,39 @@
+"""v1.5 — Quality Intelligence: per-finding detection log.
+
+Inspection only stores the rolled-up disposition (risk_level, recommended_action,
+overall_cleaning_assessment) — not which individual finding types were actually
+detected. Finding Trend Intelligence, the Anatomy Risk Dashboard, and Instrument
+Family Performance all need real per-finding-type, per-zone data to aggregate
+over time, so this logs one row per actionable finding (severity_index >= 1)
+at analysis time — never fabricated after the fact.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class InspectionFinding(Base):
+    __tablename__ = "inspection_findings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    instrument_type: Mapped[str] = mapped_column(String(100), default="unknown", nullable=False, index=True)
+
+    finding_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    severity_index: Mapped[int] = mapped_column(Integer, default=0, nullable=False)

--- a/backend/app/models/mentor_coaching_review.py
+++ b/backend/app/models/mentor_coaching_review.py
@@ -1,0 +1,39 @@
+"""v1.4 — Supervisor Coaching Dashboard review store.
+
+Captures a supervisor's review of the SPD Mentor Engine's coaching output for
+an inspection — approve as-is, edit the recommendation, and/or add an
+educational comment. Deliberately separate from SupervisorReview (which
+captures AI-agreement for ML ground truth) — this table tracks coaching
+quality/effectiveness, not model performance.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class MentorCoachingReview(Base):
+    __tablename__ = "mentor_coaching_reviews"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    reviewer_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    reviewer_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    approved: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    edited_recommendation: Mapped[str] = mapped_column(String(1000), default="", nullable=False)
+    educational_comment: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/models/root_cause.py
+++ b/backend/app/models/root_cause.py
@@ -1,0 +1,49 @@
+"""v1.5 — Root Cause Intelligence.
+
+A finding can be categorized by its probable root cause (by a supervisor —
+never inferred automatically, since guessing "why" a finding occurred without
+a human judgment would be a fabricated causal claim). Recurring root causes
+across inspections are what Root Cause Intelligence trends.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# Accepted root-cause vocabulary. "unknown" is a legitimate, honest choice —
+# not every finding has an identifiable cause at review time.
+ROOT_CAUSES: list[str] = [
+    "incomplete_manual_cleaning",
+    "improper_brushing",
+    "improper_flushing",
+    "missed_inspection_zone",
+    "poor_lighting",
+    "image_quality",
+    "instrument_damage",
+    "manufacturer_wear",
+    "unknown",
+]
+
+
+class RootCauseAssignment(Base):
+    __tablename__ = "root_cause_assignments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    finding_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    root_cause: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    assigned_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -137,6 +137,20 @@ def submit_supervisor_review(
         inspection.override_reason = body.rationale.strip()
         inspection.override_by = _actor(current_user)
         inspection.override_at = datetime.now(timezone.utc)
+
+    # v1.4 — technician competency tracking, derived from this same review.
+    from app.services.competency_service import record_finding_reviewed, record_supervisor_correction
+
+    if inspection.technician:
+        record_finding_reviewed(
+            db, tenant_id=tenant_id, technician=inspection.technician, inspection_id=inspection_id,
+        )
+        if agreement != "agree" or body.override_action.strip():
+            record_supervisor_correction(
+                db, tenant_id=tenant_id, technician=inspection.technician,
+                finding_type=body.finding_type.strip(), inspection_id=inspection_id,
+            )
+
     db.commit()
     db.refresh(review)
 

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -376,6 +376,12 @@ async def create_inspection(
     risk_level_val: Optional[str] = None
     recommended_action_val: Optional[str] = None
     cleaning_assessment_val: Optional[str] = None
+    # v1.5 — Quality Intelligence: disposition + coverage, persisted for later
+    # reporting (pass/reclean/remove-from-service rates, coverage compliance).
+    disposition_val: Optional[str] = None
+    coverage_pct_val: Optional[int] = None
+    coverage_quality_val: Optional[str] = None
+    ai_confidence_val: Optional[float] = None
 
     if body.has_image:
         analysis = analyze_inspection(
@@ -397,6 +403,11 @@ async def create_inspection(
         risk_level_val = analysis.get("risk_level")
         recommended_action_val = analysis.get("recommended_action")
         cleaning_assessment_val = analysis.get("overall_cleaning_assessment")
+        disposition_val = analysis.get("clinical_decision", {}).get("overall_result")
+        coverage = analysis.get("inspection_coverage") or {}
+        coverage_pct_val = coverage.get("overall_coverage")
+        coverage_quality_val = coverage.get("quality")
+        ai_confidence_val = analysis.get("confidence")
         if analysis["analysis_status"] == "completed":
             baseline_status = "approved_baseline_found"
             baseline_source_val = analysis["baseline_source"]
@@ -446,10 +457,33 @@ async def create_inspection(
         recommended_action=recommended_action_val,
         overall_cleaning_assessment=cleaning_assessment_val,
         technician=actor,
+        disposition=disposition_val,
+        coverage_pct=coverage_pct_val,
+        coverage_quality=coverage_quality_val,
+        ai_confidence=ai_confidence_val,
     )
     db.add(row)
     db.commit()
     db.refresh(row)
+
+    # v1.5 — Quality Intelligence: log each actionable finding (severity >= 1)
+    # for real trend/anatomy-risk/instrument-family aggregation. Only findings
+    # from a completed analysis are real detections — nothing logged for
+    # no-baseline/manual-entry inspections.
+    if analysis is not None and analysis.get("analysis_status") == "completed":
+        from app.models.inspection_finding import InspectionFinding
+
+        for f in analysis.get("predicted_findings", []):
+            if f.get("severity_index", 0) >= 1:
+                db.add(InspectionFinding(
+                    inspection_id=row.id,
+                    tenant_id=tenant_id,
+                    instrument_type=body.instrument_type,
+                    finding_type=f["type"],
+                    zone=f.get("instrument_zone", ""),
+                    severity_index=f["severity_index"],
+                ))
+        db.commit()
 
     log_audit_event(
         db,

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -107,6 +107,9 @@ class InspectionCreate(BaseModel):
     inspected_zones: Optional[List[str]] = Field(None)
     # Technician-declared finding categories (optional — AI determines findings)
     finding_categories: Optional[List[str]] = Field(None)
+    # v1.4 — SPD Mentor Engine Training Mode: explain every finding, anatomy,
+    # recommendation, and terminology in the returned analysis.
+    training_mode: bool = Field(False)
 
     @field_validator("instrument_type")
     @classmethod
@@ -387,6 +390,7 @@ async def create_inspection(
             keydot_id=body.keydot_id,
             decoder_backend=body.identifier_source or "declared",
             inspected_zones=body.inspected_zones,
+            training_mode=body.training_mode,
         )
         # Persist the SPD verdict regardless of completion state so history and
         # the dashboard show what the analysis concluded.
@@ -409,6 +413,8 @@ async def create_inspection(
         baseline_status = "not_applicable"
         risk_score_val = calculate_risk(detected_issue, conf_val)
         score_status = "scored"
+
+    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
 
     row = models.Inspection(
         file_name=body.file_name or "manual-entry",
@@ -439,12 +445,12 @@ async def create_inspection(
         risk_level=risk_level_val,
         recommended_action=recommended_action_val,
         overall_cleaning_assessment=cleaning_assessment_val,
+        technician=actor,
     )
     db.add(row)
     db.commit()
     db.refresh(row)
 
-    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
     log_audit_event(
         db,
         tenant_id=tenant_id,

--- a/backend/app/routes/quality_dashboard.py
+++ b/backend/app/routes/quality_dashboard.py
@@ -1,0 +1,253 @@
+"""v1.5 — Quality Intelligence & Continuous Improvement API surface.
+
+- GET  /api/quality/dashboard                — Deliverable 1: KPI dashboard
+- GET  /api/quality/finding-trends           — Deliverable 2: finding trend intelligence
+- GET  /api/quality/anatomy-risk             — Deliverable 3: anatomy risk dashboard
+- GET  /api/quality/instrument-performance   — Deliverable 4: instrument family performance
+- GET  /api/quality/technician-quality       — Deliverable 5: technician quality (leadership only)
+- GET  /api/quality/supervisor-quality       — Deliverable 6: supervisor quality
+- POST /api/quality/root-cause               — Deliverable 7: assign a root cause
+- GET  /api/quality/root-cause-trends        — Deliverable 7: root cause trends
+- GET  /api/quality/capa-suggestions         — Deliverable 8: CAPA suggestions
+- POST /api/quality/capa-suggestions/create  — Deliverable 8: materialize a suggestion into a real CAPA
+- GET  /api/quality/benchmark                — Deliverable 9: period-over-period benchmarking
+- GET  /api/quality/executive-score          — Deliverable 10: executive quality score
+- GET/POST/PATCH /api/quality/improvement-initiatives — Deliverable 11: continuous improvement tracker
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.root_cause import ROOT_CAUSES
+from app.services.anatomy_risk_service import anatomy_risk_dashboard
+from app.services.capa_suggestion_service import create_capa_from_suggestion, generate_capa_suggestions
+from app.services.competency_service import technician_quality_dashboard
+from app.services.continuous_improvement_service import (
+    create_initiative, list_initiatives, update_initiative,
+)
+from app.services.finding_trend_service import finding_trends
+from app.services.instrument_performance_service import instrument_family_performance
+from app.services.quality_dashboard_service import benchmark, dashboard_summary, executive_quality_score
+from app.services.root_cause_service import assign_root_cause, root_cause_trends
+from app.services.supervisor_quality_service import supervisor_quality_dashboard
+
+router = APIRouter(prefix="/api/quality", tags=["quality-intelligence"])
+
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+@router.get("/dashboard")
+def get_dashboard(
+    request: Request,
+    period: str = "all_time",
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return dashboard_summary(db, _tenant(current_user, request), period)
+
+
+@router.get("/finding-trends")
+def get_finding_trends(
+    request: Request,
+    granularity: str = "monthly",
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return finding_trends(db, _tenant(current_user, request), granularity)
+
+
+@router.get("/anatomy-risk")
+def get_anatomy_risk(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return anatomy_risk_dashboard(db, _tenant(current_user, request))
+
+
+@router.get("/instrument-performance")
+def get_instrument_performance(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return instrument_family_performance(db, _tenant(current_user, request))
+
+
+@router.get("/technician-quality")
+def get_technician_quality(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    """Only visible to authorized leadership (admin/spd_manager)."""
+    return technician_quality_dashboard(db, _tenant(current_user, request))
+
+
+@router.get("/supervisor-quality")
+def get_supervisor_quality(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return supervisor_quality_dashboard(db, _tenant(current_user, request))
+
+
+class RootCauseIn(BaseModel):
+    inspection_id: int
+    finding_type: str = Field(..., max_length=40)
+    root_cause: str = Field(..., max_length=40)
+
+
+@router.post("/root-cause", status_code=201)
+def post_root_cause(
+    body: RootCauseIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    if body.root_cause not in ROOT_CAUSES:
+        raise HTTPException(status_code=422, detail=f"root_cause must be one of {ROOT_CAUSES}")
+    row = assign_root_cause(
+        db, tenant_id=_tenant(current_user, request), inspection_id=body.inspection_id,
+        finding_type=body.finding_type, root_cause=body.root_cause, assigned_by=_actor(current_user),
+    )
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id, "root_cause": row.root_cause, "finding_type": row.finding_type}
+
+
+@router.get("/root-cause-trends")
+def get_root_cause_trends(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return root_cause_trends(db, _tenant(current_user, request))
+
+
+@router.get("/capa-suggestions")
+def get_capa_suggestions(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return {"suggestions": generate_capa_suggestions(db, _tenant(current_user, request))}
+
+
+class CapaSuggestionIn(BaseModel):
+    trigger: str
+    occurrences: int
+    recommendation: str
+    suggested_title: str
+    corrective_action: str
+    preventive_action: str
+
+
+@router.post("/capa-suggestions/create", status_code=201)
+def post_capa_from_suggestion(
+    body: CapaSuggestionIn,
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    capa = create_capa_from_suggestion(body.model_dump(), owner=_actor(current_user))
+    return capa
+
+
+@router.get("/benchmark")
+def get_benchmark(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return benchmark(db, _tenant(current_user, request))
+
+
+@router.get("/executive-score")
+def get_executive_score(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return executive_quality_score(db, _tenant(current_user, request))
+
+
+class InitiativeIn(BaseModel):
+    initiative: str = Field(..., max_length=500)
+    owner: str = Field("", max_length=255)
+    target_date: date | None = None
+    expected_impact: str = Field("", max_length=2000)
+
+
+class InitiativeUpdateIn(BaseModel):
+    status: str | None = Field(None, max_length=20)
+    actual_impact: str | None = Field(None, max_length=2000)
+
+
+@router.get("/improvement-initiatives")
+def get_initiatives(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    rows = list_initiatives(db, _tenant(current_user, request))
+    return {
+        "initiatives": [
+            {
+                "id": r.id, "initiative": r.initiative, "owner": r.owner,
+                "target_date": r.target_date.isoformat() if r.target_date else None,
+                "status": r.status, "expected_impact": r.expected_impact,
+                "actual_impact": r.actual_impact,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.post("/improvement-initiatives", status_code=201)
+def post_initiative(
+    body: InitiativeIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    row = create_initiative(
+        db, tenant_id=_tenant(current_user, request), initiative=body.initiative,
+        owner=body.owner, target_date=body.target_date, expected_impact=body.expected_impact,
+    )
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id, "initiative": row.initiative, "status": row.status}
+
+
+@router.patch("/improvement-initiatives/{initiative_id}")
+def patch_initiative(
+    initiative_id: int,
+    body: InitiativeUpdateIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    row = update_initiative(
+        db, initiative_id=initiative_id, tenant_id=_tenant(current_user, request),
+        status=body.status, actual_impact=body.actual_impact,
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Initiative not found.")
+    db.commit()
+    return {"id": row.id, "status": row.status, "actual_impact": row.actual_impact}

--- a/backend/app/routes/spd_mentor.py
+++ b/backend/app/routes/spd_mentor.py
@@ -1,0 +1,232 @@
+"""v1.4 — SPD Mentor Engine API surface.
+
+- GET  /api/mentor/education                      — Educational Knowledge Library (all articles)
+- GET  /api/mentor/education/{finding_type}        — single article
+- POST /api/mentor/education/{finding_type}/complete — mark an article completed (competency tracking)
+- GET  /api/mentor/competency/{technician}         — technician competency summary
+- GET  /api/inspections/{inspection_id}/mentor     — re-derive the SPD Mentor payload for a past inspection
+- GET  /api/mentor/coaching-queue                  — Supervisor Coaching Dashboard: inspections awaiting review
+- POST /api/inspections/{inspection_id}/coaching-review — approve/edit/comment on the AI's coaching
+- GET  /api/mentor/coaching-effectiveness          — aggregate coaching-review stats
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.mentor_coaching_review import MentorCoachingReview
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.competency_service import competency_summary, record_education_completed
+from app.services.education_library import get_article, list_articles
+
+router = APIRouter(tags=["spd-mentor"])
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+# ── Educational Knowledge Library ────────────────────────────────────────────
+@router.get("/mentor/education")
+def get_education_library(
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    return {"articles": list_articles()}
+
+
+@router.get("/mentor/education/{finding_type}")
+def get_education_article(
+    finding_type: str,
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    article = get_article(finding_type)
+    if article is None:
+        raise HTTPException(status_code=404, detail=f"No education article for '{finding_type}'.")
+    return article
+
+
+@router.post("/mentor/education/{finding_type}/complete", status_code=201)
+def complete_education_article(
+    finding_type: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator")),
+):
+    article = get_article(finding_type)
+    if article is None:
+        raise HTTPException(status_code=404, detail=f"No education article for '{finding_type}'.")
+
+    technician = _actor(current_user)
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    record_education_completed(db, tenant_id=tenant_id, technician=technician, finding_type=finding_type)
+    db.commit()
+    return competency_summary(db, technician)
+
+
+# ── Competency Support ────────────────────────────────────────────────────────
+@router.get("/mentor/competency/{technician}")
+def get_competency_summary(
+    technician: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator")),
+):
+    role = getattr(current_user, "role", "viewer")
+    if role not in ("admin", "spd_manager") and _actor(current_user) != technician:
+        raise HTTPException(status_code=403, detail="You may only view your own competency summary.")
+    return competency_summary(db, technician)
+
+
+# ── Per-inspection mentor re-derivation (Training Mode viewer) ───────────────
+@router.get("/inspections/{inspection_id}/mentor")
+def get_inspection_mentor(
+    inspection_id: int,
+    request: Request,
+    training_mode: bool = False,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Re-derive the SPD Mentor payload for a previously-submitted inspection.
+
+    Mirrors the clinical-report.pdf endpoint's pattern: analysis is
+    deterministic from the stored inspection's identity, so re-running it
+    reproduces the same findings — this lets a technician revisit an
+    inspection with Training Mode on without re-uploading images.
+    """
+    tenant_id = getattr(current_user, "tenant_id", None)
+    query = db.query(models.Inspection).filter(models.Inspection.id == inspection_id)
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    row = query.first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    analysis = analyze_inspection(
+        db,
+        instrument_type=row.instrument_type,
+        tenant_id=row.tenant_id,
+        has_image=bool(row.has_image),
+        image_sha256=row.image_sha256,
+        instrument_barcode=row.instrument_barcode,
+        instrument_udi=row.instrument_udi,
+        training_mode=training_mode,
+    )
+    return analysis["clinical_decision"]["spd_mentor"]
+
+
+# ── Supervisor Coaching Dashboard ─────────────────────────────────────────────
+class CoachingReviewIn(BaseModel):
+    approved: bool = Field(True)
+    edited_recommendation: str = Field("", max_length=1000)
+    educational_comment: str = Field("", max_length=2000)
+
+
+@router.get("/mentor/coaching-queue")
+def get_coaching_queue(
+    request: Request,
+    limit: int = 25,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Recent inspections whose AI coaching has not yet been reviewed by a
+    supervisor, most recent first."""
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    query = db.query(models.Inspection).filter(models.Inspection.has_image.is_(True))
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    rows = query.order_by(models.Inspection.id.desc()).limit(max(1, min(limit, 100))).all()
+
+    reviewed_ids = {
+        r.inspection_id
+        for r in db.query(MentorCoachingReview.inspection_id)
+        .filter(MentorCoachingReview.inspection_id.in_([row.id for row in rows]))
+        .all()
+    } if rows else set()
+
+    return {
+        "queue": [
+            {
+                "inspection_id": row.id,
+                "instrument_type": row.instrument_type,
+                "technician": row.technician,
+                "risk_level": row.risk_level,
+                "recommended_action": row.recommended_action,
+                "coaching_reviewed": row.id in reviewed_ids,
+            }
+            for row in rows
+        ],
+    }
+
+
+@router.post("/inspections/{inspection_id}/coaching-review", status_code=201)
+def submit_coaching_review(
+    inspection_id: int,
+    body: CoachingReviewIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    inspection = db.query(models.Inspection).filter(models.Inspection.id == inspection_id).first()
+    if inspection is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+
+    review = MentorCoachingReview(
+        inspection_id=inspection_id,
+        tenant_id=tenant_id,
+        reviewer_name=_actor(current_user),
+        reviewer_role=getattr(current_user, "role", "spd_manager"),
+        approved=body.approved,
+        edited_recommendation=body.edited_recommendation.strip(),
+        educational_comment=body.educational_comment.strip(),
+    )
+    db.add(review)
+    db.commit()
+    db.refresh(review)
+
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id,
+        actor_email=_actor(current_user), actor_role=getattr(current_user, "role", "spd_manager"),
+        action_type="mentor_coaching_review", resource_type="inspection",
+        resource_id=str(inspection_id),
+    )
+    return {
+        "id": review.id,
+        "inspection_id": inspection_id,
+        "approved": review.approved,
+        "edited_recommendation": review.edited_recommendation,
+        "educational_comment": review.educational_comment,
+    }
+
+
+@router.get("/mentor/coaching-effectiveness")
+def get_coaching_effectiveness(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Aggregate stats on how often supervisors approve the AI's coaching
+    unchanged vs. edit or add educational comments — derived only from
+    recorded reviews, empty when there are none yet."""
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    query = db.query(MentorCoachingReview)
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(MentorCoachingReview.tenant_id == tenant_id)
+    reviews = query.all()
+
+    total = len(reviews)
+    approved_unchanged = sum(1 for r in reviews if r.approved and not r.edited_recommendation)
+    edited = sum(1 for r in reviews if r.edited_recommendation)
+    with_comment = sum(1 for r in reviews if r.educational_comment)
+
+    return {
+        "total_reviews": total,
+        "approved_unchanged": approved_unchanged,
+        "edited": edited,
+        "with_educational_comment": with_comment,
+        "approved_unchanged_pct": round(100 * approved_unchanged / total) if total else None,
+    }

--- a/backend/app/routes/spd_mentor.py
+++ b/backend/app/routes/spd_mentor.py
@@ -5,6 +5,7 @@
 - POST /api/mentor/education/{finding_type}/complete — mark an article completed (competency tracking)
 - GET  /api/mentor/competency/{technician}         — technician competency summary
 - GET  /api/inspections/{inspection_id}/mentor     — re-derive the SPD Mentor payload for a past inspection
+- POST /api/mentor/build                           — rebuild the SPD Mentor payload from an already-displayed result (no re-derivation)
 - GET  /api/mentor/coaching-queue                  — Supervisor Coaching Dashboard: inspections awaiting review
 - POST /api/inspections/{inspection_id}/coaching-review — approve/edit/comment on the AI's coaching
 - GET  /api/mentor/coaching-effectiveness          — aggregate coaching-review stats
@@ -96,6 +97,15 @@ def get_inspection_mentor(
     deterministic from the stored inspection's identity, so re-running it
     reproduces the same findings — this lets a technician revisit an
     inspection with Training Mode on without re-uploading images.
+
+    Caveat (shared with clinical-report.pdf): technician-declared finding
+    categories are not persisted on the Inspection row, so if the original
+    analysis was biased by a declared finding, this re-derivation can differ
+    from what was originally shown. The Training Mode toggle on a
+    just-submitted inspection uses POST /mentor/build instead, which
+    reconstructs the payload from the exact result already on screen — use
+    this endpoint only when that client-side result isn't available (e.g.
+    revisiting history later).
     """
     tenant_id = getattr(current_user, "tenant_id", None)
     query = db.query(models.Inspection).filter(models.Inspection.id == inspection_id)
@@ -116,6 +126,28 @@ def get_inspection_mentor(
         training_mode=training_mode,
     )
     return analysis["clinical_decision"]["spd_mentor"]
+
+
+class MentorBuildIn(BaseModel):
+    result: dict = Field(..., description="The raw analysis result already shown on screen.")
+    overall: str = Field(..., description="The clinical_decision.overall_result already shown on screen.")
+
+
+@router.post("/mentor/build")
+def build_mentor_from_client_result(
+    body: MentorBuildIn,
+    training_mode: bool = False,
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Rebuild the SPD Mentor payload for the exact result already displayed
+    client-side (from a just-submitted inspection). Purely a re-format of
+    data the caller already has — no DB re-derivation, so toggling Training
+    Mode can never change the findings or disposition being explained,
+    unlike GET /inspections/{id}/mentor's best-effort re-derivation.
+    """
+    from app.services.spd_mentor_engine import build_spd_mentor
+
+    return build_spd_mentor(body.result, body.overall, training_mode=training_mode)
 
 
 # ── Supervisor Coaching Dashboard ─────────────────────────────────────────────

--- a/backend/app/services/anatomy_risk_service.py
+++ b/backend/app/services/anatomy_risk_service.py
@@ -1,0 +1,82 @@
+"""v1.5 — Anatomy Risk Dashboard (Deliverable 3).
+
+Highest-risk anatomy zones, most frequent contamination/damage by zone, and
+most-missed inspection zones — derived from real InspectionFinding rows (what
+was actually detected, where) and Inspection Coverage Engine data (what was
+actually missing), not a generic anatomy taxonomy guess.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.inspection_finding import InspectionFinding
+
+
+def _contamination_types() -> set[str]:
+    from app.services.baseline_comparison_scoring_service import CLEANING_KPIS
+    return set(CLEANING_KPIS)
+
+
+def anatomy_risk_dashboard(db: Session, tenant_id: str, days: int = 180) -> dict:
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    findings = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.tenant_id == tenant_id, InspectionFinding.created_at >= since)
+        .all()
+    )
+    contamination = _contamination_types()
+
+    zone_counts: dict[str, int] = defaultdict(int)
+    zone_contamination: dict[str, int] = defaultdict(int)
+    zone_damage: dict[str, int] = defaultdict(int)
+    for f in findings:
+        zone = f.zone or "unspecified region"
+        zone_counts[zone] += 1
+        if f.finding_type in contamination:
+            zone_contamination[zone] += 1
+        else:
+            zone_damage[zone] += 1
+
+    def _top(counter: dict[str, int], n: int = 10) -> list[dict]:
+        return [
+            {"zone": z, "count": c}
+            for z, c in sorted(counter.items(), key=lambda kv: kv[1], reverse=True)[:n]
+        ]
+
+    # Most-missed zones: inspections where the coverage engine recorded a
+    # required zone as missing (persisted nowhere per-zone today — derived
+    # from the guidance list computed at analysis time isn't stored either,
+    # so this reports on the honestly-available signal: inspections with an
+    # assessed-but-incomplete coverage_quality).
+    incomplete = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= since,
+            models.Inspection.coverage_quality.in_(["incomplete", "insufficient"]),
+        )
+        .count()
+    )
+    assessed = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= since,
+            models.Inspection.coverage_pct.isnot(None),
+        )
+        .count()
+    )
+
+    return {
+        "highest_risk_anatomy_zones": _top(zone_counts),
+        "most_frequent_contamination_zones": _top(zone_contamination),
+        "most_frequent_damage_zones": _top(zone_damage),
+        "coverage_incomplete_inspections": incomplete,
+        "coverage_assessed_inspections": assessed,
+        "coverage_incomplete_pct": round(100 * incomplete / assessed, 1) if assessed else None,
+        "human_review_required": True,
+    }

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -851,10 +851,11 @@ def executive_summary(result: dict, overall_result: str) -> list[str]:
     return [ln for ln in lines if ln]
 
 
-def build_clinical_decision(result: dict) -> dict:
+def build_clinical_decision(result: dict, training_mode: bool = False) -> dict:
     """Assemble the full Explainable-AI Clinical Decision Support payload
     (Phases 13.1–13.11) from an already-computed analysis result."""
     from app.services.clinical_mentor import build_mentor  # lazy: avoid cycle
+    from app.services.spd_mentor_engine import build_spd_mentor  # lazy: avoid cycle
 
     findings = {x["type"]: x for x in result.get("predicted_findings", [])}
     overall = _overall_result(result)
@@ -951,6 +952,9 @@ def build_clinical_decision(result: dict) -> dict:
         # Phase 14 — Clinical Mentor: interpretation, why-this-matters, expanded
         # actions, standards guidance, learning mode, risk separation, mentor.
         **build_mentor(result, overall),
+        # v1.4 — SPD Mentor Engine: corrective action chains, anatomy coaching,
+        # confidence coaching, clinical decision summary, education cards.
+        "spd_mentor": build_spd_mentor(result, overall, training_mode=training_mode),
     }
 
 
@@ -967,6 +971,7 @@ def analyze_inspection(
     keydot_id: Optional[str] = None,
     decoder_backend: str = "declared",
     inspected_zones: Optional[list[str]] = None,
+    training_mode: bool = False,
 ) -> dict[str, Any]:
     """Run the deterministic baseline-comparison analysis.
 
@@ -984,8 +989,12 @@ def analyze_inspection(
 
     # ── Governance gate: no approved baseline → no final score ──────────────
     if not resolution["baseline_found"]:
+        from app.services.instrument_anatomy import get_anatomy
+
         no_baseline = {
             "analysis_status": "supervisor_review_required",
+            "instrument_type": instrument_type,
+            "instrument_anatomy": get_anatomy(instrument_type),
             "baseline_source": None,
             "baseline_version": None,
             "baseline_comparison_label": None,
@@ -1015,7 +1024,7 @@ def analyze_inspection(
             "human_review_required": True,
             "placeholder_scoring": True,
         }
-        no_baseline["clinical_decision"] = build_clinical_decision(no_baseline)
+        no_baseline["clinical_decision"] = build_clinical_decision(no_baseline, training_mode=training_mode)
         return no_baseline
 
     seed = _seed_from(image_sha256, f"{instrument_type}:{instrument_barcode or ''}")
@@ -1308,6 +1317,7 @@ def analyze_inspection(
 
     result = {
         "analysis_status": "completed",
+        "instrument_type": instrument_type,
         "baseline_source": source,
         "baseline_role": _baseline_role(source),
         "baseline_comparison_label": _baseline_comparison_label(source),
@@ -1350,5 +1360,5 @@ def analyze_inspection(
         "production_validated": False,
     }
     # Phase 13: Explainable Clinical Decision Support payload.
-    result["clinical_decision"] = build_clinical_decision(result)
+    result["clinical_decision"] = build_clinical_decision(result, training_mode=training_mode)
     return result

--- a/backend/app/services/capa_suggestion_service.py
+++ b/backend/app/services/capa_suggestion_service.py
@@ -1,0 +1,118 @@
+"""v1.5 — CAPA Integration (Deliverable 8).
+
+Suggests Corrective and Preventive Actions from real recurring patterns —
+repeated findings in the same anatomy zone, repeated condition findings on an
+instrument family, or a cluster of low-confidence/low-coverage inspections.
+These are suggestions for a human to review and act on (via
+POST /api/quality/capa-suggestions/{id}/create), never auto-created CAPAs —
+consistent with the platform-wide rule that AI output never bypasses human
+review.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.inspection_finding import InspectionFinding
+from app.services.instrument_anatomy import resolve_family
+
+# A finding-type/zone or finding-type/family repeated at least this many times
+# in the lookback window triggers a suggestion.
+_REPEAT_THRESHOLD = 3
+_LOOKBACK_DAYS = 90
+
+_CONDITION_TYPES = {"rust", "corrosion", "pitting", "crack", "insulation_damage", "missing_component"}
+
+
+def generate_capa_suggestions(db: Session, tenant_id: str) -> list[dict]:
+    since = datetime.now(timezone.utc) - timedelta(days=_LOOKBACK_DAYS)
+    findings = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.tenant_id == tenant_id, InspectionFinding.created_at >= since)
+        .all()
+    )
+
+    suggestions: list[dict] = []
+
+    # Repeated contamination in the same zone -> cleaning competency review.
+    zone_counts: dict[tuple[str, str], int] = defaultdict(int)
+    for f in findings:
+        if f.finding_type not in _CONDITION_TYPES and f.zone:
+            zone_counts[(f.finding_type, f.zone)] += 1
+    for (finding_type, zone), count in zone_counts.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated {finding_type} in {zone}",
+                "occurrences": count,
+                "recommendation": "Review manual cleaning competency for this anatomy zone.",
+                "suggested_title": f"CAPA: Repeated {finding_type} in {zone}",
+                "corrective_action": f"Retrain on manual brushing/flushing technique for {zone}.",
+                "preventive_action": f"Add {zone} to the guided-capture required-zone checklist and monitor recurrence.",
+            })
+
+    # Repeated condition findings on an instrument family -> storage/maintenance.
+    family_counts: dict[tuple[str, str], int] = defaultdict(int)
+    for f in findings:
+        if f.finding_type in _CONDITION_TYPES:
+            family_counts[(f.finding_type, resolve_family(f.instrument_type))] += 1
+    for (finding_type, family), count in family_counts.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated {finding_type} on {family}",
+                "occurrences": count,
+                "recommendation": "Evaluate storage and maintenance practices for this instrument family.",
+                "suggested_title": f"CAPA: Repeated {finding_type} on {family}",
+                "corrective_action": f"Inspect storage conditions and maintenance schedule for {family}.",
+                "preventive_action": f"Add {family} to the preventive-maintenance rotation and monitor recurrence.",
+            })
+
+    # Repeated poor image quality (low confidence, incomplete coverage) by technician.
+    insp_rows = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= since,
+            models.Inspection.has_image.is_(True),
+            models.Inspection.technician.isnot(None),
+        )
+        .all()
+    )
+    by_technician: dict[str, int] = defaultdict(int)
+    for r in insp_rows:
+        low_confidence = r.confidence is not None and r.confidence < 0.7
+        low_coverage = r.coverage_pct is not None and r.coverage_pct < 75
+        if low_confidence or low_coverage:
+            by_technician[r.technician] += 1
+    for technician, count in by_technician.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated low-confidence/low-coverage inspections by {technician}",
+                "occurrences": count,
+                "recommendation": "Technician image capture refresher.",
+                "suggested_title": f"CAPA: Image capture quality — {technician}",
+                "corrective_action": f"Schedule an image-capture refresher for {technician}.",
+                "preventive_action": "Add lighting/angle guidance to the guided-capture workflow.",
+            })
+
+    suggestions.sort(key=lambda s: s["occurrences"], reverse=True)
+    return suggestions
+
+
+def create_capa_from_suggestion(suggestion: dict, *, owner: str = "Quality / Operations") -> dict:
+    """Materialize a chosen suggestion into a real CAPA via the existing
+    capa_service — this is the human-review step, never automatic."""
+    from app.services.capa_service import create_capa
+
+    return create_capa(
+        title=suggestion["suggested_title"],
+        source="quality_intelligence_suggestion",
+        description=suggestion["trigger"],
+        risk_level="medium",
+        owner=owner,
+        corrective_action=suggestion["corrective_action"],
+        preventive_action=suggestion["preventive_action"],
+        status="open",
+    )

--- a/backend/app/services/clinical_mentor.py
+++ b/backend/app/services/clinical_mentor.py
@@ -154,6 +154,17 @@ FINDING_EDUCATION: dict[str, dict] = {
         "spd_response": "Remove from service; complete assembly or replace.",
         "supervisor_tips": "Verify against the tray content list and instrument photo.",
     },
+    "wear": {
+        "why_it_matters": (
+            "Wear is a gradual loss of material or sharpness that can reduce instrument "
+            "performance and, if progressive, lead to functional failure."
+        ),
+        "definition": "Gradual surface or edge degradation from repeated use and reprocessing cycles.",
+        "typical_causes": "Normal use over the instrument's service life, repeated sterilization cycles, or mechanical stress.",
+        "clinical_significance": "Worn cutting edges or jaw inserts can compromise instrument function even without contamination.",
+        "spd_response": "Monitor minor wear; evaluate for repair or retirement if function is affected.",
+        "supervisor_tips": "Compare against the instrument's inspection history to judge whether wear is progressive.",
+    },
 }
 
 # ── Expanded next-action checklists (Phase 14.3) ─────────────────────────────

--- a/backend/app/services/competency_service.py
+++ b/backend/app/services/competency_service.py
@@ -1,0 +1,128 @@
+"""v1.4 — Technician competency support.
+
+Records competency events (findings reviewed, supervisor corrections, repeated
+errors, education completed) and builds per-technician competency summaries.
+Repeated-error detection and training progress are both derived only from
+events actually recorded — nothing is fabricated for technicians with no
+recorded activity.
+"""
+from __future__ import annotations
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.competency_event import CompetencyEvent
+
+# A finding-type correction recorded this many times (or more) for the same
+# technician is flagged as a repeated error.
+_REPEATED_ERROR_THRESHOLD = 2
+
+
+def _record(db: Session, *, tenant_id: str, technician: str, event_type: str,
+            finding_type: str = "", inspection_id: int | None = None) -> CompetencyEvent:
+    event = CompetencyEvent(
+        tenant_id=tenant_id,
+        technician=technician,
+        event_type=event_type,
+        finding_type=finding_type,
+        inspection_id=inspection_id,
+    )
+    db.add(event)
+    return event
+
+
+def record_finding_reviewed(db: Session, *, tenant_id: str, technician: str, inspection_id: int) -> None:
+    """A supervisor reviewed one of this technician's inspections."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="finding_reviewed", inspection_id=inspection_id)
+
+
+def record_supervisor_correction(db: Session, *, tenant_id: str, technician: str,
+                                  finding_type: str, inspection_id: int) -> None:
+    """A supervisor disagreed with, partially agreed with, or overrode the AI
+    on one of this technician's inspections. Also detects and logs a repeated
+    error when the same technician has been corrected on the same finding
+    type before."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="supervisor_correction", finding_type=finding_type,
+            inspection_id=inspection_id)
+
+    if not finding_type:
+        return
+    prior_corrections = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(
+            CompetencyEvent.technician == technician,
+            CompetencyEvent.event_type == "supervisor_correction",
+            CompetencyEvent.finding_type == finding_type,
+        )
+        .scalar()
+        or 0
+    )
+    if prior_corrections >= _REPEATED_ERROR_THRESHOLD:
+        _record(db, tenant_id=tenant_id, technician=technician,
+                event_type="repeated_error", finding_type=finding_type,
+                inspection_id=inspection_id)
+
+
+def record_education_completed(db: Session, *, tenant_id: str, technician: str, finding_type: str) -> None:
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="education_completed", finding_type=finding_type)
+
+
+def _count(db: Session, technician: str, event_type: str) -> int:
+    return (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == event_type)
+        .scalar()
+        or 0
+    )
+
+
+def competency_summary(db: Session, technician: str) -> dict:
+    """Per-technician competency summary derived entirely from recorded
+    competency events — an empty summary for a technician with no recorded
+    activity, never a fabricated score."""
+    findings_reviewed = _count(db, technician, "finding_reviewed")
+    supervisor_corrections = _count(db, technician, "supervisor_correction")
+
+    repeated_error_rows = (
+        db.query(CompetencyEvent.finding_type, func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == "repeated_error")
+        .group_by(CompetencyEvent.finding_type)
+        .all()
+    )
+    repeated_errors = {finding_type: count for finding_type, count in repeated_error_rows}
+
+    education_rows = (
+        db.query(CompetencyEvent.finding_type)
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == "education_completed")
+        .distinct()
+        .all()
+    )
+    education_completed = sorted(row[0] for row in education_rows if row[0])
+
+    # Training progress: a simple, honest ratio — corrections resolved without
+    # becoming a repeated error, out of all recorded activity. None (not 0)
+    # when there is no activity to score yet.
+    total_activity = findings_reviewed + supervisor_corrections
+    training_progress_pct = (
+        round(100 * (1 - (sum(repeated_errors.values()) / supervisor_corrections)))
+        if supervisor_corrections else None
+    )
+
+    return {
+        "technician": technician,
+        "findings_reviewed": findings_reviewed,
+        "supervisor_corrections": supervisor_corrections,
+        "repeated_errors": repeated_errors,
+        "education_completed": education_completed,
+        "training_progress_pct": training_progress_pct,
+        "has_activity": total_activity > 0,
+    }

--- a/backend/app/services/competency_service.py
+++ b/backend/app/services/competency_service.py
@@ -126,3 +126,54 @@ def competency_summary(db: Session, technician: str) -> dict:
         "training_progress_pct": training_progress_pct,
         "has_activity": total_activity > 0,
     }
+
+
+# ── Technician Quality Dashboard (v1.5, Deliverable 5) ───────────────────────
+def technician_quality_dashboard(db: Session, tenant_id: str) -> dict:
+    """Per-technician quality rollup for leadership — inspection count,
+    coverage quality, average AI confidence, supervisor agreement, repeat
+    corrections, and training progress. Visible only to authorized roles;
+    enforced by the route, not this function."""
+    from app.db import models
+    from app.models.supervisor_review import SupervisorReview
+
+    rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.technician.isnot(None))
+        .all()
+    )
+    by_technician: dict[str, list] = {}
+    for r in rows:
+        by_technician.setdefault(r.technician, []).append(r)
+
+    technicians = []
+    for technician, insp_rows in by_technician.items():
+        coverage = [r.coverage_pct for r in insp_rows if r.coverage_pct is not None]
+        confidences = [r.ai_confidence for r in insp_rows if r.has_image and r.ai_confidence is not None]
+
+        insp_ids = [r.id for r in insp_rows]
+        reviews = (
+            db.query(SupervisorReview)
+            .filter(SupervisorReview.inspection_id.in_(insp_ids))
+            .all()
+        ) if insp_ids else []
+        agreement_pct = (
+            round(100 * sum(1 for r in reviews if r.agreement == "agree") / len(reviews), 1)
+            if reviews else None
+        )
+
+        summary = competency_summary(db, technician)
+
+        technicians.append({
+            "technician": technician,
+            "inspection_count": len(insp_rows),
+            "avg_coverage_pct": round(sum(coverage) / len(coverage), 1) if coverage else None,
+            "avg_ai_confidence_pct": round(100 * sum(confidences) / len(confidences), 1) if confidences else None,
+            "supervisor_agreement_pct": agreement_pct,
+            "supervisor_corrections": summary["supervisor_corrections"],
+            "repeated_errors": summary["repeated_errors"],
+            "training_progress_pct": summary["training_progress_pct"],
+        })
+
+    technicians.sort(key=lambda t: t["inspection_count"], reverse=True)
+    return {"technicians": technicians, "human_review_required": True}

--- a/backend/app/services/continuous_improvement_service.py
+++ b/backend/app/services/continuous_improvement_service.py
@@ -1,0 +1,53 @@
+"""v1.5 — Continuous Improvement Tracker (Deliverable 11)."""
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.models.continuous_improvement import ContinuousImprovementInitiative
+
+
+def create_initiative(
+    db: Session, *, tenant_id: str, initiative: str, owner: str = "",
+    target_date: date | None = None, expected_impact: str = "",
+) -> ContinuousImprovementInitiative:
+    row = ContinuousImprovementInitiative(
+        tenant_id=tenant_id,
+        initiative=initiative,
+        owner=owner,
+        target_date=target_date,
+        expected_impact=expected_impact,
+    )
+    db.add(row)
+    return row
+
+
+def list_initiatives(db: Session, tenant_id: str) -> list[ContinuousImprovementInitiative]:
+    return (
+        db.query(ContinuousImprovementInitiative)
+        .filter(ContinuousImprovementInitiative.tenant_id == tenant_id)
+        .order_by(ContinuousImprovementInitiative.created_at.desc())
+        .all()
+    )
+
+
+def update_initiative(
+    db: Session, *, initiative_id: int, tenant_id: str,
+    status: str | None = None, actual_impact: str | None = None,
+) -> ContinuousImprovementInitiative | None:
+    row = (
+        db.query(ContinuousImprovementInitiative)
+        .filter(
+            ContinuousImprovementInitiative.id == initiative_id,
+            ContinuousImprovementInitiative.tenant_id == tenant_id,
+        )
+        .first()
+    )
+    if row is None:
+        return None
+    if status is not None:
+        row.status = status
+    if actual_impact is not None:
+        row.actual_impact = actual_impact
+    return row

--- a/backend/app/services/education_library.py
+++ b/backend/app/services/education_library.py
@@ -1,0 +1,81 @@
+"""v1.4 — Educational Knowledge Library.
+
+Structured SPD education articles for the twelve contamination/condition
+categories LumenAI recognizes. Each article is built from the same source of
+truth already used by the AI Mentor (clinical_mentor.FINDING_EDUCATION) and
+the instrument anatomy library (instrument_anatomy.py) — nothing here is
+duplicated content, it is reshaped into a browsable reference.
+"""
+from __future__ import annotations
+
+from app.services.baseline_comparison_scoring_service import KPI_LABELS
+from app.services.clinical_mentor import FINDING_EDUCATION
+from app.services.instrument_anatomy import INSTRUMENT_ANATOMY
+from app.services.spd_mentor_engine import IFU_REFERENCE_NOTE, corrective_action_chain
+
+# The twelve categories the v1.4 spec enumerates, in spec order. Internal keys
+# match clinical_mentor.FINDING_EDUCATION / KPI_LABELS.
+CATEGORIES: list[str] = [
+    "blood", "bone", "tissue", "other_organic_residue", "debris",
+    "rust", "corrosion", "crack", "wear", "pitting",
+    "missing_component", "insulation_damage",
+]
+
+# instrument_anatomy.py's per-zone contamination_risks/condition_risks lists
+# are the same default vocabulary on every zone (no per-zone override is ever
+# supplied), so they cannot distinguish "typical" locations for one finding
+# type from another. Instead, derive typical locations from what the zone data
+# *does* differentiate: contamination/organic findings collect in zones the
+# codebase already marks as high-retention; structural/condition findings
+# concentrate in zones with high/critical inherent risk. Insulation damage is
+# tied to the one zone actually named for it.
+_CONTAMINATION_FINDINGS = {"blood", "bone", "tissue", "other_organic_residue", "debris"}
+
+
+def _typical_anatomy_locations(finding_type: str) -> list[str]:
+    """Zone names, across all instrument families, that are typical retention/
+    risk sites for this finding type — derived from each zone's own risk
+    classification in instrument_anatomy.py."""
+    zones: set[str] = set()
+    if finding_type == "insulation_damage":
+        target = {"insulation edge"}
+    else:
+        target = None
+
+    for defn in INSTRUMENT_ANATOMY.values():
+        for zone in defn["zones"]:
+            name = zone["zone_name"]
+            if target is not None:
+                if name in target:
+                    zones.add(name)
+                continue
+            if finding_type in _CONTAMINATION_FINDINGS:
+                if zone["retention_risk"] == "high":
+                    zones.add(name)
+            else:
+                if zone["zone_risk_level"] in ("high", "critical"):
+                    zones.add(name)
+    return sorted(zones)
+
+
+def get_article(finding_type: str) -> dict | None:
+    """Full knowledge-library article for one finding type."""
+    edu = FINDING_EDUCATION.get(finding_type)
+    if not edu:
+        return None
+    return {
+        "finding": KPI_LABELS.get(finding_type, finding_type),
+        "finding_type": finding_type,
+        "definition": edu["definition"],
+        "clinical_importance": edu["clinical_significance"],
+        "typical_anatomy_locations": _typical_anatomy_locations(finding_type),
+        "inspection_tips": edu["supervisor_tips"],
+        "cleaning_considerations": edu["typical_causes"],
+        "corrective_actions": corrective_action_chain(finding_type),
+        "reference": IFU_REFERENCE_NOTE,
+    }
+
+
+def list_articles() -> list[dict]:
+    """All twelve knowledge-library articles, spec order."""
+    return [a for a in (get_article(k) for k in CATEGORIES) if a is not None]

--- a/backend/app/services/finding_trend_service.py
+++ b/backend/app/services/finding_trend_service.py
@@ -1,0 +1,74 @@
+"""v1.5 — Finding Trend Intelligence (Deliverable 2).
+
+Aggregates real InspectionFinding rows (logged at analysis time) by finding
+type and time bucket. A finding type with zero rows in a bucket reports 0,
+not an omitted key — the dashboard shows the full 12-category taxonomy so
+"nothing found" is visible, not silently absent.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.inspection_finding import InspectionFinding
+
+# The twelve categories the v1.5 spec tracks. "wear" has no dedicated scoring
+# KPI in the detection engine today, so it will always report 0 — an honest
+# gap, not a fabricated count.
+TREND_FINDING_TYPES: list[str] = [
+    "blood", "bone", "tissue", "other_organic_residue", "debris",
+    "rust", "corrosion", "crack", "wear", "pitting",
+    "missing_component", "insulation_damage",
+]
+
+_GRANULARITY_DAYS = {"daily": 1, "weekly": 7, "monthly": 30, "quarterly": 90, "yearly": 365}
+_LOOKBACK_BUCKETS = {"daily": 14, "weekly": 12, "monthly": 12, "quarterly": 8, "yearly": 5}
+
+
+def _bucket_label(dt: datetime, granularity: str) -> str:
+    if granularity == "daily":
+        return dt.strftime("%Y-%m-%d")
+    if granularity == "weekly":
+        iso = dt.isocalendar()
+        return f"{iso[0]}-W{iso[1]:02d}"
+    if granularity == "monthly":
+        return dt.strftime("%Y-%m")
+    if granularity == "quarterly":
+        return f"{dt.year}-Q{(dt.month - 1) // 3 + 1}"
+    return str(dt.year)
+
+
+def finding_trends(db: Session, tenant_id: str, granularity: str = "monthly") -> dict:
+    if granularity not in _GRANULARITY_DAYS:
+        granularity = "monthly"
+
+    lookback_days = _GRANULARITY_DAYS[granularity] * _LOOKBACK_BUCKETS[granularity]
+    since = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+
+    rows = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.tenant_id == tenant_id, InspectionFinding.created_at >= since)
+        .all()
+    )
+
+    buckets: dict[str, dict[str, int]] = {}
+    for r in rows:
+        label = _bucket_label(r.created_at, granularity)
+        bucket = buckets.setdefault(label, {ft: 0 for ft in TREND_FINDING_TYPES})
+        if r.finding_type in bucket:
+            bucket[r.finding_type] += 1
+
+    series = [
+        {"period": label, "counts": counts}
+        for label, counts in sorted(buckets.items())
+    ]
+
+    totals = {ft: sum(b["counts"][ft] for b in series) for ft in TREND_FINDING_TYPES}
+
+    return {
+        "granularity": granularity,
+        "series": series,
+        "totals": totals,
+        "human_review_required": True,
+    }

--- a/backend/app/services/instrument_performance_service.py
+++ b/backend/app/services/instrument_performance_service.py
@@ -1,0 +1,60 @@
+"""v1.5 — Instrument Family Performance (Deliverable 4).
+
+Ranks instrument families by inspection frequency, pass/fail/repair rate, and
+supervisor intervention rate — derived from real Inspection rows, grouped by
+the same anatomy-family resolution the rest of the platform already uses
+(instrument_anatomy.resolve_family), not a re-typed instrument list.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.services.instrument_anatomy import resolve_family
+
+_REPAIRABLE_ISSUES = {"crack", "corrosion", "insulation_damage"}
+
+
+def _rate(n: int, d: int) -> float | None:
+    return round(100 * n / d, 1) if d else None
+
+
+def instrument_family_performance(db: Session, tenant_id: str, days: int = 180) -> dict:
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.created_at >= since)
+        .all()
+    )
+
+    by_family: dict[str, list] = defaultdict(list)
+    for r in rows:
+        by_family[resolve_family(r.instrument_type)].append(r)
+
+    families = []
+    for family, family_rows in by_family.items():
+        scored = [r for r in family_rows if r.has_image and r.disposition]
+        total = len(scored)
+        pass_ct = sum(1 for r in scored if r.disposition == "PASS")
+        fail_ct = sum(1 for r in scored if r.disposition in ("REPROCESS", "REMOVE FROM SERVICE"))
+        repair_ct = sum(
+            1 for r in scored
+            if r.disposition == "REMOVE FROM SERVICE" and (r.detected_issue or "") in _REPAIRABLE_ISSUES
+        )
+        override_ct = sum(1 for r in family_rows if (r.override_by or "").strip())
+
+        families.append({
+            "family": family,
+            "inspection_count": len(family_rows),
+            "pass_rate_pct": _rate(pass_ct, total),
+            "failure_rate_pct": _rate(fail_ct, total),
+            "repair_rate_pct": _rate(repair_ct, total),
+            "supervisor_intervention_rate_pct": _rate(override_ct, len(family_rows)),
+        })
+
+    families.sort(key=lambda f: f["inspection_count"], reverse=True)
+
+    return {"families": families, "human_review_required": True}

--- a/backend/app/services/quality_dashboard_service.py
+++ b/backend/app/services/quality_dashboard_service.py
@@ -1,0 +1,227 @@
+"""v1.5 — Quality Intelligence Dashboard: core KPIs, benchmarking, and the
+executive quality score.
+
+Every metric here is computed live from real Inspection/SupervisorReview rows
+for the requesting tenant — nothing is mocked or simulated. A metric with no
+underlying data returns None (not zero, not a fabricated placeholder) so the
+dashboard can honestly show "not enough data yet."
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.supervisor_review import SupervisorReview
+
+_REPAIRABLE_ISSUES = {"crack", "corrosion", "insulation_damage"}
+
+
+def _rate(n: int, d: int) -> float | None:
+    return round(100 * n / d, 1) if d else None
+
+
+def _period_start(period: str, now: datetime | None = None) -> datetime | None:
+    """Start of the named period, or None for 'all_time'."""
+    now = now or datetime.now(timezone.utc)
+    if period == "day":
+        return now - timedelta(days=1)
+    if period == "week":
+        return now - timedelta(weeks=1)
+    if period == "month":
+        return now - timedelta(days=30)
+    if period == "quarter":
+        return now - timedelta(days=90)
+    if period == "year":
+        return now - timedelta(days=365)
+    return None  # "all_time"
+
+
+def _inspections(db: Session, tenant_id: str, period: str = "all_time"):
+    q = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id)
+    start = _period_start(period)
+    if start is not None:
+        q = q.filter(models.Inspection.created_at >= start)
+    return q.all()
+
+
+def dashboard_summary(db: Session, tenant_id: str, period: str = "all_time") -> dict:
+    """Deliverable 1 — Quality Intelligence Dashboard KPIs."""
+    rows = _inspections(db, tenant_id, period)
+    return {"period": period, **_summarize_rows(rows), "human_review_required": True}
+
+
+# ── Benchmarking (Deliverable 9) ─────────────────────────────────────────────
+def _classify_change(current: float | None, previous: float | None, *, higher_is_better: bool) -> str:
+    if current is None or previous is None:
+        return "insufficient_data"
+    delta = current - previous
+    if abs(delta) < 1.0:
+        return "stable"
+    improved = delta > 0 if higher_is_better else delta < 0
+    return "improvement" if improved else "regression"
+
+
+# Metrics where a higher percentage is a WORSE outcome.
+_LOWER_IS_BETTER = {"reclean_rate_pct", "remove_from_service_rate_pct", "supervisor_override_rate_pct"}
+
+
+def benchmark(db: Session, tenant_id: str) -> dict:
+    """Deliverable 9 — current month vs previous month vs quarter vs rolling 12mo."""
+    now = datetime.now(timezone.utc)
+    current_month_start = now - timedelta(days=30)
+    previous_month_start = now - timedelta(days=60)
+
+    current = dashboard_summary(db, tenant_id, "month")
+
+    prev_rows = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= previous_month_start,
+            models.Inspection.created_at < current_month_start,
+        )
+        .all()
+    )
+    previous = _summarize_rows(prev_rows)
+    quarter = dashboard_summary(db, tenant_id, "quarter")
+    rolling_year = dashboard_summary(db, tenant_id, "year")
+
+    comparisons = {}
+    for metric in (
+        "pass_rate_pct", "reclean_rate_pct", "repair_rate_pct",
+        "remove_from_service_rate_pct", "supervisor_override_rate_pct",
+        "baseline_compliance_pct", "coverage_compliance_pct", "ai_confidence_trend_pct",
+    ):
+        comparisons[metric] = _classify_change(
+            current.get(metric), previous.get(metric),
+            higher_is_better=metric not in _LOWER_IS_BETTER,
+        )
+
+    return {
+        "current_month": current,
+        "previous_month": previous,
+        "quarter": quarter,
+        "rolling_12_months": rolling_year,
+        "comparison_current_vs_previous_month": comparisons,
+    }
+
+
+def _summarize_rows(rows: list) -> dict:
+    """Same shape as dashboard_summary but from an already-fetched row list
+    (used for the previous-month window, which isn't a simple "since" filter)."""
+    scored = [r for r in rows if r.has_image and r.disposition]
+    total = len(scored)
+    pass_ct = sum(1 for r in scored if r.disposition == "PASS")
+    reclean_ct = sum(1 for r in scored if r.disposition == "REPROCESS")
+    remove_ct = sum(1 for r in scored if r.disposition == "REMOVE FROM SERVICE")
+    repair_ct = sum(
+        1 for r in scored
+        if r.disposition == "REMOVE FROM SERVICE" and (r.detected_issue or "") in _REPAIRABLE_ISSUES
+    )
+    override_ct = sum(1 for r in rows if (r.override_by or "").strip())
+    baseline_ct = sum(1 for r in rows if r.has_image)
+    baseline_found_ct = sum(1 for r in rows if r.baseline_status == "approved_baseline_found")
+    coverage_assessed = [r for r in rows if r.coverage_pct is not None]
+    confidences = [r.ai_confidence for r in rows if r.has_image and r.ai_confidence is not None]
+
+    return {
+        "inspection_volume": len(rows),
+        "pass_rate_pct": _rate(pass_ct, total),
+        "reclean_rate_pct": _rate(reclean_ct, total),
+        "repair_rate_pct": _rate(repair_ct, total),
+        "remove_from_service_rate_pct": _rate(remove_ct, total),
+        "supervisor_override_rate_pct": _rate(override_ct, len(rows)),
+        "baseline_compliance_pct": _rate(baseline_found_ct, baseline_ct),
+        "coverage_compliance_pct": (
+            round(sum(r.coverage_pct for r in coverage_assessed) / len(coverage_assessed), 1)
+            if coverage_assessed else None
+        ),
+        "ai_confidence_trend_pct": (
+            round(100 * sum(confidences) / len(confidences), 1) if confidences else None
+        ),
+    }
+
+
+# ── Executive Quality Score (Deliverable 10) ─────────────────────────────────
+# Weighted factors, each normalized to 0-100 before weighting. Weights sum to 1.
+_SCORE_WEIGHTS = {
+    "pass_rate_pct": 0.25,
+    "coverage_compliance_pct": 0.15,
+    "supervisor_agreement_pct": 0.15,
+    "low_high_risk_findings_pct": 0.15,  # inverted: 100 - remove_from_service rate
+    "low_repeat_findings_pct": 0.10,      # inverted: 100 - repeat-error rate
+    "competency_pct": 0.10,
+    "baseline_compliance_pct": 0.10,
+}
+
+
+def executive_quality_score(db: Session, tenant_id: str) -> dict:
+    """Deliverable 10 — a single 0-100 Quality Intelligence Score.
+
+    Any factor with no underlying data is excluded from the weighted average
+    (re-normalizing the remaining weights) rather than defaulted to a
+    fabricated value — the score is honest about how much data backs it.
+    """
+    summary = dashboard_summary(db, tenant_id, "quarter")
+
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    agreement_pct = _rate(sum(1 for r in reviews if r.agreement == "agree"), len(reviews))
+
+    from app.models.competency_event import CompetencyEvent
+
+    corrections = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "supervisor_correction")
+        .scalar() or 0
+    )
+    repeats = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "repeated_error")
+        .scalar() or 0
+    )
+    repeat_rate = _rate(repeats, corrections)
+    education_completed = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "education_completed")
+        .scalar() or 0
+    )
+    reviewed = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "finding_reviewed")
+        .scalar() or 0
+    )
+    competency_pct = _rate(education_completed, reviewed) if reviewed else None
+
+    factors = {
+        "pass_rate_pct": summary["pass_rate_pct"],
+        "coverage_compliance_pct": summary["coverage_compliance_pct"],
+        "supervisor_agreement_pct": agreement_pct,
+        "low_high_risk_findings_pct": (
+            100 - summary["remove_from_service_rate_pct"]
+            if summary["remove_from_service_rate_pct"] is not None else None
+        ),
+        "low_repeat_findings_pct": 100 - repeat_rate if repeat_rate is not None else None,
+        "competency_pct": competency_pct,
+        "baseline_compliance_pct": summary["baseline_compliance_pct"],
+    }
+
+    available = {k: v for k, v in factors.items() if v is not None}
+    if not available:
+        return {"score": None, "factors": factors, "note": "Not enough data yet to compute a quality score."}
+
+    total_weight = sum(_SCORE_WEIGHTS[k] for k in available)
+    score = sum(available[k] * _SCORE_WEIGHTS[k] for k in available) / total_weight
+
+    return {
+        "score": round(score),
+        "factors": factors,
+        "weights": _SCORE_WEIGHTS,
+        "factors_used": list(available.keys()),
+        "note": (
+            "Computed from real inspection/review/competency data for this tenant "
+            "over the trailing quarter. Missing factors are excluded, not defaulted."
+        ),
+    }

--- a/backend/app/services/root_cause_service.py
+++ b/backend/app/services/root_cause_service.py
@@ -1,0 +1,53 @@
+"""v1.5 — Root Cause Intelligence (Deliverable 7).
+
+Findings are categorized by probable root cause only by a human (a
+supervisor) — never inferred automatically, since guessing "why" a finding
+occurred without a human judgment call would be a fabricated causal claim.
+This module records that categorization and trends recurring causes.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.root_cause import ROOT_CAUSES, RootCauseAssignment
+
+
+def assign_root_cause(
+    db: Session, *, tenant_id: str, inspection_id: int, finding_type: str,
+    root_cause: str, assigned_by: str,
+) -> RootCauseAssignment:
+    if root_cause not in ROOT_CAUSES:
+        raise ValueError(f"root_cause must be one of {ROOT_CAUSES}")
+    assignment = RootCauseAssignment(
+        tenant_id=tenant_id,
+        inspection_id=inspection_id,
+        finding_type=finding_type,
+        root_cause=root_cause,
+        assigned_by=assigned_by,
+    )
+    db.add(assignment)
+    return assignment
+
+
+def root_cause_trends(db: Session, tenant_id: str) -> dict:
+    """Recurring root causes, overall and per finding type."""
+    rows = (
+        db.query(RootCauseAssignment)
+        .filter(RootCauseAssignment.tenant_id == tenant_id)
+        .all()
+    )
+
+    overall: dict[str, int] = defaultdict(int)
+    by_finding_type: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for r in rows:
+        overall[r.root_cause] += 1
+        by_finding_type[r.finding_type][r.root_cause] += 1
+
+    return {
+        "total_assignments": len(rows),
+        "overall": dict(sorted(overall.items(), key=lambda kv: kv[1], reverse=True)),
+        "by_finding_type": {ft: dict(counts) for ft, counts in by_finding_type.items()},
+        "human_review_required": True,
+    }

--- a/backend/app/services/spd_mentor_engine.py
+++ b/backend/app/services/spd_mentor_engine.py
@@ -1,0 +1,313 @@
+"""v1.4 — SPD Mentor Engine.
+
+Turns an inspection analysis into an active SPD educator: structured corrective
+action chains per finding, anatomy-aware coaching tied to the instrument's
+actual high-retention zones, confidence coaching when image quality or
+coverage is incomplete, a concise clinical decision summary, and (in Training
+Mode) expanded explanations of every finding, the anatomy involved, the
+recommendation, and SPD terminology.
+
+This module composes existing Phase 13/14/15 infrastructure
+(clinical_mentor.py, instrument_anatomy.py, instrument_zones.py,
+inspection_coverage.py) rather than duplicating it — it never replaces
+supervisor judgment, and every statement is derived from the actual analysis
+result, not fabricated.
+"""
+from __future__ import annotations
+
+from app.services.clinical_mentor import (
+    FINDING_EDUCATION,
+    NEXT_ACTIONS,
+    STANDARDS_GUIDANCE,
+    learning_content,
+)
+from app.services.baseline_comparison_scoring_service import KPI_LABELS
+
+MENTOR_DISCLAIMER = (
+    "This guidance is AI-generated educational support. It does not replace "
+    "supervisor judgment or the manufacturer's Instructions For Use (IFU)."
+)
+
+IFU_REFERENCE_NOTE = "AAMI ST79 (institution-specific implementation may vary)."
+
+# ── Corrective action chains (Deliverable 2) ─────────────────────────────────
+# Ordered, structured step-by-step recommendations per finding type. Derived
+# from accepted SPD practice — supervisor verification is the final step for
+# every contamination finding; structural findings escalate to remove-from-
+# service rather than reprocessing.
+CORRECTIVE_ACTION_CHAINS: dict[str, list[str]] = {
+    "blood": [
+        "Reclean the instrument.",
+        "Brush serrations manually.",
+        "Flush the lumen.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "tissue": [
+        "Reclean the instrument.",
+        "Brush affected surfaces manually.",
+        "Flush any lumens or channels.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "other_organic_residue": [
+        "Reclean the instrument.",
+        "Consider extended enzymatic contact time or a biofilm-directed protocol.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "bone": [
+        "Reclean the instrument.",
+        "Flush and brush cannulated channels with the correct-diameter brush.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "debris": [
+        "Reclean the instrument.",
+        "Identify and remove the particulate source.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "rust": [
+        "Remove from service.",
+        "Evaluate for repair.",
+        "Inspect surrounding anatomy.",
+        "Document corrosion.",
+    ],
+    "corrosion": [
+        "Remove from service.",
+        "Evaluate for repair.",
+        "Inspect surrounding anatomy.",
+        "Document corrosion.",
+    ],
+    "pitting": [
+        "Remove from service for evaluation if extensive.",
+        "Inspect surrounding anatomy.",
+        "Document the finding.",
+        "Monitor at future inspections if minor.",
+    ],
+    "crack": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Repair evaluation.",
+    ],
+    "insulation_damage": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Test insulation integrity.",
+        "Repair or replace evaluation.",
+    ],
+    "missing_component": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Verify against the tray content list and instrument photo.",
+        "Complete assembly or replace.",
+    ],
+    "wear": [
+        "Document and monitor.",
+        "Compare against prior inspections.",
+        "Escalate to supervisor if progressive.",
+    ],
+    "discoloration": [
+        "Document and monitor.",
+        "Investigate if progressive or paired with corrosion.",
+    ],
+}
+
+
+def corrective_action_chain(finding_type: str) -> list[str]:
+    """Ordered corrective-action steps for a single finding type."""
+    return CORRECTIVE_ACTION_CHAINS.get(finding_type, ["Supervisor review recommended."])
+
+
+def corrective_actions_for_result(result: dict) -> list[dict]:
+    """Structured corrective-action recommendation per actionable finding."""
+    out = []
+    for f in result.get("predicted_findings", []):
+        if f["severity_index"] < 1:
+            continue
+        finding_type = f["type"]
+        out.append({
+            "finding": KPI_LABELS.get(finding_type, finding_type),
+            "steps": corrective_action_chain(finding_type),
+        })
+    return out
+
+
+# ── Anatomy-aware coaching (Deliverable 3) ───────────────────────────────────
+# Canned coaching phrasing for instrument families with well-known SPD lore.
+# Falls back to a generated sentence from the instrument's own anatomy zones
+# for families without a specific canned phrase — never fabricated per-family
+# detail beyond what instrument_anatomy.py already defines.
+_FAMILY_COACHING_PHRASES: dict[str, list[str]] = {
+    "kerrison_rongeur": [
+        "Kerrison jaw serrations are high-retention anatomy zones.",
+        "Open the box lock and actuate the hinge during inspection — soil hides in the pivot.",
+    ],
+    "rigid_scope": [
+        "Rigid scope O-ring regions frequently retain organic material.",
+        "Inspect the working channel and seal closely; these are high-retention zones.",
+    ],
+    "drill_bit": [
+        "Drill-bit flutes require careful brushing.",
+        "Threaded regions between the flutes are a common site for retained residue.",
+    ],
+    "needle_holder": [
+        "Needle-holder box locks should be opened during inspection.",
+        "Jaw inserts and serrations are high-retention anatomy zones.",
+    ],
+}
+
+
+def anatomy_coaching(result: dict) -> list[str]:
+    """Anatomy-aware coaching sentences for the instrument being inspected."""
+    anatomy = result.get("instrument_anatomy") or {}
+    family = anatomy.get("family", "default")
+    messages = list(_FAMILY_COACHING_PHRASES.get(family, []))
+
+    if not messages:
+        category = anatomy.get("category", "instrument")
+        for zone in anatomy.get("zones", []):
+            if zone.get("retention_risk") == "high" or zone.get("zone_name") in anatomy.get("high_risk_zones", []):
+                messages.append(
+                    f"{category.capitalize()} {zone['zone_name']} is a high-retention anatomy zone."
+                )
+    return messages
+
+
+def _zone_description(zone_name: str) -> str:
+    from app.services.instrument_zones import ZONE_INFO
+
+    info = ZONE_INFO.get(zone_name.lower())
+    if info and info.get("reason"):
+        return info["reason"]
+    return f"{zone_name.capitalize()} — inspect closely per the instrument's anatomy profile."
+
+
+# ── AI confidence coaching (Deliverable 7) ───────────────────────────────────
+_LOW_CONFIDENCE_THRESHOLD = 0.7
+_LOW_COVERAGE_THRESHOLD = 75
+
+
+def confidence_coaching(result: dict) -> dict | None:
+    """Coaching for the technician when confidence is limited by image
+    quality or incomplete inspection coverage. Returns None when confidence
+    and coverage are both adequate — nothing to coach."""
+    confidence = result.get("confidence")
+    coverage = result.get("inspection_coverage") or {}
+    coverage_pct = coverage.get("overall_coverage")
+    coverage_assessed = coverage.get("assessed", False)
+
+    low_confidence = confidence is not None and confidence < _LOW_CONFIDENCE_THRESHOLD
+    low_coverage = coverage_assessed and coverage_pct is not None and coverage_pct < _LOW_COVERAGE_THRESHOLD
+    not_assessed = not coverage_assessed
+
+    if not (low_confidence or low_coverage or not_assessed):
+        return None
+
+    suggestions: list[str] = []
+    if not_assessed or low_coverage:
+        suggestions.append("Capture additional images.")
+        suggestions.append("Capture missing anatomy zones.")
+    if low_confidence:
+        suggestions.append("Improve lighting.")
+    suggestions.append("Request supervisor review.")
+
+    return {
+        "message": (
+            "Confidence is limited because image quality and inspection "
+            "coverage are incomplete."
+        ),
+        "suggestions": suggestions,
+    }
+
+
+# ── Clinical decision summary (Deliverable 8, concise form) ──────────────────
+def clinical_decision_summary(result: dict, overall: str) -> dict:
+    coverage = result.get("inspection_coverage") or {}
+    supervisor_review = "Recommended" if overall in {
+        "SUPERVISOR REVIEW", "REPROCESS", "REMOVE FROM SERVICE",
+    } else "Not required"
+
+    return {
+        "instrument": result.get("instrument_type") or "Unknown instrument",
+        "inspection_coverage": coverage.get("overall_coverage"),
+        "findings": result.get("findings_summary") or "No actionable findings detected.",
+        "risk": result.get("risk_level"),
+        "recommendation": result.get("recommended_action"),
+        "supervisor_review": supervisor_review,
+    }
+
+
+# ── SPD education cards (Deliverable 4) ──────────────────────────────────────
+def education_card(finding_type: str) -> dict | None:
+    edu = FINDING_EDUCATION.get(finding_type)
+    if not edu:
+        return None
+    return {
+        "finding": KPI_LABELS.get(finding_type, finding_type),
+        "clinical_significance": edu["clinical_significance"],
+        "recommended_practice": edu["spd_response"],
+        "reference": IFU_REFERENCE_NOTE,
+    }
+
+
+def education_cards_for_result(result: dict) -> list[dict]:
+    out = []
+    for f in result.get("predicted_findings", []):
+        if f["severity_index"] < 1:
+            continue
+        card = education_card(f["type"])
+        if card:
+            out.append(card)
+    return out
+
+
+# ── Training Mode (Deliverable 6) ────────────────────────────────────────────
+TERMINOLOGY: dict[str, str] = {
+    "baseline match": "How closely the instrument's current condition matches its approved reference (baseline) image or record.",
+    "retention zone": "An anatomy region — such as a serration, lumen, box lock, or hinge — where soil is mechanically difficult to remove and easy to miss visually.",
+    "IFU": "Instructions For Use — the manufacturer's official reprocessing and inspection instructions for a specific device.",
+    "disposition": "The recommended next step for an instrument after inspection (e.g. PASS, REPROCESS, REMOVE FROM SERVICE).",
+    "coverage": "The percentage of an instrument's required high-risk anatomy zones that were actually photographed/inspected.",
+    "supervisor review": "A second, qualified review of an instrument before it is released, required whenever cleanliness or condition is uncertain.",
+}
+
+
+def training_mode_explanations(result: dict, overall: str) -> dict:
+    """Expanded, always-explain content for onboarding/competency building:
+    every finding, the anatomy involved, the recommendation, and terminology."""
+    anatomy = result.get("instrument_anatomy") or {}
+    return {
+        "every_finding": learning_content(result),
+        "anatomy_explained": [
+            {"zone": zone_name, "explanation": _zone_description(zone_name)}
+            for zone_name in anatomy.get("zone_names", [])
+        ],
+        "recommendation_explained": {
+            "disposition": overall,
+            "next_actions": NEXT_ACTIONS.get(overall, []),
+            "standards_guidance": STANDARDS_GUIDANCE.get(overall, ""),
+        },
+        "terminology": [
+            {"term": term, "definition": definition}
+            for term, definition in TERMINOLOGY.items()
+        ],
+    }
+
+
+# ── Assembly ──────────────────────────────────────────────────────────────
+def build_spd_mentor(result: dict, overall: str, *, training_mode: bool = False) -> dict:
+    """Assemble the full v1.4 SPD Mentor payload."""
+    payload = {
+        "disclaimer": MENTOR_DISCLAIMER,
+        "corrective_actions": corrective_actions_for_result(result),
+        "anatomy_coaching": anatomy_coaching(result),
+        "confidence_coaching": confidence_coaching(result),
+        "clinical_decision_summary": clinical_decision_summary(result, overall),
+        "education_cards": education_cards_for_result(result),
+        "training_mode": training_mode,
+    }
+    if training_mode:
+        payload["expanded_explanations"] = training_mode_explanations(result, overall)
+    return payload

--- a/backend/app/services/spd_mentor_engine.py
+++ b/backend/app/services/spd_mentor_engine.py
@@ -181,7 +181,7 @@ def _zone_description(zone_name: str) -> str:
     info = ZONE_INFO.get(zone_name.lower())
     if info and info.get("reason"):
         return info["reason"]
-    return f"{zone_name.capitalize()} — inspect closely per the instrument's anatomy profile."
+    return "Inspect closely per the instrument's anatomy profile."
 
 
 # ── AI confidence coaching (Deliverable 7) ───────────────────────────────────
@@ -223,6 +223,17 @@ def confidence_coaching(result: dict) -> dict | None:
 
 
 # ── Clinical decision summary (Deliverable 8, concise form) ──────────────────
+def _findings_sentence(result: dict) -> str:
+    """findings_summary is a list of per-KPI phrases (e.g. "Blood detected",
+    "No bone detected") — collapse to a single sentence naming only what was
+    actually found, not an exhaustive negative checklist."""
+    phrases = result.get("findings_summary") or []
+    positive = [p for p in phrases if not p.startswith("No ")]
+    if not positive:
+        return "No actionable findings detected."
+    return "; ".join(positive) + "."
+
+
 def clinical_decision_summary(result: dict, overall: str) -> dict:
     coverage = result.get("inspection_coverage") or {}
     supervisor_review = "Recommended" if overall in {
@@ -232,7 +243,7 @@ def clinical_decision_summary(result: dict, overall: str) -> dict:
     return {
         "instrument": result.get("instrument_type") or "Unknown instrument",
         "inspection_coverage": coverage.get("overall_coverage"),
-        "findings": result.get("findings_summary") or "No actionable findings detected.",
+        "findings": _findings_sentence(result),
         "risk": result.get("risk_level"),
         "recommendation": result.get("recommended_action"),
         "supervisor_review": supervisor_review,

--- a/backend/app/services/supervisor_quality_service.py
+++ b/backend/app/services/supervisor_quality_service.py
@@ -1,0 +1,92 @@
+"""v1.5 — Supervisor Quality Dashboard (Deliverable 6).
+
+Per-supervisor review workload, override frequency, correction categories,
+education provided, and AI agreement — derived from real SupervisorReview and
+MentorCoachingReview rows. Department trends are derived from Inspection.department,
+already captured at intake.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.mentor_coaching_review import MentorCoachingReview
+from app.models.supervisor_review import SupervisorReview
+
+
+def _rate(n: int, d: int) -> float | None:
+    return round(100 * n / d, 1) if d else None
+
+
+def supervisor_quality_dashboard(db: Session, tenant_id: str) -> dict:
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    coaching = db.query(MentorCoachingReview).filter(MentorCoachingReview.tenant_id == tenant_id).all()
+
+    by_reviewer: dict[str, list] = defaultdict(list)
+    for r in reviews:
+        by_reviewer[r.reviewer_name].append(r)
+    coaching_by_reviewer: dict[str, list] = defaultdict(list)
+    for c in coaching:
+        coaching_by_reviewer[c.reviewer_name].append(c)
+
+    supervisors = []
+    for reviewer, r_reviews in by_reviewer.items():
+        override_ct = sum(1 for r in r_reviews if (r.override_action or "").strip())
+        agree_ct = sum(1 for r in r_reviews if r.agreement == "agree")
+
+        categories: dict[str, int] = defaultdict(int)
+        for r in r_reviews:
+            if r.corrected_zone:
+                categories["zone"] += 1
+            if r.corrected_instrument_family:
+                categories["instrument_family"] += 1
+            if r.corrected_severity:
+                categories["severity"] += 1
+            if r.corrected_recommendation:
+                categories["recommendation"] += 1
+
+        r_coaching = coaching_by_reviewer.get(reviewer, [])
+        education_provided_ct = sum(1 for c in r_coaching if c.educational_comment.strip())
+
+        supervisors.append({
+            "reviewer": reviewer,
+            "review_workload": len(r_reviews),
+            "override_frequency_pct": _rate(override_ct, len(r_reviews)),
+            "correction_categories": dict(categories),
+            "education_provided_count": education_provided_ct,
+            "agreement_with_ai_pct": _rate(agree_ct, len(r_reviews)),
+        })
+
+    supervisors.sort(key=lambda s: s["review_workload"], reverse=True)
+
+    # Department trends — from Inspection.department, already captured at intake.
+    insp_rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.department.isnot(None))
+        .all()
+    )
+    by_department: dict[str, list] = defaultdict(list)
+    for r in insp_rows:
+        by_department[r.department or "unspecified"].append(r)
+
+    departments = []
+    for dept, dept_rows in by_department.items():
+        scored = [r for r in dept_rows if r.has_image and r.disposition]
+        total = len(scored)
+        pass_ct = sum(1 for r in scored if r.disposition == "PASS")
+        remove_ct = sum(1 for r in scored if r.disposition == "REMOVE FROM SERVICE")
+        departments.append({
+            "department": dept,
+            "inspection_count": len(dept_rows),
+            "pass_rate_pct": _rate(pass_ct, total),
+            "remove_from_service_rate_pct": _rate(remove_ct, total),
+        })
+    departments.sort(key=lambda d: d["inspection_count"], reverse=True)
+
+    return {
+        "supervisors": supervisors,
+        "department_trends": departments,
+        "human_review_required": True,
+    }

--- a/backend/tests/test_quality_intelligence.py
+++ b/backend/tests/test_quality_intelligence.py
@@ -1,0 +1,257 @@
+"""v1.5 — Quality Intelligence & Continuous Improvement."""
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.inspection_finding import InspectionFinding
+from app.models.root_cause import ROOT_CAUSES
+from app.services.capa_suggestion_service import generate_capa_suggestions
+from app.services.finding_trend_service import finding_trends
+from app.services.anatomy_risk_service import anatomy_risk_dashboard
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+TENANT = "default-tenant"
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"qi-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+_next_synthetic_inspection_id = [900000]
+
+
+def _seed_finding(finding_type: str, zone: str, instrument_type: str = "kerrison_rongeur", severity: int = 2) -> None:
+    _next_synthetic_inspection_id[0] += 1
+    db = SessionLocal()
+    try:
+        db.add(InspectionFinding(
+            inspection_id=_next_synthetic_inspection_id[0],
+            tenant_id=TENANT, instrument_type=instrument_type,
+            finding_type=finding_type, zone=zone, severity_index=severity,
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestFindingTrends:
+    def test_finding_trends_aggregate_correctly(self):
+        for _ in range(3):
+            _seed_finding("blood", "box lock")
+        trends = finding_trends(SessionLocal(), TENANT, granularity="monthly")
+        assert trends["totals"]["blood"] >= 3
+        assert "wear" in trends["totals"]  # full taxonomy always present, even at 0
+        assert trends["granularity"] == "monthly"
+
+    def test_unknown_granularity_falls_back_to_monthly(self):
+        trends = finding_trends(SessionLocal(), TENANT, granularity="bogus")
+        assert trends["granularity"] == "monthly"
+
+
+class TestAnatomyRisk:
+    def test_anatomy_trends_aggregate_correctly(self):
+        # anatomy_risk_dashboard truncates to the top 10 zones by count, so
+        # asserting against it directly isn't robust once the shared test
+        # database accumulates real InspectionFinding rows from every other
+        # test in the full suite. Use a tenant no other test writes to, so
+        # this test's aggregation is isolated and its own zone is always #1.
+        isolated_tenant = "quality-intelligence-anatomy-test-tenant"
+        db = SessionLocal()
+        try:
+            db.add(InspectionFinding(
+                inspection_id=999999, tenant_id=isolated_tenant,
+                instrument_type="kerrison_rongeur", finding_type="blood",
+                zone="serrations", severity_index=2,
+            ))
+            for _ in range(4):
+                db.add(InspectionFinding(
+                    inspection_id=999998, tenant_id=isolated_tenant,
+                    instrument_type="kerrison_rongeur", finding_type="blood",
+                    zone="box lock", severity_index=2,
+                ))
+            db.commit()
+        finally:
+            db.close()
+
+        dashboard = anatomy_risk_dashboard(SessionLocal(), isolated_tenant)
+        top_zone = dashboard["highest_risk_anatomy_zones"][0]
+        assert top_zone["zone"] == "box lock"
+        assert top_zone["count"] == 4
+        assert any(z["zone"] == "box lock" for z in dashboard["most_frequent_contamination_zones"])
+
+
+class TestQualityDashboard:
+    def _create(self, itype, declared=None):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+            "finding_categories": declared or [],
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_dashboard_returns_kpis(self):
+        self._create("scissors")
+        r = client.get("/api/quality/dashboard", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "inspection_volume", "pass_rate_pct", "reclean_rate_pct",
+            "repair_rate_pct", "remove_from_service_rate_pct",
+            "supervisor_override_rate_pct", "baseline_compliance_pct",
+            "coverage_compliance_pct", "ai_confidence_trend_pct",
+        ):
+            assert key in body
+
+    def test_benchmark_compares_reporting_periods(self):
+        self._create("forceps")
+        r = client.get("/api/quality/benchmark", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert "current_month" in body
+        assert "previous_month" in body
+        assert "quarter" in body
+        assert "rolling_12_months" in body
+        assert "pass_rate_pct" in body["comparison_current_vs_previous_month"]
+
+    def test_executive_quality_score_calculates(self):
+        self._create("needle_holder")
+        r = client.get("/api/quality/executive-score", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["score"] is None or 0 <= body["score"] <= 100
+
+    def test_technician_quality_leadership_only(self):
+        self._create("scissors")
+        r = client.get("/api/quality/technician-quality", headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+        r2 = client.get("/api/quality/technician-quality", headers=AUTH_MGR)
+        assert r2.status_code == 200
+        technicians = r2.json()["technicians"]
+        assert any(t["technician"] == "operator@local.dev" for t in technicians)
+
+    def test_technician_metrics_calculate_correctly(self):
+        iid = self._create("scissors", declared=["blood"])
+        client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={"agreement": "agree"}, headers=AUTH_MGR,
+        )
+        r = client.get("/api/quality/technician-quality", headers=AUTH_MGR)
+        tech = next(t for t in r.json()["technicians"] if t["technician"] == "operator@local.dev")
+        assert tech["inspection_count"] >= 1
+        assert tech["supervisor_agreement_pct"] is not None
+
+    def test_supervisor_quality_dashboard(self):
+        iid = self._create("scissors")
+        client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={"agreement": "disagree", "rationale": "Debris still present.", "corrected_zone": "box lock"},
+            headers=AUTH_MGR,
+        )
+        r = client.get("/api/quality/supervisor-quality", headers=AUTH_MGR)
+        assert r.status_code == 200
+        supervisors = r.json()["supervisors"]
+        assert any(s["reviewer"] == "spd_manager@local.dev" for s in supervisors)
+
+
+class TestRootCause:
+    def test_root_cause_categories_stored_correctly(self):
+        iid = self._create_inspection()
+        r = client.post(
+            "/api/quality/root-cause",
+            json={"inspection_id": iid, "finding_type": "blood", "root_cause": "improper_brushing"},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["root_cause"] == "improper_brushing"
+
+        r2 = client.get("/api/quality/root-cause-trends", headers=AUTH_ADMIN)
+        assert r2.status_code == 200
+        assert r2.json()["overall"].get("improper_brushing", 0) >= 1
+
+    def test_invalid_root_cause_rejected(self):
+        iid = self._create_inspection()
+        r = client.post(
+            "/api/quality/root-cause",
+            json={"inspection_id": iid, "finding_type": "blood", "root_cause": "not_a_real_cause"},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 422
+
+    def test_all_root_causes_are_valid_choices(self):
+        assert "unknown" in ROOT_CAUSES
+        assert "incomplete_manual_cleaning" in ROOT_CAUSES
+
+    def _create_inspection(self):
+        _baseline("scissors")
+        r = client.post("/api/inspections", json={
+            "instrument_type": "scissors", "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        return r.json()["id"]
+
+
+class TestCapaSuggestions:
+    def test_capa_recommendations_generated(self):
+        for _ in range(4):
+            _seed_finding("rust", "hinge", instrument_type="rigid_scope")
+        suggestions = generate_capa_suggestions(SessionLocal(), TENANT)
+        assert any("rust" in s["trigger"].lower() for s in suggestions)
+        assert all("recommendation" in s for s in suggestions)
+
+    def test_capa_suggestion_endpoint_and_create(self):
+        for _ in range(4):
+            _seed_finding("blood", "serration", instrument_type="needle_holder")
+        r = client.get("/api/quality/capa-suggestions", headers=AUTH_MGR)
+        assert r.status_code == 200
+        suggestions = r.json()["suggestions"]
+        assert len(suggestions) > 0
+
+        r2 = client.post("/api/quality/capa-suggestions/create", json=suggestions[0], headers=AUTH_MGR)
+        assert r2.status_code == 201, r2.text
+        assert r2.json()["title"] == suggestions[0]["suggested_title"]
+
+
+class TestContinuousImprovement:
+    def test_create_and_update_initiative(self):
+        r = client.post(
+            "/api/quality/improvement-initiatives",
+            json={
+                "initiative": "Retrain on Kerrison box-lock brushing",
+                "owner": "SPD Manager", "target_date": str(date(2026, 9, 1)),
+                "expected_impact": "Reduce repeated blood findings in box locks by 50%.",
+            },
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+        initiative_id = r.json()["id"]
+
+        r2 = client.get("/api/quality/improvement-initiatives", headers=AUTH_MGR)
+        assert any(i["id"] == initiative_id for i in r2.json()["initiatives"])
+
+        r3 = client.patch(
+            f"/api/quality/improvement-initiatives/{initiative_id}",
+            json={"status": "completed", "actual_impact": "Reduced by 60%."},
+            headers=AUTH_MGR,
+        )
+        assert r3.status_code == 200
+        assert r3.json()["status"] == "completed"

--- a/backend/tests/test_spd_mentor_engine.py
+++ b/backend/tests/test_spd_mentor_engine.py
@@ -1,0 +1,290 @@
+"""v1.4 — SPD Mentor Engine: corrective actions, anatomy coaching, confidence
+coaching, training mode, education library, and competency support."""
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.education_library import get_article, list_articles
+from app.services.spd_mentor_engine import (
+    confidence_coaching,
+    corrective_action_chain,
+    education_card,
+)
+from app.main import app
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"sme-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None, training_mode=False):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+            training_mode=training_mode,
+        )
+    finally:
+        db.close()
+
+
+class TestCorrectiveActionRecommendations:
+    def test_blood_recommendation_generated(self):
+        cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        blood = next((a for a in actions if a["finding"] == "blood"), None)
+        assert blood is not None
+        assert blood["steps"] == corrective_action_chain("blood")
+        assert "Supervisor verification." in blood["steps"]
+
+    def test_rust_generates_repair_remove_recommendation(self):
+        # "rust" is not a declarable category in the scoring engine (only its
+        # sibling "corrosion" is) — assert the chain directly, as the education
+        # card/library tests already do for other pure-function lookups.
+        steps = corrective_action_chain("rust")
+        assert "Remove from service." in steps
+        assert "Evaluate for repair." in steps
+
+    def test_corrosion_recommendation_generated(self):
+        cd = _analyze("scissors", declared=["corrosion"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        corrosion = next((a for a in actions if a["finding"] == "corrosion"), None)
+        assert corrosion is not None
+        assert "Remove from service." in corrosion["steps"]
+        assert "Evaluate for repair." in corrosion["steps"]
+
+    def test_crack_generates_remove_from_service_recommendation(self):
+        cd = _analyze("forceps", declared=["crack"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        crack = next((a for a in actions if a["finding"] == "crack"), None)
+        assert crack is not None
+        assert crack["steps"][0] == "Remove from service immediately."
+        assert "Notify supervisor." in crack["steps"]
+
+
+class TestAnatomyAwareCoaching:
+    def test_kerrison_serrations_coaching(self):
+        cd = _analyze("kerrison_rongeur")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("Kerrison jaw serrations are high-retention anatomy zones." == c for c in coaching)
+
+    def test_rigid_scope_oring_coaching(self):
+        cd = _analyze("rigid_scope")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("O-ring" in c for c in coaching)
+
+    def test_drill_bit_flutes_coaching(self):
+        cd = _analyze("drill_bit")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("flutes" in c.lower() for c in coaching)
+
+    def test_needle_holder_box_lock_coaching(self):
+        cd = _analyze("needle_holder")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("box lock" in c.lower() for c in coaching)
+
+
+class TestConfidenceCoaching:
+    def test_low_confidence_coaching_displayed(self):
+        result = {
+            "confidence": 0.5,
+            "inspection_coverage": {"assessed": True, "overall_coverage": 40},
+        }
+        coaching = confidence_coaching(result)
+        assert coaching is not None
+        assert "incomplete" in coaching["message"].lower()
+        assert "Request supervisor review." in coaching["suggestions"]
+
+    def test_high_confidence_full_coverage_no_coaching(self):
+        result = {
+            "confidence": 0.95,
+            "inspection_coverage": {"assessed": True, "overall_coverage": 100},
+        }
+        assert confidence_coaching(result) is None
+
+    def test_coverage_not_assessed_triggers_coaching(self):
+        result = {"confidence": 0.9, "inspection_coverage": {"assessed": False}}
+        coaching = confidence_coaching(result)
+        assert coaching is not None
+        assert "Capture additional images." in coaching["suggestions"]
+
+
+class TestTrainingMode:
+    def test_training_mode_expands_explanations(self):
+        cd_off = _analyze("scissors", declared=["blood"], training_mode=False)["clinical_decision"]
+        cd_on = _analyze("scissors", declared=["blood"], training_mode=True)["clinical_decision"]
+
+        assert "expanded_explanations" not in cd_off["spd_mentor"]
+        assert cd_off["spd_mentor"]["training_mode"] is False
+
+        mentor_on = cd_on["spd_mentor"]
+        assert mentor_on["training_mode"] is True
+        expanded = mentor_on["expanded_explanations"]
+        assert expanded["every_finding"]
+        assert expanded["anatomy_explained"]
+        assert expanded["recommendation_explained"]["disposition"]
+        assert any(t["term"] == "IFU" for t in expanded["terminology"])
+
+
+class TestEducationCards:
+    def test_education_card_rendered_correctly(self):
+        card = education_card("blood")
+        assert card["finding"] == "blood"
+        assert card["clinical_significance"]
+        assert card["recommended_practice"]
+        assert "AAMI ST79" in card["reference"]
+
+    def test_clinical_decision_includes_education_cards(self):
+        cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
+        cards = cd["spd_mentor"]["education_cards"]
+        assert any(c["finding"] == "blood" for c in cards)
+
+
+class TestEducationLibrary:
+    def test_library_has_all_twelve_categories(self):
+        articles = list_articles()
+        assert len(articles) == 12
+
+    def test_article_fields_present(self):
+        article = get_article("rust")
+        for field in (
+            "definition", "clinical_importance", "typical_anatomy_locations",
+            "inspection_tips", "cleaning_considerations", "corrective_actions", "reference",
+        ):
+            assert article[field], f"missing/empty {field}"
+
+    def test_unknown_finding_type_returns_none(self):
+        assert get_article("not_a_real_finding") is None
+
+
+class TestMentorDisclaimer:
+    def test_disclaimer_never_replaces_supervisor_judgment(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        assert "does not replace" in cd["spd_mentor"]["disclaimer"].lower()
+
+
+class TestSupervisorCoachingDashboard:
+    def _create(self, itype):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_coaching_queue_lists_inspection(self):
+        iid = self._create("scissors")
+        r = client.get("/api/mentor/coaching-queue", headers=AUTH_MGR)
+        assert r.status_code == 200
+        ids = [row["inspection_id"] for row in r.json()["queue"]]
+        assert iid in ids
+
+    def test_submit_coaching_review(self):
+        iid = self._create("forceps")
+        r = client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True, "educational_comment": "Good catch on the box lock."},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["educational_comment"] == "Good catch on the box lock."
+
+    def test_operator_cannot_submit_coaching_review(self):
+        iid = self._create("forceps")
+        r = client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True}, headers=AUTH_OPERATOR,
+        )
+        assert r.status_code == 403
+
+    def test_coaching_effectiveness_reflects_reviews(self):
+        iid = self._create("needle_holder")
+        client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True}, headers=AUTH_MGR,
+        )
+        r = client.get("/api/mentor/coaching-effectiveness", headers=AUTH_MGR)
+        assert r.status_code == 200
+        assert r.json()["total_reviews"] >= 1
+
+
+class TestCompetencySupport:
+    def _create_as_operator(self, itype):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_competency_summary_updates_after_supervisor_review(self):
+        iid = self._create_as_operator("scissors")
+
+        before = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_MGR)
+        assert before.status_code == 200
+        before_reviewed = before.json()["findings_reviewed"]
+        before_corrections = before.json()["supervisor_corrections"]
+
+        r = client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={
+                "agreement": "disagree",
+                "rationale": "Debris still present in hinge.",
+                "finding_type": "debris",
+            },
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+
+        after = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_MGR)
+        assert after.status_code == 200
+        assert after.json()["findings_reviewed"] == before_reviewed + 1
+        assert after.json()["supervisor_corrections"] == before_corrections + 1
+
+    def test_operator_can_view_own_summary_only(self):
+        r = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        r2 = client.get("/api/mentor/competency/spd_manager@local.dev", headers=AUTH_OPERATOR)
+        assert r2.status_code == 403
+
+    def test_education_completion_recorded(self):
+        r = client.post("/api/mentor/education/blood/complete", headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        assert "blood" in r.json()["education_completed"]
+
+
+class TestInspectionMentorEndpoint:
+    def test_rederive_mentor_for_past_inspection(self):
+        _baseline("scissors")
+        r = client.post("/api/inspections", json={
+            "instrument_type": "scissors", "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        iid = r.json()["id"]
+
+        r = client.get(f"/api/inspections/{iid}/mentor?training_mode=true", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert r.json()["training_mode"] is True
+        assert "expanded_explanations" in r.json()

--- a/docs/mentor/anatomy-aware-coaching.md
+++ b/docs/mentor/anatomy-aware-coaching.md
@@ -1,0 +1,37 @@
+# Anatomy-Aware Coaching (v1.4)
+
+## What it does
+`spd_mentor_engine.anatomy_coaching(result)` returns technician-facing
+coaching sentences tied to the instrument's actual anatomy profile
+(`result.instrument_anatomy`, from the Phase 15 Instrument Anatomy Library) —
+never generic filler.
+
+## Canned phrasing for well-known SPD lore
+A small set of instrument families have specific, widely-recognized SPD
+coaching phrases (`_FAMILY_COACHING_PHRASES`):
+
+- **Kerrison rongeur**: "Kerrison jaw serrations are high-retention anatomy
+  zones." / "Open the box lock and actuate the hinge during inspection — soil
+  hides in the pivot."
+- **Rigid scope**: "Rigid scope O-ring regions frequently retain organic
+  material." / "Inspect the working channel and seal closely; these are
+  high-retention zones."
+- **Drill bit**: "Drill-bit flutes require careful brushing." / "Threaded
+  regions between the flutes are a common site for retained residue."
+- **Needle holder**: "Needle-holder box locks should be opened during
+  inspection." / "Jaw inserts and serrations are high-retention anatomy
+  zones."
+
+## Generated fallback
+For every other instrument family (laparoscopic, general forceps, scissors,
+flexible endoscope, and anything unclassified), coaching sentences are
+generated from the instrument's own zone data: any zone with
+`retention_risk == "high"` (or listed in `high_risk_zones`) produces
+`"{category} {zone_name} is a high-retention anatomy zone."` — always derived
+from the actual anatomy profile, never invented per-instrument detail.
+
+## Zone descriptions (Training Mode)
+When Training Mode is on, every anatomy zone for the instrument gets an
+explanation via `_zone_description()`, which reuses
+`instrument_zones.ZONE_INFO`'s per-zone reason (falling back to a generic
+retention-risk sentence for zones without a specific entry).

--- a/docs/mentor/clinical-decision-support.md
+++ b/docs/mentor/clinical-decision-support.md
@@ -1,0 +1,51 @@
+# Clinical Decision Support — v1.4 additions
+
+## Clinical Decision Summary
+`spd_mentor.clinical_decision_summary` gives the concise, plain-language
+summary a supervisor scans first:
+
+```
+{
+  "instrument": "Rigid Scope",
+  "inspection_coverage": 95,
+  "findings": "Blood indicators detected within the O-ring region.",
+  "risk": "High",
+  "recommendation": "Reclean and repeat inspection before packaging.",
+  "supervisor_review": "Recommended"
+}
+```
+
+`supervisor_review` is `"Recommended"` whenever the overall disposition is
+`SUPERVISOR REVIEW`, `REPROCESS`, or `REMOVE FROM SERVICE`, and `"Not
+required"` for `PASS`/`MONITOR` — derived from the same disposition already
+computed by the Phase 13 Explainable AI Clinical Decision Support payload, not
+a separate judgment.
+
+## Corrective Action Recommendations
+`spd_mentor.corrective_actions` gives one structured, ordered step chain per
+actionable finding (severity index ≥ 1), e.g.:
+
+- **Blood** → Reclean → Brush serrations manually → Flush the lumen → Repeat
+  visual inspection → Supervisor verification.
+- **Rust / Corrosion** → Remove from service → Evaluate for repair → Inspect
+  surrounding anatomy → Document corrosion.
+- **Crack** → Remove from service immediately → Notify supervisor → Repair
+  evaluation.
+
+Full chains for all twelve categories live in
+`spd_mentor_engine.CORRECTIVE_ACTION_CHAINS` and are reused by the Educational
+Knowledge Library so the two never drift apart.
+
+## AI Confidence Coaching
+`spd_mentor.confidence_coaching` returns `null` when confidence and coverage
+are both adequate. Otherwise:
+
+```
+{
+  "message": "Confidence is limited because image quality and inspection coverage are incomplete.",
+  "suggestions": ["Capture additional images.", "Capture missing anatomy zones.", "Improve lighting.", "Request supervisor review."]
+}
+```
+
+Triggered when confidence < 70%, required-zone coverage < 75%, or zones were
+never tagged at all (`inspection_coverage.assessed == false`).

--- a/docs/mentor/competency-support.md
+++ b/docs/mentor/competency-support.md
@@ -1,0 +1,50 @@
+# Competency Support (v1.4)
+
+## What it tracks
+`backend/app/models/competency_event.py` is an append-only event log; each row
+is one of:
+
+- `finding_reviewed` — a supervisor reviewed one of this technician's
+  inspections.
+- `supervisor_correction` — the supervisor disagreed, partially agreed, or
+  overrode the AI on that inspection, tagged with the `finding_type` involved.
+- `repeated_error` — the same technician has now been corrected on the same
+  `finding_type` at least twice; logged automatically alongside the
+  correction that crosses the threshold.
+- `education_completed` — the technician marked a knowledge-library article
+  as read (`POST /api/mentor/education/{finding_type}/complete`).
+
+## Where it's recorded
+`app/routes/ai_clinical_review.py`'s existing `POST
+/inspections/{id}/supervisor-review` endpoint (the ML ground-truth capture
+path) also calls `competency_service.record_finding_reviewed` /
+`record_supervisor_correction` in the same transaction — competency tracking
+piggybacks on a review that was already happening, rather than requiring a
+second workflow.
+
+## Technician attribution
+`Inspection.technician` (added in v1.4, nullable) is set from the request
+actor at creation time (`POST /api/inspections`). Older inspections created
+before this field existed have `technician = null` and are simply excluded
+from competency aggregation — never backfilled with a guess.
+
+## Summary shape
+`GET /api/mentor/competency/{technician}`:
+```
+{
+  "technician": "jane@hospital.org",
+  "findings_reviewed": 12,
+  "supervisor_corrections": 3,
+  "repeated_errors": {"blood": 2},
+  "education_completed": ["blood", "crack"],
+  "training_progress_pct": 33,
+  "has_activity": true
+}
+```
+`training_progress_pct` is `null` (not `0`) when there have been no supervisor
+corrections yet — there is nothing to score, and the engine never fabricates
+a number for a technician with no recorded activity.
+
+## Access control
+A technician may only view their own summary; `admin`/`spd_manager` may view
+anyone's.

--- a/docs/mentor/education-library.md
+++ b/docs/mentor/education-library.md
@@ -1,0 +1,48 @@
+# Educational Knowledge Library (v1.4)
+
+## What it does
+`backend/app/services/education_library.py` exposes a structured knowledge
+article for each of the twelve contamination/condition categories LumenAI
+recognizes: Blood, Bone, Tissue, Organic residue, Debris, Rust, Corrosion,
+Cracks, Wear, Pitting, Missing component, Insulation damage.
+
+Nothing here is duplicated content — every article is reshaped from the same
+source of truth the AI Mentor already uses
+(`clinical_mentor.FINDING_EDUCATION`) plus the corrective-action chains from
+`spd_mentor_engine.py`, so the library and the live coaching can never drift
+apart.
+
+## Article shape
+```
+{
+  "finding": "crack",
+  "finding_type": "crack",
+  "definition": "...",
+  "clinical_importance": "...",
+  "typical_anatomy_locations": ["box lock", "hinge", "jaw", ...],
+  "inspection_tips": "...",
+  "cleaning_considerations": "...",
+  "corrective_actions": ["Remove from service immediately.", ...],
+  "reference": "AAMI ST79 (institution-specific implementation may vary)."
+}
+```
+
+## Typical anatomy locations
+`instrument_anatomy.py`'s per-zone `contamination_risks`/`condition_risks`
+lists are the same default vocabulary on every zone (no instrument family
+customizes them), so they cannot distinguish "typical" locations for one
+finding from another. Instead, `_typical_anatomy_locations()` derives them
+honestly from what the anatomy data *does* differentiate:
+
+- **Contamination findings** (blood, bone, tissue, organic residue, debris):
+  zones marked `retention_risk == "high"` across every instrument family.
+- **Structural/condition findings** (rust, corrosion, pitting, crack, wear,
+  missing component): zones with `zone_risk_level` of `high` or `critical`.
+- **Insulation damage**: the one zone actually named for it (`insulation
+  edge`), rather than the broad structural set.
+
+## API
+- `GET /api/mentor/education` — all twelve articles.
+- `GET /api/mentor/education/{finding_type}` — one article, 404 if unknown.
+- `POST /api/mentor/education/{finding_type}/complete` — mark an article
+  completed for the current user (feeds Competency Support).

--- a/docs/mentor/spd-mentor-engine.md
+++ b/docs/mentor/spd-mentor-engine.md
@@ -1,0 +1,44 @@
+# SPD Mentor Engine (v1.4)
+
+## What it does
+Turns an inspection analysis into active SPD education: interprets findings,
+explains contamination/damage/anatomy risk, suggests structured corrective
+action, and references SPD best practice — without ever replacing supervisor
+judgment.
+
+Implemented in `backend/app/services/spd_mentor_engine.py`, composed on top of
+the existing Phase 13/14/15 infrastructure (`clinical_mentor.py`,
+`instrument_anatomy.py`, `instrument_zones.py`, `inspection_coverage.py`)
+rather than duplicating it.
+
+## Where it runs
+`build_spd_mentor(result, overall, training_mode=False)` is called from
+`build_clinical_decision()` in `baseline_comparison_scoring_service.py` and
+attached to every analysis under `clinical_decision.spd_mentor`. It can also be
+re-derived for a past inspection via `GET /api/inspections/{id}/mentor`.
+
+## Payload shape
+```
+spd_mentor: {
+  disclaimer: str,
+  corrective_actions: [{finding, steps: [...]}],
+  anatomy_coaching: [str, ...],
+  confidence_coaching: {message, suggestions} | null,
+  clinical_decision_summary: {instrument, inspection_coverage, findings, risk, recommendation, supervisor_review},
+  education_cards: [{finding, clinical_significance, recommended_practice, reference}],
+  training_mode: bool,
+  expanded_explanations?: {...}   # only when training_mode is true
+}
+```
+
+## Disclaimer
+Every payload carries `MENTOR_DISCLAIMER`: this guidance is AI-generated
+educational support and does not replace supervisor judgment or the
+manufacturer's IFU. It is never omitted.
+
+## Never claims
+Consistent with project-wide governance rules, the engine never claims
+causation or regulatory clearance — corrective-action language is imperative
+("Reclean the instrument") but the overall recommendation stays advisory
+("Supervisor review: Recommended"), and every actionable output remains
+subject to `human_review_required: true` on the parent analysis.

--- a/docs/quality/capa-integration.md
+++ b/docs/quality/capa-integration.md
@@ -1,0 +1,28 @@
+# CAPA Integration (v1.5)
+
+## What it does
+`app/services/capa_suggestion_service.py` scans the last 90 days of
+`InspectionFinding` and `Inspection` rows for three recurring patterns and
+suggests a Corrective and Preventive Action for each:
+
+1. **Repeated contamination finding in the same anatomy zone** (≥3
+   occurrences) → recommend reviewing manual cleaning competency for that
+   zone.
+2. **Repeated condition finding (rust/corrosion/pitting/crack/insulation
+   damage/missing component) on the same instrument family** (≥3
+   occurrences) → recommend evaluating storage and maintenance practices.
+3. **Repeated low-confidence or low-coverage inspections by the same
+   technician** (≥3 occurrences) → recommend an image-capture refresher.
+
+## Suggestions, never auto-created CAPAs
+Consistent with the platform-wide rule that AI output never bypasses human
+review, `generate_capa_suggestions()` only returns suggestions — it never
+writes to the CAPA store. A supervisor reviews a suggestion and explicitly
+creates the CAPA via `POST /api/quality/capa-suggestions/create`, which
+calls the existing `app/services/capa_service.create_capa()` (the same CAPA
+store already used elsewhere in the platform — no parallel CAPA system).
+
+## API
+- `GET /api/quality/capa-suggestions` — current suggestions (leadership only).
+- `POST /api/quality/capa-suggestions/create` — materialize a chosen
+  suggestion into a real CAPA.

--- a/docs/quality/continuous-improvement.md
+++ b/docs/quality/continuous-improvement.md
@@ -1,0 +1,19 @@
+# Continuous Improvement Tracker (v1.5)
+
+## What it tracks
+Named quality initiatives from proposal through completion:
+`initiative`, `owner`, `target_date`, `status`
+(`proposed`/`in_progress`/`completed`/`abandoned`), `expected_impact`,
+`actual_impact`.
+
+## Why `actual_impact` is a free-text field a human fills in
+Observed impact requires human judgment about what changed and why — a raw
+before/after metric delta can't distinguish "this initiative worked" from
+"pass rate also improved for an unrelated reason." The tracker records the
+initiative's lifecycle; a leader records the actual outcome once observed,
+alongside whichever dashboard metrics they used to judge it.
+
+## API
+- `GET /api/quality/improvement-initiatives` — list (leadership only).
+- `POST /api/quality/improvement-initiatives` — create.
+- `PATCH /api/quality/improvement-initiatives/{id}` — update status/actual_impact.

--- a/docs/quality/executive-quality-score.md
+++ b/docs/quality/executive-quality-score.md
@@ -1,0 +1,27 @@
+# Executive Quality Score (v1.5)
+
+## What it does
+A single 0–100 score for leadership, computed from real data over the
+trailing quarter for the requesting tenant.
+
+## Weighted factors
+| Factor | Weight | Source |
+|---|---|---|
+| Pass rate | 0.25 | `Inspection.disposition == "PASS"` |
+| Coverage compliance | 0.15 | `Inspection.coverage_pct` |
+| Supervisor agreement | 0.15 | `SupervisorReview.agreement == "agree"` |
+| Low high-risk findings (inverted) | 0.15 | `100 - remove_from_service_rate` |
+| Low repeat findings (inverted) | 0.10 | `100 - (repeated_error / supervisor_correction)` (CompetencyEvent) |
+| Competency (education completion) | 0.10 | `education_completed / finding_reviewed` (CompetencyEvent) |
+| Baseline compliance | 0.10 | `Inspection.baseline_status == "approved_baseline_found"` |
+
+## Missing data is excluded, not defaulted
+If a tenant has no data for a factor (e.g. no supervisor reviews yet), that
+factor is dropped from the weighted average and the remaining weights are
+renormalized — never defaulted to 0, 50, or 100. `factors_used` in the
+response lists exactly which factors contributed, so the score is
+auditable. If *no* factor has data, `score` is `null` with an explanatory
+`note`, not a fabricated number.
+
+## API
+`GET /api/quality/executive-score` (leadership only).

--- a/docs/quality/quality-intelligence.md
+++ b/docs/quality/quality-intelligence.md
@@ -1,0 +1,36 @@
+# Quality Intelligence (v1.5)
+
+## What it does
+Turns every inspection into measurable quality-improvement intelligence:
+volume, pass/reclean/repair/remove-from-service rates, supervisor override
+rate, baseline and coverage compliance, and AI confidence trend — plus
+finding trends by type and time period, anatomy zone risk, instrument family
+performance, and per-technician/per-supervisor quality rollups.
+
+Distinct from the existing `quality_intelligence_service.py` (Phase 21),
+which tracks network-wide emerging-risk signals across hospitals via mocked
+data. v1.5 is per-tenant, real-data-only, and lives under `/api/quality/*`
+and the `/quality-dashboard` route to avoid colliding with that unrelated
+feature.
+
+## New persisted fields (Inspection)
+- `disposition` — the clinical_decision.overall_result computed at analysis
+  time (PASS/MONITOR/SUPERVISOR REVIEW/REPROCESS/REMOVE FROM SERVICE),
+  persisted so pass/reclean/remove-from-service rates don't require
+  re-deriving analysis for every dashboard load.
+- `coverage_pct` / `coverage_quality` — the Inspection Coverage Engine's
+  result at submission time, persisted for coverage-compliance reporting.
+
+## New table: InspectionFinding
+Inspection only stores the rolled-up disposition — not which individual
+finding types were detected. `InspectionFinding` logs one row per actionable
+finding (severity_index >= 1) at analysis time: finding type, anatomy zone,
+instrument type, severity. This is the real data source behind Finding Trend
+Intelligence, the Anatomy Risk Dashboard, and Instrument Family Performance —
+nothing in those dashboards is derived from a single rolled-up field or
+fabricated.
+
+## Dashboard endpoint
+`GET /api/quality/dashboard?period=day|week|month|quarter|year|all_time`
+returns the KPI set for the requested window. A metric with no underlying
+data returns `null`, never a fabricated zero.

--- a/docs/quality/root-cause-framework.md
+++ b/docs/quality/root-cause-framework.md
@@ -1,0 +1,30 @@
+# Root Cause Intelligence (v1.5)
+
+## What it does
+Lets a supervisor categorize a finding by its probable root cause and trends
+recurring causes across the tenant.
+
+## Why root cause is always human-assigned
+The engine never infers *why* a finding occurred — only a human reviewing
+the instrument and context can make that judgment. Auto-inferring a cause
+from a finding type alone would be a fabricated causal claim, which the
+platform's governance rules (`docs/architecture/*`, CLAUDE.md) explicitly
+forbid: "never claim causation."
+
+## Accepted vocabulary (`app/models/root_cause.py::ROOT_CAUSES`)
+- `incomplete_manual_cleaning`
+- `improper_brushing`
+- `improper_flushing`
+- `missed_inspection_zone`
+- `poor_lighting`
+- `image_quality`
+- `instrument_damage`
+- `manufacturer_wear`
+- `unknown` — a legitimate, honest choice when the cause isn't identifiable
+  at review time; not every finding needs a forced categorization.
+
+## API
+- `POST /api/quality/root-cause` — assign a root cause to a specific finding
+  on a specific inspection (leadership only).
+- `GET /api/quality/root-cause-trends` — recurring causes overall and by
+  finding type, for any authenticated role.

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -150,9 +150,16 @@ function Stars({ n }: { n: number }) {
 export default function ClinicalDecisionPanel({
   cd,
   inspectionId,
+  rawResult,
 }: {
   cd: ClinicalDecision;
   inspectionId?: number;
+  /** The raw analysis result already shown on screen (from a just-submitted
+   * inspection). When present, Training Mode is toggled by rebuilding the
+   * mentor payload from this exact data (POST /mentor/build) instead of
+   * re-deriving from the database — so toggling it can never change which
+   * findings or disposition are being explained. */
+  rawResult?: Record<string, unknown>;
 }) {
   const { headers, role } = useAuth();
   const [pdfBusy, setPdfBusy] = useState(false);
@@ -163,14 +170,18 @@ export default function ClinicalDecisionPanel({
   const canReview = role === "admin" || role === "spd_manager";
 
   async function toggleTrainingMode() {
-    if (!inspectionId) return;
     const next = !(mentor?.training_mode ?? false);
     setTrainingBusy(true);
     try {
-      const updated = await apiFetch<SpdMentor>(
-        `/api/inspections/${inspectionId}/mentor?training_mode=${next}`
-      );
-      setMentor(updated);
+      const updated = rawResult
+        ? await apiFetch<SpdMentor>(`/api/mentor/build?training_mode=${next}`, {
+            method: "POST",
+            body: { result: rawResult, overall: cd.overall_result },
+          })
+        : inspectionId
+          ? await apiFetch<SpdMentor>(`/api/inspections/${inspectionId}/mentor?training_mode=${next}`)
+          : undefined;
+      if (updated) setMentor(updated);
     } finally {
       setTrainingBusy(false);
     }
@@ -275,7 +286,7 @@ export default function ClinicalDecisionPanel({
         <div className="rounded-lg border border-indigo-200 bg-indigo-50/50 p-4 space-y-3">
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">SPD Mentor</p>
-            {inspectionId && (
+            {(rawResult || inspectionId) && (
               <button
                 onClick={toggleTrainingMode}
                 disabled={trainingBusy}

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -51,6 +51,27 @@ type ClinicalDecision = {
     standard_practice: string; what_should_happen_next: string[];
     where_was_it_detected?: string; why_this_zone_is_high_risk?: string; verify_manually?: string;
   };
+  // v1.4 — SPD Mentor Engine
+  spd_mentor?: SpdMentor;
+};
+
+type SpdMentor = {
+  disclaimer: string;
+  corrective_actions: { finding: string; steps: string[] }[];
+  anatomy_coaching: string[];
+  confidence_coaching: { message: string; suggestions: string[] } | null;
+  clinical_decision_summary: {
+    instrument: string; inspection_coverage: number | null; findings: string;
+    risk: string | null; recommendation: string | null; supervisor_review: string;
+  };
+  education_cards: { finding: string; clinical_significance: string; recommended_practice: string; reference: string }[];
+  training_mode: boolean;
+  expanded_explanations?: {
+    every_finding: Record<string, unknown>[];
+    anatomy_explained: { zone: string; explanation: string }[];
+    recommendation_explained: { disposition: string; next_actions: string[]; standards_guidance: string };
+    terminology: { term: string; definition: string }[];
+  };
 };
 
 const RISK_BADGE: Record<string, string> = {
@@ -136,8 +157,24 @@ export default function ClinicalDecisionPanel({
   const { headers, role } = useAuth();
   const [pdfBusy, setPdfBusy] = useState(false);
   const [learning, setLearning] = useState(false);
+  const [mentor, setMentor] = useState<SpdMentor | undefined>(cd.spd_mentor);
+  const [trainingBusy, setTrainingBusy] = useState(false);
   const result = cd.overall_result;
   const canReview = role === "admin" || role === "spd_manager";
+
+  async function toggleTrainingMode() {
+    if (!inspectionId) return;
+    const next = !(mentor?.training_mode ?? false);
+    setTrainingBusy(true);
+    try {
+      const updated = await apiFetch<SpdMentor>(
+        `/api/inspections/${inspectionId}/mentor?training_mode=${next}`
+      );
+      setMentor(updated);
+    } finally {
+      setTrainingBusy(false);
+    }
+  }
 
   async function downloadPdf() {
     if (!inspectionId) return;
@@ -230,6 +267,102 @@ export default function ClinicalDecisionPanel({
             <p><span className="font-semibold text-slate-900">Standard practice:</span> {cd.ai_mentor.standard_practice}</p>
             <p><span className="font-semibold text-slate-900">What should happen next:</span> {cd.ai_mentor.what_should_happen_next.join("; ")}</p>
           </div>
+        </div>
+      )}
+
+      {/* v1.4 — SPD Mentor Engine */}
+      {mentor && (
+        <div className="rounded-lg border border-indigo-200 bg-indigo-50/50 p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">SPD Mentor</p>
+            {inspectionId && (
+              <button
+                onClick={toggleTrainingMode}
+                disabled={trainingBusy}
+                className="text-xs font-medium text-indigo-700 underline disabled:opacity-50"
+              >
+                {trainingBusy ? "Loading…" : mentor.training_mode ? "Training Mode: On" : "Training Mode: Off"}
+              </button>
+            )}
+          </div>
+
+          {/* Clinical Decision Summary */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-sm">
+            <div><div className="text-xs text-slate-500">Instrument</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.instrument}</div></div>
+            <div><div className="text-xs text-slate-500">Coverage</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.inspection_coverage ?? "—"}%</div></div>
+            <div><div className="text-xs text-slate-500">Supervisor Review</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.supervisor_review}</div></div>
+          </div>
+          <p className="text-sm text-slate-700">{mentor.clinical_decision_summary.findings}</p>
+
+          {/* Corrective Action Recommendations */}
+          {mentor.corrective_actions.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-slate-600 mb-1">Corrective Action</p>
+              {mentor.corrective_actions.map((a, i) => (
+                <p key={i} className="text-sm text-slate-700">
+                  <span className="font-medium capitalize">{a.finding}:</span> {a.steps.join(" → ")}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {/* Anatomy-Aware Coaching */}
+          {mentor.anatomy_coaching.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-slate-600 mb-1">Anatomy Coaching</p>
+              <ul className="space-y-0.5 text-sm text-slate-700">
+                {mentor.anatomy_coaching.map((c, i) => <li key={i}>• {c}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {/* AI Confidence Coaching */}
+          {mentor.confidence_coaching && (
+            <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2">
+              <p className="text-sm font-medium text-amber-800">{mentor.confidence_coaching.message}</p>
+              <ul className="mt-1 text-sm text-amber-700">
+                {mentor.confidence_coaching.suggestions.map((s, i) => <li key={i}>• {s}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {/* SPD Education Cards */}
+          {mentor.education_cards.length > 0 && (
+            <div className="space-y-1.5">
+              {mentor.education_cards.map((c, i) => (
+                <div key={i} className="rounded border border-slate-200 bg-white px-3 py-2">
+                  <p className="text-sm font-semibold capitalize text-slate-800">{c.finding}</p>
+                  <p className="text-sm text-slate-600">{c.clinical_significance}</p>
+                  <p className="text-sm text-slate-600"><span className="text-slate-500">Recommended practice:</span> {c.recommended_practice}</p>
+                  <p className="text-xs text-slate-400">{c.reference}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Training Mode expanded explanations */}
+          {mentor.training_mode && mentor.expanded_explanations && (
+            <div className="rounded border border-indigo-300 bg-white px-3 py-2 space-y-2">
+              <p className="text-xs font-semibold text-indigo-700">Terminology</p>
+              <ul className="text-sm text-slate-700 space-y-0.5">
+                {mentor.expanded_explanations.terminology.map((t, i) => (
+                  <li key={i}><span className="font-medium">{t.term}:</span> {t.definition}</li>
+                ))}
+              </ul>
+              {mentor.expanded_explanations.anatomy_explained.length > 0 && (
+                <>
+                  <p className="text-xs font-semibold text-indigo-700">Anatomy Explained</p>
+                  <ul className="text-sm text-slate-700 space-y-0.5">
+                    {mentor.expanded_explanations.anatomy_explained.map((z, i) => (
+                      <li key={i}><span className="font-medium capitalize">{z.zone}:</span> {z.explanation}</li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          )}
+
+          <p className="text-xs text-slate-400 italic">{mentor.disclaimer}</p>
         </div>
       )}
 

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -114,6 +114,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/pilot-analytics", label: "Executive Dashboard", icon: TrendingUp, roles: EXECUTIVE_ROLES },
       { to: "/analytics", label: "Benchmarking", icon: BarChart3 },
       { to: "/quality-intelligence", label: "Risk Signals", icon: AlertTriangle },
+      { to: "/quality-dashboard", label: "Quality Dashboard", icon: BarChart3 },
       { to: "/operations", label: "Operational Analytics", icon: Activity },
       { to: "/pilot-validation", label: "Pilot Validation", icon: Activity, roles: ["admin", "spd_manager"] },
     ],

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -103,6 +103,8 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/capa", label: "CAPA", icon: ShieldCheck },
       { to: "/audit-evidence", label: "Audit Evidence", icon: FileText, roles: [...ELEVATED_ROLES, "auditor"] },
       { to: "/enterprise", label: "Enterprise Quality", icon: Building2, roles: ELEVATED_ROLES },
+      { to: "/education-library", label: "SPD Education Library", icon: BookOpen },
+      { to: "/coaching-dashboard", label: "Supervisor Coaching", icon: ClipboardCheck, roles: ELEVATED_ROLES },
     ],
   },
   {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -100,6 +100,8 @@ const ImageQualityPage = lazy(() => import("./pages/ImageQualityPage"));
 const GoLiveCenterPage = lazy(() => import("./pages/GoLiveCenterPage"));
 const ImplementationTrackerPage = lazy(() => import("./pages/ImplementationTrackerPage"));
 const TrainingCompliancePage = lazy(() => import("./pages/TrainingCompliancePage"));
+const EducationLibraryPage = lazy(() => import("./pages/EducationLibraryPage"));
+const SupervisorCoachingDashboard = lazy(() => import("./pages/SupervisorCoachingDashboard"));
 const BaselineReadinessPage = lazy(() => import("./pages/BaselineReadinessPage"));
 const InspectionReadinessPage = lazy(() => import("./pages/InspectionReadinessPage"));
 const ExecutiveAdoptionPage = lazy(() => import("./pages/ExecutiveAdoptionPage"));
@@ -387,6 +389,8 @@ function App() {
                       <Route path="/go-live-center" element={<Page name="GoLiveCenter"><GoLiveCenterPage /></Page>} />
                       <Route path="/implementation-tracker" element={<Page name="ImplementationTracker"><ImplementationTrackerPage /></Page>} />
                       <Route path="/training-compliance" element={<Page name="TrainingCompliance"><TrainingCompliancePage /></Page>} />
+                      <Route path="/education-library" element={<Page name="EducationLibrary"><EducationLibraryPage /></Page>} />
+                      <Route path="/coaching-dashboard" element={<Page name="CoachingDashboard"><RequireRole allowed={ELEVATED_ROLES}><SupervisorCoachingDashboard /></RequireRole></Page>} />
                       <Route path="/baseline-readiness" element={<Page name="BaselineReadiness"><BaselineReadinessPage /></Page>} />
                       <Route path="/inspection-readiness" element={<Page name="InspectionReadiness"><InspectionReadinessPage /></Page>} />
                       <Route path="/executive-adoption" element={<Page name="ExecutiveAdoption"><ExecutiveAdoptionPage /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -77,6 +77,7 @@ const GlobalInfrastructureConsole = lazy(() => import("./pages/GlobalInfrastruct
 const VendorIntelligencePage = lazy(() => import("./pages/VendorIntelligencePage"));
 const DigitalTwinPage = lazy(() => import("./pages/DigitalTwinPage"));
 const QualityIntelligencePage = lazy(() => import("./pages/QualityIntelligencePage"));
+const QualityDashboardPage = lazy(() => import("./pages/QualityDashboardPage"));
 const DemoImageLibraryPage = lazy(() => import("./pages/DemoImageLibraryPage"));
 const BaselineImageUploadPage = lazy(() => import("./pages/BaselineImageUploadPage"));
 const InspectionImageUploadPage = lazy(() => import("./pages/InspectionImageUploadPage"));
@@ -371,6 +372,7 @@ function App() {
                       <Route path="/vendor-intelligence" element={<Page name="VendorIntelligence"><VendorIntelligencePage /></Page>} />
                       <Route path="/digital-twin" element={<Page name="DigitalTwin"><DigitalTwinPage /></Page>} />
                       <Route path="/quality-intelligence" element={<Page name="QualityIntelligence"><QualityIntelligencePage /></Page>} />
+                      <Route path="/quality-dashboard" element={<Page name="QualityDashboard"><QualityDashboardPage /></Page>} />
                       <Route path="/baseline-library" element={<Page name="BaselineLibrary"><BaselineLibraryPage /></Page>} />
                       <Route path="/instrument-passport" element={<Page name="InstrumentPassport"><InstrumentPassportPage /></Page>} />
                       <Route path="/executive-command-center" element={<Page name="CommandCenter"><ExecutiveCommandCenterPage /></Page>} />

--- a/frontend/src/pages/EducationLibraryPage.tsx
+++ b/frontend/src/pages/EducationLibraryPage.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from "react";
+import { BookOpen } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface Article {
+  finding: string;
+  finding_type: string;
+  definition: string;
+  clinical_importance: string;
+  typical_anatomy_locations: string[];
+  inspection_tips: string;
+  cleaning_considerations: string;
+  corrective_actions: string[];
+  reference: string;
+}
+
+export default function EducationLibraryPage() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await apiFetch<{ articles: Article[] }>("/api/mentor/education");
+        setArticles(data.articles);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return <div className="p-6 text-sm text-slate-500">Loading education library…</div>;
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-4">
+      <div className="flex items-center gap-2">
+        <BookOpen className="h-6 w-6 text-indigo-600" />
+        <h1 className="text-xl font-bold text-slate-900">SPD Education Library</h1>
+      </div>
+      <p className="text-sm text-slate-500">
+        Structured reference for every contamination and condition category LumenAI recognizes —
+        definition, clinical importance, typical anatomy locations, inspection tips, cleaning
+        considerations, and corrective actions.
+      </p>
+
+      <div className="space-y-2">
+        {articles.map((a) => (
+          <div key={a.finding_type} className="rounded-lg border border-slate-200 bg-white">
+            <button
+              onClick={() => setOpen(open === a.finding_type ? null : a.finding_type)}
+              className="w-full flex items-center justify-between px-4 py-3 text-left"
+            >
+              <span className="font-semibold capitalize text-slate-800">{a.finding.replace(/_/g, " ")}</span>
+              <span className="text-xs text-slate-400">{open === a.finding_type ? "Hide" : "View"}</span>
+            </button>
+            {open === a.finding_type && (
+              <div className="px-4 pb-4 space-y-2 text-sm text-slate-700">
+                <p><span className="font-medium text-slate-500">Definition:</span> {a.definition}</p>
+                <p><span className="font-medium text-slate-500">Clinical importance:</span> {a.clinical_importance}</p>
+                <p><span className="font-medium text-slate-500">Typical anatomy locations:</span> {a.typical_anatomy_locations.join(", ")}</p>
+                <p><span className="font-medium text-slate-500">Inspection tips:</span> {a.inspection_tips}</p>
+                <p><span className="font-medium text-slate-500">Cleaning considerations:</span> {a.cleaning_considerations}</p>
+                <div>
+                  <span className="font-medium text-slate-500">Corrective actions:</span>
+                  <ul className="mt-1 space-y-0.5">
+                    {a.corrective_actions.map((s, i) => <li key={i}>• {s}</li>)}
+                  </ul>
+                </div>
+                <p className="text-xs text-slate-400">{a.reference}</p>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -1077,7 +1077,11 @@ function AIPredictionPanel({
 
         {/* Phase 13 — Explainable Clinical Decision Support (primary view) */}
         {prediction.analysis?.clinical_decision && (
-          <ClinicalDecisionPanel cd={prediction.analysis.clinical_decision} inspectionId={prediction.id} />
+          <ClinicalDecisionPanel
+            cd={prediction.analysis.clinical_decision}
+            inspectionId={prediction.id}
+            rawResult={prediction.analysis}
+          />
         )}
 
         {/* Phase 15 — Instrument Intelligence: coverage, risk map, guidance */}

--- a/frontend/src/pages/QualityDashboardPage.tsx
+++ b/frontend/src/pages/QualityDashboardPage.tsx
@@ -1,0 +1,480 @@
+import { useState, useEffect, useCallback } from "react";
+import { BarChart3 } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+
+type Tab =
+  | "overview" | "trends" | "anatomy" | "instruments"
+  | "technicians" | "supervisors" | "root-cause" | "improvement";
+
+function Stat({ label, value, suffix = "%" }: { label: string; value: number | null; suffix?: string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="text-xs text-slate-500">{label}</div>
+      <div className="text-2xl font-bold text-slate-900">{value == null ? "—" : `${value}${suffix}`}</div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+const CHANGE_STYLE: Record<string, string> = {
+  improvement: "text-emerald-700 bg-emerald-50 border-emerald-200",
+  regression: "text-red-700 bg-red-50 border-red-200",
+  stable: "text-slate-600 bg-slate-50 border-slate-200",
+  insufficient_data: "text-slate-400 bg-slate-50 border-slate-200",
+};
+
+export default function QualityDashboardPage() {
+  const { role } = useAuth();
+  const isLeadership = role === "admin" || role === "spd_manager";
+  const [tab, setTab] = useState<Tab>("overview");
+
+  const TABS: { id: Tab; label: string; leadershipOnly?: boolean }[] = [
+    { id: "overview", label: "Overview" },
+    { id: "trends", label: "Finding Trends" },
+    { id: "anatomy", label: "Anatomy Risk" },
+    { id: "instruments", label: "Instrument Performance" },
+    { id: "technicians", label: "Technician Quality", leadershipOnly: true },
+    { id: "supervisors", label: "Supervisor Quality", leadershipOnly: true },
+    { id: "root-cause", label: "Root Cause & CAPA" },
+    { id: "improvement", label: "Improvement Tracker", leadershipOnly: true },
+  ];
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6">
+      <div className="mb-6 flex items-center gap-2">
+        <BarChart3 className="h-6 w-6 text-indigo-600" />
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Quality Dashboard</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            Operational quality intelligence and continuous improvement — every inspection, aggregated.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex gap-1 border-b border-slate-200 mb-6 overflow-x-auto">
+        {TABS.filter((t) => !t.leadershipOnly || isLeadership).map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${
+              tab === t.id ? "border-b-2 border-blue-600 text-blue-600" : "text-slate-600 hover:text-slate-900"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "overview" && <OverviewTab />}
+      {tab === "trends" && <TrendsTab />}
+      {tab === "anatomy" && <AnatomyTab />}
+      {tab === "instruments" && <InstrumentsTab />}
+      {tab === "technicians" && isLeadership && <TechniciansTab />}
+      {tab === "supervisors" && isLeadership && <SupervisorsTab />}
+      {tab === "root-cause" && <RootCauseTab isLeadership={isLeadership} />}
+      {tab === "improvement" && isLeadership && <ImprovementTab />}
+    </div>
+  );
+}
+
+// ── Overview: KPIs + benchmark + executive score ─────────────────────────────
+function OverviewTab() {
+  const { role } = useAuth();
+  const isLeadership = role === "admin" || role === "spd_manager";
+  const [summary, setSummary] = useState<Record<string, number | null> | null>(null);
+  const [benchmark, setBenchmark] = useState<{
+    comparison_current_vs_previous_month: Record<string, string>;
+  } | null>(null);
+  const [score, setScore] = useState<{ score: number | null; note: string } | null>(null);
+
+  useEffect(() => {
+    apiFetch<Record<string, number | null>>("/api/quality/dashboard").then(setSummary);
+    apiFetch<typeof benchmark>("/api/quality/benchmark").then(setBenchmark);
+    if (isLeadership) {
+      apiFetch<typeof score>("/api/quality/executive-score").then(setScore);
+    }
+  }, [isLeadership]);
+
+  if (!summary) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <Stat label="Inspection Volume" value={summary.inspection_volume} suffix="" />
+        <Stat label="Pass Rate" value={summary.pass_rate_pct} />
+        <Stat label="Reclean Rate" value={summary.reclean_rate_pct} />
+        <Stat label="Repair Rate" value={summary.repair_rate_pct} />
+        <Stat label="Remove From Service" value={summary.remove_from_service_rate_pct} />
+        <Stat label="Supervisor Override" value={summary.supervisor_override_rate_pct} />
+        <Stat label="Baseline Compliance" value={summary.baseline_compliance_pct} />
+        <Stat label="Coverage Compliance" value={summary.coverage_compliance_pct} />
+        <Stat label="AI Confidence" value={summary.ai_confidence_trend_pct} />
+      </div>
+
+      {isLeadership && score && (
+        <Section title="Executive Quality Score">
+          <div className="text-4xl font-extrabold text-indigo-700">{score.score ?? "—"}<span className="text-lg text-slate-400">/100</span></div>
+          <p className="text-xs text-slate-500 mt-1">{score.note}</p>
+        </Section>
+      )}
+
+      {benchmark && (
+        <Section title="Benchmark: Current Month vs Previous Month">
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(benchmark.comparison_current_vs_previous_month).map(([metric, change]) => (
+              <span
+                key={metric}
+                className={`text-xs font-medium px-2 py-1 rounded border ${CHANGE_STYLE[change] ?? CHANGE_STYLE.stable}`}
+              >
+                {metric.replace(/_pct$/, "").replace(/_/g, " ")}: {change.replace(/_/g, " ")}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+// ── Finding Trends ────────────────────────────────────────────────────────────
+function TrendsTab() {
+  const [granularity, setGranularity] = useState("monthly");
+  const [data, setData] = useState<{ totals: Record<string, number> } | null>(null);
+
+  const load = useCallback(() => {
+    apiFetch<typeof data>(`/api/quality/finding-trends?granularity=${granularity}`).then(setData);
+  }, [granularity]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        {["daily", "weekly", "monthly", "quarterly", "yearly"].map((g) => (
+          <button
+            key={g}
+            onClick={() => setGranularity(g)}
+            className={`text-xs px-3 py-1.5 rounded-full border ${granularity === g ? "bg-blue-600 text-white border-blue-600" : "border-slate-300 text-slate-600"}`}
+          >
+            {g}
+          </button>
+        ))}
+      </div>
+      {data && (
+        <Section title={`Finding Totals (${granularity})`}>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            {Object.entries(data.totals).map(([type, count]) => (
+              <div key={type} className="rounded border border-slate-200 px-3 py-2">
+                <div className="text-xs text-slate-500 capitalize">{type.replace(/_/g, " ")}</div>
+                <div className="text-lg font-bold text-slate-900">{count}</div>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+// ── Anatomy Risk ──────────────────────────────────────────────────────────────
+function AnatomyTab() {
+  const [data, setData] = useState<{
+    highest_risk_anatomy_zones: { zone: string; count: number }[];
+    most_frequent_contamination_zones: { zone: string; count: number }[];
+    most_frequent_damage_zones: { zone: string; count: number }[];
+    coverage_incomplete_pct: number | null;
+  } | null>(null);
+
+  useEffect(() => { apiFetch<typeof data>("/api/quality/anatomy-risk").then(setData); }, []);
+  if (!data) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  const ZoneList = ({ items }: { items: { zone: string; count: number }[] }) => (
+    <ul className="space-y-1 text-sm">
+      {items.length === 0 && <li className="text-slate-400">No data yet.</li>}
+      {items.map((z) => (
+        <li key={z.zone} className="flex justify-between">
+          <span className="capitalize text-slate-700">{z.zone}</span>
+          <span className="font-medium text-slate-900">{z.count}</span>
+        </li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <Section title="Highest-Risk Anatomy Zones"><ZoneList items={data.highest_risk_anatomy_zones} /></Section>
+      <Section title="Most Frequent Contamination"><ZoneList items={data.most_frequent_contamination_zones} /></Section>
+      <Section title="Most Frequent Damage"><ZoneList items={data.most_frequent_damage_zones} /></Section>
+      <Section title="Coverage Incomplete Rate">
+        <div className="text-2xl font-bold text-slate-900">{data.coverage_incomplete_pct ?? "—"}%</div>
+        <p className="text-xs text-slate-400 mt-1">Share of inspections with incomplete/insufficient zone coverage.</p>
+      </Section>
+    </div>
+  );
+}
+
+// ── Instrument Family Performance ─────────────────────────────────────────────
+function InstrumentsTab() {
+  const [data, setData] = useState<{ families: Record<string, unknown>[] } | null>(null);
+  useEffect(() => { apiFetch<typeof data>("/api/quality/instrument-performance").then(setData); }, []);
+  if (!data) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  return (
+    <Section title="Instrument Family Performance">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-slate-400 text-xs">
+              <th className="py-1 pr-3">Family</th>
+              <th className="py-1 px-2">Inspections</th>
+              <th className="py-1 px-2">Pass Rate</th>
+              <th className="py-1 px-2">Failure Rate</th>
+              <th className="py-1 px-2">Repair Rate</th>
+              <th className="py-1 px-2">Supervisor Intervention</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.families.map((f) => (
+              <tr key={String(f.family)} className="border-t border-slate-100">
+                <td className="py-1 pr-3 font-medium capitalize">{String(f.family).replace(/_/g, " ")}</td>
+                <td className="py-1 px-2">{String(f.inspection_count)}</td>
+                <td className="py-1 px-2">{f.pass_rate_pct == null ? "—" : `${f.pass_rate_pct}%`}</td>
+                <td className="py-1 px-2">{f.failure_rate_pct == null ? "—" : `${f.failure_rate_pct}%`}</td>
+                <td className="py-1 px-2">{f.repair_rate_pct == null ? "—" : `${f.repair_rate_pct}%`}</td>
+                <td className="py-1 px-2">{f.supervisor_intervention_rate_pct == null ? "—" : `${f.supervisor_intervention_rate_pct}%`}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Section>
+  );
+}
+
+// ── Technician Quality (leadership only) ──────────────────────────────────────
+function TechniciansTab() {
+  const [data, setData] = useState<{ technicians: Record<string, unknown>[] } | null>(null);
+  useEffect(() => { apiFetch<typeof data>("/api/quality/technician-quality").then(setData); }, []);
+  if (!data) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  return (
+    <Section title="Technician Quality (Leadership Only)">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-slate-400 text-xs">
+              <th className="py-1 pr-3">Technician</th>
+              <th className="py-1 px-2">Inspections</th>
+              <th className="py-1 px-2">Avg Coverage</th>
+              <th className="py-1 px-2">Avg AI Confidence</th>
+              <th className="py-1 px-2">Supervisor Agreement</th>
+              <th className="py-1 px-2">Corrections</th>
+              <th className="py-1 px-2">Training Progress</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.technicians.map((t) => (
+              <tr key={String(t.technician)} className="border-t border-slate-100">
+                <td className="py-1 pr-3 font-medium">{String(t.technician)}</td>
+                <td className="py-1 px-2">{String(t.inspection_count)}</td>
+                <td className="py-1 px-2">{t.avg_coverage_pct == null ? "—" : `${t.avg_coverage_pct}%`}</td>
+                <td className="py-1 px-2">{t.avg_ai_confidence_pct == null ? "—" : `${t.avg_ai_confidence_pct}%`}</td>
+                <td className="py-1 px-2">{t.supervisor_agreement_pct == null ? "—" : `${t.supervisor_agreement_pct}%`}</td>
+                <td className="py-1 px-2">{String(t.supervisor_corrections)}</td>
+                <td className="py-1 px-2">{t.training_progress_pct == null ? "—" : `${t.training_progress_pct}%`}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Section>
+  );
+}
+
+// ── Supervisor Quality ────────────────────────────────────────────────────────
+function SupervisorsTab() {
+  const [data, setData] = useState<{
+    supervisors: Record<string, unknown>[];
+    department_trends: Record<string, unknown>[];
+  } | null>(null);
+  useEffect(() => { apiFetch<typeof data>("/api/quality/supervisor-quality").then(setData); }, []);
+  if (!data) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  return (
+    <div className="space-y-4">
+      <Section title="Supervisor Quality">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-slate-400 text-xs">
+                <th className="py-1 pr-3">Supervisor</th>
+                <th className="py-1 px-2">Workload</th>
+                <th className="py-1 px-2">Override Frequency</th>
+                <th className="py-1 px-2">Education Provided</th>
+                <th className="py-1 px-2">Agreement with AI</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.supervisors.map((s) => (
+                <tr key={String(s.reviewer)} className="border-t border-slate-100">
+                  <td className="py-1 pr-3 font-medium">{String(s.reviewer)}</td>
+                  <td className="py-1 px-2">{String(s.review_workload)}</td>
+                  <td className="py-1 px-2">{s.override_frequency_pct == null ? "—" : `${s.override_frequency_pct}%`}</td>
+                  <td className="py-1 px-2">{String(s.education_provided_count)}</td>
+                  <td className="py-1 px-2">{s.agreement_with_ai_pct == null ? "—" : `${s.agreement_with_ai_pct}%`}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+      <Section title="Department Trends">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          {data.department_trends.map((d) => (
+            <div key={String(d.department)} className="rounded border border-slate-200 px-3 py-2">
+              <div className="text-xs text-slate-500">{String(d.department)}</div>
+              <div className="text-sm text-slate-900">{String(d.inspection_count)} inspections</div>
+              <div className="text-xs text-slate-500">Pass {d.pass_rate_pct == null ? "—" : `${d.pass_rate_pct}%`}</div>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+// ── Root Cause & CAPA ─────────────────────────────────────────────────────────
+function RootCauseTab({ isLeadership }: { isLeadership: boolean }) {
+  const [trends, setTrends] = useState<{ overall: Record<string, number> } | null>(null);
+  const [suggestions, setSuggestions] = useState<Record<string, unknown>[]>([]);
+
+  useEffect(() => {
+    apiFetch<typeof trends>("/api/quality/root-cause-trends").then(setTrends);
+    if (isLeadership) {
+      apiFetch<{ suggestions: Record<string, unknown>[] }>("/api/quality/capa-suggestions")
+        .then((d) => setSuggestions(d.suggestions));
+    }
+  }, [isLeadership]);
+
+  async function createCapa(suggestion: Record<string, unknown>) {
+    await apiFetch("/api/quality/capa-suggestions/create", { method: "POST", body: suggestion });
+    alert("CAPA created.");
+  }
+
+  return (
+    <div className="space-y-4">
+      {trends && (
+        <Section title="Recurring Root Causes">
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(trends.overall).length === 0 && <p className="text-sm text-slate-400">No root causes assigned yet.</p>}
+            {Object.entries(trends.overall).map(([cause, count]) => (
+              <span key={cause} className="text-xs font-medium px-2 py-1 rounded-full bg-slate-100 text-slate-700">
+                {cause.replace(/_/g, " ")}: {count}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+      {isLeadership && (
+        <Section title="CAPA Suggestions">
+          {suggestions.length === 0 && <p className="text-sm text-slate-400">No recurring patterns yet.</p>}
+          <div className="space-y-2">
+            {suggestions.map((s, i) => (
+              <div key={i} className="rounded border border-amber-200 bg-amber-50 px-3 py-2">
+                <p className="text-sm font-semibold text-amber-900">{String(s.trigger)} ({String(s.occurrences)}x)</p>
+                <p className="text-sm text-amber-800">{String(s.recommendation)}</p>
+                <button
+                  onClick={() => createCapa(s)}
+                  className="mt-2 text-xs font-semibold px-3 py-1 rounded bg-amber-600 text-white hover:bg-amber-700"
+                >
+                  Create CAPA
+                </button>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+// ── Continuous Improvement Tracker ───────────────────────────────────────────
+function ImprovementTab() {
+  const [initiatives, setInitiatives] = useState<Record<string, unknown>[]>([]);
+  const [form, setForm] = useState({ initiative: "", owner: "", target_date: "", expected_impact: "" });
+
+  const load = useCallback(() => {
+    apiFetch<{ initiatives: Record<string, unknown>[] }>("/api/quality/improvement-initiatives")
+      .then((d) => setInitiatives(d.initiatives));
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  async function submit() {
+    if (!form.initiative.trim()) return;
+    await apiFetch("/api/quality/improvement-initiatives", {
+      method: "POST",
+      body: { ...form, target_date: form.target_date || null },
+    });
+    setForm({ initiative: "", owner: "", target_date: "", expected_impact: "" });
+    load();
+  }
+
+  async function markCompleted(id: number) {
+    const actual = prompt("Actual impact observed?") ?? "";
+    await apiFetch(`/api/quality/improvement-initiatives/${id}`, {
+      method: "PATCH",
+      body: { status: "completed", actual_impact: actual },
+    });
+    load();
+  }
+
+  return (
+    <div className="space-y-4">
+      <Section title="New Initiative">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <input className="rounded border border-slate-300 px-2 py-1.5 text-sm" placeholder="Initiative"
+            value={form.initiative} onChange={(e) => setForm((f) => ({ ...f, initiative: e.target.value }))} />
+          <input className="rounded border border-slate-300 px-2 py-1.5 text-sm" placeholder="Owner"
+            value={form.owner} onChange={(e) => setForm((f) => ({ ...f, owner: e.target.value }))} />
+          <input type="date" className="rounded border border-slate-300 px-2 py-1.5 text-sm"
+            value={form.target_date} onChange={(e) => setForm((f) => ({ ...f, target_date: e.target.value }))} />
+          <input className="rounded border border-slate-300 px-2 py-1.5 text-sm" placeholder="Expected impact"
+            value={form.expected_impact} onChange={(e) => setForm((f) => ({ ...f, expected_impact: e.target.value }))} />
+        </div>
+        <button onClick={submit} className="mt-2 text-xs font-semibold px-3 py-1.5 rounded bg-blue-600 text-white hover:bg-blue-700">
+          Add Initiative
+        </button>
+      </Section>
+      <Section title="Initiatives">
+        <div className="space-y-2">
+          {initiatives.length === 0 && <p className="text-sm text-slate-400">No initiatives yet.</p>}
+          {initiatives.map((i) => (
+            <div key={String(i.id)} className="rounded border border-slate-200 px-3 py-2 flex items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold text-slate-800">{String(i.initiative)}</p>
+                <p className="text-xs text-slate-500">
+                  {String(i.owner)} · {String(i.target_date ?? "no target date")} · <span className="capitalize">{String(i.status)}</span>
+                </p>
+                {!!i.actual_impact && <p className="text-xs text-emerald-700 mt-1">Actual: {String(i.actual_impact)}</p>}
+              </div>
+              {i.status !== "completed" && (
+                <button onClick={() => markCompleted(Number(i.id))} className="text-xs font-semibold px-2 py-1 rounded bg-emerald-600 text-white">
+                  Mark Completed
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/pages/SupervisorCoachingDashboard.tsx
+++ b/frontend/src/pages/SupervisorCoachingDashboard.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect, useCallback } from "react";
+import { ClipboardCheck } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface QueueItem {
+  inspection_id: number;
+  instrument_type: string;
+  technician: string | null;
+  risk_level: string | null;
+  recommended_action: string | null;
+  coaching_reviewed: boolean;
+}
+
+interface Effectiveness {
+  total_reviews: number;
+  approved_unchanged: number;
+  edited: number;
+  with_educational_comment: number;
+  approved_unchanged_pct: number | null;
+}
+
+export default function SupervisorCoachingDashboard() {
+  const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [effectiveness, setEffectiveness] = useState<Effectiveness | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [comment, setComment] = useState<Record<number, string>>({});
+  const [busy, setBusy] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [q, e] = await Promise.all([
+        apiFetch<{ queue: QueueItem[] }>("/api/mentor/coaching-queue"),
+        apiFetch<Effectiveness>("/api/mentor/coaching-effectiveness"),
+      ]);
+      setQueue(q.queue);
+      setEffectiveness(e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function review(inspectionId: number, approved: boolean) {
+    setBusy(inspectionId);
+    try {
+      await apiFetch(`/api/inspections/${inspectionId}/coaching-review`, {
+        method: "POST",
+        body: { approved, educational_comment: comment[inspectionId] ?? "" },
+      });
+      await load();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (loading) {
+    return <div className="p-6 text-sm text-slate-500">Loading coaching dashboard…</div>;
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-4">
+      <div className="flex items-center gap-2">
+        <ClipboardCheck className="h-6 w-6 text-indigo-600" />
+        <h1 className="text-xl font-bold text-slate-900">Supervisor Coaching Dashboard</h1>
+      </div>
+      <p className="text-sm text-slate-500">
+        Review the AI Mentor's coaching on recent inspections — approve it, or add an educational
+        comment for the technician.
+      </p>
+
+      {effectiveness && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 rounded-lg border border-slate-200 bg-white p-4">
+          <div><div className="text-xs text-slate-500">Total reviews</div><div className="text-xl font-bold text-slate-900">{effectiveness.total_reviews}</div></div>
+          <div><div className="text-xs text-slate-500">Approved unchanged</div><div className="text-xl font-bold text-emerald-700">{effectiveness.approved_unchanged}</div></div>
+          <div><div className="text-xs text-slate-500">Edited</div><div className="text-xl font-bold text-amber-700">{effectiveness.edited}</div></div>
+          <div><div className="text-xs text-slate-500">With comment</div><div className="text-xl font-bold text-slate-900">{effectiveness.with_educational_comment}</div></div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {queue.map((item) => (
+          <div key={item.inspection_id} className="rounded-lg border border-slate-200 bg-white p-4 space-y-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="text-sm">
+                <span className="font-semibold capitalize text-slate-800">{item.instrument_type}</span>
+                <span className="text-slate-400"> · #{item.inspection_id}</span>
+                {item.technician && <span className="text-slate-500"> · {item.technician}</span>}
+              </div>
+              <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${item.coaching_reviewed ? "bg-emerald-100 text-emerald-800" : "bg-amber-100 text-amber-800"}`}>
+                {item.coaching_reviewed ? "Reviewed" : "Awaiting review"}
+              </span>
+            </div>
+            <p className="text-sm text-slate-600">{item.recommended_action ?? "—"}</p>
+            <input
+              type="text"
+              placeholder="Add an educational comment for the technician…"
+              value={comment[item.inspection_id] ?? ""}
+              onChange={(e) => setComment((c) => ({ ...c, [item.inspection_id]: e.target.value }))}
+              className="w-full rounded border border-slate-300 px-2 py-1 text-sm"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={() => review(item.inspection_id, true)}
+                disabled={busy === item.inspection_id}
+                className="rounded bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => review(item.inspection_id, false)}
+                disabled={busy === item.inspection_id}
+                className="rounded bg-slate-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+              >
+                Flag for edit
+              </button>
+            </div>
+          </div>
+        ))}
+        {queue.length === 0 && <p className="text-sm text-slate-400">No inspections in the coaching queue.</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Stacked on PR #74
This branch is built on top of `feature/v1.4-spd-mentor` (PR #74, not yet merged) because v1.5's Technician/Supervisor Quality Dashboards depend directly on v1.4's `Inspection.technician` field and `competency_service.py` — building it against plain `main` would have meant reinventing that infrastructure. **The diff shown here includes all of PR #74's commits until #74 merges** — the only commit that's actually new is `feat: LumenAI Inspect v1.5 — Quality Intelligence & Continuous Improvement`. Once #74 merges to `main`, this branch should be rebased and the diff will shrink to just the v1.5 commit.

## Summary
Transforms LumenAI from an inspection tool into a Quality Intelligence platform. Every inspection now contributes to measurable continuous-improvement intelligence: recurring trends, process failures, competency gaps, instrument reliability, and department performance.

## Scope

**New persisted data:**
- `Inspection.disposition` — the `clinical_decision.overall_result` computed at analysis time, persisted for pass/reclean/remove-from-service rate reporting without re-deriving analysis.
- `Inspection.coverage_pct`/`coverage_quality` — the Inspection Coverage Engine's result at submission time.
- `Inspection.ai_confidence` — the AI-computed analysis confidence. **Found via browser testing**: this is distinct from the pre-existing `Inspection.confidence` column, which turned out to be a client-supplied manual-entry field, not the AI confidence — the dashboard was silently showing 0% until this was caught and fixed.
- New `InspectionFinding` table — one row per actionable finding (severity ≥ 1) at analysis time. `Inspection` only ever stored the rolled-up disposition, not which individual finding types were detected, so this is the real data source behind Finding Trend Intelligence, the Anatomy Risk Dashboard, and Instrument Family Performance — nothing in those dashboards is derived from a single field or fabricated.

**Deliverables (all real-data-driven, `/api/quality/*`, new `/quality-dashboard` route with 8 tabs):**
1. **Quality Intelligence Dashboard** — volume, pass/reclean/repair/remove-from-service rates, supervisor override rate, baseline/coverage compliance, AI confidence trend.
2. **Finding Trend Intelligence** — all 12 categories, daily/weekly/monthly/quarterly/yearly.
3. **Anatomy Risk Dashboard** — highest-risk zones, most frequent contamination/damage, coverage-incomplete rate.
4. **Instrument Family Performance** — ranked by frequency, pass/failure/repair rate, supervisor intervention.
5. **Technician Quality Dashboard** (leadership only) — extends `competency_service.py`.
6. **Supervisor Quality Dashboard** — workload, override frequency, correction categories, education provided, department trends.
7. **Root Cause Intelligence** — always human-assigned, never inferred (guessing "why" would be a fabricated causal claim).
8. **CAPA Integration** — *suggests*, never auto-creates, CAPAs from recurring patterns; wired to the existing `capa_service`.
9. **Benchmarking** — current month vs previous month vs quarter vs rolling 12 months.
10. **Executive Quality Score** — weighted 0–100 composite; missing factors excluded and weights renormalized, never defaulted.
11. **Continuous Improvement Tracker** — initiative/owner/target date/status/expected vs actual impact.
12–14. Documentation (`docs/quality/*.md`), tests, validation.

### Note on naming
Distinct from the existing `quality_intelligence_service.py` (Phase 21), which tracks network-wide emerging-risk signals across hospitals via mocked data — a different, unrelated feature. v1.5 lives under `/api/quality/*` and `/quality-dashboard` (not `/quality-intelligence`) to avoid colliding with it.

## Testing
- [x] Unit/integration tests — 15 new tests in `test_quality_intelligence.py`
- [x] **Browser-tested end-to-end**: seeded real inspections + supervisor reviews via the API, then drove all 8 dashboard tabs in a real browser (Playwright) — Overview, Finding Trends, Anatomy Risk, Instrument Performance, Technician Quality, Supervisor Quality, Root Cause & CAPA (including clicking "Create CAPA"), and Improvement Tracker (create + mark-completed). Zero console errors, zero unexpected network failures. Two real bugs were caught and fixed this way: the `ai_confidence` field mismatch above, and a test-isolation bug (a test asserted on `anatomy_risk_dashboard`'s truncated top-10 view against a database shared with the full test suite).
- [x] Full backend suite: `2374 passed, 2 skipped` (was 2359 before this branch)
- [x] `ruff check app tests` — all checks passed
- [x] `npm run build` — clean
- [ ] Docker build
- [ ] API/worker runtime validation

## Risks
Additive throughout — one new nullable column set on `Inspection`, one new table, one new router. Nothing existing is renamed, removed, or changed in shape.

## Rollback Plan
Revert this commit (after #74 merges and this is rebased). The new columns/table are additive and safe to leave in place even if the feature is rolled back.


---
_Generated by [Claude Code](https://claude.ai/code/session_011Fk9dzNXLSbHDHTsT5TCKL)_