### PR TITLE
LumenAI Inspect v1.9 — Pilot Deployment Loop & Production Workflow Hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,9 @@ generated_governance_packets/
 backend/.env
 .pytest_cache/
 
-# Local runtime evidence/test artifacts
-evidence/
+# Local runtime evidence/test artifacts (root-level only — docs/evidence/
+# is the tracked Clinical Evidence Repository and must not be ignored)
+/evidence/
 tmp/
 baselines/
 .venv-pdf/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,147 @@
+# LumenAI™
+## AI-Powered Pre-Sterilization Clinical Intelligence Platform for Sterile Processing
+
+> **LumenAI™ is an AI-powered Pre-Sterilization Clinical Intelligence Platform that combines computer vision, instrument intelligence, anatomy-aware reasoning, manufacturer baselines, and human expertise to prevent contaminated, damaged, or clinically unsafe surgical instruments from progressing to packaging and sterilization.**
+
+---
+
+## Our Mission
+
+To improve patient safety by providing explainable, anatomy-aware clinical inspection intelligence that enables Sterile Processing professionals to identify contamination, damage, and quality risks before instruments proceed to packaging and sterilization.
+
+---
+
+## What Makes LumenAI Different?
+
+LumenAI is not simply an image analysis application.
+
+It is a **Clinical Intelligence Operating System (CIOS)** purpose-built for Sterile Processing.
+
+Unlike traditional computer vision platforms, LumenAI reasons like an experienced SPD professional by combining:
+
+- 🧠 Instrument Intelligence
+- 🔬 Anatomy Intelligence
+- 📷 AI Computer Vision
+- 📚 Manufacturer & Vendor Baselines
+- 🩺 Clinical Reasoning
+- 👩‍⚕️ Supervisor Validation
+- 📊 Enterprise Intelligence
+- 🔄 Continuous Learning
+
+Every recommendation is explainable, auditable, and designed to support—not replace—clinical expertise.
+
+---
+
+## Clinical Workflow
+
+```text
+Point of Use
+      │
+      ▼
+Transportation
+      │
+      ▼
+Decontamination
+      │
+      ▼
+Assembly & Inspection
+      │
+      ▼
+🟦 LumenAI Clinical Inspection
+      │
+      ▼
+Supervisor Validation
+      │
+      ▼
+Packaging
+      │
+      ▼
+Sterilization
+      │
+      ▼
+Sterile Storage
+      │
+      ▼
+Operating Room
+```
+
+LumenAI serves as the **clinical quality gate before packaging and sterilization**, helping ensure instruments are ready to move safely to the next stage of the SPD workflow.
+
+---
+
+## Clinical Intelligence Architecture
+
+```text
+Image Acquisition
+        │
+        ▼
+Computer Vision
+        │
+        ▼
+Instrument Intelligence
+        │
+        ▼
+Anatomy Intelligence
+        │
+        ▼
+Zone Intelligence
+        │
+        ▼
+Clinical Finding Intelligence
+        │
+        ▼
+Clinical Reasoning Engine
+        │
+        ▼
+Clinical Decision Engine
+        │
+        ▼
+Human Validation
+        │
+        ▼
+Continuous Learning
+        │
+        ▼
+Enterprise Intelligence
+```
+
+---
+
+## Core Platform Capabilities
+
+- AI-assisted clinical inspection
+- Instrument registry and passport
+- Manufacturer baseline management
+- Vendor baseline management
+- Anatomy-aware inspection guidance
+- Zone-aware contamination and damage assessment
+- Explainable clinical recommendations
+- Supervisor review and validation
+- Knowledge Graph-powered reasoning
+- Multi-agent clinical intelligence
+- Executive dashboards and analytics
+- Enterprise deployment with RBAC, tenant isolation, and audit logging
+
+---
+
+## Guiding Principle
+
+> **Prevent harm before sterilization.**
+
+Every inspection, recommendation, and workflow in LumenAI is designed to support safer instruments, better clinical decisions, and improved patient outcomes before instruments proceed to packaging and sterilization.
+
+---
+
+## Version
+
+**Current Release:** LumenAI Clinical Intelligence Platform **v1.0.0**
+
+For the complete platform definition, architecture, design principles, and roadmap, see:
+
+📄 **[VERSION_1_0.md](VERSION_1_0.md)**
+
+---
+
 # LumenAI Enterprise Governance Suite v1.0.0
 
 ## Compliance Evidence v1.0 — Public Portfolio Ready

--- a/VERSION_1_0.md
+++ b/VERSION_1_0.md
@@ -1,0 +1,586 @@
+# LumenAI Clinical Intelligence Platform
+## VERSION_1_0.md
+
+**Version:** 1.0.0
+
+**Codename:** Clinical Intelligence Foundation
+
+**Status:** Production Architecture Frozen
+
+**Release Date:** 2026-07-03
+
+---
+
+# Vision
+
+To become the world's leading AI-powered Clinical Intelligence Platform for Sterile Processing by preventing contaminated, damaged, or clinically unsafe surgical instruments from progressing to packaging and sterilization.
+
+LumenAI combines Artificial Intelligence, Computer Vision, Instrument Intelligence, Anatomy Intelligence, Clinical Reasoning, and Human Expertise into a single enterprise platform that improves patient safety and surgical quality.
+
+---
+
+# Mission
+
+LumenAI is an AI-powered **Pre-Sterilization Clinical Inspection Platform** that prevents contaminated, damaged, or clinically unsafe surgical instruments from progressing to packaging and sterilization by combining:
+
+- Instrument Intelligence
+- Anatomy-aware Computer Vision
+- Manufacturer Baselines
+- Clinical Reasoning
+- Human Expertise
+- Enterprise Intelligence
+
+---
+
+# What LumenAI Is
+
+LumenAI is a Clinical Intelligence Operating System (CIOS) for Sterile Processing.
+
+The platform assists SPD professionals by:
+
+- identifying instruments
+- understanding instrument anatomy
+- detecting contamination and damage
+- comparing against manufacturer-approved baselines
+- reasoning using SPD knowledge
+- recommending appropriate actions
+- learning continuously through supervisor validation
+
+---
+
+# What LumenAI Is NOT
+
+LumenAI is NOT:
+
+- a sterilization monitoring system
+- a biological indicator monitoring platform
+- a sterilizer performance monitoring system
+- a sterility assurance system
+- an autonomous decision maker
+- a replacement for SPD professionals
+- a medical device that independently approves instruments for patient use
+
+LumenAI operates **before sterilization** as a clinical inspection quality gate.
+
+---
+
+# Clinical Workflow Boundary
+
+```
+Point of Use
+
+↓
+
+Transportation
+
+↓
+
+Decontamination
+
+↓
+
+Assembly
+
+↓
+
+Clinical Inspection
+
+↓
+
+LumenAI
+
+↓
+
+Supervisor Review
+
+↓
+
+Packaging
+
+↓
+
+Sterilization
+
+↓
+
+Sterile Storage
+
+↓
+
+Operating Room
+```
+
+LumenAI's responsibility ends when an instrument is approved to proceed to packaging and sterilization.
+
+---
+
+# Platform Philosophy
+
+LumenAI follows one guiding principle:
+
+> **Prevent harm before sterilization.**
+
+The platform focuses on identifying contamination, damage, missing components, corrosion, and cleaning failures while the instrument can still be corrected.
+
+---
+
+# Core Architecture
+
+```
+Image Acquisition
+
+↓
+
+Computer Vision
+
+↓
+
+Instrument Intelligence
+
+↓
+
+Anatomy Intelligence
+
+↓
+
+Zone Intelligence
+
+↓
+
+Clinical Finding Intelligence
+
+↓
+
+Clinical Reasoning
+
+↓
+
+Clinical Decision Engine
+
+↓
+
+Human Validation
+
+↓
+
+Continuous Learning
+
+↓
+
+Enterprise Intelligence
+```
+
+This architecture is frozen for Version 1.0.
+
+Future development must preserve this architecture.
+
+---
+
+# Clinical Ontology
+
+Every component within LumenAI uses the same ontology.
+
+```
+Instrument
+
+↓
+
+Manufacturer
+
+↓
+
+Instrument Family
+
+↓
+
+Model
+
+↓
+
+Anatomy
+
+↓
+
+Inspection Zone
+
+↓
+
+Finding
+
+↓
+
+Severity
+
+↓
+
+SPD Risk
+
+↓
+
+Clinical Interpretation
+
+↓
+
+Recommendation
+
+↓
+
+Supervisor Decision
+
+↓
+
+Learning Signal
+```
+
+All APIs, databases, AI models, dashboards, reports, and training datasets map to this ontology.
+
+---
+
+# Design Principles
+
+## 1. Instrument First
+
+Always identify the instrument before interpreting findings.
+
+---
+
+## 2. Anatomy First
+
+Every finding must reference an anatomy zone whenever possible.
+
+Bad:
+
+Blood detected.
+
+Good:
+
+Blood detected in the Kerrison jaw serrations.
+
+---
+
+## 3. Clinical Reasoning Before Prediction
+
+The AI should explain:
+
+- what
+- where
+- why
+- risk
+- recommendation
+
+Not simply produce a probability.
+
+---
+
+## 4. Human Expertise Is Final
+
+The supervisor remains the final authority.
+
+Every supervisor correction improves the platform.
+
+---
+
+# Core Capabilities
+
+## Clinical Inspection
+
+- AI image analysis
+- contamination detection
+- damage detection
+- AI confidence
+- explainable recommendations
+
+---
+
+## Instrument Intelligence
+
+- manufacturer identification
+- instrument family
+- model
+- registry
+- passport
+
+---
+
+## Anatomy Intelligence
+
+- anatomy profiles
+- high-risk zones
+- coverage engine
+- missing image guidance
+
+---
+
+## Baseline Intelligence
+
+- manufacturer baselines
+- vendor baselines
+- approval workflow
+- governance
+
+---
+
+## Clinical Reasoning
+
+- SPD Knowledge Graph
+- AI Mentor
+- explainable AI
+- clinical recommendations
+
+---
+
+## Human Intelligence
+
+- supervisor validation
+- overrides
+- audit trail
+- continuous learning
+
+---
+
+## Enterprise Intelligence
+
+- dashboards
+- analytics
+- ROI
+- customer success
+- executive reporting
+
+---
+
+## Platform Intelligence
+
+- RBAC
+- JWT
+- tenant isolation
+- audit logging
+- architecture governance
+- ontology governance
+- multi-agent orchestration
+
+---
+
+# AI Decision Framework
+
+Every inspection follows this sequence.
+
+```
+Image
+
+↓
+
+Instrument Identification
+
+↓
+
+Anatomy Recognition
+
+↓
+
+Inspection Coverage
+
+↓
+
+Baseline Comparison
+
+↓
+
+Finding Detection
+
+↓
+
+Severity Classification
+
+↓
+
+Zone Risk Assessment
+
+↓
+
+Clinical Reasoning
+
+↓
+
+Recommendation
+
+↓
+
+Supervisor Validation
+
+↓
+
+Learning
+
+↓
+
+Enterprise Analytics
+```
+
+This order must never be bypassed.
+
+---
+
+# Decision Outcomes
+
+LumenAI may recommend only:
+
+- READY FOR PACKAGING
+- READY FOR STERILIZATION
+- REQUIRES RECLEANING
+- SUPERVISOR REVIEW
+- REPAIR
+- REMOVE FROM SERVICE
+
+Final disposition remains the responsibility of authorized personnel.
+
+---
+
+# Security Principles
+
+Version 1.0 includes:
+
+- RBAC
+- JWT Authentication
+- Tenant Isolation
+- Audit Logging
+- Baseline Governance
+- Supervisor Validation
+- Immutable Decision History
+
+---
+
+# Governance
+
+Every inspection records:
+
+- Model Version
+- Dataset Version
+- Knowledge Graph Version
+- Clinical Rule Version
+- Ontology Version
+- Architecture Version
+
+All recommendations must be reproducible and auditable.
+
+---
+
+# Success Criteria
+
+Version 1.0 enables a hospital to:
+
+✓ Register instruments
+
+✓ Register manufacturer baselines
+
+✓ Register vendor baselines
+
+✓ Upload inspection images
+
+✓ Receive anatomy-aware AI analysis
+
+✓ Review AI reasoning
+
+✓ Validate recommendations
+
+✓ Capture supervisor feedback
+
+✓ Build enterprise analytics
+
+✓ Demonstrate measurable operational value
+
+✓ Improve pre-sterilization quality assurance
+
+---
+
+# Known Limitations
+
+Version 1.0 intentionally does NOT include:
+
+- autonomous clinical decision making
+- sterilizer validation
+- biological indicator monitoring
+- sterility assurance
+- FDA diagnostic claims
+- full anatomy segmentation
+- real-time OR integration
+- predictive maintenance beyond pre-sterilization inspection
+- robotic inspection
+
+These capabilities are reserved for future platform versions.
+
+---
+
+# Future Roadmap
+
+## Version 2.0
+
+Advanced Computer Vision
+
+- anatomy segmentation
+- heatmaps
+- bounding boxes
+- multi-view analysis
+- vision-language models
+
+---
+
+## Version 3.0
+
+Connected Enterprise
+
+- Censis integration
+- SPM integration
+- CMMS integration
+- ERP integration
+- manufacturer APIs
+
+---
+
+## Version 4.0
+
+Predictive Intelligence
+
+- advanced digital twin
+- degradation forecasting
+- maintenance optimization
+- fleet analytics
+
+---
+
+## Version 5.0
+
+Global Clinical Intelligence Network
+
+- cross-hospital benchmarking
+- manufacturer collaboration
+- research partnerships
+- global SPD knowledge graph
+
+---
+
+# Engineering Commitment
+
+Every new feature must answer "YES" to the following questions:
+
+- Does it support the mission?
+- Does it preserve the architecture?
+- Does it use the Clinical Ontology?
+- Does it improve patient safety?
+- Does it strengthen human decision-making?
+- Is it explainable?
+- Is it auditable?
+- Is it architecture-compliant?
+
+If the answer is **No** to any of these questions, the feature must be redesigned before implementation.
+
+---
+
+# Closing Statement
+
+LumenAI is more than an image analysis application.
+
+It is a Clinical Intelligence Platform designed to augment the expertise of Sterile Processing professionals through explainable artificial intelligence, anatomy-aware reasoning, enterprise governance, and continuous learning.
+
+Every inspection should contribute to safer instruments, better decisions, improved workflows, and ultimately, better patient outcomes.
+
+**Version 1.0 establishes the architectural foundation upon which all future LumenAI innovations will be built.**

--- a/backend/app/agents/anatomy_agent.py
+++ b/backend/app/agents/anatomy_agent.py
@@ -1,0 +1,47 @@
+"""Phase 22 §2 — Anatomy Intelligence Agent.
+
+Consumes the Instrument Context and determines anatomy zones, required
+image views, high-retention areas, and which zones were actually inspected
+vs. missing. Wraps app/services/instrument_zones.py's high-retention
+taxonomy — introduces no new zone-assignment logic.
+"""
+from __future__ import annotations
+
+from app.agents.context import AnatomyContext, InstrumentContext
+from app.services.instrument_anatomy import get_anatomy
+
+
+class AnatomyIntelligenceAgent:
+    NAME = "Anatomy Intelligence Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["resolve_required_zones", "determine_missing_zones", "score_inspection_completeness"]
+    DEPENDS_ON = ["InstrumentIntelligenceAgent"]
+
+    def run(self, instrument_ctx: InstrumentContext, inspected_zones: list[str] | None) -> AnatomyContext:
+        anatomy = get_anatomy(instrument_ctx.instrument_type)
+        required = anatomy["required_images"]
+
+        if inspected_zones is None:
+            return AnatomyContext(
+                instrument_family=instrument_ctx.instrument_family,
+                anatomy_zones=anatomy["zone_names"],
+                required_zones=required,
+                high_retention_zones=instrument_ctx.high_risk_zones,
+                inspected_zones=None,
+                missing_zones=required,
+                inspection_completeness=None,
+            )
+
+        inspected_norm = {z.strip().lower() for z in inspected_zones}
+        missing = [z for z in required if z.lower() not in inspected_norm]
+        completeness = round(100 * (len(required) - len(missing)) / len(required)) if required else 100
+
+        return AnatomyContext(
+            instrument_family=instrument_ctx.instrument_family,
+            anatomy_zones=anatomy["zone_names"],
+            required_zones=required,
+            high_retention_zones=instrument_ctx.high_risk_zones,
+            inspected_zones=inspected_zones,
+            missing_zones=missing,
+            inspection_completeness=completeness,
+        )

--- a/backend/app/agents/clinical_reasoning_agent.py
+++ b/backend/app/agents/clinical_reasoning_agent.py
@@ -1,0 +1,70 @@
+"""Phase 22 §6 — Clinical Reasoning Agent.
+
+Consumes Instrument, Anatomy, Coverage, and Findings (Contamination +
+Damage) context, plus the knowledge graph, and produces a clinical
+interpretation, a traceable reasoning chain, and a risk assessment. Wraps
+app/services/knowledge_graph_service.py — introduces no new reasoning
+logic of its own.
+"""
+from __future__ import annotations
+
+from app.agents.context import (
+    AnatomyContext,
+    ClinicalReasoningContext,
+    ContaminationContext,
+    CoverageContext,
+    DamageContext,
+    InstrumentContext,
+)
+from app.services.knowledge_graph_service import reasoning_chain
+
+
+class ClinicalReasoningAgent:
+    NAME = "Clinical Reasoning Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["synthesize_clinical_interpretation", "build_reasoning_chain", "assess_risk"]
+    DEPENDS_ON = [
+        "InstrumentIntelligenceAgent", "AnatomyIntelligenceAgent", "InspectionCoverageAgent",
+        "ContaminationDetectionAgent", "DamageDetectionAgent",
+    ]
+
+    def run(
+        self,
+        instrument_ctx: InstrumentContext,
+        anatomy_ctx: AnatomyContext,
+        coverage_ctx: CoverageContext,
+        contamination_ctx: ContaminationContext,
+        damage_ctx: DamageContext,
+        risk_score: int,
+    ) -> ClinicalReasoningContext:
+        if not contamination_ctx.findings and not damage_ctx.findings:
+            interpretation = (
+                f"No contamination or damage findings on this {instrument_ctx.instrument_type}. "
+                f"Coverage: {coverage_ctx.coverage_quality}."
+            )
+            chain: list[dict] = []
+        else:
+            primary = contamination_ctx.findings[0] if contamination_ctx.findings else None
+            chain_result = reasoning_chain(
+                instrument_ctx.instrument_type,
+                primary.finding_type if primary else damage_ctx.findings[0].finding_type,
+                manufacturer=instrument_ctx.manufacturer,
+                model=instrument_ctx.model,
+            )
+            chain = chain_result["chain"]
+            interpretation = chain_result["narrative"]
+
+        risk_level = "low"
+        if risk_score >= 85:
+            risk_level = "critical"
+        elif risk_score >= 70:
+            risk_level = "high"
+        elif risk_score >= 40:
+            risk_level = "medium"
+
+        return ClinicalReasoningContext(
+            interpretation=interpretation,
+            reasoning_chain=chain,
+            risk_level=risk_level,
+            risk_score=risk_score,
+        )

--- a/backend/app/agents/contamination_agent.py
+++ b/backend/app/agents/contamination_agent.py
@@ -1,0 +1,46 @@
+"""Phase 22 §4 — Contamination Detection Agent.
+
+Owns blood, bone, tissue, organic residue, and debris. Reads the real
+inspection's persisted finding (detected_issue/confidence/risk_score) —
+it does not run new detection; the underlying scoring already happened in
+app/services/baseline_comparison_scoring_service.py before this pipeline
+runs on a historical inspection.
+
+Note: the current Inspection schema persists one detected_issue per row
+(a future CV release could emit multiple simultaneous findings — see
+app/services/ml/feature_store.py) — so `findings` here has at most one
+entry today, honestly reflecting what's actually stored.
+"""
+from __future__ import annotations
+
+from app.agents.context import ContaminationContext, ContaminationFinding
+from app.services.clinical_mentor import FINDING_EDUCATION
+from app.services.instrument_zones import zone_fields
+
+CONTAMINATION_FINDING_TYPES = {"blood", "bone", "tissue", "debris", "other"}
+
+
+class ContaminationDetectionAgent:
+    NAME = "Contamination Detection Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["detect_organic_contamination", "assign_contamination_zone", "explain_clinical_significance"]
+    DEPENDS_ON = ["InstrumentIntelligenceAgent", "AnatomyIntelligenceAgent"]
+
+    def run(self, instrument_type: str, detected_issue: str, confidence: float, risk_score: int) -> ContaminationContext:
+        issue = (detected_issue or "").strip().lower()
+        if issue not in CONTAMINATION_FINDING_TYPES:
+            return ContaminationContext(findings=[], has_contamination=False)
+
+        zinfo = zone_fields(instrument_type, issue)
+        education = FINDING_EDUCATION.get(issue, {})
+        severity = "high" if risk_score >= 70 else ("medium" if risk_score >= 40 else "low")
+
+        finding = ContaminationFinding(
+            finding_type=issue,
+            probability=confidence / 100 if confidence and confidence > 1 else confidence,
+            severity=severity,
+            confidence=confidence,
+            zone=zinfo["instrument_zone"],
+            clinical_significance=education.get("clinical_significance", ""),
+        )
+        return ContaminationContext(findings=[finding], has_contamination=True)

--- a/backend/app/agents/context.py
+++ b/backend/app/agents/context.py
@@ -1,0 +1,121 @@
+"""Phase 22 §11 — Agent Context Objects.
+
+Every agent in the multi-agent pipeline reads a typed input context and
+produces a typed output context. No agent reads raw frontend state or a
+raw request payload directly — the orchestrator (app/agents/orchestrator.py)
+is the only thing that touches the database row, and every agent after the
+first only ever sees the previous agent's context object.
+
+These are pydantic models purely for structure/serialization — they carry
+no business logic themselves.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class InstrumentContext(BaseModel):
+    instrument_type: str
+    manufacturer: str = ""
+    model: str = ""
+    instrument_family: str
+    instrument_category: str
+    anatomy_zones: list[str] = []
+    high_risk_zones: list[str] = []
+    ifu_reference: str = ""
+    digital_twin_available: bool = False
+    profile_found: bool = True
+    warning: Optional[str] = None
+
+
+class AnatomyContext(BaseModel):
+    instrument_family: str
+    anatomy_zones: list[str] = []
+    required_zones: list[str] = []
+    high_retention_zones: list[str] = []
+    inspected_zones: Optional[list[str]] = None
+    missing_zones: list[str] = []
+    inspection_completeness: Optional[int] = None  # 0-100, None when not assessed
+
+
+class CoverageContext(BaseModel):
+    coverage_pct: Optional[int] = None
+    required_images: list[str] = []
+    missing_images: list[str] = []
+    coverage_quality: str = "not_assessed"
+    capture_guidance: list[str] = []
+
+
+class ContaminationFinding(BaseModel):
+    finding_type: str
+    probability: Optional[float] = None
+    severity: str = "none"
+    confidence: Optional[float] = None
+    zone: str = ""
+    clinical_significance: str = ""
+
+
+class ContaminationContext(BaseModel):
+    findings: list[ContaminationFinding] = []
+    has_contamination: bool = False
+
+
+class DamageFinding(BaseModel):
+    finding_type: str
+    severity: str = "none"
+    repair_recommendation: str = ""
+    trend: str = "stable"
+
+
+class DamageContext(BaseModel):
+    findings: list[DamageFinding] = []
+    has_damage: bool = False
+
+
+class ClinicalReasoningContext(BaseModel):
+    interpretation: str
+    reasoning_chain: list[dict] = []
+    risk_level: Optional[str] = None
+    risk_score: Optional[int] = None
+
+
+class RecommendationContext(BaseModel):
+    readiness_state: str  # READY_FOR_PACKAGING | REQUIRES_RECLEANING | REQUIRES_SUPERVISOR_REVIEW | REQUIRES_REPAIR | REMOVED_FROM_SERVICE | PENDING_ANALYSIS
+    repair_candidate: bool = False
+    explanation: str = ""
+    human_review_required: bool = True
+
+
+class SupervisorContext(BaseModel):
+    review_exists: bool = False
+    agreement: Optional[str] = None
+    corrections: dict = {}
+    override_action: str = ""
+    ground_truth_label: Optional[str] = None
+    training_label_created: bool = False
+
+
+class LearningContext(BaseModel):
+    knowledge_confidence: Optional[float] = None
+    reasoning_confidence: Optional[float] = None
+    clinical_recommendation_confidence: Optional[float] = None
+    zone_confidence: Optional[float] = None
+    sample_sizes: dict = {}
+    note: str = ""
+
+
+class EnterpriseContext(BaseModel):
+    facility: Optional[str] = None
+    facility_readiness_rate: Optional[float] = None
+    most_common_contamination_type: list[dict] = []
+    highest_risk_anatomy_zone: Optional[str] = None
+    note: str = ""
+
+
+class AgentTraceEntry(BaseModel):
+    agent: str
+    version: str
+    input_summary: dict
+    output_summary: dict

--- a/backend/app/agents/coverage_agent.py
+++ b/backend/app/agents/coverage_agent.py
@@ -1,0 +1,30 @@
+"""Phase 22 §3 — Inspection Coverage Agent.
+
+Consumes the Anatomy Context and produces coverage %, missing images, and
+capture guidance ("Upload O-ring image.", "Capture hinge close-up.").
+Wraps app/services/inspection_coverage.py — introduces no new coverage
+logic of its own.
+"""
+from __future__ import annotations
+
+from app.agents.context import AnatomyContext, CoverageContext
+from app.services.inspection_coverage import compute_coverage, missing_image_guidance
+
+
+class InspectionCoverageAgent:
+    NAME = "Inspection Coverage Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["compute_coverage_percent", "generate_capture_guidance"]
+    DEPENDS_ON = ["AnatomyIntelligenceAgent"]
+
+    def run(self, instrument_type: str, anatomy_ctx: AnatomyContext) -> CoverageContext:
+        coverage = compute_coverage(instrument_type, anatomy_ctx.inspected_zones)
+        guidance = missing_image_guidance(instrument_type, anatomy_ctx.inspected_zones)
+
+        return CoverageContext(
+            coverage_pct=coverage["overall_coverage"],
+            required_images=coverage["required_zones"],
+            missing_images=coverage["missing"],
+            coverage_quality=coverage["quality"],
+            capture_guidance=guidance,
+        )

--- a/backend/app/agents/damage_agent.py
+++ b/backend/app/agents/damage_agent.py
@@ -27,7 +27,7 @@ class DamageDetectionAgent:
         severity = "critical" if risk_score >= 85 else ("high" if risk_score >= 70 else ("medium" if risk_score >= 40 else "low"))
         repairable = issue in _REPAIRABLE_ISSUES
         repair_recommendation = (
-            "Route to repair evaluation." if repairable and severity in ("medium", "high")
+            "Route to repair evaluation." if repairable and severity in ("medium", "high", "critical")
             else "Remove from service pending replacement." if not repairable and severity in ("high", "critical")
             else "Monitor and re-inspect at next cycle."
         )

--- a/backend/app/agents/damage_agent.py
+++ b/backend/app/agents/damage_agent.py
@@ -1,0 +1,48 @@
+"""Phase 22 §5 — Damage Detection Agent.
+
+Owns rust, corrosion, crack, pitting, wear, missing component, and
+insulation damage. Reads the real inspection's persisted finding — see the
+note in contamination_agent.py about the current one-finding-per-row
+schema limitation, which applies here too.
+"""
+from __future__ import annotations
+
+from app.agents.context import DamageContext, DamageFinding
+from app.services.pre_sterilization_command_center_service import _REPAIRABLE_ISSUES
+
+DAMAGE_FINDING_TYPES = {"rust", "corrosion", "crack", "pitting", "wear", "missing_component", "insulation_damage"}
+
+
+class DamageDetectionAgent:
+    NAME = "Damage Detection Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["detect_structural_damage", "recommend_repair_or_removal", "track_damage_trend"]
+    DEPENDS_ON = ["InstrumentIntelligenceAgent", "AnatomyIntelligenceAgent"]
+
+    def run(self, detected_issue: str, risk_score: int, prior_risk_score: int | None = None) -> DamageContext:
+        issue = (detected_issue or "").strip().lower()
+        if issue not in DAMAGE_FINDING_TYPES:
+            return DamageContext(findings=[], has_damage=False)
+
+        severity = "critical" if risk_score >= 85 else ("high" if risk_score >= 70 else ("medium" if risk_score >= 40 else "low"))
+        repairable = issue in _REPAIRABLE_ISSUES
+        repair_recommendation = (
+            "Route to repair evaluation." if repairable and severity in ("medium", "high")
+            else "Remove from service pending replacement." if not repairable and severity in ("high", "critical")
+            else "Monitor and re-inspect at next cycle."
+        )
+
+        trend = "stable"
+        if prior_risk_score is not None:
+            if risk_score > prior_risk_score:
+                trend = "worsening"
+            elif risk_score < prior_risk_score:
+                trend = "improving"
+
+        finding = DamageFinding(
+            finding_type=issue,
+            severity=severity,
+            repair_recommendation=repair_recommendation,
+            trend=trend,
+        )
+        return DamageContext(findings=[finding], has_damage=True)

--- a/backend/app/agents/enterprise_agent.py
+++ b/backend/app/agents/enterprise_agent.py
@@ -1,0 +1,49 @@
+"""Phase 22 §10 — Enterprise Intelligence Agent.
+
+Aggregates hospital/market/manufacturer/instrument/failure-mode data for
+executive dashboards, ROI, and benchmarking. Wraps
+app/services/pre_sterilization_command_center_service.py and
+app/services/knowledge_graph_service.py's enterprise analytics — this
+agent composes existing aggregation, it does not recompute new figures.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.agents.context import EnterpriseContext
+from app.db import models
+from app.services.knowledge_graph_service import enterprise_knowledge_analytics
+from app.services.pre_sterilization_command_center_service import _annotate, _reviewed_ids, facility_readiness
+
+
+class EnterpriseIntelligenceAgent:
+    NAME = "Enterprise Intelligence Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["aggregate_facility_readiness", "aggregate_findings_by_manufacturer", "aggregate_contamination_types"]
+    DEPENDS_ON = ["ContinuousLearningAgent"]
+
+    def run(self, db: Session, tenant_id: str, facility: str | None = None) -> EnterpriseContext:
+        analytics = enterprise_knowledge_analytics(db, tenant_id)
+
+        cases = (
+            db.query(models.Inspection)
+            .filter(models.Inspection.tenant_id == tenant_id)
+            .order_by(models.Inspection.created_at.desc())
+            .limit(5000)
+            .all()
+        )
+        reviewed_ids = _reviewed_ids(db, tenant_id)
+        annotated = _annotate(cases, reviewed_ids)
+        facilities = facility_readiness(annotated)
+        facility_rate = None
+        if facility:
+            match = next((f for f in facilities if f["facility"] == facility), None)
+            facility_rate = match["readiness_rate"] if match else None
+
+        return EnterpriseContext(
+            facility=facility,
+            facility_readiness_rate=facility_rate,
+            most_common_contamination_type=analytics["most_common_contamination_type"],
+            highest_risk_anatomy_zone=analytics["highest_risk_anatomy_zone"],
+            note="Aggregated from real Inspection/SupervisorReview/PilotValidationCase rows for this tenant.",
+        )

--- a/backend/app/agents/enterprise_agent.py
+++ b/backend/app/agents/enterprise_agent.py
@@ -45,5 +45,5 @@ class EnterpriseIntelligenceAgent:
             facility_readiness_rate=facility_rate,
             most_common_contamination_type=analytics["most_common_contamination_type"],
             highest_risk_anatomy_zone=analytics["highest_risk_anatomy_zone"],
-            note="Aggregated from real Inspection/SupervisorReview/PilotValidationCase rows for this tenant.",
+            note="Aggregated from real Inspection/SupervisorReview rows for this tenant.",
         )

--- a/backend/app/agents/instrument_agent.py
+++ b/backend/app/agents/instrument_agent.py
@@ -1,0 +1,56 @@
+"""Phase 22 §1 — Instrument Intelligence Agent.
+
+Identifies manufacturer/family/model/category and loads the anatomy
+profile, inspection requirements, high-risk zones, IFU reference, and
+digital-twin availability. Wraps existing structured knowledge
+(instrument_anatomy.py) and real DB rows — introduces no new detection
+logic.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.agents.context import InstrumentContext
+from app.services.instrument_anatomy import anatomy_profile
+
+
+class InstrumentIntelligenceAgent:
+    NAME = "Instrument Intelligence Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["resolve_instrument_family", "load_anatomy_profile", "check_digital_twin_availability"]
+    DEPENDS_ON: list[str] = []
+
+    def run(self, db: Session, tenant_id: str, instrument_type: str, manufacturer: str = "", model: str = "") -> InstrumentContext:
+        from app.models.digital_quality_twin import QualityTwinState
+        from app.models.instrument_knowledge import InstrumentKnowledge
+
+        profile = anatomy_profile(instrument_type, manufacturer=manufacturer, model=model)
+        has_twin = db.query(QualityTwinState.id).filter(QualityTwinState.tenant_id == tenant_id).first() is not None
+
+        ifu_reference = ""
+        if manufacturer and model:
+            knowledge = (
+                db.query(InstrumentKnowledge)
+                .filter(
+                    InstrumentKnowledge.tenant_id == tenant_id,
+                    InstrumentKnowledge.manufacturer == manufacturer,
+                    InstrumentKnowledge.model == model,
+                )
+                .first()
+            )
+            if knowledge:
+                ifu_reference = knowledge.ifu_reference
+
+        return InstrumentContext(
+            instrument_type=instrument_type,
+            manufacturer=manufacturer,
+            model=model,
+            instrument_family=profile["instrument_family"],
+            instrument_category=profile["category"],
+            anatomy_zones=profile["anatomy_zones"],
+            high_risk_zones=profile["high_risk_zones"],
+            ifu_reference=ifu_reference,
+            digital_twin_available=has_twin,
+            profile_found=profile["profile_found"],
+            warning=profile["warning"],
+        )

--- a/backend/app/agents/learning_agent.py
+++ b/backend/app/agents/learning_agent.py
@@ -1,0 +1,33 @@
+"""Phase 22 §9 — Continuous Learning Agent.
+
+Reports the knowledge graph's confidence signals (Phase 21
+learning_confidence) — knowledge confidence, reasoning confidence,
+clinical recommendation confidence, zone confidence, and per-family
+instrument profile confidence. Recomputed live from real supervisor
+reviews and Phase 18 ground truth on every call — this agent does not
+mutate a persisted model state or fabricate a training event.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.agents.context import LearningContext
+from app.services.knowledge_graph_service import learning_confidence
+
+
+class ContinuousLearningAgent:
+    NAME = "Continuous Learning Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["report_knowledge_confidence", "report_reasoning_confidence", "report_instrument_profile_confidence"]
+    DEPENDS_ON = ["SupervisorAgent"]
+
+    def run(self, db: Session, tenant_id: str) -> LearningContext:
+        confidence = learning_confidence(db, tenant_id)
+        return LearningContext(
+            knowledge_confidence=confidence["knowledge_confidence"],
+            reasoning_confidence=confidence["reasoning_confidence"],
+            clinical_recommendation_confidence=confidence["clinical_recommendation_confidence"],
+            zone_confidence=confidence["zone_confidence"],
+            sample_sizes=confidence["sample_sizes"],
+            note=confidence["note"],
+        )

--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -15,6 +15,7 @@ Enterprise only ever sees prior context objects.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -47,6 +48,9 @@ def _trace_entry(agent, input_summary: dict, output_ctx) -> dict:
     return {
         "agent": agent.NAME,
         "version": agent.VERSION,
+        # Real wall-clock time this agent's step completed during this live
+        # pipeline run — not a fabricated/reconstructed historical time.
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "input_summary": input_summary,
         "output_summary": output_ctx.model_dump(),
     }

--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -1,0 +1,120 @@
+"""Phase 22 §13 — Agent Orchestrator.
+
+Runs the full multi-agent pipeline for one real inspection:
+
+Instrument -> Anatomy -> Coverage -> Contamination -> Damage ->
+Clinical Reasoning -> Recommendation -> Supervisor -> Learning -> Enterprise
+
+Each agent receives only the typed context object(s) produced by the
+agents before it — no agent reads the raw Inspection row directly except
+where explicitly wired here, and none reads raw frontend state. The
+orchestrator is the only place that touches the database directly on
+behalf of the pipeline; every agent after Instrument/Coverage/Supervisor/
+Enterprise only ever sees prior context objects.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.agents.anatomy_agent import AnatomyIntelligenceAgent
+from app.agents.clinical_reasoning_agent import ClinicalReasoningAgent
+from app.agents.contamination_agent import ContaminationDetectionAgent
+from app.agents.coverage_agent import InspectionCoverageAgent
+from app.agents.damage_agent import DamageDetectionAgent
+from app.agents.enterprise_agent import EnterpriseIntelligenceAgent
+from app.agents.instrument_agent import InstrumentIntelligenceAgent
+from app.agents.learning_agent import ContinuousLearningAgent
+from app.agents.recommendation_agent import RecommendationAgent
+from app.agents.supervisor_agent import SupervisorAgent
+
+_AGENTS = {
+    "instrument": InstrumentIntelligenceAgent(),
+    "anatomy": AnatomyIntelligenceAgent(),
+    "coverage": InspectionCoverageAgent(),
+    "contamination": ContaminationDetectionAgent(),
+    "damage": DamageDetectionAgent(),
+    "reasoning": ClinicalReasoningAgent(),
+    "recommendation": RecommendationAgent(),
+    "supervisor": SupervisorAgent(),
+    "learning": ContinuousLearningAgent(),
+    "enterprise": EnterpriseIntelligenceAgent(),
+}
+
+
+def _trace_entry(agent, input_summary: dict, output_ctx) -> dict:
+    return {
+        "agent": agent.NAME,
+        "version": agent.VERSION,
+        "input_summary": input_summary,
+        "output_summary": output_ctx.model_dump(),
+    }
+
+
+def run_pipeline(db: Session, inspection, tenant_id: str) -> dict:
+    """Section 13/14 — run every agent in order and return the full result
+    plus the explainable trace (Section 14: which agent produced which
+    decision)."""
+    trace: list[dict] = []
+
+    try:
+        inspected_zones = json.loads(inspection.inspected_zones_json or "null")
+    except (TypeError, ValueError):
+        inspected_zones = None
+
+    instrument_ctx = _AGENTS["instrument"].run(
+        db, tenant_id, inspection.instrument_type, inspection.vendor_name or "", "",
+    )
+    trace.append(_trace_entry(_AGENTS["instrument"], {"instrument_type": inspection.instrument_type}, instrument_ctx))
+
+    anatomy_ctx = _AGENTS["anatomy"].run(instrument_ctx, inspected_zones)
+    trace.append(_trace_entry(_AGENTS["anatomy"], {"instrument_family": instrument_ctx.instrument_family}, anatomy_ctx))
+
+    coverage_ctx = _AGENTS["coverage"].run(inspection.instrument_type, anatomy_ctx)
+    trace.append(_trace_entry(_AGENTS["coverage"], {"missing_zones": anatomy_ctx.missing_zones}, coverage_ctx))
+
+    contamination_ctx = _AGENTS["contamination"].run(
+        inspection.instrument_type, inspection.detected_issue, inspection.confidence, inspection.risk_score,
+    )
+    trace.append(_trace_entry(_AGENTS["contamination"], {"detected_issue": inspection.detected_issue}, contamination_ctx))
+
+    damage_ctx = _AGENTS["damage"].run(inspection.detected_issue, inspection.risk_score)
+    trace.append(_trace_entry(_AGENTS["damage"], {"detected_issue": inspection.detected_issue}, damage_ctx))
+
+    reasoning_ctx = _AGENTS["reasoning"].run(
+        instrument_ctx, anatomy_ctx, coverage_ctx, contamination_ctx, damage_ctx, inspection.risk_score,
+    )
+    trace.append(_trace_entry(
+        _AGENTS["reasoning"],
+        {"has_contamination": contamination_ctx.has_contamination, "has_damage": damage_ctx.has_damage},
+        reasoning_ctx,
+    ))
+
+    recommendation_ctx = _AGENTS["recommendation"].run(inspection, reasoning_ctx)
+    trace.append(_trace_entry(_AGENTS["recommendation"], {"risk_level": reasoning_ctx.risk_level}, recommendation_ctx))
+
+    supervisor_ctx = _AGENTS["supervisor"].run(db, inspection.id)
+    trace.append(_trace_entry(_AGENTS["supervisor"], {"readiness_state": recommendation_ctx.readiness_state}, supervisor_ctx))
+
+    learning_ctx = _AGENTS["learning"].run(db, tenant_id)
+    trace.append(_trace_entry(_AGENTS["learning"], {"review_exists": supervisor_ctx.review_exists}, learning_ctx))
+
+    enterprise_ctx = _AGENTS["enterprise"].run(db, tenant_id, inspection.facility_name or inspection.site_name)
+    trace.append(_trace_entry(_AGENTS["enterprise"], {"facility": inspection.facility_name or inspection.site_name}, enterprise_ctx))
+
+    return {
+        "inspection_id": inspection.id,
+        "instrument_context": instrument_ctx.model_dump(),
+        "anatomy_context": anatomy_ctx.model_dump(),
+        "coverage_context": coverage_ctx.model_dump(),
+        "contamination_context": contamination_ctx.model_dump(),
+        "damage_context": damage_ctx.model_dump(),
+        "clinical_reasoning_context": reasoning_ctx.model_dump(),
+        "recommendation_context": recommendation_ctx.model_dump(),
+        "supervisor_context": supervisor_ctx.model_dump(),
+        "learning_context": learning_ctx.model_dump(),
+        "enterprise_context": enterprise_ctx.model_dump(),
+        "trace": trace,
+        "human_review_required": True,
+    }

--- a/backend/app/agents/recommendation_agent.py
+++ b/backend/app/agents/recommendation_agent.py
@@ -1,0 +1,33 @@
+"""Phase 22 §7 — Recommendation Agent.
+
+Produces one of: READY FOR PACKAGING, REQUIRES RECLEANING, REQUIRES
+SUPERVISOR REVIEW, REQUIRES REPAIR, REMOVED FROM SERVICE, PENDING
+ANALYSIS — the same six readiness states already defined in
+app/services/pre_sterilization_command_center_service.py (Phase 20),
+reused here rather than re-invented. Explains every recommendation using
+the Clinical Reasoning Agent's interpretation.
+"""
+from __future__ import annotations
+
+from app.agents.context import ClinicalReasoningContext, RecommendationContext
+from app.services.pre_sterilization_command_center_service import classify_readiness
+
+
+class RecommendationAgent:
+    NAME = "Recommendation Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["classify_packaging_readiness", "explain_recommendation"]
+    DEPENDS_ON = ["ClinicalReasoningAgent"]
+
+    def run(self, inspection, reasoning_ctx: ClinicalReasoningContext) -> RecommendationContext:
+        classified = classify_readiness(inspection)
+        explanation = reasoning_ctx.interpretation or (
+            f"Readiness state {classified['readiness_state']} determined from the persisted "
+            f"scoring outcome; no additional findings narrative available."
+        )
+        return RecommendationContext(
+            readiness_state=classified["readiness_state"],
+            repair_candidate=classified["repair_candidate"],
+            explanation=explanation,
+            human_review_required=True,
+        )

--- a/backend/app/agents/registry.py
+++ b/backend/app/agents/registry.py
@@ -1,0 +1,76 @@
+"""Phase 22 §12 — Agent Registry.
+
+A static registry of every agent in the pipeline: status, version,
+capabilities, dependencies, and health. Health is a simple self-check —
+these agents are deterministic in-process Python wrapping existing
+services, not external calls, so "ok" reflects that the agent's
+dependencies (the services/modules it wraps) import successfully, not a
+fabricated uptime/latency metric.
+"""
+from __future__ import annotations
+
+import importlib
+
+from app.agents.anatomy_agent import AnatomyIntelligenceAgent
+from app.agents.clinical_reasoning_agent import ClinicalReasoningAgent
+from app.agents.contamination_agent import ContaminationDetectionAgent
+from app.agents.coverage_agent import InspectionCoverageAgent
+from app.agents.damage_agent import DamageDetectionAgent
+from app.agents.enterprise_agent import EnterpriseIntelligenceAgent
+from app.agents.instrument_agent import InstrumentIntelligenceAgent
+from app.agents.learning_agent import ContinuousLearningAgent
+from app.agents.recommendation_agent import RecommendationAgent
+from app.agents.supervisor_agent import SupervisorAgent
+
+PIPELINE_ORDER = [
+    InstrumentIntelligenceAgent,
+    AnatomyIntelligenceAgent,
+    InspectionCoverageAgent,
+    ContaminationDetectionAgent,
+    DamageDetectionAgent,
+    ClinicalReasoningAgent,
+    RecommendationAgent,
+    SupervisorAgent,
+    ContinuousLearningAgent,
+    EnterpriseIntelligenceAgent,
+]
+
+# Modules each agent wraps — used for the registry's health self-check.
+_WRAPPED_MODULES = {
+    "Instrument Intelligence Agent": "app.services.instrument_anatomy",
+    "Anatomy Intelligence Agent": "app.services.instrument_anatomy",
+    "Inspection Coverage Agent": "app.services.inspection_coverage",
+    "Contamination Detection Agent": "app.services.clinical_mentor",
+    "Damage Detection Agent": "app.services.pre_sterilization_command_center_service",
+    "Clinical Reasoning Agent": "app.services.knowledge_graph_service",
+    "Recommendation Agent": "app.services.pre_sterilization_command_center_service",
+    "Supervisor Agent": "app.models.supervisor_review",
+    "Continuous Learning Agent": "app.services.knowledge_graph_service",
+    "Enterprise Intelligence Agent": "app.services.knowledge_graph_service",
+}
+
+
+def _health(agent_name: str) -> str:
+    module_path = _WRAPPED_MODULES.get(agent_name)
+    if not module_path:
+        return "unknown"
+    try:
+        importlib.import_module(module_path)
+        return "ok"
+    except Exception:
+        return "degraded"
+
+
+def get_registry() -> list[dict]:
+    entries = []
+    for i, agent_cls in enumerate(PIPELINE_ORDER):
+        entries.append({
+            "name": agent_cls.NAME,
+            "version": agent_cls.VERSION,
+            "capabilities": agent_cls.CAPABILITIES,
+            "depends_on": agent_cls.DEPENDS_ON,
+            "pipeline_position": i + 1,
+            "status": "active",
+            "health": _health(agent_cls.NAME),
+        })
+    return entries

--- a/backend/app/agents/supervisor_agent.py
+++ b/backend/app/agents/supervisor_agent.py
@@ -1,18 +1,22 @@
 """Phase 22 §8 — Supervisor Agent.
 
 Reports whether a human supervisor has already reviewed this inspection —
-agreement, corrections, override, and whether a training label (Phase 18
-PilotValidationCase) exists. This agent never fabricates or simulates a
-supervisor decision: only a human submitting
-POST /inspections/{id}/supervisor-review creates one (Design Principle 4 —
-human expertise is the final authority). The agent is read-only.
+agreement, corrections, override, and whether a ground-truth training label
+exists. This agent never fabricates or simulates a supervisor decision: only
+a human submitting POST /inspections/{id}/supervisor-review creates one
+(Design Principle 4 — human expertise is the final authority). The agent is
+read-only.
+
+The ground-truth label is read from SupervisorReview.ground_truth itself
+(derived at submit time by app.services.ml.ground_truth.classify_ground_truth)
+rather than a separate training-case table — the review row already is the
+label.
 """
 from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
 from app.agents.context import SupervisorContext
-from app.models.pilot_validation import PilotValidationCase
 from app.models.supervisor_review import SupervisorReview
 
 
@@ -29,14 +33,8 @@ class SupervisorAgent:
             .order_by(SupervisorReview.id.desc())
             .first()
         )
-        case = (
-            db.query(PilotValidationCase)
-            .filter(PilotValidationCase.inspection_id == inspection_id)
-            .order_by(PilotValidationCase.id.desc())
-            .first()
-        )
         if review is None:
-            return SupervisorContext(review_exists=False, training_label_created=case is not None)
+            return SupervisorContext(review_exists=False, training_label_created=False)
 
         corrections = {}
         if review.corrected_zone:
@@ -53,6 +51,6 @@ class SupervisorAgent:
             agreement=review.agreement,
             corrections=corrections,
             override_action=review.override_action,
-            ground_truth_label=case.ground_truth_label if case else None,
-            training_label_created=case is not None,
+            ground_truth_label=review.ground_truth or None,
+            training_label_created=bool(review.ground_truth),
         )

--- a/backend/app/agents/supervisor_agent.py
+++ b/backend/app/agents/supervisor_agent.py
@@ -1,0 +1,58 @@
+"""Phase 22 §8 — Supervisor Agent.
+
+Reports whether a human supervisor has already reviewed this inspection —
+agreement, corrections, override, and whether a training label (Phase 18
+PilotValidationCase) exists. This agent never fabricates or simulates a
+supervisor decision: only a human submitting
+POST /inspections/{id}/supervisor-review creates one (Design Principle 4 —
+human expertise is the final authority). The agent is read-only.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.agents.context import SupervisorContext
+from app.models.pilot_validation import PilotValidationCase
+from app.models.supervisor_review import SupervisorReview
+
+
+class SupervisorAgent:
+    NAME = "Supervisor Agent"
+    VERSION = "1.0.0"
+    CAPABILITIES = ["report_supervisor_review_status", "report_training_label_status"]
+    DEPENDS_ON = ["RecommendationAgent"]
+
+    def run(self, db: Session, inspection_id: int) -> SupervisorContext:
+        review = (
+            db.query(SupervisorReview)
+            .filter(SupervisorReview.inspection_id == inspection_id)
+            .order_by(SupervisorReview.id.desc())
+            .first()
+        )
+        case = (
+            db.query(PilotValidationCase)
+            .filter(PilotValidationCase.inspection_id == inspection_id)
+            .order_by(PilotValidationCase.id.desc())
+            .first()
+        )
+        if review is None:
+            return SupervisorContext(review_exists=False, training_label_created=case is not None)
+
+        corrections = {}
+        if review.corrected_zone:
+            corrections["zone"] = review.corrected_zone
+        if review.corrected_instrument_family:
+            corrections["instrument_family"] = review.corrected_instrument_family
+        if review.corrected_severity:
+            corrections["severity"] = review.corrected_severity
+        if review.corrected_recommendation:
+            corrections["recommendation"] = review.corrected_recommendation
+
+        return SupervisorContext(
+            review_exists=True,
+            agreement=review.agreement,
+            corrections=corrections,
+            override_action=review.override_action,
+            ground_truth_label=case.ground_truth_label if case else None,
+            training_label_created=case is not None,
+        )

--- a/backend/app/cios/certificate.py
+++ b/backend/app/cios/certificate.py
@@ -1,0 +1,120 @@
+"""Phase 23 §8 — Clinical Readiness Certificate.
+
+A printable Pre-Sterilization Clinical Readiness Certificate. This is
+explicitly NOT a sterilization certificate — it documents the clinical
+inspection that happens before packaging and sterilization, consistent
+with the pre-sterilization boundary
+(docs/architecture/pre-sterilization-boundary.md).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.cios.decision_ledger import list_decisions
+from app.cios.governance import governance_snapshot
+
+
+def build_certificate(db, inspection, tenant_id: str, cios_result: dict) -> dict:
+    ctx = cios_result["clinical_context"]
+    decisions = list_decisions(db, tenant_id, inspection.id)
+
+    return {
+        "certificate_type": "pre_sterilization_clinical_readiness_certificate",
+        "not_a_sterilization_certificate": True,
+        "disclaimer": (
+            "This certificate documents the clinical inspection performed before packaging "
+            "and sterilization. It is not a sterilization certificate, a biological indicator "
+            "record, or a sterilizer performance validation of any kind."
+        ),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "inspection_id": inspection.id,
+        "instrument": {
+            "instrument_type": ctx["instrument_type"],
+            "manufacturer": ctx["manufacturer"] or "not specified",
+            "model": ctx["model"] or "not specified",
+            "instrument_family": ctx["instrument_family"],
+        },
+        "inspection_date": inspection.created_at.isoformat() if inspection.created_at else None,
+        "clinical_decision": cios_result["agent_result"]["recommendation_context"],
+        "inspection_coverage": ctx["coverage"],
+        "baseline_used": ctx["baseline"],
+        "findings": ctx["findings"],
+        "clinical_reasoning": ctx["knowledge_graph_links"]["reasoning_chain"],
+        "recommendation": ctx["recommendation"],
+        "supervisor_approval": ctx["supervisor_review"],
+        "audit_ids": {
+            "inspection_id": inspection.id,
+            "decision_ledger_entry_ids": [d["id"] for d in decisions],
+        },
+        "governance_versions": governance_snapshot(),
+        "digital_signature_placeholder": {
+            "signed": False,
+            "note": "Digital signature capture is not yet implemented — this is a structural placeholder for a future e-signature integration.",
+        },
+        "human_review_required": True,
+    }
+
+
+def render_certificate_pdf(certificate: dict) -> bytes:
+    """Render the certificate to a simple, printable PDF."""
+    import io
+
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import getSampleStyleSheet
+    from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+    buf = io.BytesIO()
+    styles = getSampleStyleSheet()
+    doc = SimpleDocTemplate(buf, pagesize=letter, leftMargin=50, rightMargin=50, topMargin=50, bottomMargin=50)
+    story = []
+
+    story.append(Paragraph("Pre-Sterilization Clinical Readiness Certificate", styles["Title"]))
+    story.append(Paragraph(certificate["disclaimer"], styles["Italic"]))
+    story.append(Spacer(1, 12))
+
+    instrument = certificate["instrument"]
+    rows = [
+        ["Inspection ID", str(certificate["inspection_id"])],
+        ["Instrument", instrument["instrument_type"]],
+        ["Manufacturer", instrument["manufacturer"]],
+        ["Model", instrument["model"]],
+        ["Instrument Family", instrument["instrument_family"]],
+        ["Inspection Date", certificate["inspection_date"] or "—"],
+        ["Recommendation", certificate["recommendation"].get("readiness_state", "—")],
+    ]
+    table = Table(rows, colWidths=[160, 320])
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#1e40af")),
+        ("TEXTCOLOR", (0, 0), (0, -1), colors.white),
+        ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+        ("GRID", (0, 0), (-1, -1), 0.5, colors.lightgrey),
+        ("FONTSIZE", (0, 0), (-1, -1), 10),
+    ]))
+    story.append(table)
+    story.append(Spacer(1, 16))
+
+    story.append(Paragraph("Clinical Reasoning", styles["Heading3"]))
+    for step in certificate["clinical_reasoning"]:
+        story.append(Paragraph(f"{step['node']}: {step['value']}", styles["Normal"]))
+    story.append(Spacer(1, 16))
+
+    story.append(Paragraph("Governance Versions", styles["Heading3"]))
+    for key, value in certificate["governance_versions"].items():
+        story.append(Paragraph(f"{key}: {value}", styles["Normal"]))
+    story.append(Spacer(1, 16))
+
+    story.append(Paragraph(
+        f"Digital signature: {'signed' if certificate['digital_signature_placeholder']['signed'] else 'not signed — placeholder only'}",
+        styles["Normal"],
+    ))
+    story.append(Spacer(1, 8))
+    story.append(Paragraph(
+        "This is not a sterilization certificate. Human supervisor review is required before this "
+        "instrument proceeds to packaging and sterilization.",
+        styles["Italic"],
+    ))
+
+    doc.build(story)
+    buf.seek(0)
+    return buf.read()

--- a/backend/app/cios/context.py
+++ b/backend/app/cios/context.py
@@ -1,0 +1,56 @@
+"""Phase 23 §2 — Shared Clinical Context.
+
+One immutable context object every module in the Clinical Intelligence
+Operating System reads and (via `with_updates`) returns an updated copy
+of. Frozen (pydantic `model_config = ConfigDict(frozen=True)`) so no
+module can mutate another module's contribution in place — every "update"
+is a new object, keeping the pipeline's data flow the same
+append-only/traceable shape as the rest of the platform (audit events,
+ground-truth labels, ledger entries — nothing here is ever edited after
+the fact, only added to).
+
+This composes (does not replace) the typed per-agent context objects from
+Phase 22 (app/agents/context.py) — ClinicalContext is the single envelope
+the CIOS orchestrator assembles from those agents' outputs so downstream
+consumers (the ledger, the event bus, the certificate, the dashboard) have
+one object to read instead of ten.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ClinicalContext(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    inspection_id: int
+    tenant_id: str
+
+    instrument_type: str = ""
+    manufacturer: str = ""
+    model: str = ""
+    instrument_family: str = ""
+
+    anatomy_profile: dict = {}
+    inspection_zones: list[str] = []
+
+    coverage: dict = {}
+    baseline: dict = {}
+
+    findings: list[dict] = []
+    severity: Optional[str] = None
+    risk: dict = {}
+
+    recommendation: dict = {}
+    supervisor_review: dict = {}
+    digital_twin: dict = {}
+    knowledge_graph_links: dict = {}
+    audit: dict = {}
+
+    def with_updates(self, **kwargs) -> "ClinicalContext":
+        """Return a new, updated ClinicalContext — the original is never
+        mutated. Every module in the pipeline calls this instead of
+        assigning to a field."""
+        return self.model_copy(update=kwargs)

--- a/backend/app/cios/dashboard.py
+++ b/backend/app/cios/dashboard.py
@@ -1,0 +1,115 @@
+"""Phase 23 §9 — Enterprise Health Dashboard aggregation (/cios-dashboard).
+
+Every figure here is computed live from real rows or from the honest,
+already-established Phase 20/21/22 aggregate functions — nothing is
+fabricated, and a metric is `None` rather than a misleading default when
+there isn't enough data yet.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.agents.registry import get_registry
+from app.cios.governance import governance_snapshot
+from app.db import models
+from app.models.digital_quality_twin import QualityTwinState
+from app.models.supervisor_review import SupervisorReview
+from app.services.inspection_coverage import compute_coverage
+from app.services.knowledge_graph_service import enterprise_knowledge_analytics, learning_confidence
+from app.services.pre_sterilization_command_center_service import (
+    _annotate,
+    _reviewed_ids,
+    clinical_inspection_readiness,
+)
+
+
+def _average_inspection_time_minutes(inspections: list, reviews_by_inspection: dict) -> float | None:
+    durations = []
+    for insp in inspections:
+        review = reviews_by_inspection.get(insp.id)
+        if review is None or insp.created_at is None or review.created_at is None:
+            continue
+        delta = review.created_at - insp.created_at
+        durations.append(delta.total_seconds() / 60)
+    return round(sum(durations) / len(durations), 1) if durations else None
+
+
+def _coverage_rate(inspections: list) -> float | None:
+    imaged = [i for i in inspections if i.has_image]
+    if not imaged:
+        return None
+    complete = 0
+    for insp in imaged:
+        try:
+            inspected = json.loads(insp.inspected_zones_json or "null")
+        except (TypeError, ValueError):
+            inspected = None
+        coverage = compute_coverage(insp.instrument_type, inspected)
+        if coverage["quality"] in ("complete", "acceptable"):
+            complete += 1
+    return round(complete / len(imaged), 4)
+
+
+def build_dashboard(db: Session, tenant_id: str) -> dict:
+    inspections = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id)
+        .order_by(models.Inspection.created_at.desc())
+        .limit(5000)
+        .all()
+    )
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    reviews_by_inspection = {}
+    for r in reviews:
+        existing = reviews_by_inspection.get(r.inspection_id)
+        if existing is None or r.created_at > existing.created_at:
+            reviews_by_inspection[r.inspection_id] = r
+
+    reviewed_ids = _reviewed_ids(db, tenant_id)
+    annotated = _annotate(inspections, reviewed_ids)
+    readiness = clinical_inspection_readiness(annotated)
+
+    scored = [i for i in inspections if i.score_status == "scored" and i.confidence]
+    ai_confidence = round(sum(i.confidence for i in scored) / len(scored), 2) if scored else None
+
+    confidence = learning_confidence(db, tenant_id)
+    analytics = enterprise_knowledge_analytics(db, tenant_id)
+
+    registry = get_registry()
+    degraded = [a["name"] for a in registry if a["health"] != "ok"]
+
+    twin_count = db.query(QualityTwinState.id).filter(QualityTwinState.tenant_id == tenant_id).count()
+
+    readiness_rate = readiness["readiness_rate"]
+    coverage_rate = _coverage_rate(inspections)
+    knowledge_confidence = confidence["knowledge_confidence"]
+    risk_components = [c for c in (readiness_rate, coverage_rate, knowledge_confidence) if c is not None]
+    enterprise_risk_index = round((1 - sum(risk_components) / len(risk_components)) * 100, 1) if risk_components else None
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "system_health": {
+            "overall_status": "ok" if not degraded else "degraded",
+            "degraded_agents": degraded,
+            "agent_count": len(registry),
+        },
+        "inspection_throughput": len(inspections),
+        "average_inspection_time_minutes": _average_inspection_time_minutes(inspections, reviews_by_inspection),
+        "coverage_rate": coverage_rate,
+        "supervisor_agreement_rate": knowledge_confidence,
+        "ai_confidence": ai_confidence,
+        "governance_versions": governance_snapshot(),
+        "digital_twin_health": {
+            "available": twin_count > 0,
+            "snapshot_count": twin_count,
+        },
+        "most_common_findings": analytics["most_common_findings_by_manufacturer"],
+        "most_common_zones": analytics["most_missed_anatomy_zones"],
+        "enterprise_risk_index": enterprise_risk_index,
+        "readiness_rate": readiness_rate,
+        "human_review_required": True,
+        "note": "Enterprise Risk Index is a composite indicator (readiness rate, coverage rate, supervisor agreement) — not a validated clinical risk score.",
+    }

--- a/backend/app/cios/decision_ledger.py
+++ b/backend/app/cios/decision_ledger.py
@@ -1,0 +1,74 @@
+"""Phase 23 §5 — Clinical Decision Ledger service.
+
+Records and reads ClinicalDecisionLedgerEntry rows. Every entry snapshots
+the governance versions active at the moment it was recorded — see
+app/cios/governance.py.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.cios.governance import governance_snapshot
+from app.models.clinical_decision_ledger import ClinicalDecisionLedgerEntry
+
+
+def record_decision(
+    db: Session,
+    tenant_id: str,
+    inspection_id: int,
+    decision_type: str,
+    made_by: str,
+    rationale: str = "",
+    evidence: dict | None = None,
+    confidence: float | None = None,
+) -> ClinicalDecisionLedgerEntry:
+    versions = governance_snapshot()
+    entry = ClinicalDecisionLedgerEntry(
+        tenant_id=tenant_id,
+        inspection_id=inspection_id,
+        decision_type=decision_type,
+        made_by=made_by,
+        rationale=rationale,
+        evidence_json=json.dumps(evidence or {}, default=str),
+        confidence=confidence,
+        model_version=versions["model_version"],
+        knowledge_graph_version=versions["knowledge_graph_version"],
+        ontology_version=versions["ontology_version"],
+        architecture_version=versions["architecture_version"],
+        inspection_pipeline_version=versions["inspection_pipeline_version"],
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+def list_decisions(db: Session, tenant_id: str, inspection_id: int) -> list[dict]:
+    rows = (
+        db.query(ClinicalDecisionLedgerEntry)
+        .filter(
+            ClinicalDecisionLedgerEntry.tenant_id == tenant_id,
+            ClinicalDecisionLedgerEntry.inspection_id == inspection_id,
+        )
+        .order_by(ClinicalDecisionLedgerEntry.created_at.asc())
+        .all()
+    )
+    return [
+        {
+            "id": r.id,
+            "decision_type": r.decision_type,
+            "made_by": r.made_by,
+            "rationale": r.rationale,
+            "evidence": json.loads(r.evidence_json or "{}"),
+            "confidence": r.confidence,
+            "model_version": r.model_version,
+            "knowledge_graph_version": r.knowledge_graph_version,
+            "ontology_version": r.ontology_version,
+            "architecture_version": r.architecture_version,
+            "inspection_pipeline_version": r.inspection_pipeline_version,
+            "created_at": r.created_at.isoformat() if r.created_at else "",
+        }
+        for r in rows
+    ]

--- a/backend/app/cios/event_bus.py
+++ b/backend/app/cios/event_bus.py
@@ -1,0 +1,61 @@
+"""Phase 23 §6 — Enterprise Event Bus.
+
+A synchronous, in-process event bus: `emit()` persists a real event row
+(app/models/cios_event.py::CIOSEvent) whenever the CIOS orchestrator
+observes something clinically significant. No event is emitted unless the
+underlying condition it names is actually true in the current context —
+e.g. `BloodDetected` only fires when a contamination finding of type
+"blood" was really present.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.cios_event import CIOSEvent
+
+EVENT_TYPES = [
+    "InspectionStarted",
+    "BaselineLoaded",
+    "CoverageIncomplete",
+    "BloodDetected",
+    "CorrosionDetected",
+    "RecommendationGenerated",
+    "SupervisorApproved",
+    "InstrumentRemovedFromService",
+    "KnowledgeUpdated",
+    "ModelFeedbackCaptured",
+]
+
+
+def emit(db: Session, tenant_id: str, event_type: str, inspection_id: int | None = None, payload: dict | None = None) -> CIOSEvent:
+    if event_type not in EVENT_TYPES:
+        raise ValueError(f"Unknown event type '{event_type}'. Known types: {EVENT_TYPES}")
+    event = CIOSEvent(
+        tenant_id=tenant_id,
+        inspection_id=inspection_id,
+        event_type=event_type,
+        payload_json=json.dumps(payload or {}, default=str),
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+def list_events(db: Session, tenant_id: str, inspection_id: int | None = None, limit: int = 100) -> list[dict]:
+    q = db.query(CIOSEvent).filter(CIOSEvent.tenant_id == tenant_id)
+    if inspection_id is not None:
+        q = q.filter(CIOSEvent.inspection_id == inspection_id)
+    rows = q.order_by(CIOSEvent.created_at.desc()).limit(limit).all()
+    return [
+        {
+            "id": r.id,
+            "event_type": r.event_type,
+            "inspection_id": r.inspection_id,
+            "payload": json.loads(r.payload_json or "{}"),
+            "created_at": r.created_at.isoformat() if r.created_at else "",
+        }
+        for r in rows
+    ]

--- a/backend/app/cios/governance.py
+++ b/backend/app/cios/governance.py
@@ -1,0 +1,33 @@
+"""Phase 23 §10 — Platform Governance.
+
+Tracks the versions every inspection is governed by. These are code-level
+constants, not per-tenant mutable state — bump them here when the
+underlying artifact actually changes (a new architecture doc revision, a
+new ontology chain, a newly promoted model, etc.), and every inspection
+processed after that point references the new value. Past Decision Ledger
+entries keep the version snapshot that was active *when they were
+created* (see app/models/clinical_decision_ledger.py) — they are never
+retroactively rewritten.
+"""
+from __future__ import annotations
+
+ARCHITECTURE_VERSION = "19.5"          # docs/architecture/ — frozen reference architecture
+ONTOLOGY_VERSION = "1.0"               # docs/architecture/lumenai-clinical-ontology.md chain
+KNOWLEDGE_GRAPH_VERSION = "21.0"       # docs/knowledge-graph/ — node/relationship taxonomy
+MODEL_VERSION = "baseline-comparison-scoring-pilot-1"  # active scoring engine, see app/services/baseline_comparison_scoring_service.py
+DATASET_VERSION = "pilot-v1"           # default Phase 18 ground-truth dataset version
+CLINICAL_RULE_VERSION = "1.0"          # see app/cios/rule_registry.py
+INSPECTION_PIPELINE_VERSION = "22.0"   # Phase 22 multi-agent pipeline, see app/agents/registry.py
+
+
+def governance_snapshot() -> dict:
+    """The full version snapshot every inspection/ledger entry references."""
+    return {
+        "architecture_version": ARCHITECTURE_VERSION,
+        "ontology_version": ONTOLOGY_VERSION,
+        "knowledge_graph_version": KNOWLEDGE_GRAPH_VERSION,
+        "model_version": MODEL_VERSION,
+        "dataset_version": DATASET_VERSION,
+        "clinical_rule_version": CLINICAL_RULE_VERSION,
+        "inspection_pipeline_version": INSPECTION_PIPELINE_VERSION,
+    }

--- a/backend/app/cios/orchestrator.py
+++ b/backend/app/cios/orchestrator.py
@@ -25,6 +25,7 @@ from app.cios.context import ClinicalContext
 from app.cios.decision_ledger import record_decision
 from app.cios.governance import governance_snapshot
 from app.cios.state_machine import derive_state
+from app.models.clinical_decision_ledger import ClinicalDecisionLedgerEntry
 from app.models.supervisor_review import SupervisorReview
 
 # Phase 22 pipeline order, relabeled to the Section 3 Pipeline Monitor's
@@ -157,16 +158,35 @@ def run_cios_pipeline(db: Session, inspection, tenant_id: str) -> dict:
     monitor = _pipeline_monitor(result)
     state = derive_state(inspection, review)
     timeline = _timeline(inspection, result, review)
-    events = _emit_events(db, tenant_id, inspection, result)
 
-    ledger_entry = record_decision(
-        db, tenant_id, inspection.id,
-        decision_type="ai_recommendation",
-        made_by="ai",
-        rationale=result["recommendation_context"]["explanation"],
-        evidence={"reasoning_chain": result["clinical_reasoning_context"]["reasoning_chain"]},
-        confidence=inspection.confidence,
+    # This is called from GET/read endpoints (dashboard refresh, certificate
+    # download) as well as the initial run — event emission and the decision
+    # ledger are permanent audit stores with no dedup, so only emit/record the
+    # AI's recommendation once per inspection. Subsequent calls return the
+    # already-recorded events/ledger entry rather than appending duplicates.
+    existing_decision = (
+        db.query(ClinicalDecisionLedgerEntry)
+        .filter(
+            ClinicalDecisionLedgerEntry.tenant_id == tenant_id,
+            ClinicalDecisionLedgerEntry.inspection_id == inspection.id,
+            ClinicalDecisionLedgerEntry.decision_type == "ai_recommendation",
+        )
+        .order_by(ClinicalDecisionLedgerEntry.id.asc())
+        .first()
     )
+    if existing_decision is None:
+        events = _emit_events(db, tenant_id, inspection, result)
+        ledger_entry = record_decision(
+            db, tenant_id, inspection.id,
+            decision_type="ai_recommendation",
+            made_by="ai",
+            rationale=result["recommendation_context"]["explanation"],
+            evidence={"reasoning_chain": result["clinical_reasoning_context"]["reasoning_chain"]},
+            confidence=inspection.confidence,
+        )
+    else:
+        events = event_bus.list_events(db, tenant_id, inspection.id, limit=500)
+        ledger_entry = existing_decision
 
     return {
         "inspection_id": inspection.id,

--- a/backend/app/cios/orchestrator.py
+++ b/backend/app/cios/orchestrator.py
@@ -1,0 +1,182 @@
+"""Phase 23 §1 — Clinical Intelligence Orchestrator.
+
+The single coordination point for the Clinical Intelligence Operating
+System. No module communicates directly with another — everything flows
+through here. This wraps (does not duplicate) the Phase 22 multi-agent
+pipeline (app/agents/orchestrator.py::run_pipeline) and adds the CIOS
+layer on top of it: the unified immutable Clinical Context, the pipeline
+monitor, the inspection state, the explainable timeline, real event
+emission, and a Decision Ledger entry for the AI's recommendation.
+
+Failure handling: if the underlying agent pipeline raises, this function
+lets the exception propagate (a 500 at the API layer) rather than
+returning a partial or fabricated result — the same "fail loudly, never
+fabricate" rule documented in docs/agents/agent-orchestrator.md.
+"""
+from __future__ import annotations
+
+from datetime import timezone
+
+from sqlalchemy.orm import Session
+
+from app.agents.orchestrator import run_pipeline
+from app.cios import event_bus
+from app.cios.context import ClinicalContext
+from app.cios.decision_ledger import record_decision
+from app.cios.governance import governance_snapshot
+from app.cios.state_machine import derive_state
+from app.models.supervisor_review import SupervisorReview
+
+# Phase 22 pipeline order, relabeled to the Section 3 Pipeline Monitor's
+# short display names.
+_MONITOR_STEPS = [
+    ("Instrument Agent", "instrument_context"),
+    ("Anatomy Agent", "anatomy_context"),
+    ("Coverage Agent", "coverage_context"),
+    ("Contamination Agent", "contamination_context"),
+    ("Damage Agent", "damage_context"),
+    ("Clinical Reasoning Agent", "clinical_reasoning_context"),
+    ("Recommendation Agent", "recommendation_context"),
+    ("Supervisor Agent", "supervisor_context"),
+    ("Learning Agent", "learning_context"),
+    ("Enterprise Agent", "enterprise_context"),
+]
+
+
+def _pipeline_monitor(result: dict) -> list[dict]:
+    """Section 3 — Complete / Pending / Queued per agent.
+
+    Every deterministic agent (Instrument .. Recommendation) is Complete
+    once it has run. Supervisor is Complete only if a real human review
+    exists, else Pending. Learning/Enterprise are Queued while Supervisor
+    is still Pending — this inspection hasn't contributed its learning
+    signal yet, even though the aggregate confidence numbers they report
+    are already computed from *other* reviewed inspections.
+    """
+    supervisor_done = result["supervisor_context"]["review_exists"]
+    monitor = []
+    for label, key in _MONITOR_STEPS:
+        if label == "Supervisor Agent":
+            status = "Complete" if supervisor_done else "Pending"
+        elif label in ("Learning Agent", "Enterprise Agent"):
+            status = "Complete" if supervisor_done else "Queued"
+        else:
+            status = "Complete"
+        monitor.append({"agent": label, "status": status})
+    return monitor
+
+
+def _build_clinical_context(inspection, tenant_id: str, result: dict) -> ClinicalContext:
+    return ClinicalContext(
+        inspection_id=inspection.id,
+        tenant_id=tenant_id,
+        instrument_type=result["instrument_context"]["instrument_type"],
+        manufacturer=result["instrument_context"]["manufacturer"],
+        model=result["instrument_context"]["model"],
+        instrument_family=result["instrument_context"]["instrument_family"],
+        anatomy_profile=result["anatomy_context"],
+        inspection_zones=result["anatomy_context"]["anatomy_zones"],
+        coverage=result["coverage_context"],
+        baseline={"baseline_status": inspection.baseline_status, "baseline_source": inspection.baseline_source},
+        findings=result["contamination_context"]["findings"] + result["damage_context"]["findings"],
+        severity=(result["contamination_context"]["findings"] or result["damage_context"]["findings"] or [{}])[0].get("severity"),
+        risk={"risk_level": result["clinical_reasoning_context"]["risk_level"], "risk_score": result["clinical_reasoning_context"]["risk_score"]},
+        recommendation=result["recommendation_context"],
+        supervisor_review=result["supervisor_context"],
+        digital_twin={"available": result["instrument_context"]["digital_twin_available"]},
+        knowledge_graph_links={"reasoning_chain": result["clinical_reasoning_context"]["reasoning_chain"]},
+        audit={"governance": governance_snapshot()},
+    )
+
+
+def _emit_events(db: Session, tenant_id: str, inspection, result: dict) -> list[dict]:
+    emitted = []
+
+    def _emit(event_type: str, payload: dict | None = None):
+        row = event_bus.emit(db, tenant_id, event_type, inspection.id, payload)
+        emitted.append({"event_type": row.event_type, "id": row.id})
+
+    _emit("InspectionStarted", {"instrument_type": inspection.instrument_type})
+    if inspection.baseline_status == "approved_baseline_found":
+        _emit("BaselineLoaded", {"baseline_source": inspection.baseline_source})
+    if result["coverage_context"]["coverage_quality"] in ("incomplete", "insufficient", "not_assessed"):
+        _emit("CoverageIncomplete", {"coverage_quality": result["coverage_context"]["coverage_quality"]})
+    for f in result["contamination_context"]["findings"]:
+        if f["finding_type"] == "blood":
+            _emit("BloodDetected", {"zone": f["zone"], "severity": f["severity"]})
+    for f in result["damage_context"]["findings"]:
+        if f["finding_type"] == "corrosion":
+            _emit("CorrosionDetected", {"severity": f["severity"]})
+    _emit("RecommendationGenerated", {"readiness_state": result["recommendation_context"]["readiness_state"]})
+
+    supervisor = result["supervisor_context"]
+    if supervisor["review_exists"] and supervisor["agreement"] in ("agree", "partially_agree") and not supervisor["override_action"]:
+        _emit("SupervisorApproved", {"agreement": supervisor["agreement"]})
+    if result["recommendation_context"]["readiness_state"] == "REMOVED_FROM_SERVICE":
+        _emit("InstrumentRemovedFromService", {"instrument_type": inspection.instrument_type})
+    if supervisor["training_label_created"]:
+        _emit("ModelFeedbackCaptured", {"ground_truth_label": supervisor["ground_truth_label"]})
+
+    return emitted
+
+
+def _timeline(inspection, result: dict, review) -> list[dict]:
+    """Section 7 — real timestamps only. Steps that happen synchronously
+    inside one scoring call (image capture through recommendation) are
+    reported at the trace entries' real (very close together) execution
+    times; the supervisor step uses the real SupervisorReview timestamp,
+    which can be genuinely minutes or hours after the AI steps."""
+    events = [{
+        "timestamp": inspection.created_at.isoformat() if inspection.created_at else None,
+        "label": f"Inspection created — {inspection.instrument_type} image captured.",
+    }]
+    for entry in result["trace"]:
+        events.append({"timestamp": entry["timestamp"], "label": f"{entry['agent']} completed."})
+    if review is not None:
+        events.append({
+            "timestamp": review.created_at.astimezone(timezone.utc).isoformat() if review.created_at else None,
+            "label": f"Supervisor {review.agreement}" + (f" (override: {review.override_action})" if review.override_action else ""),
+        })
+    return events
+
+
+def run_cios_pipeline(db: Session, inspection, tenant_id: str) -> dict:
+    """Section 1 — the single entry point every consumer (API, dashboard,
+    certificate generator) should call. Runs the full Phase 22 agent
+    pipeline, then assembles the CIOS layer on top of it."""
+    result = run_pipeline(db, inspection, tenant_id)
+
+    review = (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.inspection_id == inspection.id)
+        .order_by(SupervisorReview.id.desc())
+        .first()
+    )
+
+    clinical_context = _build_clinical_context(inspection, tenant_id, result)
+    monitor = _pipeline_monitor(result)
+    state = derive_state(inspection, review)
+    timeline = _timeline(inspection, result, review)
+    events = _emit_events(db, tenant_id, inspection, result)
+
+    ledger_entry = record_decision(
+        db, tenant_id, inspection.id,
+        decision_type="ai_recommendation",
+        made_by="ai",
+        rationale=result["recommendation_context"]["explanation"],
+        evidence={"reasoning_chain": result["clinical_reasoning_context"]["reasoning_chain"]},
+        confidence=inspection.confidence,
+    )
+
+    return {
+        "inspection_id": inspection.id,
+        "clinical_context": clinical_context.model_dump(),
+        "pipeline_monitor": monitor,
+        "inspection_state": state,
+        "timeline": timeline,
+        "events_emitted": events,
+        "decision_ledger_entry_id": ledger_entry.id,
+        "governance": governance_snapshot(),
+        "agent_result": result,
+        "human_review_required": True,
+    }

--- a/backend/app/cios/rule_registry.py
+++ b/backend/app/cios/rule_registry.py
@@ -1,0 +1,119 @@
+"""Phase 23 §11 — Clinical Rule Registry.
+
+Every rule here is a real rule already enforced somewhere in the codebase
+— this registry documents and versions rules that exist, it does not
+invent hypothetical ones. `evidence` points at the function that actually
+implements the rule so the registry can never drift from reality.
+"""
+from __future__ import annotations
+
+CLINICAL_RULE_REGISTRY: list[dict] = [
+    {
+        "rule_id": "RULE-001",
+        "name": "Structural defect escalation",
+        "purpose": "Escalate moderate-or-greater crack, missing component, or insulation damage to REMOVE FROM SERVICE.",
+        "evidence": "app/services/baseline_comparison_scoring_service.py::recommended_action (structural defects block)",
+        "applies_to": ["crack", "missing_component", "insulation_damage"],
+        "priority": "critical",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-002",
+        "name": "Severe corrosion escalation",
+        "purpose": "Escalate severity-3+ corrosion to REMOVE FROM SERVICE.",
+        "evidence": "app/services/baseline_comparison_scoring_service.py::recommended_action (corrosion severity_index >= 3)",
+        "applies_to": ["corrosion"],
+        "priority": "critical",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-003",
+        "name": "Residual contamination reprocessing",
+        "purpose": "Route moderate+ blood/tissue/organic-residue/debris/bone to REPROCESS.",
+        "evidence": "app/services/baseline_comparison_scoring_service.py::recommended_action (contamination_actionable)",
+        "applies_to": ["blood", "tissue", "other_organic_residue", "debris", "bone"],
+        "priority": "high",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-004",
+        "name": "High-retention zone escalation",
+        "purpose": "Escalate trace+ contamination in a high-retention zone (serrations, box locks, lumens, hinges, o-ring areas, drill-bit flutes, ratchets, insulation edges) to REPROCESS even at low severity elsewhere.",
+        "evidence": "app/services/instrument_zones.py::is_high_retention; baseline_comparison_scoring_service.py::_overall_result",
+        "applies_to": ["blood", "tissue", "other_organic_residue", "debris", "bone"],
+        "priority": "high",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-005",
+        "name": "No-baseline supervisor gate",
+        "purpose": "Withhold final scoring and require supervisor review when no approved baseline exists for the instrument.",
+        "evidence": "app/services/baseline_comparison_scoring_service.py::analyze_inspection (governance gate)",
+        "applies_to": ["all instruments"],
+        "priority": "critical",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-006",
+        "name": "Baseline mismatch supervisor review",
+        "purpose": "Route to SUPERVISOR REVIEW when baseline match score is below 70%.",
+        "evidence": "app/services/baseline_comparison_scoring_service.py::recommended_action (baseline_match_score < 0.70)",
+        "applies_to": ["all instruments"],
+        "priority": "medium",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-007",
+        "name": "Repairable structural defect classification",
+        "purpose": "Classify a REMOVE FROM SERVICE outcome as a repair candidate only when the defect is crack, corrosion, or insulation damage — never contamination.",
+        "evidence": "app/services/pre_sterilization_command_center_service.py::classify_readiness, _REPAIRABLE_ISSUES",
+        "applies_to": ["crack", "corrosion", "insulation_damage"],
+        "priority": "medium",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-008",
+        "name": "Critical finding safety threshold",
+        "purpose": "Block a pilot GO decision when any critical finding type's false-negative rate exceeds 5%.",
+        "evidence": "app/services/pilot_validation_service.py::CRITICAL_FN_RATE_THRESHOLD, evaluate_go_no_go",
+        "applies_to": ["blood", "tissue", "organic_residue", "crack", "missing_component"],
+        "priority": "critical",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-009",
+        "name": "Incomplete zone coverage flag",
+        "purpose": "Flag an inspection's coverage as not_assessed/incomplete/insufficient when required high-risk zones were not tagged as inspected.",
+        "evidence": "app/services/inspection_coverage.py::compute_coverage",
+        "applies_to": ["all instruments"],
+        "priority": "medium",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+    {
+        "rule_id": "RULE-010",
+        "name": "Human final authority",
+        "purpose": "No AI recommendation is a final disposition — every readiness state requires supervisor review or override before an instrument proceeds to packaging.",
+        "evidence": "docs/architecture/design-principles.md (Principle 4); app/routes/ai_clinical_review.py",
+        "applies_to": ["all instruments"],
+        "priority": "critical",
+        "version": "1.0",
+        "approval_status": "approved",
+    },
+]
+
+
+def get_rule(rule_id: str) -> dict | None:
+    return next((r for r in CLINICAL_RULE_REGISTRY if r["rule_id"] == rule_id), None)
+
+
+def rules_applying_to(finding_type: str) -> list[dict]:
+    return [r for r in CLINICAL_RULE_REGISTRY if finding_type in r["applies_to"] or "all instruments" in r["applies_to"]]

--- a/backend/app/cios/state_machine.py
+++ b/backend/app/cios/state_machine.py
@@ -1,0 +1,90 @@
+"""Phase 23 §4 — Inspection State Machine.
+
+Formal states every inspection passes through, derived honestly from real
+persisted fields — never fabricated timestamps for states that happen
+synchronously inside one scoring call and therefore have no distinct
+historical record. See docs/cios/inspection-state-machine.md for exactly
+which states can be individually timestamped vs. which are reported as
+"reached" without a separate historical timestamp.
+"""
+from __future__ import annotations
+
+INSPECTION_STATES = [
+    "NEW",
+    "IMAGE_CAPTURED",
+    "INSTRUMENT_IDENTIFIED",
+    "ANATOMY_IDENTIFIED",
+    "BASELINE_LOADED",
+    "COVERAGE_VALIDATED",
+    "ANALYZED",
+    "CLINICAL_REVIEW",
+    "SUPERVISOR_PENDING",
+    "APPROVED",
+    "REQUIRES_ACTION",
+    "COMPLETE",
+]
+
+# Valid forward transitions. APPROVED/REQUIRES_ACTION are the only branch
+# point; both lead to COMPLETE.
+_TRANSITIONS: dict[str, list[str]] = {
+    "NEW": ["IMAGE_CAPTURED"],
+    "IMAGE_CAPTURED": ["INSTRUMENT_IDENTIFIED"],
+    "INSTRUMENT_IDENTIFIED": ["ANATOMY_IDENTIFIED"],
+    "ANATOMY_IDENTIFIED": ["BASELINE_LOADED"],
+    "BASELINE_LOADED": ["COVERAGE_VALIDATED"],
+    "COVERAGE_VALIDATED": ["ANALYZED"],
+    "ANALYZED": ["CLINICAL_REVIEW"],
+    "CLINICAL_REVIEW": ["SUPERVISOR_PENDING"],
+    "SUPERVISOR_PENDING": ["APPROVED", "REQUIRES_ACTION"],
+    "APPROVED": ["COMPLETE"],
+    "REQUIRES_ACTION": ["COMPLETE"],
+    "COMPLETE": [],
+}
+
+
+def is_valid_transition(from_state: str, to_state: str) -> bool:
+    return to_state in _TRANSITIONS.get(from_state, [])
+
+
+def derive_state(inspection, review=None) -> dict:
+    """Derive the current state and the ordered list of states reached so
+    far, from real persisted Inspection/SupervisorReview fields.
+
+    Several states (INSTRUMENT_IDENTIFIED / ANATOMY_IDENTIFIED /
+    BASELINE_LOADED / COVERAGE_VALIDATED) happen synchronously inside one
+    scoring call in the current implementation and have no distinct
+    persisted timestamp — they are reported as reached (not skipped) but
+    without a fabricated individual timestamp. See
+    docs/cios/inspection-state-machine.md.
+    """
+    branch: str | None = None  # "APPROVED" or "REQUIRES_ACTION", once known
+
+    if not inspection.has_image and inspection.score_status == "pending":
+        current = "NEW"
+    elif inspection.score_status == "pending":
+        current = "IMAGE_CAPTURED"
+    elif inspection.score_status in ("scored", "supervisor_review_required"):
+        current = "ANALYZED" if review is None else "CLINICAL_REVIEW"
+        if inspection.supervisor_review_required or inspection.score_status == "supervisor_review_required":
+            if review is None:
+                current = "SUPERVISOR_PENDING"
+        if review is not None:
+            if review.override_action or review.agreement == "disagree":
+                branch = "REQUIRES_ACTION"
+            else:
+                branch = "APPROVED"
+            current = branch
+        if inspection.status in ("reviewed", "closed") and review is not None:
+            current = "COMPLETE"
+    else:
+        current = "NEW"
+
+    linear_prefix = INSPECTION_STATES[:9]  # NEW .. SUPERVISOR_PENDING
+    if current in linear_prefix:
+        reached = linear_prefix[: linear_prefix.index(current) + 1]
+    elif current == "COMPLETE":
+        reached = linear_prefix + [branch or "APPROVED", "COMPLETE"]
+    else:  # APPROVED or REQUIRES_ACTION
+        reached = linear_prefix + [current]
+
+    return {"current_state": current, "states_reached": reached}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -52,6 +52,12 @@ class Settings:
     enable_enterprise_audit: bool
     enable_enterprise_rbac: bool
 
+    # v1.2 — Guided Capture coverage gate. When True, an inspection with
+    # incomplete/insufficient coverage cannot reach a final AI decision
+    # without a recorded supervisor override (see app/services/guided_capture.py).
+    # Default False: non-blocking, matching the v1.1 "advisory, not a gate" default.
+    require_full_coverage_before_final_decision: bool
+
     allowed_origins: list[str]
 
     @property
@@ -107,6 +113,7 @@ def get_settings() -> Settings:
         reports_root=os.getenv("REPORTS_ROOT", "reports"),
         enable_enterprise_audit=_bool_env("ENABLE_ENTERPRISE_AUDIT", True),
         enable_enterprise_rbac=_bool_env("ENABLE_ENTERPRISE_RBAC", True),
+        require_full_coverage_before_final_decision=_bool_env("REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION", False),
         allowed_origins=allowed_origins,
     )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -117,6 +117,8 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.instrument_knowledge")  # register instrument knowledge library
     importlib.import_module("app.models.model_registry")        # register P17 model registry table
     importlib.import_module("app.models.shadow_prediction")     # register P17 shadow-prediction table
+    importlib.import_module("app.models.competency_event")       # register v1.4 technician competency events
+    importlib.import_module("app.models.mentor_coaching_review") # register v1.4 supervisor coaching reviews
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -126,7 +128,7 @@ async def lifespan(_app: FastAPI):
         from app.db.column_migrator import ensure_columns
         from app.models.inspection import Inspection
         from app.models.supervisor_review import SupervisorReview
-        ensure_columns(engine, Inspection)
+        ensure_columns(engine, Inspection)  # includes v1.4's `technician` column
         ensure_columns(engine, SupervisorReview)
     except Exception as _mig_e:
         import logging
@@ -598,6 +600,9 @@ app.include_router(agent_router, prefix=settings.API_PREFIX)
 app.include_router(stream_router, prefix=settings.API_PREFIX)
 
 app.include_router(vendor_analytics_router, prefix=settings.API_PREFIX)
+
+from app.routes.spd_mentor import router as spd_mentor_router
+app.include_router(spd_mentor_router, prefix=settings.API_PREFIX)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -117,6 +117,8 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.instrument_knowledge")  # register instrument knowledge library
     importlib.import_module("app.models.model_registry")        # register P17 model registry table
     importlib.import_module("app.models.shadow_prediction")     # register P17 shadow-prediction table
+    importlib.import_module("app.models.clinical_decision_ledger")  # register P23 CIOS decision ledger table
+    importlib.import_module("app.models.cios_event")            # register P23 CIOS event bus table
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -949,6 +951,9 @@ app.include_router(knowledge_graph_router)
 
 from app.routes.agents_pipeline import router as agents_pipeline_router
 app.include_router(agents_pipeline_router)
+
+from app.routes.cios import router as cios_router
+app.include_router(cios_router)
 
 from fastapi.openapi.utils import get_openapi
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -941,6 +941,9 @@ app.include_router(p24_router)
 from app.routes.p25_infrastructure import router as p25_router
 app.include_router(p25_router)
 
+from app.routes.pre_sterilization_command_center import router as pre_sterilization_command_center_router
+app.include_router(pre_sterilization_command_center_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -127,6 +127,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.inspection_image_tag")  # register v1.2 image-view tag table
     importlib.import_module("app.models.disposition_override")   # register v1.6 supervisor disposition workspace
     importlib.import_module("app.models.workflow")               # register v1.7 workflow intelligence tables
+    importlib.import_module("app.models.knowledge")               # register v1.8 institutional knowledge tables
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -623,6 +624,9 @@ app.include_router(clinical_readiness_router)
 
 from app.routes.workflow import router as workflow_router
 app.include_router(workflow_router)
+
+from app.routes.knowledge import router as knowledge_router
+app.include_router(knowledge_router)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -119,6 +119,9 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.shadow_prediction")     # register P17 shadow-prediction table
     importlib.import_module("app.models.competency_event")       # register v1.4 technician competency events
     importlib.import_module("app.models.mentor_coaching_review") # register v1.4 supervisor coaching reviews
+    importlib.import_module("app.models.inspection_finding")      # register v1.5 per-finding detection log
+    importlib.import_module("app.models.root_cause")              # register v1.5 root-cause assignments
+    importlib.import_module("app.models.continuous_improvement")  # register v1.5 improvement tracker
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -603,6 +606,9 @@ app.include_router(vendor_analytics_router, prefix=settings.API_PREFIX)
 
 from app.routes.spd_mentor import router as spd_mentor_router
 app.include_router(spd_mentor_router, prefix=settings.API_PREFIX)
+
+from app.routes.quality_dashboard import router as quality_dashboard_router
+app.include_router(quality_dashboard_router)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -125,6 +125,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.clinical_decision_ledger")  # register P23 CIOS decision ledger table
     importlib.import_module("app.models.cios_event")            # register P23 CIOS event bus table
     importlib.import_module("app.models.inspection_image_tag")  # register v1.2 image-view tag table
+    importlib.import_module("app.models.disposition_override")   # register v1.6 supervisor disposition workspace
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -615,6 +616,9 @@ app.include_router(spd_mentor_router, prefix=settings.API_PREFIX)
 
 from app.routes.quality_dashboard import router as quality_dashboard_router
 app.include_router(quality_dashboard_router)
+
+from app.routes.clinical_readiness import router as clinical_readiness_router
+app.include_router(clinical_readiness_router)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -126,6 +126,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.cios_event")            # register P23 CIOS event bus table
     importlib.import_module("app.models.inspection_image_tag")  # register v1.2 image-view tag table
     importlib.import_module("app.models.disposition_override")   # register v1.6 supervisor disposition workspace
+    importlib.import_module("app.models.workflow")               # register v1.7 workflow intelligence tables
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -619,6 +620,9 @@ app.include_router(quality_dashboard_router)
 
 from app.routes.clinical_readiness import router as clinical_readiness_router
 app.include_router(clinical_readiness_router)
+
+from app.routes.workflow import router as workflow_router
+app.include_router(workflow_router)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -944,6 +944,9 @@ app.include_router(p25_router)
 from app.routes.pre_sterilization_command_center import router as pre_sterilization_command_center_router
 app.include_router(pre_sterilization_command_center_router)
 
+from app.routes.knowledge_graph import router as knowledge_graph_router
+app.include_router(knowledge_graph_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -947,6 +947,9 @@ app.include_router(pre_sterilization_command_center_router)
 from app.routes.knowledge_graph import router as knowledge_graph_router
 app.include_router(knowledge_graph_router)
 
+from app.routes.agents_pipeline import router as agents_pipeline_router
+app.include_router(agents_pipeline_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -128,6 +128,8 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.disposition_override")   # register v1.6 supervisor disposition workspace
     importlib.import_module("app.models.workflow")               # register v1.7 workflow intelligence tables
     importlib.import_module("app.models.knowledge")               # register v1.8 institutional knowledge tables
+    importlib.import_module("app.models.pilot_config")             # register v1.9 pilot site config table
+    importlib.import_module("app.models.pilot_error_log")          # register v1.9 pilot error log table
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -627,6 +629,9 @@ app.include_router(workflow_router)
 
 from app.routes.knowledge import router as knowledge_router
 app.include_router(knowledge_router)
+
+from app.routes.pilot_deployment import router as pilot_deployment_router
+app.include_router(pilot_deployment_router)
 
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -119,6 +119,7 @@ async def lifespan(_app: FastAPI):
     importlib.import_module("app.models.shadow_prediction")     # register P17 shadow-prediction table
     importlib.import_module("app.models.clinical_decision_ledger")  # register P23 CIOS decision ledger table
     importlib.import_module("app.models.cios_event")            # register P23 CIOS event bus table
+    importlib.import_module("app.models.inspection_image_tag")  # register v1.2 image-view tag table
     wait_for_db()
     Base.metadata.create_all(bind=engine)
     # Back-fill columns added to existing tables (create_all never alters them).
@@ -588,6 +589,9 @@ app.include_router(instrument_intelligence_router, prefix=settings.API_PREFIX)
 
 from app.routes.instrument_intelligence_admin import router as instrument_intelligence_admin_router
 app.include_router(instrument_intelligence_admin_router, prefix=settings.API_PREFIX)
+
+from app.routes.guided_capture import router as guided_capture_router
+app.include_router(guided_capture_router, prefix=settings.API_PREFIX)
 
 from app.routes.model_pipeline import router as model_pipeline_router
 app.include_router(model_pipeline_router, prefix=settings.API_PREFIX)

--- a/backend/app/models/cios_event.py
+++ b/backend/app/models/cios_event.py
@@ -1,0 +1,28 @@
+"""Phase 23 §6 — Enterprise Event Bus event store.
+
+Persisted, queryable events emitted by the CIOS orchestrator as it
+processes an inspection — reusable by future integrations (webhooks,
+downstream analytics, notification routing) without those integrations
+needing to re-derive when something clinically significant happened.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class CIOSEvent(Base):
+    __tablename__ = "cios_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    event_type: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    payload_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)

--- a/backend/app/models/clinical_decision_ledger.py
+++ b/backend/app/models/clinical_decision_ledger.py
@@ -4,8 +4,7 @@ A permanent, append-only record of every decision made about an
 inspection: who made it (AI or a named supervisor), why, what evidence
 supported it, how confident it was, and which platform versions were
 active at the time. Entries are never edited or deleted — a correction is
-a new entry, not a rewrite (the same append-only pattern as AuditLog and
-PilotValidationCase).
+a new entry, not a rewrite (the same append-only pattern as AuditLog).
 """
 from __future__ import annotations
 

--- a/backend/app/models/clinical_decision_ledger.py
+++ b/backend/app/models/clinical_decision_ledger.py
@@ -1,0 +1,45 @@
+"""Phase 23 §5 — Clinical Decision Ledger.
+
+A permanent, append-only record of every decision made about an
+inspection: who made it (AI or a named supervisor), why, what evidence
+supported it, how confident it was, and which platform versions were
+active at the time. Entries are never edited or deleted — a correction is
+a new entry, not a rewrite (the same append-only pattern as AuditLog and
+PilotValidationCase).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ClinicalDecisionLedgerEntry(Base):
+    __tablename__ = "clinical_decision_ledger"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+
+    # ai_recommendation | supervisor_approval | supervisor_override
+    decision_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    made_by: Mapped[str] = mapped_column(String(255), nullable=False)  # "ai" or a reviewer's email
+    rationale: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Governance version snapshot at the moment this decision was recorded —
+    # never recomputed from current constants after the fact.
+    model_version: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    knowledge_graph_version: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    ontology_version: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    architecture_version: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    inspection_pipeline_version: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/backend/app/models/competency_event.py
+++ b/backend/app/models/competency_event.py
@@ -1,0 +1,37 @@
+"""v1.4 — Technician competency tracking.
+
+A lightweight event log the SPD Mentor Engine's competency service reads to
+build per-technician summaries: findings reviewed, supervisor corrections,
+repeated errors, and education completed. Deliberately separate from
+SupervisorReview (the ML ground-truth label store) — this table tracks
+technician learning/competency, not model performance.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class CompetencyEvent(Base):
+    __tablename__ = "competency_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    technician: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    # finding_reviewed | supervisor_correction | repeated_error | education_completed
+    event_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    finding_type: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/models/continuous_improvement.py
+++ b/backend/app/models/continuous_improvement.py
@@ -1,0 +1,45 @@
+"""v1.5 — Continuous Improvement Tracker.
+
+Tracks named quality initiatives (e.g. "retrain on Kerrison box-lock
+brushing") from proposal through completion. `actual_impact` is filled in by
+a human once observed — never computed/inferred automatically, since a
+before/after quality delta requires human judgment about what changed and
+why, not just a raw metric diff.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Date, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+INITIATIVE_STATUSES: list[str] = ["proposed", "in_progress", "completed", "abandoned"]
+
+
+class ContinuousImprovementInitiative(Base):
+    __tablename__ = "continuous_improvement_initiatives"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    initiative: Mapped[str] = mapped_column(String(500), nullable=False)
+    owner: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    target_date: Mapped[Date | None] = mapped_column(Date, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default="proposed", nullable=False, index=True)
+    expected_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    actual_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/models/disposition_override.py
+++ b/backend/app/models/disposition_override.py
@@ -1,0 +1,46 @@
+"""v1.6 — Supervisor Disposition Workspace (Deliverable 6).
+
+Records a supervisor's action on the AI's disposition recommendation:
+approve as-is, or override it (modify, escalate, request reclean, request
+repair, remove from service, require manufacturer review). A reason is
+required for every action except a plain approval — enforced at the route,
+not just the model.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# approve requires no reason; every other action does.
+DISPOSITION_ACTIONS: list[str] = [
+    "approve", "modify", "escalate", "reclean", "repair",
+    "remove_from_service", "manufacturer_review",
+]
+
+
+class DispositionOverride(Base):
+    __tablename__ = "disposition_overrides"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    reviewer_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    reviewer_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    action: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    ai_recommended_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    modified_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    reason: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -82,3 +82,17 @@ class Inspection(Base):
     # JSON-encoded: "null" means not tagged (coverage not_assessed), "[...]" is
     # an explicit (possibly empty) list — see app/services/inspection_coverage.py.
     inspected_zones_json: Mapped[str] = mapped_column(String(2000), default="null", nullable=False)
+
+    # v1.2 — Guided Capture & Coverage Gate. coverage_status/coverage_score are
+    # a snapshot of compute_coverage() at creation time (so history/dashboards
+    # don't need to recompute it); coverage_gate_status governs whether the
+    # inspection can proceed to a final AI decision without a supervisor
+    # override, when org policy requires full coverage.
+    coverage_status: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    coverage_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # ready | draft | blocked_pending_override
+    coverage_gate_status: Mapped[str] = mapped_column(String(30), default="ready", nullable=False)
+    is_draft: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    coverage_override_reason: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    coverage_override_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    coverage_override_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -124,3 +124,11 @@ class Inspection(Base):
     coverage_override_reason: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     coverage_override_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
     coverage_override_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # v1.7 — Workflow Intelligence. Real OR-urgency/loaner signal declared at
+    # intake time, used by the prioritization engine. Nullable/blank for older
+    # rows and for inspections where no procedure context was declared — never
+    # fabricated as "routine" when actually unknown.
+    # emergency | trauma | first_case | routine | None
+    procedure_priority: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    is_loaner_instrument: Mapped[bool | None] = mapped_column(Boolean, nullable=True)

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -77,3 +77,9 @@ class Inspection(Base):
     risk_level: Mapped[str | None] = mapped_column(String(20), nullable=True)
     recommended_action: Mapped[str | None] = mapped_column(String(500), nullable=True)
     overall_cleaning_assessment: Mapped[str | None] = mapped_column(String(80), nullable=True)
+
+    # v1.4 — the technician who submitted the inspection (request actor at
+    # creation time), so the SPD Mentor Engine's competency service can
+    # attribute findings-reviewed/supervisor-corrections to a real person
+    # instead of fabricating attribution. Nullable/blank for older rows.
+    technician: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -77,3 +77,8 @@ class Inspection(Base):
     risk_level: Mapped[str | None] = mapped_column(String(20), nullable=True)
     recommended_action: Mapped[str | None] = mapped_column(String(500), nullable=True)
     overall_cleaning_assessment: Mapped[str | None] = mapped_column(String(80), nullable=True)
+
+    # Zones the technician tagged as inspected (anatomy-aware coverage engine).
+    # JSON-encoded: "null" means not tagged (coverage not_assessed), "[...]" is
+    # an explicit (possibly empty) list — see app/services/inspection_coverage.py.
+    inspected_zones_json: Mapped[str] = mapped_column(String(2000), default="null", nullable=False)

--- a/backend/app/models/inspection.py
+++ b/backend/app/models/inspection.py
@@ -83,3 +83,21 @@ class Inspection(Base):
     # attribute findings-reviewed/supervisor-corrections to a real person
     # instead of fabricating attribution. Nullable/blank for older rows.
     technician: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # v1.5 — Quality Intelligence. `disposition` is the one of
+    # PASS/MONITOR/SUPERVISOR REVIEW/REPROCESS/REMOVE FROM SERVICE computed at
+    # analysis time (clinical_decision.overall_result) — persisted so pass
+    # rate/reclean rate/remove-from-service rate can be reported later without
+    # re-deriving analysis. `coverage_pct`/`coverage_quality` are the
+    # Inspection Coverage Engine's result at submission time, persisted for
+    # the same reason (coverage compliance reporting). All nullable/blank for
+    # older rows or inspections with no image.
+    disposition: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    coverage_pct: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    coverage_quality: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    # v1.5 — the AI-computed analysis confidence (0-1), distinct from the
+    # pre-existing `confidence` column above (a client-supplied manual-entry
+    # field for the no-image path). Persisted so "AI Confidence Trend" can be
+    # reported without re-deriving analysis.
+    ai_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/backend/app/models/inspection_finding.py
+++ b/backend/app/models/inspection_finding.py
@@ -1,0 +1,39 @@
+"""v1.5 — Quality Intelligence: per-finding detection log.
+
+Inspection only stores the rolled-up disposition (risk_level, recommended_action,
+overall_cleaning_assessment) — not which individual finding types were actually
+detected. Finding Trend Intelligence, the Anatomy Risk Dashboard, and Instrument
+Family Performance all need real per-finding-type, per-zone data to aggregate
+over time, so this logs one row per actionable finding (severity_index >= 1)
+at analysis time — never fabricated after the fact.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class InspectionFinding(Base):
+    __tablename__ = "inspection_findings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    instrument_type: Mapped[str] = mapped_column(String(100), default="unknown", nullable=False, index=True)
+
+    finding_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    severity_index: Mapped[int] = mapped_column(Integer, default=0, nullable=False)

--- a/backend/app/models/inspection_image_tag.py
+++ b/backend/app/models/inspection_image_tag.py
@@ -1,0 +1,43 @@
+"""v1.2 — Image View Tagging.
+
+Each image uploaded during Guided Capture is tagged with which anatomy zone
+and image view it depicts, plus a technician-assessed capture quality and
+optional notes. This is metadata about the *view*, not pixel-level detection —
+the same "structured knowledge, not computer vision" honesty convention as the
+rest of the anatomy/coverage engine (see app/services/instrument_anatomy.py).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# Technician's own assessment of whether the captured image is usable.
+CAPTURE_QUALITY_VALUES = ("good", "acceptable", "poor", "unusable")
+
+
+class InspectionImageTag(Base):
+    __tablename__ = "inspection_image_tags"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    anatomy_zone: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    image_view: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    capture_quality: Mapped[str] = mapped_column(String(20), default="acceptable", nullable=False)
+    notes: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    # Optional — links to the retained-image store when image retention is
+    # enabled; blank when only the hash-only convention applies.
+    image_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -1,0 +1,168 @@
+"""v1.8 — Institutional Knowledge & Clinical Memory.
+
+Four additive tables, deliberately distinct from existing knowledge-adjacent
+stores rather than overloading them:
+  * KnowledgeArticle — user-authored institutional knowledge (best
+    practices, local standards, lessons learned, FAQs, teaching points).
+    Distinct from `education_library.py` (a fixed, code-generated reference
+    for the 12 finding categories) and `InstrumentKnowledge` (manufacturer/
+    model technical data) — this is what SPD staff write themselves, with
+    governance (author/reviewer/approval/version/archive).
+  * ClinicalCase — an auto-saved snapshot of a significant inspection
+    (critical finding, supervisor override, or repair/remove-from-service
+    outcome), preserving what happened and why for future reference.
+  * OrganizationStandard — per-tenant local policy that supplements (never
+    replaces) manufacturer IFUs.
+  * KnowledgeQueryLog — every question asked of the AI Knowledge Assistant,
+    for "most common questions" analytics.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Knowledge article categories ────────────────────────────────────────────
+BEST_PRACTICE = "best_practice"
+LOCAL_STANDARD = "local_standard"
+APPROVED_WORKFLOW = "approved_workflow"
+CLINICAL_PEARL = "clinical_pearl"
+LESSON_LEARNED = "lesson_learned"
+FAQ = "faq"
+COMPETENCY_GUIDANCE = "competency_guidance"
+MANUFACTURER_CLARIFICATION = "manufacturer_clarification"
+TEACHING_POINT = "teaching_point"
+
+ARTICLE_CATEGORIES = [
+    BEST_PRACTICE, LOCAL_STANDARD, APPROVED_WORKFLOW, CLINICAL_PEARL,
+    LESSON_LEARNED, FAQ, COMPETENCY_GUIDANCE, MANUFACTURER_CLARIFICATION, TEACHING_POINT,
+]
+
+# ── Governance approval states ───────────────────────────────────────────────
+DRAFT = "draft"
+PENDING_REVIEW = "pending_review"
+APPROVED = "approved"
+REJECTED = "rejected"
+ARCHIVED = "archived"
+
+APPROVAL_STATES = [DRAFT, PENDING_REVIEW, APPROVED, REJECTED, ARCHIVED]
+
+# ── Organization standard types ──────────────────────────────────────────────
+INSPECTION_STANDARD = "inspection_standard"
+PHOTOGRAPHY_STANDARD = "photography_standard"
+COVERAGE_REQUIREMENT = "coverage_requirement"
+SUPERVISOR_APPROVAL_THRESHOLD = "supervisor_approval_threshold"
+COMPETENCY_REQUIREMENT = "competency_requirement"
+
+STANDARD_TYPES = [
+    INSPECTION_STANDARD, PHOTOGRAPHY_STANDARD, COVERAGE_REQUIREMENT,
+    SUPERVISOR_APPROVAL_THRESHOLD, COMPETENCY_REQUIREMENT,
+]
+
+
+class KnowledgeArticle(Base):
+    __tablename__ = "knowledge_articles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    category: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+
+    author: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    reviewer: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    approval_status: Mapped[str] = mapped_column(String(20), default=DRAFT, nullable=False, index=True)
+    version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    last_reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Search facets — JSON-encoded lists kept as text for SQLite/Postgres
+    # portability, blank/"[]" unless actually supplied (never fabricated).
+    applicable_instruments: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    applicable_findings: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    applicable_manufacturers: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    anatomy_zone: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    procedure: Mapped[str] = mapped_column(String(200), default="", nullable=False)
+    specialty: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+
+    # Teaching-point specific fields (Deliverable 3) — blank when not a
+    # teaching_point-category article.
+    common_mistake: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    prevention_tip: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    references: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    # The inspection/override that prompted this article, if any (teaching
+    # points and lessons learned are usually born from a real case).
+    source_inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    view_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+
+class ClinicalCase(Base):
+    __tablename__ = "clinical_cases"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True, unique=True)
+    instrument_type: Mapped[str] = mapped_column(String(100), default="unknown", nullable=False, index=True)
+    finding_type: Mapped[str] = mapped_column(String(40), default="", nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # JSON-encoded snapshot of the AI's findings at save time.
+    ai_findings: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    supervisor_corrections: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    final_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    clinical_reasoning: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    educational_notes: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    outcome: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    view_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+
+class OrganizationStandard(Base):
+    __tablename__ = "organization_standards"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    standard_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    created_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+
+class KnowledgeQueryLog(Base):
+    __tablename__ = "knowledge_query_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    actor: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    query_text: Mapped[str] = mapped_column(String(1000), nullable=False)
+    matched_category: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/models/mentor_coaching_review.py
+++ b/backend/app/models/mentor_coaching_review.py
@@ -1,0 +1,39 @@
+"""v1.4 — Supervisor Coaching Dashboard review store.
+
+Captures a supervisor's review of the SPD Mentor Engine's coaching output for
+an inspection — approve as-is, edit the recommendation, and/or add an
+educational comment. Deliberately separate from SupervisorReview (which
+captures AI-agreement for ML ground truth) — this table tracks coaching
+quality/effectiveness, not model performance.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class MentorCoachingReview(Base):
+    __tablename__ = "mentor_coaching_reviews"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+
+    reviewer_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    reviewer_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    approved: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    edited_recommendation: Mapped[str] = mapped_column(String(1000), default="", nullable=False)
+    educational_comment: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/models/pilot_config.py
+++ b/backend/app/models/pilot_config.py
@@ -1,0 +1,46 @@
+"""v1.9 — Pilot Site Configuration (Deliverable 4).
+
+One row per tenant. Deliberately separate from `OrganizationStandard`
+(v1.8, a list of free-text policy documents supervisors author) — this is
+the small set of structured, machine-read settings the pilot's own
+workflow guardrails (coverage gating, supervisor review thresholds) and
+the Pilot Data Collection Dashboard read directly. Supplements, never
+replaces, manufacturer IFUs or the AI's own scoring engines.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class PilotSiteConfig(Base):
+    __tablename__ = "pilot_site_configs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, unique=True, index=True)
+
+    facility_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    department: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+    # JSON-encoded lists, kept as text for SQLite/Postgres portability.
+    enabled_instrument_families: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    required_inspection_zones: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    baseline_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    # Minimum coverage percent below which an inspection is flagged incomplete.
+    minimum_coverage_pct: Mapped[int] = mapped_column(Integer, default=75, nullable=False)
+    # Readiness score at/below which a supervisor review is mandatory before
+    # packaging, independent of the disposition engine's own recommendation.
+    supervisor_review_threshold_score: Mapped[int] = mapped_column(Integer, default=70, nullable=False)
+
+    updated_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)

--- a/backend/app/models/pilot_error_log.py
+++ b/backend/app/models/pilot_error_log.py
@@ -1,0 +1,46 @@
+"""v1.9 — Production Error Logging (Deliverable 7).
+
+A safe, structured log of operational failures — upload failure, AI
+analysis failure, baseline lookup failure, role permission failure,
+report generation failure. Deliberately narrow: `detail` is a short,
+developer-facing failure reason (exception message / HTTP status), never
+image bytes, patient/procedure identifiers, or any other PHI. This is
+distinct from the existing `AuditLog` (compliance/access trail of
+successful actions) and `AlertEvent` (external Slack/Teams/email dispatch
+for critical clinical findings) — this is an internal reliability signal.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+UPLOAD_FAILURE = "upload_failure"
+AI_ANALYSIS_FAILURE = "ai_analysis_failure"
+BASELINE_LOOKUP_FAILURE = "baseline_lookup_failure"
+ROLE_PERMISSION_FAILURE = "role_permission_failure"
+REPORT_GENERATION_FAILURE = "report_generation_failure"
+
+ERROR_TYPES = [
+    UPLOAD_FAILURE, AI_ANALYSIS_FAILURE, BASELINE_LOOKUP_FAILURE,
+    ROLE_PERMISSION_FAILURE, REPORT_GENERATION_FAILURE,
+]
+
+
+class PilotErrorLog(Base):
+    __tablename__ = "pilot_error_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    error_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    # Short, developer-facing reason only — never PHI, never image bytes.
+    detail: Mapped[str] = mapped_column(String(500), default="", nullable=False)
+    actor_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/models/root_cause.py
+++ b/backend/app/models/root_cause.py
@@ -1,0 +1,49 @@
+"""v1.5 — Root Cause Intelligence.
+
+A finding can be categorized by its probable root cause (by a supervisor —
+never inferred automatically, since guessing "why" a finding occurred without
+a human judgment would be a fabricated causal claim). Recurring root causes
+across inspections are what Root Cause Intelligence trends.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# Accepted root-cause vocabulary. "unknown" is a legitimate, honest choice —
+# not every finding has an identifiable cause at review time.
+ROOT_CAUSES: list[str] = [
+    "incomplete_manual_cleaning",
+    "improper_brushing",
+    "improper_flushing",
+    "missed_inspection_zone",
+    "poor_lighting",
+    "image_quality",
+    "instrument_damage",
+    "manufacturer_wear",
+    "unknown",
+]
+
+
+class RootCauseAssignment(Base):
+    __tablename__ = "root_cause_assignments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(100), default="default-tenant", nullable=False, index=True
+    )
+    finding_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    root_cause: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    assigned_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)

--- a/backend/app/models/supervisor_review.py
+++ b/backend/app/models/supervisor_review.py
@@ -55,6 +55,11 @@ class SupervisorReview(Base):
     instrument_family_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     corrected_instrument_family: Mapped[str] = mapped_column(String(60), default="", nullable=False)
     corrected_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False)
+    # v1.1 — image-view and missing-zone feedback (Inspection Coverage Engine).
+    image_view_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    corrected_image_view: Mapped[str] = mapped_column(String(60), default="", nullable=False)
+    missing_zone_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    corrected_missing_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False)
     corrected_severity: Mapped[str] = mapped_column(String(30), default="", nullable=False)
     corrected_recommendation: Mapped[str] = mapped_column(String(50), default="", nullable=False)
     final_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/models/workflow.py
+++ b/backend/app/models/workflow.py
@@ -1,0 +1,97 @@
+"""v1.7 — Workflow Intelligence & Smart Work Queue.
+
+Three additive tables:
+  * InspectionAssignment — who is/was responsible for an inspection. Multiple
+    rows per inspection are kept (reassignment history); the latest row is
+    the current assignment.
+  * WorkflowStateEvent — an append-only, audited log of workflow-state
+    transitions (Deliverable 4). The current state of an inspection is the
+    `to_state` of its latest event — never inferred by mutating a single
+    "current state" column, so the full transition history is always
+    reconstructable.
+  * WorkflowNotification — an in-app notification queue for technicians,
+    supervisors, and managers (Deliverable 10). Distinct from the existing
+    Slack/Teams/email `AlertEvent` dispatcher in app/notifications/notifier.py
+    (external channels for critical-finding alerts) — this is a per-recipient
+    in-app queue for workflow events (assignment, overdue, review required).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Workflow states (Deliverable 4) ─────────────────────────────────────────
+WAITING = "Waiting"
+ASSIGNED = "Assigned"
+IMAGE_CAPTURE = "Image Capture"
+AI_ANALYSIS = "AI Analysis"
+SUPERVISOR_REVIEW = "Supervisor Review"
+RECLEAN = "Reclean"
+REPAIR = "Repair"
+COMPLETED = "Completed"
+CANCELLED = "Cancelled"
+
+WORKFLOW_STATES = [
+    WAITING, ASSIGNED, IMAGE_CAPTURE, AI_ANALYSIS, SUPERVISOR_REVIEW,
+    RECLEAN, REPAIR, COMPLETED, CANCELLED,
+]
+
+
+class InspectionAssignment(Base):
+    __tablename__ = "inspection_assignments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    technician: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    assigned_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    note: Mapped[str] = mapped_column(String(500), default="", nullable=False)
+
+
+class WorkflowStateEvent(Base):
+    __tablename__ = "workflow_state_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    from_state: Mapped[str] = mapped_column(String(30), default="", nullable=False)
+    to_state: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    actor: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    reason: Mapped[str] = mapped_column(String(500), default="", nullable=False)
+
+
+class WorkflowNotification(Base):
+    __tablename__ = "workflow_notifications"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    inspection_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    notification_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    # A specific person if known, otherwise blank and recipient_role fans out
+    # to everyone with that role (rendered as a role-scoped feed, not stored
+    # per-person, so it isn't lost when technician assignment changes).
+    recipient_role: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    recipient_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    read: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routes/agents_pipeline.py
+++ b/backend/app/routes/agents_pipeline.py
@@ -1,0 +1,77 @@
+"""Phase 22 — Multi-Agent Clinical Intelligence Platform routes.
+
+Distinct from the pre-existing single-purpose app/agent/spd_agent.py
+(legacy, unrelated). This is the Phase 22 multi-agent pipeline: registry,
+orchestrated run, and explainable trace for a real inspection.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.agents.orchestrator import run_pipeline
+from app.agents.registry import get_registry
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+
+router = APIRouter(prefix="/api/agents", tags=["multi-agent-pipeline"])
+
+_READ_ROLES = ("admin", "spd_manager", "operator", "viewer")
+
+
+@router.get("/registry")
+def get_agent_registry(current_user=Depends(require_roles(*_READ_ROLES))):
+    """Section 12 — Agent Registry: status, version, capabilities, dependencies, health."""
+    return {"agents": get_registry()}
+
+
+@router.get("/health")
+def get_agents_health(current_user=Depends(require_roles(*_READ_ROLES))):
+    registry = get_registry()
+    degraded = [a["name"] for a in registry if a["health"] != "ok"]
+    return {
+        "overall_status": "ok" if not degraded else "degraded",
+        "agent_count": len(registry),
+        "degraded_agents": degraded,
+    }
+
+
+def _get_inspection(db: Session, inspection_id: int, tenant_id: str):
+    insp = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id)
+        .first()
+    )
+    if insp is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    return insp
+
+
+@router.get("/run/{inspection_id}")
+def run_agent_pipeline(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 13 — run the full agent pipeline for one real inspection."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    insp = _get_inspection(db, inspection_id, tenant_id)
+    return run_pipeline(db, insp, tenant_id)
+
+
+@router.get("/trace/{inspection_id}")
+def get_agent_trace(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 14 — Explainable Agent Trace: which agent produced which decision."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    insp = _get_inspection(db, inspection_id, tenant_id)
+    result = run_pipeline(db, insp, tenant_id)
+    return {
+        "inspection_id": inspection_id,
+        "trace": result["trace"],
+        "final_recommendation": result["recommendation_context"],
+    }

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -137,6 +137,20 @@ def submit_supervisor_review(
         inspection.override_reason = body.rationale.strip()
         inspection.override_by = _actor(current_user)
         inspection.override_at = datetime.now(timezone.utc)
+
+    # v1.4 — technician competency tracking, derived from this same review.
+    from app.services.competency_service import record_finding_reviewed, record_supervisor_correction
+
+    if inspection.technician:
+        record_finding_reviewed(
+            db, tenant_id=tenant_id, technician=inspection.technician, inspection_id=inspection_id,
+        )
+        if agreement != "agree" or body.override_action.strip():
+            record_supervisor_correction(
+                db, tenant_id=tenant_id, technician=inspection.technician,
+                finding_type=body.finding_type.strip(), inspection_id=inspection_id,
+            )
+
     db.commit()
     db.refresh(review)
 

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -17,6 +17,7 @@ from app.audit import log_audit_event
 from app.authz import require_roles
 from app.db import models
 from app.deps import get_db
+from app.cios.decision_ledger import record_decision
 from app.enterprise_auth import get_request_tenant_id
 from app.models.supervisor_review import SupervisorReview
 from app.services.ml.ground_truth import classify_ground_truth, derive_flags_from_review
@@ -146,6 +147,17 @@ def submit_supervisor_review(
         action_type="supervisor_ai_review", resource_type="inspection",
         resource_id=str(inspection_id),
     )
+    # Phase 23 §5 — every supervisor decision is also recorded in the
+    # permanent Clinical Decision Ledger, alongside the AI's own recorded
+    # recommendation (see app/cios/orchestrator.py).
+    record_decision(
+        db, tenant_id, inspection_id,
+        decision_type="supervisor_override" if review.override_action else "supervisor_approval",
+        made_by=review.reviewer_name,
+        rationale=review.rationale,
+        evidence={"agreement": agreement, "corrected_zone": review.corrected_zone, "final_disposition": review.final_disposition},
+    )
+
     return {
         "id": review.id,
         "inspection_id": inspection_id,

--- a/backend/app/routes/ai_clinical_review.py
+++ b/backend/app/routes/ai_clinical_review.py
@@ -44,6 +44,11 @@ class SupervisorReviewIn(BaseModel):
     instrument_family_correct: bool | None = None
     corrected_instrument_family: str = Field("", max_length=60)
     corrected_zone: str = Field("", max_length=60)
+    # v1.1 — image-view and missing-zone feedback (Inspection Coverage Engine).
+    image_view_correct: bool | None = None
+    corrected_image_view: str = Field("", max_length=60)
+    missing_zone_correct: bool | None = None
+    corrected_missing_zone: str = Field("", max_length=60)
     corrected_severity: str = Field("", max_length=30)
     corrected_recommendation: str = Field("", max_length=50)
     final_disposition: str = Field("", max_length=50)
@@ -107,6 +112,10 @@ def submit_supervisor_review(
         instrument_family_correct=body.instrument_family_correct,
         corrected_instrument_family=body.corrected_instrument_family.strip(),
         corrected_zone=body.corrected_zone.strip(),
+        image_view_correct=body.image_view_correct,
+        corrected_image_view=body.corrected_image_view.strip(),
+        missing_zone_correct=body.missing_zone_correct,
+        corrected_missing_zone=body.corrected_missing_zone.strip(),
         corrected_severity=body.corrected_severity.strip(),
         corrected_recommendation=body.corrected_recommendation.strip(),
         final_disposition=body.final_disposition.strip(),

--- a/backend/app/routes/cios.py
+++ b/backend/app/routes/cios.py
@@ -1,0 +1,147 @@
+"""Phase 23 — Clinical Intelligence Operating System (CIOS) routes.
+
+Route: /cios-dashboard (frontend). API prefix below.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.cios import event_bus
+from app.cios.certificate import build_certificate, render_certificate_pdf
+from app.cios.dashboard import build_dashboard
+from app.cios.decision_ledger import list_decisions
+from app.cios.governance import governance_snapshot
+from app.cios.orchestrator import run_cios_pipeline
+from app.cios.rule_registry import CLINICAL_RULE_REGISTRY
+from app.cios.state_machine import derive_state
+from app.db import models
+from app.deps import get_db
+from app.models.supervisor_review import SupervisorReview
+
+router = APIRouter(prefix="/api/cios", tags=["clinical-intelligence-operating-system"])
+
+_READ_ROLES = ("admin", "spd_manager", "operator", "viewer")
+
+
+def _get_inspection(db: Session, inspection_id: int, tenant_id: str):
+    insp = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id)
+        .first()
+    )
+    if insp is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    return insp
+
+
+@router.get("/run/{inspection_id}")
+def run_cios(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 1 — run the full Clinical Intelligence Operating System pipeline."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    insp = _get_inspection(db, inspection_id, tenant_id)
+    return run_cios_pipeline(db, insp, tenant_id)
+
+
+@router.get("/state/{inspection_id}")
+def get_inspection_state(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 4 — Inspection State Machine."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    insp = _get_inspection(db, inspection_id, tenant_id)
+    review = (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.inspection_id == inspection_id)
+        .order_by(SupervisorReview.id.desc())
+        .first()
+    )
+    return {"inspection_id": inspection_id, **derive_state(insp, review)}
+
+
+@router.get("/decision-ledger/{inspection_id}")
+def get_decision_ledger(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 5 — Clinical Decision Ledger for one inspection."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    _get_inspection(db, inspection_id, tenant_id)
+    return {"inspection_id": inspection_id, "decisions": list_decisions(db, tenant_id, inspection_id)}
+
+
+@router.get("/events")
+def get_events(
+    inspection_id: int | None = Query(None),
+    limit: int = Query(100, le=500),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 6 — Enterprise Event Bus."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    return {"events": event_bus.list_events(db, tenant_id, inspection_id, limit)}
+
+
+@router.get("/certificate/{inspection_id}")
+def get_certificate(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 8 — Clinical Readiness Certificate (JSON)."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    insp = _get_inspection(db, inspection_id, tenant_id)
+    cios_result = run_cios_pipeline(db, insp, tenant_id)
+    return build_certificate(db, insp, tenant_id, cios_result)
+
+
+@router.get("/certificate/{inspection_id}/pdf")
+def get_certificate_pdf(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 8 — Clinical Readiness Certificate (PDF)."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    insp = _get_inspection(db, inspection_id, tenant_id)
+    cios_result = run_cios_pipeline(db, insp, tenant_id)
+    certificate = build_certificate(db, insp, tenant_id, cios_result)
+    pdf_bytes = render_certificate_pdf(certificate)
+    filename = f"lumenai_readiness_certificate_{inspection_id}_{datetime.now().strftime('%Y%m%d')}.pdf"
+    return Response(
+        content=pdf_bytes, media_type="application/pdf",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+@router.get("/governance")
+def get_governance(current_user=Depends(require_roles(*_READ_ROLES))):
+    """Section 10 — Platform Governance version snapshot."""
+    return governance_snapshot()
+
+
+@router.get("/rule-registry")
+def get_rule_registry(current_user=Depends(require_roles(*_READ_ROLES))):
+    """Section 11 — Clinical Rule Registry."""
+    return {"rules": CLINICAL_RULE_REGISTRY}
+
+
+@router.get("/dashboard")
+def get_cios_dashboard(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 9 — Enterprise Health Dashboard (/cios-dashboard)."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    return build_dashboard(db, tenant_id)

--- a/backend/app/routes/clinical_readiness.py
+++ b/backend/app/routes/clinical_readiness.py
@@ -1,0 +1,219 @@
+"""v1.6 — Clinical Service Readiness & Instrument Disposition Intelligence API.
+
+- GET  /api/clinical-readiness/dashboard                     — Deliverable 7
+- GET  /api/clinical-readiness/enterprise-analytics           — Deliverable 9
+- GET  /api/clinical-readiness/instrument-condition            — Deliverable 5 (?instrument_identity=)
+- GET  /api/inspections/{id}/evidence-panel                   — Deliverable 3
+- GET  /api/inspections/{id}/readiness-timeline               — Deliverable 4
+- GET  /api/inspections/{id}/risk-stratification              — Deliverable 8
+- GET  /api/inspections/{id}/readiness-report                 — Deliverable 10 (JSON)
+- GET  /api/inspections/{id}/readiness-report.pdf              — Deliverable 10 (PDF)
+- POST /api/inspections/{id}/disposition-action               — Deliverable 6
+- GET  /api/inspections/{id}/disposition-actions               — Deliverable 6 (history)
+"""
+from __future__ import annotations
+
+import io
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.disposition_override import DISPOSITION_ACTIONS
+from app.services.disposition_evidence_service import get_evidence_panel
+from app.services.disposition_workspace_service import (
+    InvalidDispositionAction, ReasonRequiredError, list_disposition_actions, submit_disposition_action,
+)
+from app.services.instrument_condition_service import instrument_condition_history
+from app.services.readiness_dashboard_service import enterprise_readiness_analytics, readiness_dashboard
+from app.services.readiness_engine import get_primary_finding_type
+from app.services.readiness_report_service import build_readiness_report_payload, build_readiness_report_pdf
+from app.services.readiness_timeline_service import build_timeline
+from app.services.risk_stratification_service import stratify_risk
+
+router = APIRouter(tags=["clinical-readiness"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+def _get_inspection(db: Session, tenant_id: str, inspection_id: int):
+    insp = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id)
+        .first()
+    )
+    if insp is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    return insp
+
+
+@router.get("/api/clinical-readiness/dashboard")
+def get_readiness_dashboard(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return readiness_dashboard(db, _tenant(current_user, request))
+
+
+@router.get("/api/clinical-readiness/enterprise-analytics")
+def get_enterprise_analytics(
+    request: Request,
+    days: int = 180,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return enterprise_readiness_analytics(db, _tenant(current_user, request), days=days)
+
+
+@router.get("/api/clinical-readiness/instrument-condition")
+def get_instrument_condition(
+    request: Request,
+    instrument_identity: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    history = instrument_condition_history(db, _tenant(current_user, request), instrument_identity)
+    if history is None:
+        raise HTTPException(status_code=404, detail="No inspection history found for this instrument identity.")
+    return history
+
+
+@router.get("/api/inspections/{inspection_id}/evidence-panel")
+def get_evidence_panel_endpoint(
+    inspection_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    panel = get_evidence_panel(db, _tenant(current_user, request), inspection_id)
+    if panel is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    return panel
+
+
+@router.get("/api/inspections/{inspection_id}/readiness-timeline")
+def get_readiness_timeline(
+    inspection_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    return build_timeline(db, tenant_id, insp)
+
+
+@router.get("/api/inspections/{inspection_id}/risk-stratification")
+def get_risk_stratification(
+    inspection_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    return stratify_risk(insp, primary_finding_type=get_primary_finding_type(db, insp))
+
+
+@router.get("/api/inspections/{inspection_id}/readiness-report")
+def get_readiness_report(
+    inspection_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    return build_readiness_report_payload(db, tenant_id, insp)
+
+
+@router.get("/api/inspections/{inspection_id}/readiness-report.pdf")
+def get_readiness_report_pdf(
+    inspection_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    pdf = build_readiness_report_pdf(db, tenant_id, insp)
+    return StreamingResponse(
+        io.BytesIO(pdf),
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'inline; filename="lumenai-readiness-report-{insp.id}.pdf"'},
+    )
+
+
+class DispositionActionIn(BaseModel):
+    action: str = Field(..., description=f"One of {DISPOSITION_ACTIONS}")
+    ai_recommended_disposition: str = Field("", max_length=50)
+    modified_disposition: str = Field("", max_length=50)
+    reason: str = Field("", max_length=2000)
+
+
+@router.post("/api/inspections/{inspection_id}/disposition-action", status_code=201)
+def post_disposition_action(
+    inspection_id: int,
+    body: DispositionActionIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    _get_inspection(db, tenant_id, inspection_id)
+
+    try:
+        row = submit_disposition_action(
+            db, tenant_id=tenant_id, inspection_id=inspection_id,
+            reviewer_name=_actor(current_user), reviewer_role=getattr(current_user, "role", "spd_manager"),
+            action=body.action, ai_recommended_disposition=body.ai_recommended_disposition,
+            modified_disposition=body.modified_disposition, reason=body.reason,
+        )
+    except InvalidDispositionAction as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except ReasonRequiredError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    db.commit()
+    db.refresh(row)
+    return {
+        "id": row.id, "action": row.action, "modified_disposition": row.modified_disposition,
+        "reason": row.reason,
+    }
+
+
+@router.get("/api/inspections/{inspection_id}/disposition-actions")
+def get_disposition_actions(
+    inspection_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    rows = list_disposition_actions(db, tenant_id, inspection_id)
+    return {
+        "actions": [
+            {
+                "id": r.id, "action": r.action, "reviewer_name": r.reviewer_name,
+                "ai_recommended_disposition": r.ai_recommended_disposition,
+                "modified_disposition": r.modified_disposition, "reason": r.reason,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ],
+    }

--- a/backend/app/routes/clinical_readiness.py
+++ b/backend/app/routes/clinical_readiness.py
@@ -151,7 +151,17 @@ def get_readiness_report_pdf(
 ):
     tenant_id = _tenant(current_user, request)
     insp = _get_inspection(db, tenant_id, inspection_id)
-    pdf = build_readiness_report_pdf(db, tenant_id, insp)
+    try:
+        pdf = build_readiness_report_pdf(db, tenant_id, insp)
+    except Exception as exc:
+        from app.services.pilot_error_log_service import log_error
+
+        log_error(
+            db, tenant_id=tenant_id, error_type="report_generation_failure",
+            detail=str(exc)[:500], actor_role=getattr(current_user, "role", ""), inspection_id=inspection_id,
+        )
+        db.commit()
+        raise HTTPException(status_code=500, detail="Report generation failed. This has been logged.") from exc
     return StreamingResponse(
         io.BytesIO(pdf),
         media_type="application/pdf",

--- a/backend/app/routes/clinical_readiness.py
+++ b/backend/app/routes/clinical_readiness.py
@@ -190,10 +190,19 @@ def post_disposition_action(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     from app.services import workflow_state_service
+    from app.services.clinical_case_library_service import save_or_update_case
 
     insp = _get_inspection(db, tenant_id, inspection_id)
     workflow_state_service.record_disposition_action(
         db, insp=insp, tenant_id=tenant_id, action=body.action, actor=_actor(current_user), reason=body.reason,
+    )
+
+    # v1.8 — a supervisor override is itself a significant-inspection
+    # trigger; preserve (or update) the case with the real correction.
+    save_or_update_case(
+        db, tenant_id, insp, finding_type=get_primary_finding_type(db, insp),
+        supervisor_corrections=body.reason, final_disposition=body.modified_disposition or body.ai_recommended_disposition,
+        outcome=body.action,
     )
 
     db.commit()

--- a/backend/app/routes/clinical_readiness.py
+++ b/backend/app/routes/clinical_readiness.py
@@ -189,6 +189,13 @@ def post_disposition_action(
     except ReasonRequiredError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+    from app.services import workflow_state_service
+
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    workflow_state_service.record_disposition_action(
+        db, insp=insp, tenant_id=tenant_id, action=body.action, actor=_actor(current_user), reason=body.reason,
+    )
+
     db.commit()
     db.refresh(row)
     return {

--- a/backend/app/routes/guided_capture.py
+++ b/backend/app/routes/guided_capture.py
@@ -1,0 +1,146 @@
+"""v1.2 — Guided Capture & Coverage Workflow routes.
+
+- GET  /api/guided-capture/{instrument_type} — Guided Capture Panel + Capture
+  Checklist + Coverage Score/readiness, all in one response.
+- GET  /api/inspections/{id}/image-tags — per-image view tags for an inspection.
+- POST /api/inspections/{id}/coverage-override — supervisor/admin override to
+  unlock a final AI decision despite incomplete coverage, when org policy
+  requires full coverage (see app/services/guided_capture.py).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.config import get_settings
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.inspection_image_tag import InspectionImageTag
+from app.services.guided_capture import coverage_readiness, guided_capture_panel
+
+router = APIRouter(tags=["guided-capture"])
+
+_READ_ROLES = ("admin", "spd_manager", "operator", "viewer")
+
+
+@router.get("/guided-capture/{instrument_type}")
+def get_guided_capture_panel(
+    instrument_type: str,
+    captured_zones: str | None = Query(None, description="Comma-separated list of zones already captured"),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Guided Capture Panel + Capture Checklist + Coverage Score, in one call.
+
+    ``captured_zones`` omitted means "not yet assessed" (coverage_status
+    reflects that honestly); an explicit (possibly empty) comma-separated
+    list is assessed normally.
+    """
+    zones = [z.strip() for z in captured_zones.split(",") if z.strip()] if captured_zones is not None else None
+    panel = guided_capture_panel(instrument_type, zones)
+    readiness = coverage_readiness(
+        instrument_type, zones,
+        require_full_coverage=get_settings().require_full_coverage_before_final_decision,
+    )
+    return {**panel, **readiness}
+
+
+def _get_inspection(db: Session, inspection_id: int, tenant_id: str, is_admin: bool) -> models.Inspection:
+    query = db.query(models.Inspection).filter(models.Inspection.id == inspection_id)
+    if tenant_id and not is_admin:
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    row = query.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    return row
+
+
+@router.get("/inspections/{inspection_id}/image-tags")
+def list_image_tags(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    tenant_id = getattr(current_user, "tenant_id", None)
+    is_admin = getattr(current_user, "role", "") == "admin"
+    _get_inspection(db, inspection_id, tenant_id, is_admin)
+
+    rows = (
+        db.query(InspectionImageTag)
+        .filter(InspectionImageTag.inspection_id == inspection_id)
+        .order_by(InspectionImageTag.id.asc())
+        .all()
+    )
+    return {
+        "inspection_id": inspection_id,
+        "count": len(rows),
+        "tags": [
+            {
+                "id": r.id,
+                "instrument_family": r.instrument_family,
+                "anatomy_zone": r.anatomy_zone,
+                "image_view": r.image_view,
+                "capture_quality": r.capture_quality,
+                "notes": r.notes,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+class CoverageOverrideIn(BaseModel):
+    reason: str = Field(..., min_length=10, max_length=1000)
+
+
+@router.post("/inspections/{inspection_id}/coverage-override", status_code=200)
+def apply_coverage_override(
+    inspection_id: int,
+    body: CoverageOverrideIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Section 7 — Supervisor Override. Lets a supervisor/admin proceed to a
+    final AI decision despite missing zone coverage, with a required reason.
+    Audit-logged; does not alter the coverage score itself, only the gate."""
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    is_admin = getattr(current_user, "role", "") == "admin"
+    row = _get_inspection(db, inspection_id, tenant_id, is_admin)
+
+    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
+    now = datetime.now(timezone.utc)
+
+    row.coverage_override_reason = body.reason
+    row.coverage_override_by = actor
+    row.coverage_override_at = now
+    row.coverage_gate_status = "ready"
+    row.is_draft = False
+    db.commit()
+
+    log_audit_event(
+        db,
+        tenant_id=tenant_id or row.tenant_id,
+        tenant_name=row.tenant_name,
+        actor_email=actor,
+        actor_role=getattr(current_user, "role", "spd_manager"),
+        action_type="coverage_override_applied",
+        resource_type="inspection",
+        resource_id=str(row.id),
+        details={"reason": body.reason, "coverage_status": row.coverage_status},
+        compliance_flag=True,
+    )
+
+    return {
+        "id": row.id,
+        "coverage_gate_status": row.coverage_gate_status,
+        "is_draft": row.is_draft,
+        "coverage_override_reason": row.coverage_override_reason,
+        "coverage_override_by": row.coverage_override_by,
+        "coverage_override_at": row.coverage_override_at.isoformat(),
+    }

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import json
 import re
 from datetime import datetime, timezone
 from typing import List, Literal, Optional
@@ -439,6 +440,7 @@ async def create_inspection(
         risk_level=risk_level_val,
         recommended_action=recommended_action_val,
         overall_cleaning_assessment=cleaning_assessment_val,
+        inspected_zones_json=json.dumps(body.inspected_zones),
     )
     db.add(row)
     db.commit()

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -618,6 +618,18 @@ async def create_inspection(
         # Attach the full explainable AI analysis output (placeholder scoring).
         response["analysis"] = analysis
     response["coverage_readiness"] = readiness
+
+    # v1.9 — Data Quality Guardrails: surface clear, actionable gaps
+    # (missing instrument/image/anatomy zone, poor image quality, missing
+    # baseline, incomplete coverage, missing technician identity) against
+    # the pilot site's own configured thresholds.
+    from app.services.data_quality_guardrails_service import evaluate_data_quality
+    from app.services.pilot_site_config_service import get_or_create_config
+
+    pilot_config = get_or_create_config(db, tenant_id)
+    db.commit()
+    response["data_quality"] = evaluate_data_quality(row, pilot_config=pilot_config)
+
     return response
 
 

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -376,6 +376,12 @@ async def create_inspection(
     risk_level_val: Optional[str] = None
     recommended_action_val: Optional[str] = None
     cleaning_assessment_val: Optional[str] = None
+    # v1.5 — Quality Intelligence: disposition + coverage, persisted for later
+    # reporting (pass/reclean/remove-from-service rates, coverage compliance).
+    disposition_val: Optional[str] = None
+    coverage_pct_val: Optional[int] = None
+    coverage_quality_val: Optional[str] = None
+    ai_confidence_val: Optional[float] = None
 
     if body.has_image:
         analysis = analyze_inspection(
@@ -397,6 +403,11 @@ async def create_inspection(
         risk_level_val = analysis.get("risk_level")
         recommended_action_val = analysis.get("recommended_action")
         cleaning_assessment_val = analysis.get("overall_cleaning_assessment")
+        disposition_val = analysis.get("clinical_decision", {}).get("overall_result")
+        coverage = analysis.get("inspection_coverage") or {}
+        coverage_pct_val = coverage.get("overall_coverage")
+        coverage_quality_val = coverage.get("quality")
+        ai_confidence_val = analysis.get("confidence")
         if analysis["analysis_status"] == "completed":
             baseline_status = "approved_baseline_found"
             baseline_source_val = analysis["baseline_source"]
@@ -446,10 +457,33 @@ async def create_inspection(
         recommended_action=recommended_action_val,
         overall_cleaning_assessment=cleaning_assessment_val,
         technician=actor,
+        disposition=disposition_val,
+        coverage_pct=coverage_pct_val,
+        coverage_quality=coverage_quality_val,
+        ai_confidence=ai_confidence_val,
     )
     db.add(row)
     db.commit()
     db.refresh(row)
+
+    # v1.5 — Quality Intelligence: log each actionable finding (severity >= 1)
+    # for real trend/anatomy-risk/instrument-family aggregation. Only findings
+    # from a completed analysis are real detections — nothing logged for
+    # no-baseline/manual-entry inspections.
+    if analysis is not None and analysis.get("analysis_status") == "completed":
+        from app.models.inspection_finding import InspectionFinding
+
+        for f in analysis.get("predicted_findings", []):
+            if f.get("severity_index", 0) >= 1:
+                db.add(InspectionFinding(
+                    inspection_id=row.id,
+                    tenant_id=tenant_id,
+                    instrument_type=body.instrument_type,
+                    finding_type=f["type"],
+                    zone=f.get("instrument_zone", ""),
+                    severity_index=f["severity_index"],
+                ))
+        db.commit()
 
     log_audit_event(
         db,

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -107,6 +107,9 @@ class InspectionCreate(BaseModel):
     inspected_zones: Optional[List[str]] = Field(None)
     # Technician-declared finding categories (optional — AI determines findings)
     finding_categories: Optional[List[str]] = Field(None)
+    # v1.4 — SPD Mentor Engine Training Mode: explain every finding, anatomy,
+    # recommendation, and terminology in the returned analysis.
+    training_mode: bool = Field(False)
 
     @field_validator("instrument_type")
     @classmethod
@@ -387,6 +390,7 @@ async def create_inspection(
             keydot_id=body.keydot_id,
             decoder_backend=body.identifier_source or "declared",
             inspected_zones=body.inspected_zones,
+            training_mode=body.training_mode,
         )
         # Persist the SPD verdict regardless of completion state so history and
         # the dashboard show what the analysis concluded.
@@ -409,6 +413,8 @@ async def create_inspection(
         baseline_status = "not_applicable"
         risk_score_val = calculate_risk(detected_issue, conf_val)
         score_status = "scored"
+
+    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
 
     row = models.Inspection(
         file_name=body.file_name or "manual-entry",
@@ -439,12 +445,12 @@ async def create_inspection(
         risk_level=risk_level_val,
         recommended_action=recommended_action_val,
         overall_cleaning_assessment=cleaning_assessment_val,
+        technician=actor,
     )
     db.add(row)
     db.commit()
     db.refresh(row)
 
-    actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
     log_audit_event(
         db,
         tenant_id=tenant_id,

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -124,6 +124,18 @@ class InspectionCreate(BaseModel):
     # hatch for incomplete coverage (see app/services/guided_capture.py).
     image_view_tags: Optional[List[ImageViewTagIn]] = Field(None)
     save_as_draft: bool = Field(False)
+    # v1.7 — Workflow Intelligence: real OR-urgency/loaner signal for the
+    # prioritization engine. Optional and unvalidated-to-empty (None) rather
+    # than defaulted to "routine" when not actually declared.
+    procedure_priority: Optional[str] = Field(None, max_length=20)
+    is_loaner_instrument: Optional[bool] = Field(None)
+
+    @field_validator("procedure_priority")
+    @classmethod
+    def validate_procedure_priority(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in {"emergency", "trauma", "first_case", "routine"}:
+            raise ValueError("procedure_priority must be one of emergency, trauma, first_case, routine")
+        return v
 
     @field_validator("instrument_type")
     @classmethod
@@ -302,6 +314,9 @@ def inspection_response(row: models.Inspection) -> dict:
         "coverage_override_reason": row.coverage_override_reason,
         "coverage_override_by": row.coverage_override_by,
         "coverage_override_at": row.coverage_override_at.isoformat() if row.coverage_override_at else None,
+        # v1.7 — Workflow Intelligence
+        "procedure_priority": row.procedure_priority,
+        "is_loaner_instrument": row.is_loaner_instrument,
     }
 
 
@@ -505,6 +520,8 @@ async def create_inspection(
         coverage_score=readiness["coverage_score"],
         coverage_gate_status=coverage_gate_status,
         is_draft=is_draft_val,
+        procedure_priority=body.procedure_priority,
+        is_loaner_instrument=body.is_loaner_instrument,
     )
     db.add(row)
     db.commit()
@@ -542,6 +559,29 @@ async def create_inspection(
                 capture_quality=tag.get("capture_quality", "acceptable"),
                 notes=tag.get("notes", ""),
             ))
+        db.commit()
+
+    # v1.7 — Workflow Intelligence: audit the real transitions this request
+    # just performed (image capture + AI analysis happen synchronously in
+    # this same call), then advance into Supervisor Review if the
+    # disposition engine says a human must weigh in before proceeding.
+    from app.services import workflow_state_service
+    from app.services.disposition_engine import SUPERVISOR_REVIEW_REQUIRED, recommend_disposition
+    from app.services.readiness_engine import compute_readiness, get_primary_finding_type
+
+    if body.has_image:
+        workflow_state_service.record_capture_and_analysis(db, insp=row, tenant_id=tenant_id, actor=actor)
+        db.commit()
+
+    workflow_readiness = compute_readiness(db, tenant_id, row, confirmed=False)
+    workflow_disposition = recommend_disposition(
+        workflow_readiness, row, coverage_pct=row.coverage_pct,
+        primary_finding_type=get_primary_finding_type(db, row),
+    )
+    if workflow_disposition["disposition"] == SUPERVISOR_REVIEW_REQUIRED:
+        workflow_state_service.enter_supervisor_review(
+            db, insp=row, tenant_id=tenant_id, actor="system", reason=workflow_disposition["explanation"],
+        )
         db.commit()
 
     log_audit_event(

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -83,6 +83,15 @@ _ALLOWED_BASELINE_SOURCES = {
 }
 
 
+class ImageViewTagIn(BaseModel):
+    """v1.2 — per-uploaded-image metadata (see app/models/inspection_image_tag.py)."""
+    instrument_family: str = Field("", max_length=100)
+    anatomy_zone: str = Field("", max_length=100)
+    image_view: str = Field("", max_length=100)
+    capture_quality: str = Field("acceptable", max_length=20)
+    notes: str = Field("", max_length=2000)
+
+
 class InspectionCreate(BaseModel):
     instrument_type: str = Field(..., description="Must be an approved instrument type")
     material_type: Optional[str] = Field(None, description="Must be an approved material type; optional when image present")
@@ -108,6 +117,10 @@ class InspectionCreate(BaseModel):
     inspected_zones: Optional[List[str]] = Field(None)
     # Technician-declared finding categories (optional — AI determines findings)
     finding_categories: Optional[List[str]] = Field(None)
+    # v1.2 — Guided Capture: per-image view tags and the save-as-draft escape
+    # hatch for incomplete coverage (see app/services/guided_capture.py).
+    image_view_tags: Optional[List[ImageViewTagIn]] = Field(None)
+    save_as_draft: bool = Field(False)
 
     @field_validator("instrument_type")
     @classmethod
@@ -278,6 +291,14 @@ def inspection_response(row: models.Inspection) -> dict:
         "risk_level": row.risk_level,
         "recommended_action": row.recommended_action,
         "overall_cleaning_assessment": row.overall_cleaning_assessment,
+        # v1.2 — Guided Capture coverage gate
+        "coverage_status": row.coverage_status,
+        "coverage_score": row.coverage_score,
+        "coverage_gate_status": row.coverage_gate_status,
+        "is_draft": row.is_draft,
+        "coverage_override_reason": row.coverage_override_reason,
+        "coverage_override_by": row.coverage_override_by,
+        "coverage_override_at": row.coverage_override_at.isoformat() if row.coverage_override_at else None,
     }
 
 
@@ -375,6 +396,8 @@ async def create_inspection(
     recommended_action_val: Optional[str] = None
     cleaning_assessment_val: Optional[str] = None
 
+    image_view_tags_dicts = [t.model_dump() for t in (body.image_view_tags or [])]
+
     if body.has_image:
         analysis = analyze_inspection(
             db,
@@ -388,6 +411,7 @@ async def create_inspection(
             keydot_id=body.keydot_id,
             decoder_backend=body.identifier_source or "declared",
             inspected_zones=body.inspected_zones,
+            image_view_tags=image_view_tags_dicts,
         )
         # Persist the SPD verdict regardless of completion state so history and
         # the dashboard show what the analysis concluded.
@@ -410,6 +434,20 @@ async def create_inspection(
         baseline_status = "not_applicable"
         risk_score_val = calculate_risk(detected_issue, conf_val)
         score_status = "scored"
+
+    # v1.2 — Guided Capture coverage gate. Computed regardless of has_image so
+    # a no-image manual entry still gets an honest "not_assessed" snapshot.
+    from app.config import get_settings
+    from app.services.guided_capture import coverage_readiness
+
+    readiness = coverage_readiness(
+        body.instrument_type,
+        body.inspected_zones,
+        require_full_coverage=get_settings().require_full_coverage_before_final_decision,
+        override_applied=False,
+    )
+    coverage_gate_status = readiness["gate_status"]
+    is_draft_val = body.save_as_draft or coverage_gate_status == "blocked_pending_override"
 
     row = models.Inspection(
         file_name=body.file_name or "manual-entry",
@@ -441,10 +479,29 @@ async def create_inspection(
         recommended_action=recommended_action_val,
         overall_cleaning_assessment=cleaning_assessment_val,
         inspected_zones_json=json.dumps(body.inspected_zones),
+        coverage_status=readiness["coverage_status"],
+        coverage_score=readiness["coverage_score"],
+        coverage_gate_status=coverage_gate_status,
+        is_draft=is_draft_val,
     )
     db.add(row)
     db.commit()
     db.refresh(row)
+
+    if image_view_tags_dicts:
+        from app.models.inspection_image_tag import InspectionImageTag
+
+        for tag in image_view_tags_dicts:
+            db.add(InspectionImageTag(
+                tenant_id=tenant_id,
+                inspection_id=row.id,
+                instrument_family=tag.get("instrument_family", ""),
+                anatomy_zone=tag.get("anatomy_zone", ""),
+                image_view=tag.get("image_view", ""),
+                capture_quality=tag.get("capture_quality", "acceptable"),
+                notes=tag.get("notes", ""),
+            ))
+        db.commit()
 
     actor = getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
     log_audit_event(
@@ -462,6 +519,7 @@ async def create_inspection(
     if analysis is not None:
         # Attach the full explainable AI analysis output (placeholder scoring).
         response["analysis"] = analysis
+    response["coverage_readiness"] = readiness
     return response
 
 

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -584,6 +584,24 @@ async def create_inspection(
         )
         db.commit()
 
+    # v1.8 — Clinical Case Library: automatically preserve significant
+    # inspections (a critical finding on the readiness engine's own
+    # classification) as a reusable case for future similar-case lookups.
+    from app.services.clinical_case_library_service import is_significant, save_or_update_case
+    from app.services.risk_stratification_service import stratify_risk
+
+    workflow_primary_finding = get_primary_finding_type(db, row)
+    workflow_risk = stratify_risk(row, primary_finding_type=workflow_primary_finding)
+    if is_significant(
+        risk_tier=workflow_risk["risk_tier"], is_critical_finding=workflow_readiness.get("is_critical_finding", False),
+        has_override=False, finding_type=workflow_primary_finding,
+    ):
+        save_or_update_case(
+            db, tenant_id, row, finding_type=workflow_primary_finding,
+            final_disposition=workflow_disposition["disposition"], clinical_reasoning=workflow_disposition["explanation"],
+        )
+        db.commit()
+
     log_audit_event(
         db,
         tenant_id=tenant_id,

--- a/backend/app/routes/instrument_intelligence_admin.py
+++ b/backend/app/routes/instrument_intelligence_admin.py
@@ -21,9 +21,20 @@ from app.deps import get_db
 from app.enterprise_auth import get_request_tenant_id
 from app.models.instrument_knowledge import InstrumentKnowledge
 from app.models.supervisor_review import SupervisorReview
-from app.services.instrument_anatomy import anatomy_profile
+from app.services.instrument_anatomy import anatomy_profile, list_anatomy_families
+from app.services.inspection_coverage import coverage_dashboard_summary
 
 router = APIRouter(tags=["instrument-intelligence"])
+
+
+@router.get("/instrument-anatomy")
+def list_instrument_anatomy(
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Anatomy Library — every declared instrument-family anatomy definition
+    (family, zones, required image views, high-risk zones). Backs the
+    Anatomy Library page's browse view."""
+    return {"families": list_anatomy_families()}
 
 
 @router.get("/instrument-anatomy/{instrument_type}")
@@ -38,6 +49,36 @@ def instrument_anatomy(
     required image views, per-zone descriptions/risks, manual-check steps). Falls
     back to a generic SPD profile with a supervisor-review warning when unknown."""
     return anatomy_profile(instrument_type, manufacturer, model, instrument_name)
+
+
+@router.get("/instrument-zones")
+def instrument_zone_taxonomy(
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Inspection Zones Library — the full zone taxonomy, high-retention zones,
+    and per-zone risk/reason/manual-check reference. Backs the Inspection Zones
+    library page."""
+    from app.services.instrument_zones import HIGH_RETENTION_ZONES, ZONE_INFO, ZONE_TAXONOMY
+
+    return {
+        "zone_taxonomy": ZONE_TAXONOMY,
+        "high_retention_zones": sorted(HIGH_RETENTION_ZONES),
+        "zone_info": ZONE_INFO,
+    }
+
+
+@router.get("/coverage-dashboard/summary")
+def coverage_dashboard(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Inspection Coverage Dashboard — real aggregate coverage stats (average
+    coverage, status breakdown, most commonly missing zones, per-family
+    averages) computed from stored inspections. Nothing fabricated: inspections
+    that never had zones tagged are excluded from averages, not counted as 0%."""
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    return coverage_dashboard_summary(db, tenant_id)
 
 
 class KnowledgeIn(BaseModel):

--- a/backend/app/routes/knowledge.py
+++ b/backend/app/routes/knowledge.py
@@ -1,0 +1,409 @@
+"""v1.8 — Institutional Knowledge & Clinical Memory.
+
+- GET/POST /api/knowledge/articles                       — Deliverable 1
+- GET/PATCH /api/knowledge/articles/{id}                 — Deliverable 1
+- POST /api/knowledge/articles/{id}/{submit-for-review,approve,reject,archive} — Deliverable 9
+- GET  /api/knowledge/cases, /api/knowledge/cases/{id}    — Deliverable 2
+- POST /api/inspections/{id}/teaching-point               — Deliverable 3
+- POST /api/knowledge/search                              — Deliverable 4
+- GET  /api/inspections/{id}/similar-cases                — Deliverable 5
+- GET/POST /api/knowledge/standards                       — Deliverable 6
+- GET  /api/knowledge/competency-topics[/{finding_type}]  — Deliverable 7
+- POST /api/knowledge/assistant                           — Deliverable 8
+- GET  /api/knowledge/governance-summary                  — Deliverable 9
+- GET  /api/knowledge/analytics                           — Deliverable 10
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.knowledge import ARTICLE_CATEGORIES, PENDING_REVIEW, STANDARD_TYPES, TEACHING_POINT
+from app.services import knowledge_governance_service as governance
+from app.services import knowledge_repository_service as repository
+from app.services import organization_standards_service as standards
+from app.services.ai_knowledge_assistant_service import answer_question
+from app.services.clinical_case_library_service import case_to_dict, list_cases, record_view as record_case_view, save_or_update_case
+from app.services.competency_knowledge_service import competency_topic, list_competency_topics
+from app.services.knowledge_analytics_service import knowledge_analytics
+from app.services.knowledge_search_service import smart_search
+from app.services.readiness_engine import get_primary_finding_type
+from app.services.similar_case_finder_service import find_similar_cases
+
+router = APIRouter(tags=["institutional-knowledge"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+def _get_inspection(db: Session, tenant_id: str, inspection_id: int):
+    insp = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id)
+        .first()
+    )
+    if insp is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    return insp
+
+
+# ── Institutional Knowledge Repository (Deliverable 1) ──────────────────────
+
+class ArticleIn(BaseModel):
+    category: str = Field(..., description=f"One of {ARTICLE_CATEGORIES}")
+    title: str = Field(..., min_length=1, max_length=255)
+    body: str = Field(..., min_length=1)
+    applicable_instruments: list[str] = Field(default_factory=list)
+    applicable_findings: list[str] = Field(default_factory=list)
+    applicable_manufacturers: list[str] = Field(default_factory=list)
+    anatomy_zone: str = Field("", max_length=100)
+    procedure: str = Field("", max_length=200)
+    specialty: str = Field("", max_length=100)
+
+
+@router.post("/api/knowledge/articles", status_code=201)
+def post_article(
+    body: ArticleIn, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    if body.category not in ARTICLE_CATEGORIES:
+        raise HTTPException(status_code=422, detail=f"category must be one of {ARTICLE_CATEGORIES}")
+    tenant_id = _tenant(current_user, request)
+    row = repository.create_article(
+        db, tenant_id=tenant_id, category=body.category, title=body.title, body=body.body,
+        author=_actor(current_user), applicable_instruments=body.applicable_instruments,
+        applicable_findings=body.applicable_findings, applicable_manufacturers=body.applicable_manufacturers,
+        anatomy_zone=body.anatomy_zone, procedure=body.procedure, specialty=body.specialty,
+        approval_status=PENDING_REVIEW,
+    )
+    db.commit()
+    db.refresh(row)
+    return repository.article_to_dict(row)
+
+
+@router.get("/api/knowledge/articles")
+def get_articles(
+    request: Request, category: str = "", instrument: str = "", manufacturer: str = "",
+    anatomy_zone: str = "", finding: str = "", procedure: str = "", specialty: str = "",
+    approval_status: str = "", db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    return {
+        "articles": repository.list_articles(
+            db, tenant_id, category=category, instrument=instrument, manufacturer=manufacturer,
+            anatomy_zone=anatomy_zone, finding=finding, procedure=procedure, specialty=specialty,
+            approval_status=approval_status,
+        ),
+    }
+
+
+@router.get("/api/knowledge/articles/{article_id}")
+def get_article(
+    article_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    row = repository.record_view(db, tenant_id, article_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Knowledge article not found.")
+    db.commit()
+    return repository.article_to_dict(row)
+
+
+class ArticleUpdateIn(BaseModel):
+    title: str | None = Field(None, max_length=255)
+    body: str | None = None
+
+
+@router.patch("/api/knowledge/articles/{article_id}")
+def patch_article(
+    article_id: int, body: ArticleUpdateIn, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    row = repository.update_article(db, tenant_id, article_id, title=body.title, body=body.body)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Knowledge article not found.")
+    db.commit()
+    db.refresh(row)
+    return repository.article_to_dict(row)
+
+
+# ── Knowledge Governance (Deliverable 9) ────────────────────────────────────
+
+@router.post("/api/knowledge/articles/{article_id}/submit-for-review")
+def post_submit_for_review(
+    article_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    try:
+        row = governance.submit_for_review(db, tenant_id, article_id)
+    except governance.ArticleNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    db.commit()
+    return {"id": row.id, "approval_status": row.approval_status}
+
+
+@router.post("/api/knowledge/articles/{article_id}/approve")
+def post_approve_article(
+    article_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    try:
+        row = governance.approve_article(db, tenant_id, article_id, reviewer=_actor(current_user))
+    except governance.ArticleNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    db.commit()
+    return {"id": row.id, "approval_status": row.approval_status, "reviewer": row.reviewer}
+
+
+@router.post("/api/knowledge/articles/{article_id}/reject")
+def post_reject_article(
+    article_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    try:
+        row = governance.reject_article(db, tenant_id, article_id, reviewer=_actor(current_user))
+    except governance.ArticleNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    db.commit()
+    return {"id": row.id, "approval_status": row.approval_status, "reviewer": row.reviewer}
+
+
+@router.post("/api/knowledge/articles/{article_id}/archive")
+def post_archive_article(
+    article_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    try:
+        row = governance.archive_article(db, tenant_id, article_id, reviewer=_actor(current_user))
+    except governance.ArticleNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    db.commit()
+    return {"id": row.id, "approval_status": row.approval_status}
+
+
+@router.get("/api/knowledge/governance-summary")
+def get_governance_summary(
+    request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return governance.governance_summary(db, _tenant(current_user, request))
+
+
+# ── Clinical Case Library (Deliverable 2) ───────────────────────────────────
+
+@router.get("/api/knowledge/cases")
+def get_cases(
+    request: Request, instrument: str = "", finding: str = "", db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    return {"cases": list_cases(db, tenant_id, instrument=instrument, finding=finding)}
+
+
+@router.get("/api/knowledge/cases/{case_id}")
+def get_case_detail(
+    case_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    row = record_case_view(db, tenant_id, case_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Clinical case not found.")
+    db.commit()
+    return case_to_dict(row)
+
+
+@router.get("/api/inspections/{inspection_id}/similar-cases")
+def get_similar_cases(
+    inspection_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    finding_type = get_primary_finding_type(db, insp)
+    return {
+        "inspection_id": inspection_id,
+        "finding_type": finding_type,
+        "similar_cases": find_similar_cases(
+            db, tenant_id, instrument_type=insp.instrument_type, finding_type=finding_type,
+            exclude_inspection_id=inspection_id,
+        ),
+    }
+
+
+# ── Supervisor Knowledge Capture (Deliverable 3) ────────────────────────────
+
+class TeachingPointIn(BaseModel):
+    explanation: str = Field(..., min_length=1)
+    teaching_point: str = Field(..., min_length=1, max_length=255)
+    common_mistake: str = Field("", max_length=2000)
+    prevention_tip: str = Field("", max_length=2000)
+    references: str = Field("", max_length=2000)
+
+
+@router.post("/api/inspections/{inspection_id}/teaching-point", status_code=201)
+def post_teaching_point(
+    inspection_id: int, body: TeachingPointIn, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    """After a disposition override, a supervisor may capture what future
+    technicians should know. Authored by a supervisor at the point of a
+    real clinical decision, so it is auto-approved rather than routed
+    through the general review queue — the same authority already granted
+    to disposition overrides (v1.6)."""
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    finding_type = get_primary_finding_type(db, insp)
+
+    row = repository.create_article(
+        db, tenant_id=tenant_id, category=TEACHING_POINT, title=body.teaching_point, body=body.explanation,
+        author=_actor(current_user), applicable_instruments=[insp.instrument_type],
+        applicable_findings=[finding_type] if finding_type else [],
+        common_mistake=body.common_mistake, prevention_tip=body.prevention_tip, references=body.references,
+        source_inspection_id=inspection_id, approval_status="approved",
+    )
+    row.reviewer = _actor(current_user)
+    save_or_update_case(
+        db, tenant_id, insp, finding_type=finding_type,
+        educational_notes=f"{body.teaching_point}: {body.explanation}",
+    )
+    db.commit()
+    db.refresh(row)
+    return repository.article_to_dict(row)
+
+
+# ── Smart Knowledge Search (Deliverable 4) ──────────────────────────────────
+
+class SearchIn(BaseModel):
+    query: str = Field(..., min_length=1, max_length=500)
+
+
+@router.post("/api/knowledge/search")
+def post_search(
+    body: SearchIn, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    result = smart_search(db, tenant_id, body.query, actor=_actor(current_user))
+    db.commit()
+    return result
+
+
+# ── AI Knowledge Assistant (Deliverable 8) ──────────────────────────────────
+
+class AssistantIn(BaseModel):
+    question: str = Field(..., min_length=1, max_length=500)
+    instrument_type: str = Field("", max_length=100)
+
+
+@router.post("/api/knowledge/assistant")
+def post_assistant(
+    body: AssistantIn, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    result = answer_question(
+        db, tenant_id, body.question, instrument_type=body.instrument_type, actor=_actor(current_user),
+    )
+    db.commit()
+    return result
+
+
+# ── Organization Standards (Deliverable 6) ──────────────────────────────────
+
+class StandardIn(BaseModel):
+    standard_type: str = Field(..., description=f"One of {STANDARD_TYPES}")
+    title: str = Field(..., min_length=1, max_length=255)
+    description: str = Field(..., min_length=1)
+
+
+@router.post("/api/knowledge/standards", status_code=201)
+def post_standard(
+    body: StandardIn, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    if body.standard_type not in STANDARD_TYPES:
+        raise HTTPException(status_code=422, detail=f"standard_type must be one of {STANDARD_TYPES}")
+    tenant_id = _tenant(current_user, request)
+    row = standards.create_standard(
+        db, tenant_id, standard_type=body.standard_type, title=body.title, description=body.description,
+        created_by=_actor(current_user),
+    )
+    db.commit()
+    db.refresh(row)
+    return standards.standard_to_dict(row)
+
+
+@router.get("/api/knowledge/standards")
+def get_standards(
+    request: Request, standard_type: str = "", db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    return {"standards": standards.list_standards(db, tenant_id, standard_type=standard_type)}
+
+
+@router.post("/api/knowledge/standards/{standard_id}/deactivate")
+def post_deactivate_standard(
+    standard_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    row = standards.deactivate_standard(db, tenant_id, standard_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Organization standard not found.")
+    db.commit()
+    return standards.standard_to_dict(row)
+
+
+# ── Competency Knowledge Library (Deliverable 7) ────────────────────────────
+
+@router.get("/api/knowledge/competency-topics")
+def get_competency_topics(
+    request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    return {"topics": list_competency_topics(db, tenant_id)}
+
+
+@router.get("/api/knowledge/competency-topics/{finding_type}")
+def get_competency_topic(
+    finding_type: str, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    topic = competency_topic(db, tenant_id, finding_type)
+    if topic is None:
+        raise HTTPException(status_code=404, detail="No competency topic found for that finding type.")
+    return topic
+
+
+# ── Knowledge Analytics (Deliverable 10) ────────────────────────────────────
+
+@router.get("/api/knowledge/analytics")
+def get_knowledge_analytics(
+    request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return knowledge_analytics(db, _tenant(current_user, request))

--- a/backend/app/routes/knowledge_graph.py
+++ b/backend/app/routes/knowledge_graph.py
@@ -1,0 +1,112 @@
+"""Phase 21 — SPD Clinical Knowledge Graph & Clinical Reasoning Engine routes.
+
+Route: /knowledge-graph (frontend). API prefix below.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.services.instrument_family_profiles import INSTRUMENT_FAMILY_PROFILES
+from app.services.knowledge_graph_service import (
+    enterprise_knowledge_analytics,
+    explain_inspection,
+    explore,
+    get_instrument_family_intelligence,
+    graph_schema,
+    learning_confidence,
+    list_instrument_family_intelligence,
+    reasoning_chain,
+)
+
+router = APIRouter(prefix="/api/knowledge-graph", tags=["knowledge-graph"])
+
+_READ_ROLES = ("admin", "spd_manager", "operator", "viewer")
+
+
+@router.get("/schema")
+def get_graph_schema(current_user=Depends(require_roles(*_READ_ROLES))):
+    """Section 1 — node/relationship taxonomy."""
+    return graph_schema()
+
+
+@router.get("/instrument-families")
+def get_instrument_families(current_user=Depends(require_roles(*_READ_ROLES))):
+    """Section 3 — all ten instrument family knowledge profiles."""
+    return {"families": list_instrument_family_intelligence()}
+
+
+@router.get("/instrument-families/{family_key}")
+def get_instrument_family(family_key: str, current_user=Depends(require_roles(*_READ_ROLES))):
+    profile = get_instrument_family_intelligence(family_key)
+    if profile is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown instrument family '{family_key}'. Known families: {sorted(INSTRUMENT_FAMILY_PROFILES)}",
+        )
+    return profile
+
+
+@router.get("/reasoning-chain")
+def get_reasoning_chain(
+    instrument_type: str = Query(...),
+    finding_type: str = Query(...),
+    manufacturer: str = Query(""),
+    model: str = Query(""),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 2/5 — the traceable clinical reasoning chain."""
+    return reasoning_chain(instrument_type, finding_type, manufacturer, model)
+
+
+@router.get("/explain/{inspection_id}")
+def get_explainability_graph(
+    inspection_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 6 — the "Why?" explainability graph for one real inspection."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    insp = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id)
+        .first()
+    )
+    if insp is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    return explain_inspection(db, insp)
+
+
+@router.get("/explore")
+def get_explorer(
+    category: str = Query(..., description="manufacturer|instrument|model|finding|zone|failure_mode|recommendation|supervisor_learning"),
+    q: str = Query("", description="Optional search text"),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Section 7 — Knowledge Graph Explorer."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    return explore(db, tenant_id, category, q)
+
+
+@router.get("/analytics")
+def get_enterprise_analytics(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Section 8 — Enterprise Knowledge Analytics."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    return enterprise_knowledge_analytics(db, tenant_id)
+
+
+@router.get("/learning-confidence")
+def get_learning_confidence(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Section 9 — Continuous Knowledge Learning confidence signals."""
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    return learning_confidence(db, tenant_id)

--- a/backend/app/routes/pilot_deployment.py
+++ b/backend/app/routes/pilot_deployment.py
@@ -1,0 +1,128 @@
+"""v1.9 — Pilot Deployment Loop & Production Workflow Hardening.
+
+Distinct URL prefix (`/api/pilot-deployment/*`) from the existing
+`/api/pilot/*` P14 commercial pilot-conversion routes (`routes/pilot.py`,
+a trial-subscription concept) — this module is about the first
+real-world SPD site's operational readiness, an unrelated domain that
+happens to share the English word "pilot".
+
+- GET/PUT /api/pilot-deployment/site-config     — Deliverable 4
+- POST    /api/pilot-deployment/error-log        — Deliverable 7
+- GET     /api/pilot-deployment/data-collection  — Deliverable 6
+- GET     /api/inspections/{id}/data-quality     — Deliverable 5
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.pilot_error_log import ERROR_TYPES
+from app.services.data_quality_guardrails_service import evaluate_data_quality
+from app.services.pilot_data_collection_service import pilot_data_collection_summary
+from app.services.pilot_error_log_service import log_error
+from app.services.pilot_site_config_service import config_to_dict, get_or_create_config, update_config
+
+router = APIRouter(tags=["pilot-deployment"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+@router.get("/api/pilot-deployment/site-config")
+def get_site_config(
+    request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    row = get_or_create_config(db, tenant_id)
+    db.commit()
+    return config_to_dict(row)
+
+
+class SiteConfigIn(BaseModel):
+    facility_name: str | None = Field(None, max_length=255)
+    department: str | None = Field(None, max_length=255)
+    enabled_instrument_families: list[str] | None = None
+    required_inspection_zones: list[str] | None = None
+    baseline_required: bool | None = None
+    minimum_coverage_pct: int | None = Field(None, ge=0, le=100)
+    supervisor_review_threshold_score: int | None = Field(None, ge=0, le=100)
+
+
+@router.put("/api/pilot-deployment/site-config")
+def put_site_config(
+    body: SiteConfigIn, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin")),
+):
+    tenant_id = _tenant(current_user, request)
+    row = update_config(
+        db, tenant_id, updated_by=_actor(current_user), facility_name=body.facility_name,
+        department=body.department, enabled_instrument_families=body.enabled_instrument_families,
+        required_inspection_zones=body.required_inspection_zones, baseline_required=body.baseline_required,
+        minimum_coverage_pct=body.minimum_coverage_pct,
+        supervisor_review_threshold_score=body.supervisor_review_threshold_score,
+    )
+    db.commit()
+    db.refresh(row)
+    return config_to_dict(row)
+
+
+class ErrorLogIn(BaseModel):
+    error_type: str = Field(..., description=f"One of {ERROR_TYPES}")
+    detail: str = Field("", max_length=500)
+    inspection_id: int | None = None
+
+
+@router.post("/api/pilot-deployment/error-log", status_code=201)
+def post_error_log(
+    body: ErrorLogIn, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    if body.error_type not in ERROR_TYPES:
+        raise HTTPException(status_code=422, detail=f"error_type must be one of {ERROR_TYPES}")
+    tenant_id = _tenant(current_user, request)
+    row = log_error(
+        db, tenant_id=tenant_id, error_type=body.error_type, detail=body.detail,
+        actor_role=getattr(current_user, "role", ""), inspection_id=body.inspection_id,
+    )
+    db.commit()
+    return {"logged": row is not None}
+
+
+@router.get("/api/pilot-deployment/data-collection")
+def get_data_collection(
+    request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return pilot_data_collection_summary(db, _tenant(current_user, request))
+
+
+@router.get("/api/inspections/{inspection_id}/data-quality")
+def get_inspection_data_quality(
+    inspection_id: int, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id)
+        .first()
+    )
+    if insp is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    config = get_or_create_config(db, tenant_id)
+    db.commit()
+    return evaluate_data_quality(insp, pilot_config=config)

--- a/backend/app/routes/pre_sterilization_command_center.py
+++ b/backend/app/routes/pre_sterilization_command_center.py
@@ -1,0 +1,177 @@
+"""Pre-Sterilization Command Center — the executive and operational view of
+whether instruments, trays, departments, and facilities are clinically
+ready to proceed to packaging and sterilization.
+
+Route: /pre-sterilization-command-center (frontend). API prefix below.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.services.pre_sterilization_command_center_service import (
+    _annotate,
+    _reviewed_ids,
+    baseline_coverage,
+    clinical_inspection_readiness,
+    executive_risk_dashboard,
+    facility_readiness,
+    high_risk_findings_queue,
+    instrument_readiness,
+    missing_zone_coverage_queue,
+    repair_remove_queue,
+    supervisor_review_queue,
+    tray_readiness,
+)
+
+router = APIRouter(prefix="/api/pre-sterilization-command-center", tags=["pre-sterilization-command-center"])
+
+_READ_ROLES = ("admin", "spd_manager", "operator", "viewer")
+
+
+def _tenant_cases(db: Session, current_user) -> tuple[str, list]:
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    cases = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id)
+        .order_by(models.Inspection.created_at.desc())
+        .limit(5000)
+        .all()
+    )
+    return tenant_id, cases
+
+
+def _tenant_annotated(db: Session, current_user) -> tuple[str, list, list[dict]]:
+    tenant_id, cases = _tenant_cases(db, current_user)
+    reviewed_ids = _reviewed_ids(db, tenant_id)
+    annotated = _annotate(cases, reviewed_ids)
+    return tenant_id, cases, annotated
+
+
+@router.get("/clinical-inspection-readiness")
+def get_clinical_inspection_readiness(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 1 — Clinical Inspection Readiness Score."""
+    tenant_id, _, annotated = _tenant_annotated(db, current_user)
+    return {"tenant_id": tenant_id, **clinical_inspection_readiness(annotated)}
+
+
+@router.get("/tray-readiness")
+def get_tray_readiness(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 2 — Tray Readiness Score."""
+    tenant_id, _, annotated = _tenant_annotated(db, current_user)
+    return {"tenant_id": tenant_id, "trays": tray_readiness(annotated)}
+
+
+@router.get("/instrument-readiness")
+def get_instrument_readiness(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 3 — Instrument Readiness Score."""
+    tenant_id, _, annotated = _tenant_annotated(db, current_user)
+    return {"tenant_id": tenant_id, "instruments": instrument_readiness(annotated)}
+
+
+@router.get("/facility-readiness")
+def get_facility_readiness(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 4 — Facility Readiness Score."""
+    tenant_id, _, annotated = _tenant_annotated(db, current_user)
+    return {"tenant_id": tenant_id, "facilities": facility_readiness(annotated)}
+
+
+@router.get("/high-risk-findings")
+def get_high_risk_findings(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 5 — High-Risk Findings Queue."""
+    tenant_id, _, annotated = _tenant_annotated(db, current_user)
+    items = high_risk_findings_queue(annotated)
+    return {"tenant_id": tenant_id, "count": len(items), "items": items}
+
+
+@router.get("/supervisor-review-queue")
+def get_supervisor_review_queue(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 6 — Supervisor Review Queue."""
+    tenant_id, _, annotated = _tenant_annotated(db, current_user)
+    items = supervisor_review_queue(annotated)
+    return {"tenant_id": tenant_id, "count": len(items), "items": items}
+
+
+@router.get("/missing-zone-coverage")
+def get_missing_zone_coverage(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 7 — Missing Anatomy Zone Coverage."""
+    tenant_id, cases = _tenant_cases(db, current_user)
+    items = missing_zone_coverage_queue(cases)
+    return {"tenant_id": tenant_id, "count": len(items), "items": items}
+
+
+@router.get("/baseline-coverage")
+def get_baseline_coverage(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 8 — Baseline Coverage."""
+    tenant_id, cases = _tenant_cases(db, current_user)
+    return {"tenant_id": tenant_id, **baseline_coverage(db, tenant_id, cases)}
+
+
+@router.get("/repair-remove-queue")
+def get_repair_remove_queue(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 9 — Repair / Remove From Service Queue."""
+    tenant_id, _, annotated = _tenant_annotated(db, current_user)
+    return {"tenant_id": tenant_id, **repair_remove_queue(annotated)}
+
+
+@router.get("/executive-risk-dashboard")
+def get_executive_risk_dashboard(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Module 10 — Executive Risk Dashboard."""
+    tenant_id, cases, annotated = _tenant_annotated(db, current_user)
+    return {"tenant_id": tenant_id, **executive_risk_dashboard(db, tenant_id, cases, annotated)}
+
+
+@router.get("/dashboard")
+def get_full_dashboard(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """Aggregator — all ten modules in one call for the command-center page."""
+    tenant_id, cases, annotated = _tenant_annotated(db, current_user)
+    return {
+        "tenant_id": tenant_id,
+        "clinical_inspection_readiness": clinical_inspection_readiness(annotated),
+        "tray_readiness": tray_readiness(annotated),
+        "instrument_readiness": instrument_readiness(annotated),
+        "facility_readiness": facility_readiness(annotated),
+        "high_risk_findings_queue": high_risk_findings_queue(annotated),
+        "supervisor_review_queue": supervisor_review_queue(annotated),
+        "missing_zone_coverage_queue": missing_zone_coverage_queue(cases),
+        "baseline_coverage": baseline_coverage(db, tenant_id, cases),
+        "repair_remove_queue": repair_remove_queue(annotated),
+        "executive_risk_dashboard": executive_risk_dashboard(db, tenant_id, cases, annotated),
+        "human_review_required": True,
+    }

--- a/backend/app/routes/quality_dashboard.py
+++ b/backend/app/routes/quality_dashboard.py
@@ -1,0 +1,253 @@
+"""v1.5 — Quality Intelligence & Continuous Improvement API surface.
+
+- GET  /api/quality/dashboard                — Deliverable 1: KPI dashboard
+- GET  /api/quality/finding-trends           — Deliverable 2: finding trend intelligence
+- GET  /api/quality/anatomy-risk             — Deliverable 3: anatomy risk dashboard
+- GET  /api/quality/instrument-performance   — Deliverable 4: instrument family performance
+- GET  /api/quality/technician-quality       — Deliverable 5: technician quality (leadership only)
+- GET  /api/quality/supervisor-quality       — Deliverable 6: supervisor quality
+- POST /api/quality/root-cause               — Deliverable 7: assign a root cause
+- GET  /api/quality/root-cause-trends        — Deliverable 7: root cause trends
+- GET  /api/quality/capa-suggestions         — Deliverable 8: CAPA suggestions
+- POST /api/quality/capa-suggestions/create  — Deliverable 8: materialize a suggestion into a real CAPA
+- GET  /api/quality/benchmark                — Deliverable 9: period-over-period benchmarking
+- GET  /api/quality/executive-score          — Deliverable 10: executive quality score
+- GET/POST/PATCH /api/quality/improvement-initiatives — Deliverable 11: continuous improvement tracker
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.root_cause import ROOT_CAUSES
+from app.services.anatomy_risk_service import anatomy_risk_dashboard
+from app.services.capa_suggestion_service import create_capa_from_suggestion, generate_capa_suggestions
+from app.services.competency_service import technician_quality_dashboard
+from app.services.continuous_improvement_service import (
+    create_initiative, list_initiatives, update_initiative,
+)
+from app.services.finding_trend_service import finding_trends
+from app.services.instrument_performance_service import instrument_family_performance
+from app.services.quality_dashboard_service import benchmark, dashboard_summary, executive_quality_score
+from app.services.root_cause_service import assign_root_cause, root_cause_trends
+from app.services.supervisor_quality_service import supervisor_quality_dashboard
+
+router = APIRouter(prefix="/api/quality", tags=["quality-intelligence"])
+
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+@router.get("/dashboard")
+def get_dashboard(
+    request: Request,
+    period: str = "all_time",
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return dashboard_summary(db, _tenant(current_user, request), period)
+
+
+@router.get("/finding-trends")
+def get_finding_trends(
+    request: Request,
+    granularity: str = "monthly",
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return finding_trends(db, _tenant(current_user, request), granularity)
+
+
+@router.get("/anatomy-risk")
+def get_anatomy_risk(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return anatomy_risk_dashboard(db, _tenant(current_user, request))
+
+
+@router.get("/instrument-performance")
+def get_instrument_performance(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return instrument_family_performance(db, _tenant(current_user, request))
+
+
+@router.get("/technician-quality")
+def get_technician_quality(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    """Only visible to authorized leadership (admin/spd_manager)."""
+    return technician_quality_dashboard(db, _tenant(current_user, request))
+
+
+@router.get("/supervisor-quality")
+def get_supervisor_quality(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return supervisor_quality_dashboard(db, _tenant(current_user, request))
+
+
+class RootCauseIn(BaseModel):
+    inspection_id: int
+    finding_type: str = Field(..., max_length=40)
+    root_cause: str = Field(..., max_length=40)
+
+
+@router.post("/root-cause", status_code=201)
+def post_root_cause(
+    body: RootCauseIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    if body.root_cause not in ROOT_CAUSES:
+        raise HTTPException(status_code=422, detail=f"root_cause must be one of {ROOT_CAUSES}")
+    row = assign_root_cause(
+        db, tenant_id=_tenant(current_user, request), inspection_id=body.inspection_id,
+        finding_type=body.finding_type, root_cause=body.root_cause, assigned_by=_actor(current_user),
+    )
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id, "root_cause": row.root_cause, "finding_type": row.finding_type}
+
+
+@router.get("/root-cause-trends")
+def get_root_cause_trends(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return root_cause_trends(db, _tenant(current_user, request))
+
+
+@router.get("/capa-suggestions")
+def get_capa_suggestions(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return {"suggestions": generate_capa_suggestions(db, _tenant(current_user, request))}
+
+
+class CapaSuggestionIn(BaseModel):
+    trigger: str
+    occurrences: int
+    recommendation: str
+    suggested_title: str
+    corrective_action: str
+    preventive_action: str
+
+
+@router.post("/capa-suggestions/create", status_code=201)
+def post_capa_from_suggestion(
+    body: CapaSuggestionIn,
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    capa = create_capa_from_suggestion(body.model_dump(), owner=_actor(current_user))
+    return capa
+
+
+@router.get("/benchmark")
+def get_benchmark(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return benchmark(db, _tenant(current_user, request))
+
+
+@router.get("/executive-score")
+def get_executive_score(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return executive_quality_score(db, _tenant(current_user, request))
+
+
+class InitiativeIn(BaseModel):
+    initiative: str = Field(..., max_length=500)
+    owner: str = Field("", max_length=255)
+    target_date: date | None = None
+    expected_impact: str = Field("", max_length=2000)
+
+
+class InitiativeUpdateIn(BaseModel):
+    status: str | None = Field(None, max_length=20)
+    actual_impact: str | None = Field(None, max_length=2000)
+
+
+@router.get("/improvement-initiatives")
+def get_initiatives(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    rows = list_initiatives(db, _tenant(current_user, request))
+    return {
+        "initiatives": [
+            {
+                "id": r.id, "initiative": r.initiative, "owner": r.owner,
+                "target_date": r.target_date.isoformat() if r.target_date else None,
+                "status": r.status, "expected_impact": r.expected_impact,
+                "actual_impact": r.actual_impact,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.post("/improvement-initiatives", status_code=201)
+def post_initiative(
+    body: InitiativeIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    row = create_initiative(
+        db, tenant_id=_tenant(current_user, request), initiative=body.initiative,
+        owner=body.owner, target_date=body.target_date, expected_impact=body.expected_impact,
+    )
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id, "initiative": row.initiative, "status": row.status}
+
+
+@router.patch("/improvement-initiatives/{initiative_id}")
+def patch_initiative(
+    initiative_id: int,
+    body: InitiativeUpdateIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    row = update_initiative(
+        db, initiative_id=initiative_id, tenant_id=_tenant(current_user, request),
+        status=body.status, actual_impact=body.actual_impact,
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Initiative not found.")
+    db.commit()
+    return {"id": row.id, "status": row.status, "actual_impact": row.actual_impact}

--- a/backend/app/routes/spd_mentor.py
+++ b/backend/app/routes/spd_mentor.py
@@ -1,0 +1,232 @@
+"""v1.4 — SPD Mentor Engine API surface.
+
+- GET  /api/mentor/education                      — Educational Knowledge Library (all articles)
+- GET  /api/mentor/education/{finding_type}        — single article
+- POST /api/mentor/education/{finding_type}/complete — mark an article completed (competency tracking)
+- GET  /api/mentor/competency/{technician}         — technician competency summary
+- GET  /api/inspections/{inspection_id}/mentor     — re-derive the SPD Mentor payload for a past inspection
+- GET  /api/mentor/coaching-queue                  — Supervisor Coaching Dashboard: inspections awaiting review
+- POST /api/inspections/{inspection_id}/coaching-review — approve/edit/comment on the AI's coaching
+- GET  /api/mentor/coaching-effectiveness          — aggregate coaching-review stats
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.mentor_coaching_review import MentorCoachingReview
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.competency_service import competency_summary, record_education_completed
+from app.services.education_library import get_article, list_articles
+
+router = APIRouter(tags=["spd-mentor"])
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+# ── Educational Knowledge Library ────────────────────────────────────────────
+@router.get("/mentor/education")
+def get_education_library(
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    return {"articles": list_articles()}
+
+
+@router.get("/mentor/education/{finding_type}")
+def get_education_article(
+    finding_type: str,
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    article = get_article(finding_type)
+    if article is None:
+        raise HTTPException(status_code=404, detail=f"No education article for '{finding_type}'.")
+    return article
+
+
+@router.post("/mentor/education/{finding_type}/complete", status_code=201)
+def complete_education_article(
+    finding_type: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator")),
+):
+    article = get_article(finding_type)
+    if article is None:
+        raise HTTPException(status_code=404, detail=f"No education article for '{finding_type}'.")
+
+    technician = _actor(current_user)
+    tenant_id = getattr(current_user, "tenant_id", None) or "default-tenant"
+    record_education_completed(db, tenant_id=tenant_id, technician=technician, finding_type=finding_type)
+    db.commit()
+    return competency_summary(db, technician)
+
+
+# ── Competency Support ────────────────────────────────────────────────────────
+@router.get("/mentor/competency/{technician}")
+def get_competency_summary(
+    technician: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator")),
+):
+    role = getattr(current_user, "role", "viewer")
+    if role not in ("admin", "spd_manager") and _actor(current_user) != technician:
+        raise HTTPException(status_code=403, detail="You may only view your own competency summary.")
+    return competency_summary(db, technician)
+
+
+# ── Per-inspection mentor re-derivation (Training Mode viewer) ───────────────
+@router.get("/inspections/{inspection_id}/mentor")
+def get_inspection_mentor(
+    inspection_id: int,
+    request: Request,
+    training_mode: bool = False,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Re-derive the SPD Mentor payload for a previously-submitted inspection.
+
+    Mirrors the clinical-report.pdf endpoint's pattern: analysis is
+    deterministic from the stored inspection's identity, so re-running it
+    reproduces the same findings — this lets a technician revisit an
+    inspection with Training Mode on without re-uploading images.
+    """
+    tenant_id = getattr(current_user, "tenant_id", None)
+    query = db.query(models.Inspection).filter(models.Inspection.id == inspection_id)
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    row = query.first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    analysis = analyze_inspection(
+        db,
+        instrument_type=row.instrument_type,
+        tenant_id=row.tenant_id,
+        has_image=bool(row.has_image),
+        image_sha256=row.image_sha256,
+        instrument_barcode=row.instrument_barcode,
+        instrument_udi=row.instrument_udi,
+        training_mode=training_mode,
+    )
+    return analysis["clinical_decision"]["spd_mentor"]
+
+
+# ── Supervisor Coaching Dashboard ─────────────────────────────────────────────
+class CoachingReviewIn(BaseModel):
+    approved: bool = Field(True)
+    edited_recommendation: str = Field("", max_length=1000)
+    educational_comment: str = Field("", max_length=2000)
+
+
+@router.get("/mentor/coaching-queue")
+def get_coaching_queue(
+    request: Request,
+    limit: int = 25,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Recent inspections whose AI coaching has not yet been reviewed by a
+    supervisor, most recent first."""
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    query = db.query(models.Inspection).filter(models.Inspection.has_image.is_(True))
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(models.Inspection.tenant_id == tenant_id)
+    rows = query.order_by(models.Inspection.id.desc()).limit(max(1, min(limit, 100))).all()
+
+    reviewed_ids = {
+        r.inspection_id
+        for r in db.query(MentorCoachingReview.inspection_id)
+        .filter(MentorCoachingReview.inspection_id.in_([row.id for row in rows]))
+        .all()
+    } if rows else set()
+
+    return {
+        "queue": [
+            {
+                "inspection_id": row.id,
+                "instrument_type": row.instrument_type,
+                "technician": row.technician,
+                "risk_level": row.risk_level,
+                "recommended_action": row.recommended_action,
+                "coaching_reviewed": row.id in reviewed_ids,
+            }
+            for row in rows
+        ],
+    }
+
+
+@router.post("/inspections/{inspection_id}/coaching-review", status_code=201)
+def submit_coaching_review(
+    inspection_id: int,
+    body: CoachingReviewIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    inspection = db.query(models.Inspection).filter(models.Inspection.id == inspection_id).first()
+    if inspection is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+
+    review = MentorCoachingReview(
+        inspection_id=inspection_id,
+        tenant_id=tenant_id,
+        reviewer_name=_actor(current_user),
+        reviewer_role=getattr(current_user, "role", "spd_manager"),
+        approved=body.approved,
+        edited_recommendation=body.edited_recommendation.strip(),
+        educational_comment=body.educational_comment.strip(),
+    )
+    db.add(review)
+    db.commit()
+    db.refresh(review)
+
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id,
+        actor_email=_actor(current_user), actor_role=getattr(current_user, "role", "spd_manager"),
+        action_type="mentor_coaching_review", resource_type="inspection",
+        resource_id=str(inspection_id),
+    )
+    return {
+        "id": review.id,
+        "inspection_id": inspection_id,
+        "approved": review.approved,
+        "edited_recommendation": review.edited_recommendation,
+        "educational_comment": review.educational_comment,
+    }
+
+
+@router.get("/mentor/coaching-effectiveness")
+def get_coaching_effectiveness(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("admin", "spd_manager")),
+):
+    """Aggregate stats on how often supervisors approve the AI's coaching
+    unchanged vs. edit or add educational comments — derived only from
+    recorded reviews, empty when there are none yet."""
+    tenant_id = getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+    query = db.query(MentorCoachingReview)
+    if tenant_id and getattr(current_user, "role", "") != "admin":
+        query = query.filter(MentorCoachingReview.tenant_id == tenant_id)
+    reviews = query.all()
+
+    total = len(reviews)
+    approved_unchanged = sum(1 for r in reviews if r.approved and not r.edited_recommendation)
+    edited = sum(1 for r in reviews if r.edited_recommendation)
+    with_comment = sum(1 for r in reviews if r.educational_comment)
+
+    return {
+        "total_reviews": total,
+        "approved_unchanged": approved_unchanged,
+        "edited": edited,
+        "with_educational_comment": with_comment,
+        "approved_unchanged_pct": round(100 * approved_unchanged / total) if total else None,
+    }

--- a/backend/app/routes/spd_mentor.py
+++ b/backend/app/routes/spd_mentor.py
@@ -5,6 +5,7 @@
 - POST /api/mentor/education/{finding_type}/complete — mark an article completed (competency tracking)
 - GET  /api/mentor/competency/{technician}         — technician competency summary
 - GET  /api/inspections/{inspection_id}/mentor     — re-derive the SPD Mentor payload for a past inspection
+- POST /api/mentor/build                           — rebuild the SPD Mentor payload from an already-displayed result (no re-derivation)
 - GET  /api/mentor/coaching-queue                  — Supervisor Coaching Dashboard: inspections awaiting review
 - POST /api/inspections/{inspection_id}/coaching-review — approve/edit/comment on the AI's coaching
 - GET  /api/mentor/coaching-effectiveness          — aggregate coaching-review stats
@@ -96,6 +97,15 @@ def get_inspection_mentor(
     deterministic from the stored inspection's identity, so re-running it
     reproduces the same findings — this lets a technician revisit an
     inspection with Training Mode on without re-uploading images.
+
+    Caveat (shared with clinical-report.pdf): technician-declared finding
+    categories are not persisted on the Inspection row, so if the original
+    analysis was biased by a declared finding, this re-derivation can differ
+    from what was originally shown. The Training Mode toggle on a
+    just-submitted inspection uses POST /mentor/build instead, which
+    reconstructs the payload from the exact result already on screen — use
+    this endpoint only when that client-side result isn't available (e.g.
+    revisiting history later).
     """
     tenant_id = getattr(current_user, "tenant_id", None)
     query = db.query(models.Inspection).filter(models.Inspection.id == inspection_id)
@@ -116,6 +126,28 @@ def get_inspection_mentor(
         training_mode=training_mode,
     )
     return analysis["clinical_decision"]["spd_mentor"]
+
+
+class MentorBuildIn(BaseModel):
+    result: dict = Field(..., description="The raw analysis result already shown on screen.")
+    overall: str = Field(..., description="The clinical_decision.overall_result already shown on screen.")
+
+
+@router.post("/mentor/build")
+def build_mentor_from_client_result(
+    body: MentorBuildIn,
+    training_mode: bool = False,
+    current_user=Depends(require_roles("admin", "spd_manager", "operator", "viewer")),
+):
+    """Rebuild the SPD Mentor payload for the exact result already displayed
+    client-side (from a just-submitted inspection). Purely a re-format of
+    data the caller already has — no DB re-derivation, so toggling Training
+    Mode can never change the findings or disposition being explained,
+    unlike GET /inspections/{id}/mentor's best-effort re-derivation.
+    """
+    from app.services.spd_mentor_engine import build_spd_mentor
+
+    return build_spd_mentor(body.result, body.overall, training_mode=training_mode)
 
 
 # ── Supervisor Coaching Dashboard ─────────────────────────────────────────────

--- a/backend/app/routes/workflow.py
+++ b/backend/app/routes/workflow.py
@@ -1,0 +1,289 @@
+"""v1.7 — Workflow Intelligence & Smart Work Queue.
+
+- GET  /api/inspection-work-queue                     — Deliverable 1
+- GET  /api/operations-board                          — Deliverable 5
+- POST /api/inspections/{id}/assign                   — Deliverable 3
+- GET  /api/inspections/{id}/assignments              — Deliverable 3 (history)
+- GET  /api/inspections/{id}/workflow-state            — Deliverable 4 (history)
+- POST /api/inspections/{id}/workflow/cancel           — Deliverable 4
+- GET  /api/workflow/technician-workload               — Deliverable 3
+- GET  /api/workflow/sla-monitoring                    — Deliverable 6
+- GET  /api/workflow/escalations                       — Deliverable 7
+- GET  /api/workflow/daily-dashboard                   — Deliverable 8
+- GET  /api/workflow/shift-handoff                     — Deliverable 9
+- GET  /api/workflow/notifications                     — Deliverable 10
+- POST /api/workflow/notifications/generate            — Deliverable 10
+- POST /api/workflow/notifications/{id}/read           — Deliverable 10
+- GET  /api/workflow/analytics                         — Deliverable 11
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.db import models
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.services import workflow_state_service
+from app.services.daily_operations_dashboard_service import daily_operations_dashboard
+from app.services.escalation_engine import escalation_queue
+from app.services.operational_analytics_service import operational_analytics
+from app.services.operations_board_service import operations_board
+from app.services.shift_handoff_service import shift_handoff_report
+from app.services.sla_monitoring_service import sla_monitoring
+from app.services.technician_workload_service import technician_workload
+from app.services.work_queue_service import build_work_queue
+from app.services.workflow_notification_service import (
+    generate_workflow_notifications, list_notifications, mark_read,
+)
+
+router = APIRouter(tags=["workflow-intelligence"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _actor(user) -> str:
+    return getattr(user, "email", None) or getattr(user, "username", "unknown")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+def _get_inspection(db: Session, tenant_id: str, inspection_id: int):
+    insp = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id)
+        .first()
+    )
+    if insp is None:
+        raise HTTPException(status_code=404, detail="Inspection not found.")
+    return insp
+
+
+@router.get("/api/inspection-work-queue")
+def get_inspection_work_queue(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return build_work_queue(db, _tenant(current_user, request))
+
+
+@router.get("/api/operations-board")
+def get_operations_board(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return operations_board(db, _tenant(current_user, request))
+
+
+class AssignmentIn(BaseModel):
+    technician: str = Field(..., min_length=1, max_length=255)
+    note: str = Field("", max_length=500)
+
+
+@router.post("/api/inspections/{inspection_id}/assign", status_code=201)
+def post_assignment(
+    inspection_id: int,
+    body: AssignmentIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+
+    row = workflow_state_service.assign_technician(
+        db, insp=insp, tenant_id=tenant_id, technician=body.technician,
+        assigned_by=_actor(current_user), note=body.note,
+    )
+
+    from app.services.workflow_notification_service import notify
+    notify(
+        db, tenant_id=tenant_id, inspection_id=inspection_id, notification_type="inspection_assigned",
+        recipient_role="operator", recipient_name=body.technician,
+        message=f"Inspection #{inspection_id} ({insp.instrument_type}) assigned to you.",
+    )
+
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id, "inspection_id": row.inspection_id, "technician": row.technician, "assigned_by": row.assigned_by}
+
+
+@router.get("/api/inspections/{inspection_id}/assignments")
+def get_assignments(
+    inspection_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    _get_inspection(db, tenant_id, inspection_id)
+    from app.models.workflow import InspectionAssignment
+
+    rows = (
+        db.query(InspectionAssignment)
+        .filter(InspectionAssignment.tenant_id == tenant_id, InspectionAssignment.inspection_id == inspection_id)
+        .order_by(InspectionAssignment.id.desc())
+        .all()
+    )
+    return {
+        "assignments": [
+            {
+                "id": r.id, "technician": r.technician, "assigned_by": r.assigned_by, "note": r.note,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.get("/api/inspections/{inspection_id}/workflow-state")
+def get_workflow_state(
+    inspection_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    history = workflow_state_service.state_history(db, inspection_id)
+    return {
+        "inspection_id": inspection_id,
+        "current_state": workflow_state_service.current_state(db, insp),
+        "history": [
+            {
+                "from_state": e.from_state, "to_state": e.to_state, "actor": e.actor, "reason": e.reason,
+                "created_at": e.created_at.isoformat() if e.created_at else None,
+            }
+            for e in history
+        ],
+    }
+
+
+class CancelIn(BaseModel):
+    reason: str = Field(..., min_length=1, max_length=500)
+
+
+@router.post("/api/inspections/{inspection_id}/workflow/cancel", status_code=201)
+def post_cancel_inspection(
+    inspection_id: int,
+    body: CancelIn,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    insp = _get_inspection(db, tenant_id, inspection_id)
+    event = workflow_state_service.cancel_inspection(
+        db, insp=insp, tenant_id=tenant_id, actor=_actor(current_user), reason=body.reason,
+    )
+    db.commit()
+    db.refresh(event)
+    return {"inspection_id": inspection_id, "to_state": event.to_state, "reason": event.reason}
+
+
+@router.get("/api/workflow/technician-workload")
+def get_technician_workload(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return technician_workload(db, _tenant(current_user, request))
+
+
+@router.get("/api/workflow/sla-monitoring")
+def get_sla_monitoring(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return sla_monitoring(db, _tenant(current_user, request))
+
+
+@router.get("/api/workflow/escalations")
+def get_escalations(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return escalation_queue(db, _tenant(current_user, request))
+
+
+@router.get("/api/workflow/daily-dashboard")
+def get_daily_dashboard(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return daily_operations_dashboard(db, _tenant(current_user, request))
+
+
+@router.get("/api/workflow/shift-handoff")
+def get_shift_handoff(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return shift_handoff_report(db, _tenant(current_user, request), shift_actor=_actor(current_user))
+
+
+@router.get("/api/workflow/notifications")
+def get_notifications(
+    request: Request,
+    unread_only: bool = False,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    role = getattr(current_user, "role", "viewer")
+    rows = list_notifications(db, tenant_id, recipient_role=role, unread_only=unread_only)
+    return {
+        "notifications": [
+            {
+                "id": n.id, "inspection_id": n.inspection_id, "notification_type": n.notification_type,
+                "recipient_role": n.recipient_role, "recipient_name": n.recipient_name, "message": n.message,
+                "read": n.read, "created_at": n.created_at.isoformat() if n.created_at else None,
+            }
+            for n in rows
+        ],
+    }
+
+
+@router.post("/api/workflow/notifications/generate")
+def post_generate_notifications(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return generate_workflow_notifications(db, _tenant(current_user, request))
+
+
+@router.post("/api/workflow/notifications/{notification_id}/read")
+def post_mark_notification_read(
+    notification_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    row = mark_read(db, tenant_id, notification_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Notification not found.")
+    db.commit()
+    return {"id": row.id, "read": row.read}
+
+
+@router.get("/api/workflow/analytics")
+def get_operational_analytics(
+    request: Request,
+    days: int = 30,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    return operational_analytics(db, _tenant(current_user, request), days=days)

--- a/backend/app/services/ai_knowledge_assistant_service.py
+++ b/backend/app/services/ai_knowledge_assistant_service.py
@@ -1,0 +1,69 @@
+"""v1.8 — AI Knowledge Assistant (Deliverable 8).
+
+Answers contextual technician questions using existing structured
+knowledge — finding education (the Knowledge Graph's own source), approved
+institutional knowledge (KnowledgeArticle), and instrument anatomy
+profiles — the same deterministic, source-grounded pattern already used by
+`knowledge_graph_service.reasoning_chain()`, never a call to an external
+LLM. Every answer lists exactly which sources it drew from, so nothing is
+presented as authoritative without a traceable origin.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import KnowledgeQueryLog
+from app.services.clinical_mentor import FINDING_EDUCATION
+from app.services.instrument_anatomy import get_anatomy, resolve_family
+from app.services.knowledge_repository_service import list_articles
+from app.services.knowledge_search_service import _matched_families, _matched_findings, _matched_zones
+
+
+def answer_question(db: Session, tenant_id: str, question: str, *, instrument_type: str = "", actor: str = "") -> dict:
+    """Deliverable 8 — a grounded answer plus the sources it came from."""
+    q = (question or "").strip().lower()
+    findings = _matched_findings(q)
+    zones = _matched_zones(q)
+    families = _matched_families(q) or ([resolve_family(instrument_type)] if instrument_type else [])
+    families = [f for f in families if f != "default"]
+
+    sources: list[str] = []
+    answer_parts: list[str] = []
+
+    for finding in findings:
+        edu = FINDING_EDUCATION.get(finding, {})
+        if edu:
+            answer_parts.append(
+                f"{finding.replace('_', ' ').capitalize()}: {edu.get('clinical_significance') or edu.get('why_it_matters', '')}"
+            )
+            sources.append("Knowledge Graph / finding education")
+        for a in list_articles(db, tenant_id, finding=finding, approval_status="approved")[:3]:
+            answer_parts.append(f"Institutional guidance ({a['title']}): {a['body']}")
+            sources.append(f"Approved institutional article #{a['id']}")
+
+    for family in families:
+        anatomy = get_anatomy(family)
+        high_risk_zones = [z["zone_name"] for z in anatomy.get("zones", []) if z.get("zone_risk_level") in ("high", "critical")]
+        if high_risk_zones:
+            answer_parts.append(
+                f"For the {family.replace('_', ' ')} family, the high-risk anatomy zones are: {', '.join(high_risk_zones)}."
+            )
+            sources.append("Instrument anatomy profile")
+
+    if not answer_parts:
+        answer_parts.append(
+            "No matching institutional knowledge, finding education, or anatomy profile was found for this "
+            "question — consider adding it to the Knowledge Repository once answered."
+        )
+
+    db.add(KnowledgeQueryLog(tenant_id=tenant_id, actor=actor, query_text=question, matched_category="assistant"))
+
+    return {
+        "question": question,
+        "answer": " ".join(answer_parts),
+        "matched_findings": findings,
+        "matched_zones": zones,
+        "matched_instrument_families": families,
+        "sources": sources,
+        "human_review_required": True,
+    }

--- a/backend/app/services/anatomy_risk_service.py
+++ b/backend/app/services/anatomy_risk_service.py
@@ -1,0 +1,82 @@
+"""v1.5 — Anatomy Risk Dashboard (Deliverable 3).
+
+Highest-risk anatomy zones, most frequent contamination/damage by zone, and
+most-missed inspection zones — derived from real InspectionFinding rows (what
+was actually detected, where) and Inspection Coverage Engine data (what was
+actually missing), not a generic anatomy taxonomy guess.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.inspection_finding import InspectionFinding
+
+
+def _contamination_types() -> set[str]:
+    from app.services.baseline_comparison_scoring_service import CLEANING_KPIS
+    return set(CLEANING_KPIS)
+
+
+def anatomy_risk_dashboard(db: Session, tenant_id: str, days: int = 180) -> dict:
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    findings = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.tenant_id == tenant_id, InspectionFinding.created_at >= since)
+        .all()
+    )
+    contamination = _contamination_types()
+
+    zone_counts: dict[str, int] = defaultdict(int)
+    zone_contamination: dict[str, int] = defaultdict(int)
+    zone_damage: dict[str, int] = defaultdict(int)
+    for f in findings:
+        zone = f.zone or "unspecified region"
+        zone_counts[zone] += 1
+        if f.finding_type in contamination:
+            zone_contamination[zone] += 1
+        else:
+            zone_damage[zone] += 1
+
+    def _top(counter: dict[str, int], n: int = 10) -> list[dict]:
+        return [
+            {"zone": z, "count": c}
+            for z, c in sorted(counter.items(), key=lambda kv: kv[1], reverse=True)[:n]
+        ]
+
+    # Most-missed zones: inspections where the coverage engine recorded a
+    # required zone as missing (persisted nowhere per-zone today — derived
+    # from the guidance list computed at analysis time isn't stored either,
+    # so this reports on the honestly-available signal: inspections with an
+    # assessed-but-incomplete coverage_quality).
+    incomplete = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= since,
+            models.Inspection.coverage_quality.in_(["incomplete", "insufficient"]),
+        )
+        .count()
+    )
+    assessed = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= since,
+            models.Inspection.coverage_pct.isnot(None),
+        )
+        .count()
+    )
+
+    return {
+        "highest_risk_anatomy_zones": _top(zone_counts),
+        "most_frequent_contamination_zones": _top(zone_contamination),
+        "most_frequent_damage_zones": _top(zone_damage),
+        "coverage_incomplete_inspections": incomplete,
+        "coverage_assessed_inspections": assessed,
+        "coverage_incomplete_pct": round(100 * incomplete / assessed, 1) if assessed else None,
+        "human_review_required": True,
+    }

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -851,10 +851,11 @@ def executive_summary(result: dict, overall_result: str) -> list[str]:
     return [ln for ln in lines if ln]
 
 
-def build_clinical_decision(result: dict) -> dict:
+def build_clinical_decision(result: dict, training_mode: bool = False) -> dict:
     """Assemble the full Explainable-AI Clinical Decision Support payload
     (Phases 13.1–13.11) from an already-computed analysis result."""
     from app.services.clinical_mentor import build_mentor  # lazy: avoid cycle
+    from app.services.spd_mentor_engine import build_spd_mentor  # lazy: avoid cycle
 
     findings = {x["type"]: x for x in result.get("predicted_findings", [])}
     overall = _overall_result(result)
@@ -951,6 +952,9 @@ def build_clinical_decision(result: dict) -> dict:
         # Phase 14 — Clinical Mentor: interpretation, why-this-matters, expanded
         # actions, standards guidance, learning mode, risk separation, mentor.
         **build_mentor(result, overall),
+        # v1.4 — SPD Mentor Engine: corrective action chains, anatomy coaching,
+        # confidence coaching, clinical decision summary, education cards.
+        "spd_mentor": build_spd_mentor(result, overall, training_mode=training_mode),
     }
 
 
@@ -967,6 +971,7 @@ def analyze_inspection(
     keydot_id: Optional[str] = None,
     decoder_backend: str = "declared",
     inspected_zones: Optional[list[str]] = None,
+    training_mode: bool = False,
 ) -> dict[str, Any]:
     """Run the deterministic baseline-comparison analysis.
 
@@ -984,8 +989,12 @@ def analyze_inspection(
 
     # ── Governance gate: no approved baseline → no final score ──────────────
     if not resolution["baseline_found"]:
+        from app.services.instrument_anatomy import get_anatomy
+
         no_baseline = {
             "analysis_status": "supervisor_review_required",
+            "instrument_type": instrument_type,
+            "instrument_anatomy": get_anatomy(instrument_type),
             "baseline_source": None,
             "baseline_version": None,
             "baseline_comparison_label": None,
@@ -1015,7 +1024,7 @@ def analyze_inspection(
             "human_review_required": True,
             "placeholder_scoring": True,
         }
-        no_baseline["clinical_decision"] = build_clinical_decision(no_baseline)
+        no_baseline["clinical_decision"] = build_clinical_decision(no_baseline, training_mode=training_mode)
         return no_baseline
 
     seed = _seed_from(image_sha256, f"{instrument_type}:{instrument_barcode or ''}")
@@ -1308,6 +1317,7 @@ def analyze_inspection(
 
     result = {
         "analysis_status": "completed",
+        "instrument_type": instrument_type,
         "baseline_source": source,
         "baseline_role": _baseline_role(source),
         "baseline_comparison_label": _baseline_comparison_label(source),
@@ -1350,5 +1360,5 @@ def analyze_inspection(
         "production_validated": False,
     }
     # Phase 13: Explainable Clinical Decision Support payload.
-    result["clinical_decision"] = build_clinical_decision(result)
+    result["clinical_decision"] = build_clinical_decision(result, training_mode=training_mode)
     return result

--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -967,6 +967,7 @@ def analyze_inspection(
     keydot_id: Optional[str] = None,
     decoder_backend: str = "declared",
     inspected_zones: Optional[list[str]] = None,
+    image_view_tags: Optional[list[dict]] = None,
 ) -> dict[str, Any]:
     """Run the deterministic baseline-comparison analysis.
 
@@ -1339,6 +1340,9 @@ def analyze_inspection(
         "inspection_coverage": coverage,
         "missing_image_guidance": guidance,
         "risk_map": risk_map,
+        # v1.2 — per-image view tags (family/zone/view/quality/notes), passed
+        # straight through so the AI context reflects exactly what was tagged.
+        "image_view_tags": image_view_tags or [],
         "reason": reason,
         "critical_flags": critical_flags,
         "score_adjustments": score_adjustments,

--- a/backend/app/services/capa_suggestion_service.py
+++ b/backend/app/services/capa_suggestion_service.py
@@ -1,0 +1,118 @@
+"""v1.5 — CAPA Integration (Deliverable 8).
+
+Suggests Corrective and Preventive Actions from real recurring patterns —
+repeated findings in the same anatomy zone, repeated condition findings on an
+instrument family, or a cluster of low-confidence/low-coverage inspections.
+These are suggestions for a human to review and act on (via
+POST /api/quality/capa-suggestions/{id}/create), never auto-created CAPAs —
+consistent with the platform-wide rule that AI output never bypasses human
+review.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.inspection_finding import InspectionFinding
+from app.services.instrument_anatomy import resolve_family
+
+# A finding-type/zone or finding-type/family repeated at least this many times
+# in the lookback window triggers a suggestion.
+_REPEAT_THRESHOLD = 3
+_LOOKBACK_DAYS = 90
+
+_CONDITION_TYPES = {"rust", "corrosion", "pitting", "crack", "insulation_damage", "missing_component"}
+
+
+def generate_capa_suggestions(db: Session, tenant_id: str) -> list[dict]:
+    since = datetime.now(timezone.utc) - timedelta(days=_LOOKBACK_DAYS)
+    findings = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.tenant_id == tenant_id, InspectionFinding.created_at >= since)
+        .all()
+    )
+
+    suggestions: list[dict] = []
+
+    # Repeated contamination in the same zone -> cleaning competency review.
+    zone_counts: dict[tuple[str, str], int] = defaultdict(int)
+    for f in findings:
+        if f.finding_type not in _CONDITION_TYPES and f.zone:
+            zone_counts[(f.finding_type, f.zone)] += 1
+    for (finding_type, zone), count in zone_counts.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated {finding_type} in {zone}",
+                "occurrences": count,
+                "recommendation": "Review manual cleaning competency for this anatomy zone.",
+                "suggested_title": f"CAPA: Repeated {finding_type} in {zone}",
+                "corrective_action": f"Retrain on manual brushing/flushing technique for {zone}.",
+                "preventive_action": f"Add {zone} to the guided-capture required-zone checklist and monitor recurrence.",
+            })
+
+    # Repeated condition findings on an instrument family -> storage/maintenance.
+    family_counts: dict[tuple[str, str], int] = defaultdict(int)
+    for f in findings:
+        if f.finding_type in _CONDITION_TYPES:
+            family_counts[(f.finding_type, resolve_family(f.instrument_type))] += 1
+    for (finding_type, family), count in family_counts.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated {finding_type} on {family}",
+                "occurrences": count,
+                "recommendation": "Evaluate storage and maintenance practices for this instrument family.",
+                "suggested_title": f"CAPA: Repeated {finding_type} on {family}",
+                "corrective_action": f"Inspect storage conditions and maintenance schedule for {family}.",
+                "preventive_action": f"Add {family} to the preventive-maintenance rotation and monitor recurrence.",
+            })
+
+    # Repeated poor image quality (low confidence, incomplete coverage) by technician.
+    insp_rows = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= since,
+            models.Inspection.has_image.is_(True),
+            models.Inspection.technician.isnot(None),
+        )
+        .all()
+    )
+    by_technician: dict[str, int] = defaultdict(int)
+    for r in insp_rows:
+        low_confidence = r.confidence is not None and r.confidence < 0.7
+        low_coverage = r.coverage_pct is not None and r.coverage_pct < 75
+        if low_confidence or low_coverage:
+            by_technician[r.technician] += 1
+    for technician, count in by_technician.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated low-confidence/low-coverage inspections by {technician}",
+                "occurrences": count,
+                "recommendation": "Technician image capture refresher.",
+                "suggested_title": f"CAPA: Image capture quality — {technician}",
+                "corrective_action": f"Schedule an image-capture refresher for {technician}.",
+                "preventive_action": "Add lighting/angle guidance to the guided-capture workflow.",
+            })
+
+    suggestions.sort(key=lambda s: s["occurrences"], reverse=True)
+    return suggestions
+
+
+def create_capa_from_suggestion(suggestion: dict, *, owner: str = "Quality / Operations") -> dict:
+    """Materialize a chosen suggestion into a real CAPA via the existing
+    capa_service — this is the human-review step, never automatic."""
+    from app.services.capa_service import create_capa
+
+    return create_capa(
+        title=suggestion["suggested_title"],
+        source="quality_intelligence_suggestion",
+        description=suggestion["trigger"],
+        risk_level="medium",
+        owner=owner,
+        corrective_action=suggestion["corrective_action"],
+        preventive_action=suggestion["preventive_action"],
+        status="open",
+    )

--- a/backend/app/services/cleaning_knowledge.py
+++ b/backend/app/services/cleaning_knowledge.py
@@ -1,0 +1,170 @@
+"""Phase 21 §4 — Cleaning Knowledge Library.
+
+Per-anatomy-zone cleaning guidance: recommended cleaning method, brush type,
+flushing requirement, ultrasonic guidance, visual inspection guidance, and
+manual verification guidance.
+
+This is a clinical knowledge layer for the reasoning engine — advisory,
+paraphrased SPD practice. It is explicitly NOT a substitute for the
+device's manufacturer Instructions For Use (IFU); the IFU always governs
+when the two differ.
+"""
+from __future__ import annotations
+
+CLEANING_KNOWLEDGE: dict[str, dict] = {
+    "serrations": {
+        "cleaning_method": "Manual brushing under running water, then enzymatic soak.",
+        "brush_type": "Soft nylon serration brush matching the tooth pitch.",
+        "flushing_requirement": "Not applicable — surface zone, no lumen.",
+        "ultrasonic_guidance": "Ultrasonic cleaning recommended for residue lodged between teeth.",
+        "visual_inspection_guidance": "Inspect under magnification with the jaw fully open.",
+        "manual_verification_guidance": "Run a gloved finger/swab across the serrations to confirm no residue remains.",
+    },
+    "grooves": {
+        "cleaning_method": "Manual brushing followed by enzymatic soak.",
+        "brush_type": "Fine-bristle brush sized to the groove width.",
+        "flushing_requirement": "Not applicable — surface zone, no lumen.",
+        "ultrasonic_guidance": "Ultrasonic cleaning recommended for deep or narrow grooves.",
+        "visual_inspection_guidance": "Inspect the full groove length under magnification.",
+        "manual_verification_guidance": "Swab test along the groove to confirm no residue.",
+    },
+    "box lock": {
+        "cleaning_method": "Open fully, brush the pivot, then enzymatic soak with the joint actuated.",
+        "brush_type": "Small stiff-bristle brush that reaches the pivot recess.",
+        "flushing_requirement": "Flush the pivot recess if the design allows water ingress.",
+        "ultrasonic_guidance": "Ultrasonic cleaning with the box lock open to expose the pivot.",
+        "visual_inspection_guidance": "Inspect the open pivot under magnification for retained soil.",
+        "manual_verification_guidance": "Actuate the joint through full range and re-inspect after cleaning.",
+    },
+    "hinge": {
+        "cleaning_method": "Actuate through full range while brushing; enzymatic soak.",
+        "brush_type": "Small stiff-bristle brush.",
+        "flushing_requirement": "Flush the hinge recess if accessible.",
+        "ultrasonic_guidance": "Ultrasonic cleaning with the hinge actuated to expose all surfaces.",
+        "visual_inspection_guidance": "Inspect with the hinge open and closed.",
+        "manual_verification_guidance": "Confirm free, unrestricted movement after cleaning.",
+    },
+    "ratchet": {
+        "cleaning_method": "Brush the engagement teeth through the full ratchet range; enzymatic soak.",
+        "brush_type": "Small stiff-bristle brush that fits between ratchet teeth.",
+        "flushing_requirement": "Not applicable — surface zone, no lumen.",
+        "ultrasonic_guidance": "Ultrasonic cleaning recommended for residue between ratchet teeth.",
+        "visual_inspection_guidance": "Inspect each ratchet position under magnification.",
+        "manual_verification_guidance": "Engage and release the ratchet fully to confirm clean, positive engagement.",
+    },
+    "drill-bit flute": {
+        "cleaning_method": "Brush along the flute spiral in the direction of the flute; enzymatic soak.",
+        "brush_type": "Narrow twisted-wire or nylon flute brush matching the flute diameter.",
+        "flushing_requirement": "Flush the flute channel to clear bone debris.",
+        "ultrasonic_guidance": "Ultrasonic cleaning strongly recommended — flutes are a critical retention point.",
+        "visual_inspection_guidance": "Inspect the full flute length under magnification.",
+        "manual_verification_guidance": "Confirm no bone/tissue debris remains between spirals by touch or swab.",
+    },
+    "threaded region": {
+        "cleaning_method": "Brush along the thread direction; enzymatic soak.",
+        "brush_type": "Narrow brush sized to the thread pitch.",
+        "flushing_requirement": "Flush between threads.",
+        "ultrasonic_guidance": "Ultrasonic cleaning recommended — threads retain residue between crests.",
+        "visual_inspection_guidance": "Inspect under magnification along the full threaded length.",
+        "manual_verification_guidance": "Swab between threads to confirm no residue.",
+    },
+    "lumen opening": {
+        "cleaning_method": "Flush and brush end-to-end before enzymatic soak.",
+        "brush_type": "Lumen brush sized to the internal diameter.",
+        "flushing_requirement": "Mandatory — flush the full lumen length before and after brushing.",
+        "ultrasonic_guidance": "Ultrasonic cleaning with lumen adapter if the device supports one.",
+        "visual_inspection_guidance": "Borescope the lumen if available; otherwise inspect both openings.",
+        "manual_verification_guidance": "Confirm clear flush return (no visible soil in effluent).",
+    },
+    "inner channel": {
+        "cleaning_method": "Flush and brush the full channel length before enzymatic soak.",
+        "brush_type": "Channel brush matching the internal diameter.",
+        "flushing_requirement": "Mandatory — flush before and after brushing.",
+        "ultrasonic_guidance": "Ultrasonic cleaning with channel adapter where available.",
+        "visual_inspection_guidance": "Borescope if available.",
+        "manual_verification_guidance": "Confirm clear flush return.",
+    },
+    "biopsy channel": {
+        "cleaning_method": "Flush and brush end-to-end immediately at point of use, repeated in reprocessing.",
+        "brush_type": "Single-use channel brush sized to the biopsy channel diameter.",
+        "flushing_requirement": "Mandatory — leak test, then flush before and after brushing.",
+        "ultrasonic_guidance": "Not typically applicable to flexible-scope internal channels — follow the device IFU.",
+        "visual_inspection_guidance": "Borescope the channel end-to-end if available.",
+        "manual_verification_guidance": "Confirm brush emerges clean and flush return is clear at both ports.",
+    },
+    "suction channel": {
+        "cleaning_method": "Flush and brush the full suction channel length; verify flow after cleaning.",
+        "brush_type": "Single-use channel brush sized to the suction channel diameter.",
+        "flushing_requirement": "Mandatory — flush before and after brushing.",
+        "ultrasonic_guidance": "Not typically applicable to flexible-scope internal channels — follow the device IFU.",
+        "visual_inspection_guidance": "Borescope if available; check suction port for residue.",
+        "manual_verification_guidance": "Confirm unobstructed suction flow after cleaning.",
+    },
+    "air/water nozzle": {
+        "cleaning_method": "Flush the air/water channel and clean the nozzle opening.",
+        "brush_type": "Fine nozzle-cleaning brush or single-use cleaning adapter per IFU.",
+        "flushing_requirement": "Mandatory — flush air and water channels separately if the device has both.",
+        "ultrasonic_guidance": "Not typically applicable — follow the device IFU.",
+        "visual_inspection_guidance": "Inspect the nozzle opening for blockage or residue.",
+        "manual_verification_guidance": "Confirm patency of both air and water channels.",
+    },
+    "o-ring area": {
+        "cleaning_method": "Clean around the o-ring/port area; remove and inspect the o-ring if removable.",
+        "brush_type": "Soft brush; avoid abrasive tools that could damage the o-ring seal.",
+        "flushing_requirement": "Rinse the port area to remove residue near the seal.",
+        "ultrasonic_guidance": "Ultrasonic cleaning acceptable if the o-ring is removed per IFU.",
+        "visual_inspection_guidance": "Inspect the o-ring for wear, nicks, or missing segments.",
+        "manual_verification_guidance": "Re-seat the o-ring and confirm a clean, undamaged seal before use.",
+    },
+    "rigid scope port": {
+        "cleaning_method": "Clean the port and sheath connection; verify no residue at the connection point.",
+        "brush_type": "Soft brush sized to the port opening.",
+        "flushing_requirement": "Rinse the port and connection point.",
+        "ultrasonic_guidance": "Ultrasonic cleaning acceptable for the port assembly if removable.",
+        "visual_inspection_guidance": "Inspect the port and sheath connection under magnification.",
+        "manual_verification_guidance": "Confirm secure, clean connection before reassembly.",
+    },
+    "insulation edge": {
+        "cleaning_method": "Wipe and brush the insulation edge; do not use abrasive tools on the insulation.",
+        "brush_type": "Soft brush only — abrasive brushes can create or widen insulation breaches.",
+        "flushing_requirement": "Not applicable — surface zone.",
+        "ultrasonic_guidance": "Ultrasonic cleaning acceptable; avoid prolonged exposure that could degrade insulation.",
+        "visual_inspection_guidance": "Inspect the full insulation length for soil, nicks, or breaches.",
+        "manual_verification_guidance": "Run an insulation integrity test (per facility protocol) after cleaning.",
+    },
+    "cutting edge": {
+        "cleaning_method": "Wipe/brush the cutting edge; enzymatic soak.",
+        "brush_type": "Soft brush to avoid dulling the edge.",
+        "flushing_requirement": "Not applicable — surface zone.",
+        "ultrasonic_guidance": "Ultrasonic cleaning acceptable.",
+        "visual_inspection_guidance": "Inspect the edge for residue, nicks, or dulling.",
+        "manual_verification_guidance": "Confirm the edge is clean and, where applicable, still sharp.",
+    },
+    "surface discoloration area": {
+        "cleaning_method": "Standard surface wipe and enzymatic soak.",
+        "brush_type": "Soft general-purpose brush.",
+        "flushing_requirement": "Not applicable.",
+        "ultrasonic_guidance": "Standard ultrasonic cycle is sufficient.",
+        "visual_inspection_guidance": "Monitor for progression at the next inspection.",
+        "manual_verification_guidance": "Confirm the surface is clean; discoloration itself is a cosmetic, lower-retention finding.",
+    },
+    "unspecified region": {
+        "cleaning_method": "Standard manual cleaning per facility protocol.",
+        "brush_type": "General-purpose brush appropriate to the instrument surface.",
+        "flushing_requirement": "Follow the device IFU for any lumens or channels.",
+        "ultrasonic_guidance": "Standard ultrasonic cycle per facility protocol.",
+        "visual_inspection_guidance": "Standard visual re-inspection.",
+        "manual_verification_guidance": "Confirm no residue is visible or palpable.",
+    },
+}
+
+_DEFAULT_CLEANING = CLEANING_KNOWLEDGE["unspecified region"]
+
+
+def get_cleaning_knowledge(zone: str) -> dict:
+    """Cleaning knowledge for a zone — never a substitute for the device IFU."""
+    return {
+        "zone": zone,
+        **CLEANING_KNOWLEDGE.get((zone or "").strip().lower(), _DEFAULT_CLEANING),
+        "note": "Advisory clinical knowledge, not an IFU replacement — the device IFU governs when the two differ.",
+    }

--- a/backend/app/services/clinical_case_library_service.py
+++ b/backend/app/services/clinical_case_library_service.py
@@ -1,0 +1,121 @@
+"""v1.8 — Clinical Case Library (Deliverable 2).
+
+Automatically preserves significant inspections — a real critical finding,
+a supervisor override, or a repair/remove-from-service outcome — as a
+reusable case: what was found, what the AI said, what the supervisor
+corrected, the final disposition, and any educational notes. One case per
+inspection; later events (a disposition action after the AI's initial
+save) update the same case rather than creating a duplicate.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import ClinicalCase
+
+
+def is_significant(*, risk_tier: str, is_critical_finding: bool, has_override: bool, finding_type: str = "") -> bool:
+    """A real trigger, never a heuristic guess: any actionable finding was
+    actually detected (matching the spec's own examples — blood, bone,
+    corrosion, missing insulation, a crack are all ordinary findings, not
+    just remove-from-service-tier ones), a critical risk tier, a critical
+    finding on the readiness engine's own classification, or a supervisor
+    has already acted on this inspection."""
+    has_finding = bool((finding_type or "").strip()) and finding_type not in ("none", "unknown")
+    return has_finding or risk_tier == "Critical" or bool(is_critical_finding) or has_override
+
+
+def _ai_findings_snapshot(db: Session, inspection_id: int) -> str:
+    from app.models.inspection_finding import InspectionFinding
+
+    rows = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.inspection_id == inspection_id)
+        .order_by(InspectionFinding.severity_index.desc())
+        .all()
+    )
+    return json.dumps([
+        {"finding_type": r.finding_type, "zone": r.zone, "severity_index": r.severity_index}
+        for r in rows
+    ])
+
+
+def get_case(db: Session, tenant_id: str, inspection_id: int) -> ClinicalCase | None:
+    return (
+        db.query(ClinicalCase)
+        .filter(ClinicalCase.tenant_id == tenant_id, ClinicalCase.inspection_id == inspection_id)
+        .first()
+    )
+
+
+def save_or_update_case(
+    db: Session, tenant_id: str, insp, *, finding_type: str,
+    supervisor_corrections: str = "", final_disposition: str = "",
+    clinical_reasoning: str = "", educational_notes: str = "", outcome: str = "",
+) -> ClinicalCase:
+    existing = get_case(db, tenant_id, insp.id)
+    finding_label = (finding_type or "unspecified finding").replace("_", " ")
+    title = f"{finding_label.capitalize()} — {insp.instrument_type}"
+
+    if existing is not None:
+        if supervisor_corrections:
+            existing.supervisor_corrections = supervisor_corrections
+        if final_disposition:
+            existing.final_disposition = final_disposition
+        if clinical_reasoning:
+            existing.clinical_reasoning = clinical_reasoning
+        if educational_notes:
+            existing.educational_notes = educational_notes
+        if outcome:
+            existing.outcome = outcome
+        existing.ai_findings = _ai_findings_snapshot(db, insp.id)
+        return existing
+
+    row = ClinicalCase(
+        tenant_id=tenant_id, inspection_id=insp.id, instrument_type=insp.instrument_type,
+        finding_type=finding_type or "", title=title,
+        ai_findings=_ai_findings_snapshot(db, insp.id),
+        supervisor_corrections=supervisor_corrections, final_disposition=final_disposition,
+        clinical_reasoning=clinical_reasoning, educational_notes=educational_notes, outcome=outcome,
+    )
+    db.add(row)
+    return row
+
+
+def case_to_dict(row: ClinicalCase) -> dict:
+    try:
+        ai_findings = json.loads(row.ai_findings or "[]")
+    except (TypeError, ValueError):
+        ai_findings = []
+    return {
+        "id": row.id, "inspection_id": row.inspection_id, "instrument_type": row.instrument_type,
+        "finding_type": row.finding_type, "title": row.title, "ai_findings": ai_findings,
+        "supervisor_corrections": row.supervisor_corrections, "final_disposition": row.final_disposition,
+        "clinical_reasoning": row.clinical_reasoning, "educational_notes": row.educational_notes,
+        "outcome": row.outcome, "view_count": row.view_count,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+    }
+
+
+def list_cases(db: Session, tenant_id: str, *, instrument: str = "", finding: str = "") -> list[dict]:
+    q = db.query(ClinicalCase).filter(ClinicalCase.tenant_id == tenant_id)
+    if instrument:
+        q = q.filter(ClinicalCase.instrument_type.ilike(f"%{instrument}%"))
+    if finding:
+        q = q.filter(ClinicalCase.finding_type == finding)
+    rows = q.order_by(ClinicalCase.id.desc()).all()
+    return [case_to_dict(r) for r in rows]
+
+
+def record_view(db: Session, tenant_id: str, case_id: int) -> ClinicalCase | None:
+    row = (
+        db.query(ClinicalCase)
+        .filter(ClinicalCase.tenant_id == tenant_id, ClinicalCase.id == case_id)
+        .first()
+    )
+    if row is None:
+        return None
+    row.view_count += 1
+    return row

--- a/backend/app/services/clinical_mentor.py
+++ b/backend/app/services/clinical_mentor.py
@@ -154,6 +154,17 @@ FINDING_EDUCATION: dict[str, dict] = {
         "spd_response": "Remove from service; complete assembly or replace.",
         "supervisor_tips": "Verify against the tray content list and instrument photo.",
     },
+    "wear": {
+        "why_it_matters": (
+            "Wear is a gradual loss of material or sharpness that can reduce instrument "
+            "performance and, if progressive, lead to functional failure."
+        ),
+        "definition": "Gradual surface or edge degradation from repeated use and reprocessing cycles.",
+        "typical_causes": "Normal use over the instrument's service life, repeated sterilization cycles, or mechanical stress.",
+        "clinical_significance": "Worn cutting edges or jaw inserts can compromise instrument function even without contamination.",
+        "spd_response": "Monitor minor wear; evaluate for repair or retirement if function is affected.",
+        "supervisor_tips": "Compare against the instrument's inspection history to judge whether wear is progressive.",
+    },
 }
 
 # ── Expanded next-action checklists (Phase 14.3) ─────────────────────────────

--- a/backend/app/services/clinical_mentor.py
+++ b/backend/app/services/clinical_mentor.py
@@ -51,7 +51,7 @@ FINDING_EDUCATION: dict[str, dict] = {
         ),
         "definition": "Non-specific biological soil not otherwise classified.",
         "typical_causes": "Biofilm, dried bioburden, or detergent residue.",
-        "clinical_significance": "Any retained organic soil reduces sterilization assurance.",
+        "clinical_significance": "Any retained organic soil compromises pre-sterilization cleaning assurance.",
         "spd_response": "Return for complete cleaning; consider biofilm-directed protocols.",
         "supervisor_tips": "Biofilm may require extended contact time or ultrasonic cleaning.",
     },

--- a/backend/app/services/competency_knowledge_service.py
+++ b/backend/app/services/competency_knowledge_service.py
@@ -1,0 +1,33 @@
+"""v1.8 — Competency Knowledge Library (Deliverable 7).
+
+Organizes competency knowledge by instrument family / anatomy / finding /
+risk / inspection technique / cleaning consideration / corrective action —
+merging the existing static education_library.py reference (definition,
+clinical importance, inspection tips, cleaning considerations, corrective
+actions) with any approved institutional KnowledgeArticle entries tagged to
+the same finding type, so supervisor-contributed guidance sits alongside
+the baseline reference rather than being a second, disconnected list.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services import education_library
+from app.services.knowledge_repository_service import list_articles
+
+
+def competency_topic(db: Session, tenant_id: str, finding_type: str) -> dict | None:
+    base = education_library.get_article(finding_type)
+    if base is None:
+        return None
+    institutional = list_articles(
+        db, tenant_id, finding=finding_type, approval_status="approved",
+    )
+    return {**base, "institutional_knowledge": institutional}
+
+
+def list_competency_topics(db: Session, tenant_id: str) -> list[dict]:
+    return [
+        competency_topic(db, tenant_id, category)
+        for category in education_library.CATEGORIES
+    ]

--- a/backend/app/services/competency_service.py
+++ b/backend/app/services/competency_service.py
@@ -1,0 +1,128 @@
+"""v1.4 — Technician competency support.
+
+Records competency events (findings reviewed, supervisor corrections, repeated
+errors, education completed) and builds per-technician competency summaries.
+Repeated-error detection and training progress are both derived only from
+events actually recorded — nothing is fabricated for technicians with no
+recorded activity.
+"""
+from __future__ import annotations
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.competency_event import CompetencyEvent
+
+# A finding-type correction recorded this many times (or more) for the same
+# technician is flagged as a repeated error.
+_REPEATED_ERROR_THRESHOLD = 2
+
+
+def _record(db: Session, *, tenant_id: str, technician: str, event_type: str,
+            finding_type: str = "", inspection_id: int | None = None) -> CompetencyEvent:
+    event = CompetencyEvent(
+        tenant_id=tenant_id,
+        technician=technician,
+        event_type=event_type,
+        finding_type=finding_type,
+        inspection_id=inspection_id,
+    )
+    db.add(event)
+    return event
+
+
+def record_finding_reviewed(db: Session, *, tenant_id: str, technician: str, inspection_id: int) -> None:
+    """A supervisor reviewed one of this technician's inspections."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="finding_reviewed", inspection_id=inspection_id)
+
+
+def record_supervisor_correction(db: Session, *, tenant_id: str, technician: str,
+                                  finding_type: str, inspection_id: int) -> None:
+    """A supervisor disagreed with, partially agreed with, or overrode the AI
+    on one of this technician's inspections. Also detects and logs a repeated
+    error when the same technician has been corrected on the same finding
+    type before."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="supervisor_correction", finding_type=finding_type,
+            inspection_id=inspection_id)
+
+    if not finding_type:
+        return
+    prior_corrections = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(
+            CompetencyEvent.technician == technician,
+            CompetencyEvent.event_type == "supervisor_correction",
+            CompetencyEvent.finding_type == finding_type,
+        )
+        .scalar()
+        or 0
+    )
+    if prior_corrections >= _REPEATED_ERROR_THRESHOLD:
+        _record(db, tenant_id=tenant_id, technician=technician,
+                event_type="repeated_error", finding_type=finding_type,
+                inspection_id=inspection_id)
+
+
+def record_education_completed(db: Session, *, tenant_id: str, technician: str, finding_type: str) -> None:
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="education_completed", finding_type=finding_type)
+
+
+def _count(db: Session, technician: str, event_type: str) -> int:
+    return (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == event_type)
+        .scalar()
+        or 0
+    )
+
+
+def competency_summary(db: Session, technician: str) -> dict:
+    """Per-technician competency summary derived entirely from recorded
+    competency events — an empty summary for a technician with no recorded
+    activity, never a fabricated score."""
+    findings_reviewed = _count(db, technician, "finding_reviewed")
+    supervisor_corrections = _count(db, technician, "supervisor_correction")
+
+    repeated_error_rows = (
+        db.query(CompetencyEvent.finding_type, func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == "repeated_error")
+        .group_by(CompetencyEvent.finding_type)
+        .all()
+    )
+    repeated_errors = {finding_type: count for finding_type, count in repeated_error_rows}
+
+    education_rows = (
+        db.query(CompetencyEvent.finding_type)
+        .filter(CompetencyEvent.technician == technician, CompetencyEvent.event_type == "education_completed")
+        .distinct()
+        .all()
+    )
+    education_completed = sorted(row[0] for row in education_rows if row[0])
+
+    # Training progress: a simple, honest ratio — corrections resolved without
+    # becoming a repeated error, out of all recorded activity. None (not 0)
+    # when there is no activity to score yet.
+    total_activity = findings_reviewed + supervisor_corrections
+    training_progress_pct = (
+        round(100 * (1 - (sum(repeated_errors.values()) / supervisor_corrections)))
+        if supervisor_corrections else None
+    )
+
+    return {
+        "technician": technician,
+        "findings_reviewed": findings_reviewed,
+        "supervisor_corrections": supervisor_corrections,
+        "repeated_errors": repeated_errors,
+        "education_completed": education_completed,
+        "training_progress_pct": training_progress_pct,
+        "has_activity": total_activity > 0,
+    }

--- a/backend/app/services/competency_service.py
+++ b/backend/app/services/competency_service.py
@@ -126,3 +126,54 @@ def competency_summary(db: Session, technician: str) -> dict:
         "training_progress_pct": training_progress_pct,
         "has_activity": total_activity > 0,
     }
+
+
+# ── Technician Quality Dashboard (v1.5, Deliverable 5) ───────────────────────
+def technician_quality_dashboard(db: Session, tenant_id: str) -> dict:
+    """Per-technician quality rollup for leadership — inspection count,
+    coverage quality, average AI confidence, supervisor agreement, repeat
+    corrections, and training progress. Visible only to authorized roles;
+    enforced by the route, not this function."""
+    from app.db import models
+    from app.models.supervisor_review import SupervisorReview
+
+    rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.technician.isnot(None))
+        .all()
+    )
+    by_technician: dict[str, list] = {}
+    for r in rows:
+        by_technician.setdefault(r.technician, []).append(r)
+
+    technicians = []
+    for technician, insp_rows in by_technician.items():
+        coverage = [r.coverage_pct for r in insp_rows if r.coverage_pct is not None]
+        confidences = [r.ai_confidence for r in insp_rows if r.has_image and r.ai_confidence is not None]
+
+        insp_ids = [r.id for r in insp_rows]
+        reviews = (
+            db.query(SupervisorReview)
+            .filter(SupervisorReview.inspection_id.in_(insp_ids))
+            .all()
+        ) if insp_ids else []
+        agreement_pct = (
+            round(100 * sum(1 for r in reviews if r.agreement == "agree") / len(reviews), 1)
+            if reviews else None
+        )
+
+        summary = competency_summary(db, technician)
+
+        technicians.append({
+            "technician": technician,
+            "inspection_count": len(insp_rows),
+            "avg_coverage_pct": round(sum(coverage) / len(coverage), 1) if coverage else None,
+            "avg_ai_confidence_pct": round(100 * sum(confidences) / len(confidences), 1) if confidences else None,
+            "supervisor_agreement_pct": agreement_pct,
+            "supervisor_corrections": summary["supervisor_corrections"],
+            "repeated_errors": summary["repeated_errors"],
+            "training_progress_pct": summary["training_progress_pct"],
+        })
+
+    technicians.sort(key=lambda t: t["inspection_count"], reverse=True)
+    return {"technicians": technicians, "human_review_required": True}

--- a/backend/app/services/continuous_improvement_service.py
+++ b/backend/app/services/continuous_improvement_service.py
@@ -1,0 +1,53 @@
+"""v1.5 — Continuous Improvement Tracker (Deliverable 11)."""
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.models.continuous_improvement import ContinuousImprovementInitiative
+
+
+def create_initiative(
+    db: Session, *, tenant_id: str, initiative: str, owner: str = "",
+    target_date: date | None = None, expected_impact: str = "",
+) -> ContinuousImprovementInitiative:
+    row = ContinuousImprovementInitiative(
+        tenant_id=tenant_id,
+        initiative=initiative,
+        owner=owner,
+        target_date=target_date,
+        expected_impact=expected_impact,
+    )
+    db.add(row)
+    return row
+
+
+def list_initiatives(db: Session, tenant_id: str) -> list[ContinuousImprovementInitiative]:
+    return (
+        db.query(ContinuousImprovementInitiative)
+        .filter(ContinuousImprovementInitiative.tenant_id == tenant_id)
+        .order_by(ContinuousImprovementInitiative.created_at.desc())
+        .all()
+    )
+
+
+def update_initiative(
+    db: Session, *, initiative_id: int, tenant_id: str,
+    status: str | None = None, actual_impact: str | None = None,
+) -> ContinuousImprovementInitiative | None:
+    row = (
+        db.query(ContinuousImprovementInitiative)
+        .filter(
+            ContinuousImprovementInitiative.id == initiative_id,
+            ContinuousImprovementInitiative.tenant_id == tenant_id,
+        )
+        .first()
+    )
+    if row is None:
+        return None
+    if status is not None:
+        row.status = status
+    if actual_impact is not None:
+        row.actual_impact = actual_impact
+    return row

--- a/backend/app/services/daily_operations_dashboard_service.py
+++ b/backend/app/services/daily_operations_dashboard_service.py
@@ -1,0 +1,48 @@
+"""v1.7 — Daily Operations Dashboard (Deliverable 8)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.workflow import COMPLETED, WorkflowStateEvent
+from app.services.sla_monitoring_service import sla_monitoring
+from app.services.work_queue_service import build_work_queue
+
+
+def daily_operations_dashboard(db: Session, tenant_id: str) -> dict:
+    now = datetime.now(timezone.utc)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    completed_today = (
+        db.query(WorkflowStateEvent)
+        .filter(
+            WorkflowStateEvent.tenant_id == tenant_id, WorkflowStateEvent.to_state == COMPLETED,
+            WorkflowStateEvent.created_at >= day_start,
+        )
+        .count()
+    )
+    created_today = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.created_at >= day_start)
+        .count()
+    )
+
+    queue = build_work_queue(db, tenant_id)
+    sla = sla_monitoring(db, tenant_id)
+
+    return {
+        "date": day_start.date().isoformat(),
+        "inspections_created_today": created_today,
+        "inspections_completed_today": completed_today,
+        "pending_inspections": queue["total_pending"],
+        "high_risk_findings": len(queue["high_risk_inspections"]),
+        "average_inspection_time_minutes": sla["average_overall_turnaround_minutes"],
+        "supervisor_backlog": len(queue["supervisor_reviews"]),
+        "repair_backlog": len(queue["repair_holds"]),
+        "ready_for_packaging": sum(
+            1 for i in queue["pending_inspections"] if i["disposition"] == "Proceed to Packaging"
+        ),
+        "human_review_required": True,
+    }

--- a/backend/app/services/data_quality_guardrails_service.py
+++ b/backend/app/services/data_quality_guardrails_service.py
@@ -1,0 +1,65 @@
+"""v1.9 — Inspection Data Quality Guardrails (Deliverable 5).
+
+Evaluates a persisted inspection for real, actionable data-quality gaps
+against the pilot site's own configured thresholds — never a duplicate
+hard gate on top of the existing coverage-gate/baseline-governance logic
+(`guided_capture.py`, `baseline_comparison_scoring_service.py`), just a
+clear, human-readable summary of what's missing for the technician and the
+Pilot Data Collection Dashboard.
+"""
+from __future__ import annotations
+
+_LOW_CONFIDENCE_THRESHOLD = 0.5
+
+
+def evaluate_data_quality(insp, *, pilot_config) -> dict:
+    """Deliverable 5 — clear-message data-quality issues for one
+    inspection. `is_dataset_ready` is true only when every check passes."""
+    issues: list[dict] = []
+
+    if not insp.instrument_type or insp.instrument_type == "unknown":
+        issues.append({
+            "code": "missing_instrument",
+            "message": "No instrument type was recorded for this inspection.",
+        })
+
+    if not insp.has_image:
+        issues.append({
+            "code": "missing_image",
+            "message": "No image was captured — this inspection was scored from manual entry only.",
+        })
+    else:
+        if insp.coverage_pct is None:
+            issues.append({
+                "code": "missing_anatomy_zone",
+                "message": "No anatomy zones were tagged for this inspection.",
+            })
+        elif insp.coverage_pct < pilot_config.minimum_coverage_pct:
+            issues.append({
+                "code": "incomplete_coverage",
+                "message": f"Coverage is {insp.coverage_pct}%, below the site's {pilot_config.minimum_coverage_pct}% minimum.",
+            })
+
+        if insp.ai_confidence is not None and insp.ai_confidence < _LOW_CONFIDENCE_THRESHOLD:
+            issues.append({
+                "code": "poor_image_quality",
+                "message": f"AI confidence is only {round(insp.ai_confidence * 100)}% — image quality may be insufficient.",
+            })
+
+        if pilot_config.baseline_required and insp.baseline_status != "approved_baseline_found":
+            issues.append({
+                "code": "missing_baseline",
+                "message": "No approved baseline is on file for this instrument type.",
+            })
+
+    if not insp.technician:
+        issues.append({
+            "code": "missing_technician_identity",
+            "message": "No technician identity was recorded for this inspection.",
+        })
+
+    return {
+        "inspection_id": insp.id,
+        "issues": issues,
+        "is_dataset_ready": len(issues) == 0,
+    }

--- a/backend/app/services/disposition_engine.py
+++ b/backend/app/services/disposition_engine.py
@@ -1,0 +1,134 @@
+"""v1.6 — Instrument Disposition Engine (Deliverable 2).
+
+Generates a standardized disposition recommendation from the readiness
+classification plus signals the readiness engine doesn't itself distinguish
+(coverage completeness, manufacturer-attributable wear) — every disposition
+carries a required, non-generic explanation grounded in the actual inputs.
+"""
+from __future__ import annotations
+
+from app.services.readiness_engine import (
+    PENDING_ANALYSIS_STATUS,
+    PENDING_SUPERVISOR_REVIEW,
+    READY,
+    READY_WITH_SUPERVISOR_APPROVAL,
+    REMOVE_FROM_SERVICE_STATUS,
+    REQUIRES_RECLEANING_STATUS,
+    REQUIRES_REPAIR_STATUS,
+)
+
+PROCEED_TO_PACKAGING = "Proceed to Packaging"
+RECLEAN = "Reclean"
+REPEAT_INSPECTION = "Repeat Inspection"
+SUPERVISOR_REVIEW_REQUIRED = "Supervisor Review Required"
+REPAIR_EVALUATION = "Repair Evaluation"
+MANUFACTURER_EVALUATION = "Manufacturer Evaluation"
+REMOVE_FROM_SERVICE = "Remove From Service"
+
+DISPOSITIONS = [
+    PROCEED_TO_PACKAGING, RECLEAN, REPEAT_INSPECTION, SUPERVISOR_REVIEW_REQUIRED,
+    REPAIR_EVALUATION, MANUFACTURER_EVALUATION, REMOVE_FROM_SERVICE,
+]
+
+# Condition findings attributable to manufacturing/material quality rather
+# than SPD process — routed to Manufacturer Evaluation instead of a generic
+# repair queue when they recur on the same instrument.
+_MANUFACTURER_ATTRIBUTABLE = {"corrosion", "pitting", "insulation_damage"}
+_COVERAGE_INSUFFICIENT_THRESHOLD = 50
+
+
+def recommend_disposition(
+    readiness: dict, insp, *, coverage_pct: int | None, primary_finding_type: str | None = None,
+) -> dict:
+    """Deliverable 2 — one of the seven standardized dispositions, with a
+    required, grounded explanation.
+
+    `primary_finding_type` should be the real detected finding (see
+    `readiness_engine.get_primary_finding_type`) — `insp.detected_issue` is
+    only used as a fallback for the no-image manual-entry path."""
+    status = readiness["status"]
+    detected_issue = (
+        primary_finding_type if primary_finding_type is not None
+        else (insp.detected_issue or "").strip().lower()
+    )
+
+    # Coverage too incomplete to trust any disposition — ask for a repeat
+    # inspection before anything else, regardless of what was found.
+    if coverage_pct is not None and coverage_pct < _COVERAGE_INSUFFICIENT_THRESHOLD:
+        return {
+            "disposition": REPEAT_INSPECTION,
+            "explanation": (
+                f"Inspection coverage was only {coverage_pct}%, below the "
+                f"{_COVERAGE_INSUFFICIENT_THRESHOLD}% threshold needed to trust a disposition. "
+                "Capture the missing required zones and repeat the inspection."
+            ),
+        }
+
+    if status in (PENDING_ANALYSIS_STATUS, PENDING_SUPERVISOR_REVIEW):
+        return {
+            "disposition": SUPERVISOR_REVIEW_REQUIRED,
+            "explanation": (
+                "No approved baseline or completed scoring exists yet for this inspection — "
+                "a supervisor must review before any disposition can be recommended."
+            ),
+        }
+
+    if status == REMOVE_FROM_SERVICE_STATUS:
+        return {
+            "disposition": REMOVE_FROM_SERVICE,
+            "explanation": (
+                f"{detected_issue.capitalize() or 'A structural finding'} escalated to remove-from-service "
+                "and is not a repairable condition — the instrument should not re-enter circulation."
+            ),
+        }
+
+    if status == REQUIRES_REPAIR_STATUS:
+        if detected_issue in _MANUFACTURER_ATTRIBUTABLE and readiness.get("repair_history"):
+            return {
+                "disposition": MANUFACTURER_EVALUATION,
+                "explanation": (
+                    f"This instrument has a prior remove-from-service history and a recurring "
+                    f"{detected_issue} finding — a manufacturer-attributable material or design "
+                    "issue should be evaluated, not just a one-off repair."
+                ),
+            }
+        return {
+            "disposition": REPAIR_EVALUATION,
+            "explanation": (
+                f"{detected_issue.capitalize() or 'A structural finding'} was detected and classified "
+                "as repairable — route to repair evaluation before returning to service."
+            ),
+        }
+
+    if status == REQUIRES_RECLEANING_STATUS:
+        return {
+            "disposition": RECLEAN,
+            "explanation": (
+                f"{detected_issue.capitalize() or 'Residual contamination'} was detected — the "
+                "instrument should be recleaned and re-inspected before packaging."
+            ),
+        }
+
+    if status == READY_WITH_SUPERVISOR_APPROVAL:
+        return {
+            "disposition": PROCEED_TO_PACKAGING,
+            "explanation": (
+                "No actionable findings, and a supervisor has confirmed the AI's assessment — "
+                "the instrument may proceed to packaging."
+            ),
+        }
+
+    if status == READY:
+        return {
+            "disposition": SUPERVISOR_REVIEW_REQUIRED,
+            "explanation": (
+                "No actionable findings were detected, but no supervisor has confirmed this "
+                "assessment yet — review is required before proceeding to packaging."
+            ),
+        }
+
+    # Defensive fallback — never silently proceed on an unrecognized status.
+    return {
+        "disposition": SUPERVISOR_REVIEW_REQUIRED,
+        "explanation": f"Unrecognized readiness status '{status}' — routed to supervisor review as a safe default.",
+    }

--- a/backend/app/services/disposition_evidence_service.py
+++ b/backend/app/services/disposition_evidence_service.py
@@ -1,0 +1,67 @@
+"""v1.6 — Disposition Evidence Panel (Deliverable 3).
+
+Assembles the evidence bundle a supervisor reviews before acting on a
+disposition recommendation: coverage, findings, severity, baseline used,
+supervisor status, readiness score, recommended disposition, and clinical
+rationale. Every field is read from already-computed/persisted data — this
+module is pure assembly, not a new analysis.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.supervisor_review import SupervisorReview
+from app.services.disposition_engine import recommend_disposition
+from app.services.pre_sterilization_command_center_service import _instrument_identity
+from app.services.readiness_engine import compute_readiness, get_primary_finding_type
+
+
+def build_evidence_panel(db: Session, tenant_id: str, insp) -> dict:
+    reviews = (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.inspection_id == insp.id)
+        .order_by(SupervisorReview.id.desc())
+        .all()
+    )
+    confirmed = len(reviews) > 0
+    latest_review = reviews[0] if reviews else None
+    override_action = (insp.override_reason and (latest_review.override_action if latest_review else "")) or ""
+
+    primary_finding_type = get_primary_finding_type(db, insp)
+    readiness = compute_readiness(db, tenant_id, insp, confirmed=confirmed, override_action=override_action)
+    disposition = recommend_disposition(
+        readiness, insp, coverage_pct=insp.coverage_pct, primary_finding_type=primary_finding_type,
+    )
+
+    return {
+        "inspection_id": insp.id,
+        "instrument_identity": _instrument_identity(insp),
+        "instrument_type": insp.instrument_type,
+        "inspection_coverage_pct": insp.coverage_pct,
+        "coverage_quality": insp.coverage_quality,
+        "detected_issue": primary_finding_type or None,
+        "severity": insp.risk_level,
+        "baseline_used": insp.baseline_source,
+        "baseline_status": insp.baseline_status,
+        "supervisor_status": (
+            "reviewed" if confirmed else "pending"
+        ),
+        "supervisor_agreement": latest_review.agreement if latest_review else None,
+        "readiness_score": readiness["readiness_score"],
+        "readiness_status": readiness["status"],
+        "recommended_disposition": disposition["disposition"],
+        "clinical_rationale": disposition["explanation"],
+        "human_review_required": True,
+    }
+
+
+def get_evidence_panel(db: Session, tenant_id: str, inspection_id: int) -> dict | None:
+    insp = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id)
+        .first()
+    )
+    if insp is None:
+        return None
+    return build_evidence_panel(db, tenant_id, insp)

--- a/backend/app/services/disposition_workspace_service.py
+++ b/backend/app/services/disposition_workspace_service.py
@@ -1,0 +1,48 @@
+"""v1.6 — Supervisor Disposition Workspace service (Deliverable 6)."""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.disposition_override import DISPOSITION_ACTIONS, DispositionOverride
+
+_REASON_REQUIRED_ACTIONS = {a for a in DISPOSITION_ACTIONS if a != "approve"}
+
+
+class InvalidDispositionAction(ValueError):
+    pass
+
+
+class ReasonRequiredError(ValueError):
+    pass
+
+
+def submit_disposition_action(
+    db: Session, *, tenant_id: str, inspection_id: int, reviewer_name: str, reviewer_role: str,
+    action: str, ai_recommended_disposition: str, modified_disposition: str = "", reason: str = "",
+) -> DispositionOverride:
+    if action not in DISPOSITION_ACTIONS:
+        raise InvalidDispositionAction(f"action must be one of {DISPOSITION_ACTIONS}")
+    if action in _REASON_REQUIRED_ACTIONS and not reason.strip():
+        raise ReasonRequiredError(f"A reason is required for action '{action}'.")
+
+    row = DispositionOverride(
+        inspection_id=inspection_id,
+        tenant_id=tenant_id,
+        reviewer_name=reviewer_name,
+        reviewer_role=reviewer_role,
+        action=action,
+        ai_recommended_disposition=ai_recommended_disposition,
+        modified_disposition=modified_disposition.strip(),
+        reason=reason.strip(),
+    )
+    db.add(row)
+    return row
+
+
+def list_disposition_actions(db: Session, tenant_id: str, inspection_id: int) -> list[DispositionOverride]:
+    return (
+        db.query(DispositionOverride)
+        .filter(DispositionOverride.tenant_id == tenant_id, DispositionOverride.inspection_id == inspection_id)
+        .order_by(DispositionOverride.id.desc())
+        .all()
+    )

--- a/backend/app/services/education_library.py
+++ b/backend/app/services/education_library.py
@@ -1,0 +1,81 @@
+"""v1.4 — Educational Knowledge Library.
+
+Structured SPD education articles for the twelve contamination/condition
+categories LumenAI recognizes. Each article is built from the same source of
+truth already used by the AI Mentor (clinical_mentor.FINDING_EDUCATION) and
+the instrument anatomy library (instrument_anatomy.py) — nothing here is
+duplicated content, it is reshaped into a browsable reference.
+"""
+from __future__ import annotations
+
+from app.services.baseline_comparison_scoring_service import KPI_LABELS
+from app.services.clinical_mentor import FINDING_EDUCATION
+from app.services.instrument_anatomy import INSTRUMENT_ANATOMY
+from app.services.spd_mentor_engine import IFU_REFERENCE_NOTE, corrective_action_chain
+
+# The twelve categories the v1.4 spec enumerates, in spec order. Internal keys
+# match clinical_mentor.FINDING_EDUCATION / KPI_LABELS.
+CATEGORIES: list[str] = [
+    "blood", "bone", "tissue", "other_organic_residue", "debris",
+    "rust", "corrosion", "crack", "wear", "pitting",
+    "missing_component", "insulation_damage",
+]
+
+# instrument_anatomy.py's per-zone contamination_risks/condition_risks lists
+# are the same default vocabulary on every zone (no per-zone override is ever
+# supplied), so they cannot distinguish "typical" locations for one finding
+# type from another. Instead, derive typical locations from what the zone data
+# *does* differentiate: contamination/organic findings collect in zones the
+# codebase already marks as high-retention; structural/condition findings
+# concentrate in zones with high/critical inherent risk. Insulation damage is
+# tied to the one zone actually named for it.
+_CONTAMINATION_FINDINGS = {"blood", "bone", "tissue", "other_organic_residue", "debris"}
+
+
+def _typical_anatomy_locations(finding_type: str) -> list[str]:
+    """Zone names, across all instrument families, that are typical retention/
+    risk sites for this finding type — derived from each zone's own risk
+    classification in instrument_anatomy.py."""
+    zones: set[str] = set()
+    if finding_type == "insulation_damage":
+        target = {"insulation edge"}
+    else:
+        target = None
+
+    for defn in INSTRUMENT_ANATOMY.values():
+        for zone in defn["zones"]:
+            name = zone["zone_name"]
+            if target is not None:
+                if name in target:
+                    zones.add(name)
+                continue
+            if finding_type in _CONTAMINATION_FINDINGS:
+                if zone["retention_risk"] == "high":
+                    zones.add(name)
+            else:
+                if zone["zone_risk_level"] in ("high", "critical"):
+                    zones.add(name)
+    return sorted(zones)
+
+
+def get_article(finding_type: str) -> dict | None:
+    """Full knowledge-library article for one finding type."""
+    edu = FINDING_EDUCATION.get(finding_type)
+    if not edu:
+        return None
+    return {
+        "finding": KPI_LABELS.get(finding_type, finding_type),
+        "finding_type": finding_type,
+        "definition": edu["definition"],
+        "clinical_importance": edu["clinical_significance"],
+        "typical_anatomy_locations": _typical_anatomy_locations(finding_type),
+        "inspection_tips": edu["supervisor_tips"],
+        "cleaning_considerations": edu["typical_causes"],
+        "corrective_actions": corrective_action_chain(finding_type),
+        "reference": IFU_REFERENCE_NOTE,
+    }
+
+
+def list_articles() -> list[dict]:
+    """All twelve knowledge-library articles, spec order."""
+    return [a for a in (get_article(k) for k in CATEGORIES) if a is not None]

--- a/backend/app/services/escalation_engine.py
+++ b/backend/app/services/escalation_engine.py
@@ -1,0 +1,88 @@
+"""v1.7 — Escalation Rules Engine (Deliverable 7).
+
+Evaluates real, already-computed signals (readiness/risk, AI confidence,
+baseline status, prior override history) against fixed thresholds and
+returns which inspections should escalate, with the specific rule(s) that
+fired — never a generic "flagged" verdict.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.disposition_override import DispositionOverride
+from app.models.workflow import CANCELLED, COMPLETED
+
+_LOW_CONFIDENCE_THRESHOLD = 0.60
+_REPEATED_OVERRIDE_THRESHOLD = 2
+
+
+def _repeated_supervisor_overrides(db: Session, tenant_id: str, insp) -> int:
+    return (
+        db.query(DispositionOverride)
+        .filter(
+            DispositionOverride.tenant_id == tenant_id,
+            DispositionOverride.inspection_id == insp.id,
+            DispositionOverride.action != "approve",
+        )
+        .count()
+    )
+
+
+def evaluate_escalation(db: Session, tenant_id: str, insp, *, readiness: dict, risk_tier: str) -> dict:
+    """Deliverable 7 — which escalation rule(s), if any, fire for this
+    inspection. `escalated` is only true when at least one real rule fires."""
+    reasons: list[str] = []
+
+    if risk_tier == "Critical":
+        reasons.append("Critical contamination/risk finding.")
+
+    if insp.has_image and insp.ai_confidence is not None and insp.ai_confidence < _LOW_CONFIDENCE_THRESHOLD:
+        reasons.append(f"Low AI confidence ({round(insp.ai_confidence * 100)}%).")
+
+    if insp.has_image and insp.baseline_status != "approved_baseline_found":
+        reasons.append("No approved baseline available for this instrument.")
+
+    override_count = _repeated_supervisor_overrides(db, tenant_id, insp)
+    if override_count >= _REPEATED_OVERRIDE_THRESHOLD:
+        reasons.append(f"Repeated supervisor overrides on record ({override_count}).")
+
+    if (insp.procedure_priority or "").strip().lower() in ("emergency", "trauma"):
+        reasons.append(f"High-priority OR instrument ({insp.procedure_priority}).")
+
+    if readiness.get("repair_history") and readiness.get("is_critical_finding"):
+        reasons.append("Repeated failure history on this instrument.")
+
+    return {
+        "inspection_id": insp.id,
+        "instrument_type": insp.instrument_type,
+        "escalated": len(reasons) > 0,
+        "reasons": reasons,
+        "human_review_required": True,
+    }
+
+
+def escalation_queue(db: Session, tenant_id: str) -> dict:
+    """All currently-open inspections that meet at least one escalation rule."""
+    from app.models.supervisor_review import SupervisorReview
+    from app.services.readiness_engine import compute_readiness, get_primary_finding_type
+    from app.services.risk_stratification_service import stratify_risk
+    from app.services.workflow_state_service import current_state
+
+    rows = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).all()
+    escalations = []
+    for insp in rows:
+        state = current_state(db, insp)
+        if state in (COMPLETED, CANCELLED):
+            continue
+        confirmed = (
+            db.query(SupervisorReview.id).filter(SupervisorReview.inspection_id == insp.id).first() is not None
+        )
+        readiness = compute_readiness(db, tenant_id, insp, confirmed=confirmed)
+        primary_finding_type = get_primary_finding_type(db, insp)
+        risk = stratify_risk(insp, primary_finding_type=primary_finding_type)
+        result = evaluate_escalation(db, tenant_id, insp, readiness=readiness, risk_tier=risk["risk_tier"])
+        if result["escalated"]:
+            escalations.append(result)
+
+    return {"escalations": escalations, "total_escalated": len(escalations), "human_review_required": True}

--- a/backend/app/services/finding_trend_service.py
+++ b/backend/app/services/finding_trend_service.py
@@ -1,0 +1,74 @@
+"""v1.5 — Finding Trend Intelligence (Deliverable 2).
+
+Aggregates real InspectionFinding rows (logged at analysis time) by finding
+type and time bucket. A finding type with zero rows in a bucket reports 0,
+not an omitted key — the dashboard shows the full 12-category taxonomy so
+"nothing found" is visible, not silently absent.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.inspection_finding import InspectionFinding
+
+# The twelve categories the v1.5 spec tracks. "wear" has no dedicated scoring
+# KPI in the detection engine today, so it will always report 0 — an honest
+# gap, not a fabricated count.
+TREND_FINDING_TYPES: list[str] = [
+    "blood", "bone", "tissue", "other_organic_residue", "debris",
+    "rust", "corrosion", "crack", "wear", "pitting",
+    "missing_component", "insulation_damage",
+]
+
+_GRANULARITY_DAYS = {"daily": 1, "weekly": 7, "monthly": 30, "quarterly": 90, "yearly": 365}
+_LOOKBACK_BUCKETS = {"daily": 14, "weekly": 12, "monthly": 12, "quarterly": 8, "yearly": 5}
+
+
+def _bucket_label(dt: datetime, granularity: str) -> str:
+    if granularity == "daily":
+        return dt.strftime("%Y-%m-%d")
+    if granularity == "weekly":
+        iso = dt.isocalendar()
+        return f"{iso[0]}-W{iso[1]:02d}"
+    if granularity == "monthly":
+        return dt.strftime("%Y-%m")
+    if granularity == "quarterly":
+        return f"{dt.year}-Q{(dt.month - 1) // 3 + 1}"
+    return str(dt.year)
+
+
+def finding_trends(db: Session, tenant_id: str, granularity: str = "monthly") -> dict:
+    if granularity not in _GRANULARITY_DAYS:
+        granularity = "monthly"
+
+    lookback_days = _GRANULARITY_DAYS[granularity] * _LOOKBACK_BUCKETS[granularity]
+    since = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+
+    rows = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.tenant_id == tenant_id, InspectionFinding.created_at >= since)
+        .all()
+    )
+
+    buckets: dict[str, dict[str, int]] = {}
+    for r in rows:
+        label = _bucket_label(r.created_at, granularity)
+        bucket = buckets.setdefault(label, {ft: 0 for ft in TREND_FINDING_TYPES})
+        if r.finding_type in bucket:
+            bucket[r.finding_type] += 1
+
+    series = [
+        {"period": label, "counts": counts}
+        for label, counts in sorted(buckets.items())
+    ]
+
+    totals = {ft: sum(b["counts"][ft] for b in series) for ft in TREND_FINDING_TYPES}
+
+    return {
+        "granularity": granularity,
+        "series": series,
+        "totals": totals,
+        "human_review_required": True,
+    }

--- a/backend/app/services/guided_capture.py
+++ b/backend/app/services/guided_capture.py
@@ -1,0 +1,289 @@
+"""v1.2 — Guided Capture & Coverage Workflow.
+
+Walks a technician through the required images before AI analysis: which
+zone to capture next, the recommended camera angle/lighting/focus, and a
+plain-language instruction sentence. Built entirely on top of the existing
+anatomy library (app/services/instrument_anatomy.py) and Coverage Engine
+(app/services/inspection_coverage.py) — no new zone-assignment logic.
+
+Per-zone guidance below is instructional UI copy (camera technique), not a
+clinical claim, so it's authored directly rather than derived from data. Zones
+without a specific entry fall back to generic, honest guidance keyed off the
+zone's category (from instrument_anatomy.py) rather than fabricating
+zone-specific detail that was never defined.
+"""
+from __future__ import annotations
+
+from app.services.inspection_coverage import compute_coverage, missing_image_guidance
+from app.services.instrument_anatomy import get_anatomy
+
+# ── Per-zone capture guidance ────────────────────────────────────────────────
+# angle: recommended camera position. lighting: lighting setup. focus: what to
+# focus on / macro vs. standard. instruction: the plain-language prompt shown
+# to the technician (matches the v1.2 spec's example wording where given).
+ZONE_CAPTURE_GUIDANCE: dict[str, dict[str, str]] = {
+    "o-ring area": {
+        "angle": "Close-up, perpendicular to the o-ring/port face",
+        "lighting": "Even, diffuse lighting to avoid glare on the seal",
+        "focus": "Macro focus on the o-ring seam",
+        "instruction": "Capture close-up of o-ring area.",
+    },
+    "drill-bit flute": {
+        "angle": "Side profile, full flute length in frame",
+        "lighting": "Direct lighting along the flute to reveal residue in the spirals",
+        "focus": "Macro focus, flute threads sharp",
+        "instruction": "Capture drill-bit flute under direct lighting.",
+    },
+    "flutes": {
+        "angle": "Side profile, full flute length in frame",
+        "lighting": "Direct lighting along the flute to reveal residue in the spirals",
+        "focus": "Macro focus, flute threads sharp",
+        "instruction": "Capture drill-bit flute under direct lighting.",
+    },
+    "box lock": {
+        "angle": "Jaw open, box lock fully visible",
+        "lighting": "Direct lighting into the opened pivot",
+        "focus": "Macro focus on the pivot interior",
+        "instruction": "Capture box lock with jaw open.",
+    },
+    "serrations": {
+        "angle": "Macro, serration teeth filling the frame",
+        "lighting": "Raking side light to show residue between teeth",
+        "focus": "Macro focus, teeth in sharp detail",
+        "instruction": "Capture serrations at macro distance.",
+    },
+    "jaw": {
+        "angle": "Jaw open, full jaw face visible",
+        "lighting": "Direct lighting into the jaw",
+        "focus": "Macro focus on the jaw serrations",
+        "instruction": "Capture jaw with jaw open, serrations facing the camera.",
+    },
+    "hinge": {
+        "angle": "Side profile with the hinge actuated open",
+        "lighting": "Direct lighting into the hinge gap",
+        "focus": "Macro focus on the pivot",
+        "instruction": "Capture hinge actuated open, pivot fully visible.",
+    },
+    "distal tip": {
+        "angle": "End-on, straight down the shaft",
+        "lighting": "Even lighting to avoid tip glare",
+        "focus": "Sharp focus on the tip edge",
+        "instruction": "Capture distal tip end-on.",
+    },
+    "distal end": {
+        "angle": "End-on, straight down the insertion tube",
+        "lighting": "Even lighting to avoid lens glare",
+        "focus": "Sharp focus on the distal face",
+        "instruction": "Capture distal end end-on.",
+    },
+    "lens edge": {
+        "angle": "Close-up, lens face perpendicular to camera",
+        "lighting": "Diffuse lighting to reveal scratches without glare",
+        "focus": "Macro focus on the lens rim",
+        "instruction": "Capture lens edge in close-up under diffuse light.",
+    },
+    "threaded region": {
+        "angle": "Side profile, threads in full length",
+        "lighting": "Direct raking light across the threads",
+        "focus": "Macro focus on thread crests",
+        "instruction": "Capture threaded region under direct lighting.",
+    },
+    "biopsy channel": {
+        "angle": "Channel opening, straight-on",
+        "lighting": "Direct light into the channel opening",
+        "focus": "Macro focus at the channel mouth",
+        "instruction": "Capture biopsy channel opening straight-on.",
+    },
+    "suction channel": {
+        "angle": "Channel opening, straight-on",
+        "lighting": "Direct light into the channel opening",
+        "focus": "Macro focus at the channel mouth",
+        "instruction": "Capture suction channel opening straight-on.",
+    },
+    "ratchet": {
+        "angle": "Ratchet engaged, teeth visible",
+        "lighting": "Raking side light to reveal residue between teeth",
+        "focus": "Macro focus on the ratchet teeth",
+        "instruction": "Capture ratchet with teeth engaged and visible.",
+    },
+    "insulation edge": {
+        "angle": "Full insulation length, side profile",
+        "lighting": "Even lighting along the shaft",
+        "focus": "Sharp focus on the insulation-to-metal transition",
+        "instruction": "Capture insulation edge along the full shaft length.",
+    },
+    "working channel": {
+        "angle": "Channel opening, straight-on",
+        "lighting": "Direct light into the channel opening",
+        "focus": "Macro focus at the channel mouth",
+        "instruction": "Capture working channel opening straight-on.",
+    },
+    "sheath connection": {
+        "angle": "Close-up on the connection point",
+        "lighting": "Direct lighting on the connector",
+        "focus": "Macro focus on the connection seam",
+        "instruction": "Capture sheath connection close-up.",
+    },
+}
+
+# Fallback guidance by zone category (from instrument_anatomy.py's zone_category).
+_CATEGORY_FALLBACK: dict[str, dict[str, str]] = {
+    "cutting_working_surface": {
+        "angle": "Macro, working surface filling the frame",
+        "lighting": "Raking side light to reveal surface residue",
+        "focus": "Macro focus on the working edge",
+    },
+    "rotary_orthopedic": {
+        "angle": "Side profile, full length in frame",
+        "lighting": "Direct lighting along the length",
+        "focus": "Macro focus, cutting surface sharp",
+    },
+    "lumen_scope": {
+        "angle": "End-on or opening straight-on",
+        "lighting": "Direct light into the opening",
+        "focus": "Macro focus at the opening",
+    },
+    "mechanical": {
+        "angle": "Mechanism actuated/open, pivot visible",
+        "lighting": "Direct lighting into the mechanism",
+        "focus": "Macro focus on the pivot/joint",
+    },
+    "handle_external": {
+        "angle": "Side profile, full length in frame",
+        "lighting": "Even, diffuse lighting",
+        "focus": "Standard focus, surface detail visible",
+    },
+}
+_DEFAULT_FALLBACK = {
+    "angle": "Overall view, then a close-up",
+    "lighting": "Even, diffuse lighting",
+    "focus": "Standard focus",
+}
+
+
+def _zone_category(instrument_type: str, zone_name: str) -> str:
+    anatomy = get_anatomy(instrument_type)
+    for z in anatomy["zones"]:
+        if z["zone_name"].lower() == zone_name.lower():
+            return z["zone_category"]
+    return ""
+
+
+def zone_capture_guidance(instrument_type: str, zone_name: str) -> dict[str, str]:
+    """Camera angle, lighting, focus, and a plain-language instruction for
+    capturing one zone. Falls back to category-level generic guidance, then a
+    fully generic default — never a fabricated zone-specific claim."""
+    key = (zone_name or "").strip().lower()
+    if key in ZONE_CAPTURE_GUIDANCE:
+        return {**ZONE_CAPTURE_GUIDANCE[key]}
+
+    category = _zone_category(instrument_type, key)
+    fallback = _CATEGORY_FALLBACK.get(category, _DEFAULT_FALLBACK)
+    return {
+        **fallback,
+        "instruction": f"Capture close-up of {zone_name}.",
+    }
+
+
+def technician_guidance_sentence(instrument_type: str, zone_name: str) -> str:
+    return zone_capture_guidance(instrument_type, zone_name)["instruction"]
+
+
+def capture_checklist(instrument_type: str, captured_zones: list[str] | None) -> dict:
+    """Required / optional / captured / missing / high-risk zones."""
+    anatomy = get_anatomy(instrument_type)
+    required = anatomy["required_images"]
+    all_zones = anatomy["zone_names"]
+    optional = [z for z in all_zones if z not in required]
+    captured_norm = {z.strip().lower() for z in (captured_zones or [])}
+
+    captured = [z for z in all_zones if z.lower() in captured_norm]
+    missing = [z for z in required if z.lower() not in captured_norm]
+    high_risk = [
+        z for z in all_zones
+        if z in anatomy["high_risk_zones"]
+    ]
+
+    return {
+        "required_zones": required,
+        "optional_zones": optional,
+        "captured_zones": captured,
+        "missing_zones": missing,
+        "high_risk_zones": high_risk,
+    }
+
+
+def _next_zone_to_capture(instrument_type: str, checklist: dict) -> str | None:
+    """Prioritize missing required zones, high-risk first."""
+    missing = checklist["missing_zones"]
+    if not missing:
+        return None
+    high_risk_set = set(checklist["high_risk_zones"])
+    ordered = sorted(missing, key=lambda z: z not in high_risk_set)
+    return ordered[0]
+
+
+def guided_capture_panel(instrument_type: str, captured_zones: list[str] | None) -> dict:
+    """Architecture step — the Guided Capture Panel payload: instrument
+    family, checklist, current zone to capture, and per-zone camera guidance."""
+    anatomy = get_anatomy(instrument_type)
+    checklist = capture_checklist(instrument_type, captured_zones)
+    current_zone = _next_zone_to_capture(instrument_type, checklist)
+
+    guidance = zone_capture_guidance(instrument_type, current_zone) if current_zone else None
+
+    return {
+        "instrument_family": anatomy["family"],
+        "instrument_category": anatomy["category"],
+        **checklist,
+        "current_zone": current_zone,
+        "recommended_camera_angle": guidance["angle"] if guidance else None,
+        "lighting_tips": guidance["lighting"] if guidance else None,
+        "focus_tips": guidance["focus"] if guidance else None,
+        "example_placeholder_guidance": guidance["instruction"] if guidance else (
+            "All required zones captured — no further images needed for coverage."
+        ),
+        "all_required_captured": current_zone is None,
+    }
+
+
+def coverage_readiness(
+    instrument_type: str,
+    captured_zones: list[str] | None,
+    require_full_coverage: bool = False,
+    override_applied: bool = False,
+) -> dict:
+    """Section 3/5 — coverage score + readiness-for-AI-analysis gate.
+
+    gate_status:
+      - "ready": coverage is complete/acceptable, or org policy doesn't
+        require full coverage, or a supervisor override was already applied.
+      - "draft": coverage is incomplete/insufficient and org policy doesn't
+        require full coverage — the technician may still save/proceed.
+      - "blocked_pending_override": org policy requires full coverage, the
+        coverage is incomplete/insufficient, and no override has been applied.
+    """
+    coverage = compute_coverage(instrument_type, captured_zones)
+    guidance = missing_image_guidance(instrument_type, captured_zones)
+    missing_high_risk = [
+        z for z in coverage["missing"]
+        if z in get_anatomy(instrument_type)["high_risk_zones"]
+    ]
+
+    coverage_sufficient = coverage["quality"] in ("complete", "acceptable")
+
+    if coverage_sufficient or not require_full_coverage or override_applied:
+        gate_status = "ready"
+    else:
+        gate_status = "blocked_pending_override"
+
+    return {
+        "coverage_score": coverage["overall_coverage"],
+        "coverage_status": coverage["quality"],
+        "missing_zones": coverage["missing"],
+        "missing_high_risk_zones": missing_high_risk,
+        "missing_image_guidance": guidance,
+        "ready_for_ai_analysis": gate_status == "ready",
+        "gate_status": gate_status,
+        "require_full_coverage": require_full_coverage,
+    }

--- a/backend/app/services/inspection_coverage.py
+++ b/backend/app/services/inspection_coverage.py
@@ -9,7 +9,9 @@ CV-detected (that is a future release). The engine is deterministic and honest.
 """
 from __future__ import annotations
 
-from app.services.instrument_anatomy import get_anatomy
+import json
+
+from app.services.instrument_anatomy import get_anatomy, resolve_family
 
 
 def _norm(z: str) -> str:
@@ -116,3 +118,82 @@ def build_risk_map(instrument_type: str, findings_by_zone: dict[str, list[str]] 
             ),
         })
     return rows
+
+
+def coverage_dashboard_summary(db, tenant_id: str, recent_limit: int = 20) -> dict:
+    """Enterprise Coverage Dashboard — real aggregate coverage stats computed
+    from stored inspections (`inspected_zones_json`), never fabricated.
+
+    Inspections where zones were never tagged are excluded from the average
+    and status breakdown (they were "not assessed", not zero coverage) but are
+    counted separately so the dashboard is honest about assessment gaps.
+    """
+    from app.db import models
+
+    rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.has_image.is_(True))
+        .order_by(models.Inspection.created_at.desc(), models.Inspection.id.desc())
+        .all()
+    )
+
+    assessed: list[dict] = []
+    missing_tally: dict[str, int] = {}
+    status_breakdown = {"complete": 0, "acceptable": 0, "incomplete": 0, "insufficient": 0}
+    coverage_by_family: dict[str, list[int]] = {}
+    recent: list[dict] = []
+
+    for row in rows:
+        try:
+            zones = json.loads(row.inspected_zones_json or "null")
+        except (TypeError, ValueError):
+            zones = None
+
+        cov = compute_coverage(row.instrument_type, zones)
+        if len(recent) < recent_limit:
+            recent.append({
+                "inspection_id": row.id,
+                "instrument_type": row.instrument_type,
+                "coverage_score": cov["overall_coverage"],
+                "coverage_status": cov["quality"],
+                "missing": cov["missing"],
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+            })
+
+        if not cov["assessed"]:
+            continue
+
+        assessed.append(cov)
+        status_breakdown[cov["quality"]] = status_breakdown.get(cov["quality"], 0) + 1
+        for z in cov["missing"]:
+            missing_tally[z] = missing_tally.get(z, 0) + 1
+        family = resolve_family(row.instrument_type)
+        coverage_by_family.setdefault(family, []).append(cov["overall_coverage"])
+
+    average_coverage = (
+        round(sum(c["overall_coverage"] for c in assessed) / len(assessed))
+        if assessed else None
+    )
+    average_coverage_by_family = {
+        family: round(sum(scores) / len(scores))
+        for family, scores in coverage_by_family.items()
+    }
+    most_commonly_missing_zones = [
+        {"zone": zone, "missed_count": count}
+        for zone, count in sorted(missing_tally.items(), key=lambda kv: kv[1], reverse=True)
+    ][:10]
+
+    return {
+        "total_inspections_with_image": len(rows),
+        "assessed_count": len(assessed),
+        "not_assessed_count": len(rows) - len(assessed),
+        "average_coverage": average_coverage,
+        "coverage_status_breakdown": status_breakdown,
+        "average_coverage_by_family": average_coverage_by_family,
+        "most_commonly_missing_zones": most_commonly_missing_zones,
+        "recent_inspections": recent,
+        "note": (
+            "Computed from real inspected_zones_json data. Inspections where zones "
+            "were never tagged are excluded from averages (not assessed, not zero)."
+        ),
+    }

--- a/backend/app/services/instrument_anatomy.py
+++ b/backend/app/services/instrument_anatomy.py
@@ -226,6 +226,26 @@ INSTRUMENT_ANATOMY: dict[str, dict] = {
 }
 
 
+def list_anatomy_families() -> list[dict]:
+    """Summary of every declared anatomy family, for the Anatomy Library page.
+    Excludes the ``default`` fallback (that is the generic profile, not a family)."""
+    return [
+        {
+            "family": family,
+            "category": defn["category"],
+            "zone_names": [z["zone_name"] for z in defn["zones"]],
+            "required_images": defn["required_images"],
+            "min_images": defn["min_images"],
+            "high_risk_zones": [
+                z["zone_name"] for z in defn["zones"]
+                if z["zone_risk_level"] in ("high", "critical") or z["retention_risk"] == "high"
+            ],
+        }
+        for family, defn in INSTRUMENT_ANATOMY.items()
+        if family != "default"
+    ]
+
+
 def resolve_family(instrument_type: str) -> str:
     """Resolve free-text instrument_type onto an anatomy family key."""
     name = (instrument_type or "").lower()

--- a/backend/app/services/instrument_condition_service.py
+++ b/backend/app/services/instrument_condition_service.py
@@ -1,0 +1,109 @@
+"""v1.6 — Instrument Condition Tracker (Deliverable 5).
+
+Trends a physical instrument's condition across its full inspection history —
+cleaning findings, damage findings, corrosion history, repair history, and
+supervisor comments — grouped by the same honest instrument-identity key
+already used by the pre-sterilization readiness engine (barcode/UDI, with an
+explicit "untracked" fallback rather than a fabricated re-identification).
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.inspection_finding import InspectionFinding
+from app.models.supervisor_review import SupervisorReview
+from app.services.baseline_comparison_scoring_service import CLEANING_KPIS
+
+
+def instrument_condition_history(db: Session, tenant_id: str, instrument_identity: str) -> dict | None:
+    """Full history for one instrument identity (`barcode:...` / `udi:...`)."""
+    if instrument_identity.startswith("barcode:"):
+        barcode = instrument_identity.removeprefix("barcode:")
+        rows = (
+            db.query(models.Inspection)
+            .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.instrument_barcode == barcode)
+            .order_by(models.Inspection.created_at.asc())
+            .all()
+        )
+    elif instrument_identity.startswith("udi:"):
+        udi = instrument_identity.removeprefix("udi:")
+        rows = (
+            db.query(models.Inspection)
+            .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.instrument_udi == udi)
+            .order_by(models.Inspection.created_at.asc())
+            .all()
+        )
+    else:
+        return None
+
+    if not rows:
+        return None
+
+    inspection_ids = [r.id for r in rows]
+    findings = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.inspection_id.in_(inspection_ids))
+        .all()
+    ) if inspection_ids else []
+    reviews = (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.inspection_id.in_(inspection_ids))
+        .all()
+    ) if inspection_ids else []
+    reviews_by_inspection: dict[int, list] = {}
+    for r in reviews:
+        reviews_by_inspection.setdefault(r.inspection_id, []).append(r)
+
+    findings_by_inspection: dict[int, list] = {}
+    for f in findings:
+        findings_by_inspection.setdefault(f.inspection_id, []).append(f)
+
+    history = []
+    for insp in rows:
+        insp_findings = findings_by_inspection.get(insp.id, [])
+        cleaning_findings = [f.finding_type for f in insp_findings if f.finding_type in CLEANING_KPIS]
+        damage_findings = [f.finding_type for f in insp_findings if f.finding_type not in CLEANING_KPIS]
+        corrosion_present = any(f.finding_type in ("rust", "corrosion", "pitting") for f in insp_findings)
+        supervisor_comments = [
+            r.rationale for r in reviews_by_inspection.get(insp.id, []) if r.rationale.strip()
+        ]
+
+        history.append({
+            "inspection_id": insp.id,
+            "date": insp.created_at.isoformat() if insp.created_at else None,
+            "disposition": insp.disposition,
+            "cleaning_findings": cleaning_findings,
+            "damage_findings": damage_findings,
+            "corrosion_present": corrosion_present,
+            "repair_flag": insp.disposition == "REMOVE FROM SERVICE",
+            "supervisor_comments": supervisor_comments,
+        })
+
+    repair_count = sum(1 for h in history if h["repair_flag"])
+    corrosion_count = sum(1 for h in history if h["corrosion_present"])
+
+    # Trend: is condition improving, declining, or stable across this
+    # instrument's history? Compare the first half's clean rate to the second.
+    def _clean_rate(bucket: list[dict]) -> float | None:
+        if not bucket:
+            return None
+        clean = sum(1 for h in bucket if not h["cleaning_findings"] and not h["damage_findings"])
+        return clean / len(bucket)
+
+    mid = len(history) // 2
+    older_rate, newer_rate = _clean_rate(history[:mid]), _clean_rate(history[mid:])
+    if older_rate is None or newer_rate is None or older_rate == newer_rate:
+        trend = "stable" if len(history) > 1 else "insufficient_data"
+    else:
+        trend = "improving" if newer_rate > older_rate else "declining"
+
+    return {
+        "instrument_identity": instrument_identity,
+        "instrument_type": rows[-1].instrument_type,
+        "inspection_count": len(history),
+        "repair_count": repair_count,
+        "corrosion_history_count": corrosion_count,
+        "condition_trend": trend,
+        "history": history,
+    }

--- a/backend/app/services/instrument_family_profiles.py
+++ b/backend/app/services/instrument_family_profiles.py
@@ -1,0 +1,153 @@
+"""Phase 21 §3 — Instrument Family Intelligence.
+
+Knowledge profiles (typical contamination, typical damage, typical repair
+issues, inspection priorities, cleaning priorities, supervisor focus areas)
+for the ten instrument families SPD sees most often. Each profile links to
+a real anatomy family in `app/services/instrument_anatomy.py` so "typical
+anatomy" is always the live zone data, never a duplicated copy.
+
+Three families (Cannulated Instruments, Orthopedic Instruments, Micro
+Instruments) do not yet have a dedicated anatomy-zone taxonomy split out —
+they honestly borrow the closest existing anatomy family (flagged via
+`anatomy_family_note`) rather than fabricating zones that were never
+defined. See docs/knowledge-graph/instrument-intelligence.md.
+"""
+from __future__ import annotations
+
+from app.services.instrument_anatomy import anatomy_profile
+
+INSTRUMENT_FAMILY_PROFILES: dict[str, dict] = {
+    "rigid_scope": {
+        "display_name": "Rigid Scope",
+        "anatomy_family_key": "rigid_scope",
+        "typical_contamination": ["blood", "tissue", "other_organic_residue"],
+        "typical_damage": ["lens scratching", "o-ring wear", "seal failure"],
+        "typical_repair_issues": ["cracked lens", "bent shaft", "damaged seal"],
+        "inspection_priorities": ["o-ring area", "working channel", "distal tip", "lens edge"],
+        "cleaning_priorities": ["working channel flush and brush", "o-ring/seal inspection"],
+        "supervisor_focus_areas": ["baseline lens clarity match", "working channel patency"],
+    },
+    "flexible_endoscope": {
+        "display_name": "Flexible Endoscope",
+        "anatomy_family_key": "flexible_endoscope",
+        "typical_contamination": ["blood", "tissue", "other_organic_residue", "debris"],
+        "typical_damage": ["bending section stiffness", "insertion tube abrasion", "channel damage"],
+        "typical_repair_issues": ["biopsy channel leak", "bending section failure", "insulation breach"],
+        "inspection_priorities": ["biopsy channel", "suction channel", "distal end", "bending section"],
+        "cleaning_priorities": ["channel flush/brush end-to-end", "leak testing", "borescope internal channels"],
+        "supervisor_focus_areas": ["channel patency", "leak test result", "bending section function"],
+    },
+    "kerrison": {
+        "display_name": "Kerrison",
+        "anatomy_family_key": "kerrison_rongeur",
+        "typical_contamination": ["blood", "bone", "other_organic_residue"],
+        "typical_damage": ["dulled jaw", "worn serrations", "loose box lock"],
+        "typical_repair_issues": ["jaw misalignment", "footplate wear", "spring fatigue"],
+        "inspection_priorities": ["jaw", "serrations", "box lock", "hinge"],
+        "cleaning_priorities": ["open box lock and brush pivot", "brush jaw serrations under magnification"],
+        "supervisor_focus_areas": ["serration residue", "box lock cleanliness", "jaw alignment"],
+    },
+    "needle_holder": {
+        "display_name": "Needle Holder",
+        "anatomy_family_key": "needle_holder",
+        "typical_contamination": ["blood", "tissue"],
+        "typical_damage": ["worn tungsten carbide inserts", "misaligned jaws", "worn ratchet teeth"],
+        "typical_repair_issues": ["jaw insert replacement", "ratchet realignment"],
+        "inspection_priorities": ["jaw inserts", "serrations", "box lock", "ratchet"],
+        "cleaning_priorities": ["brush jaw inserts and serrations", "brush ratchet teeth"],
+        "supervisor_focus_areas": ["jaw insert grip integrity", "ratchet engagement"],
+    },
+    "scissors": {
+        "display_name": "Scissors",
+        "anatomy_family_key": "scissors",
+        "typical_contamination": ["blood", "tissue", "debris"],
+        "typical_damage": ["dulled cutting edge", "nicked blade", "loose box lock"],
+        "typical_repair_issues": ["blade sharpening", "box lock tightening"],
+        "inspection_priorities": ["blade", "cutting edge", "box lock"],
+        "cleaning_priorities": ["inspect and brush cutting edge", "open and brush box lock"],
+        "supervisor_focus_areas": ["blade sharpness/alignment", "cut test where applicable"],
+    },
+    "drill_bit": {
+        "display_name": "Drill Bit",
+        "anatomy_family_key": "drill_bit",
+        "typical_contamination": ["bone", "other_organic_residue", "debris"],
+        "typical_damage": ["dulled flutes", "corroded threads", "bent shank"],
+        "typical_repair_issues": ["flute resharpening", "shank straightening"],
+        "inspection_priorities": ["flutes", "threaded region", "tip"],
+        "cleaning_priorities": ["brush flutes and threaded region", "confirm no residue between spirals"],
+        "supervisor_focus_areas": ["flute residue", "cutting tip wear"],
+    },
+    "laparoscopic_instruments": {
+        "display_name": "Laparoscopic Instruments",
+        "anatomy_family_key": "laparoscopic",
+        "typical_contamination": ["blood", "tissue", "debris"],
+        "typical_damage": ["insulation breach", "bent shaft", "worn hinge"],
+        "typical_repair_issues": ["insulation replacement", "hinge repair"],
+        "inspection_priorities": ["insulation edge", "distal jaws", "hinge", "handle seam"],
+        "cleaning_priorities": ["flush lumen/cannulated channel if present", "test insulation integrity end-to-end"],
+        "supervisor_focus_areas": ["insulation integrity test result", "distal jaw alignment"],
+    },
+    "cannulated_instruments": {
+        "display_name": "Cannulated Instruments",
+        "anatomy_family_key": "laparoscopic",
+        "anatomy_family_note": (
+            "Cannulated instruments do not yet have a dedicated anatomy-zone taxonomy split out; "
+            "typical anatomy is borrowed from the laparoscopic family's lumen/cannulated channel zone."
+        ),
+        "typical_contamination": ["blood", "tissue", "debris", "other_organic_residue"],
+        "typical_damage": ["lumen obstruction", "channel scoring"],
+        "typical_repair_issues": ["channel reaming", "cannula replacement"],
+        "inspection_priorities": ["lumen/cannulated channel", "distal opening"],
+        "cleaning_priorities": ["flush the full length of the cannulation", "brush with correct-diameter brush"],
+        "supervisor_focus_areas": ["channel patency", "flush return clarity"],
+    },
+    "orthopedic_instruments": {
+        "display_name": "Orthopedic Instruments",
+        "anatomy_family_key": "drill_bit",
+        "anatomy_family_note": (
+            "Broader orthopedic instruments (saws, awls, broaches) share the drill_bit anatomy "
+            "family pending a dedicated split; drill/reamer/burr zones are the closest real match."
+        ),
+        "typical_contamination": ["bone", "other_organic_residue", "debris"],
+        "typical_damage": ["worn cutting surfaces", "corroded threads", "bent components"],
+        "typical_repair_issues": ["resharpening", "component straightening"],
+        "inspection_priorities": ["cutting/working surface", "threaded/cannulated regions", "hub/connection"],
+        "cleaning_priorities": ["brush cannulations and threaded regions", "confirm no bone debris in channels"],
+        "supervisor_focus_areas": ["cannulation patency", "cutting surface wear"],
+    },
+    "micro_instruments": {
+        "display_name": "Micro Instruments",
+        "anatomy_family_key": "default",
+        "anatomy_family_note": (
+            "No micro-instrument-specific anatomy zones exist yet; falls back to the generic "
+            "instrument profile. Flagged as a future anatomy-taxonomy expansion."
+        ),
+        "typical_contamination": ["blood", "tissue"],
+        "typical_damage": ["bent tips", "misaligned jaws", "loss of tip precision"],
+        "typical_repair_issues": ["tip realignment", "spring tension adjustment"],
+        "inspection_priorities": ["working tip", "hinge/joint"],
+        "cleaning_priorities": ["inspect under magnification", "gentle brushing to avoid further tip damage"],
+        "supervisor_focus_areas": ["tip alignment under magnification", "fine-motion function test"],
+    },
+}
+
+
+def get_family_profile(family_key: str) -> dict | None:
+    """Full knowledge profile for a family key, with live anatomy attached."""
+    profile = INSTRUMENT_FAMILY_PROFILES.get(family_key)
+    if profile is None:
+        return None
+    # Resolve via a space-separated hint (not the raw underscore key) so the
+    # keyword matcher in instrument_anatomy.py sees real words, e.g.
+    # "kerrison_rongeur" -> "kerrison rongeur".
+    anatomy = anatomy_profile(profile["anatomy_family_key"].replace("_", " "))
+    return {
+        "family_key": family_key,
+        **profile,
+        "typical_anatomy": anatomy["anatomy_zones"],
+        "high_risk_zones": anatomy["high_risk_zones"],
+    }
+
+
+def list_family_profiles() -> list[dict]:
+    return [get_family_profile(key) for key in INSTRUMENT_FAMILY_PROFILES]

--- a/backend/app/services/instrument_performance_service.py
+++ b/backend/app/services/instrument_performance_service.py
@@ -1,0 +1,60 @@
+"""v1.5 — Instrument Family Performance (Deliverable 4).
+
+Ranks instrument families by inspection frequency, pass/fail/repair rate, and
+supervisor intervention rate — derived from real Inspection rows, grouped by
+the same anatomy-family resolution the rest of the platform already uses
+(instrument_anatomy.resolve_family), not a re-typed instrument list.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.services.instrument_anatomy import resolve_family
+
+_REPAIRABLE_ISSUES = {"crack", "corrosion", "insulation_damage"}
+
+
+def _rate(n: int, d: int) -> float | None:
+    return round(100 * n / d, 1) if d else None
+
+
+def instrument_family_performance(db: Session, tenant_id: str, days: int = 180) -> dict:
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.created_at >= since)
+        .all()
+    )
+
+    by_family: dict[str, list] = defaultdict(list)
+    for r in rows:
+        by_family[resolve_family(r.instrument_type)].append(r)
+
+    families = []
+    for family, family_rows in by_family.items():
+        scored = [r for r in family_rows if r.has_image and r.disposition]
+        total = len(scored)
+        pass_ct = sum(1 for r in scored if r.disposition == "PASS")
+        fail_ct = sum(1 for r in scored if r.disposition in ("REPROCESS", "REMOVE FROM SERVICE"))
+        repair_ct = sum(
+            1 for r in scored
+            if r.disposition == "REMOVE FROM SERVICE" and (r.detected_issue or "") in _REPAIRABLE_ISSUES
+        )
+        override_ct = sum(1 for r in family_rows if (r.override_by or "").strip())
+
+        families.append({
+            "family": family,
+            "inspection_count": len(family_rows),
+            "pass_rate_pct": _rate(pass_ct, total),
+            "failure_rate_pct": _rate(fail_ct, total),
+            "repair_rate_pct": _rate(repair_ct, total),
+            "supervisor_intervention_rate_pct": _rate(override_ct, len(family_rows)),
+        })
+
+    families.sort(key=lambda f: f["inspection_count"], reverse=True)
+
+    return {"families": families, "human_review_required": True}

--- a/backend/app/services/knowledge_analytics_service.py
+++ b/backend/app/services/knowledge_analytics_service.py
@@ -1,0 +1,146 @@
+"""v1.8 — Knowledge Analytics (Deliverable 10).
+
+Rollups over real KnowledgeArticle/ClinicalCase/query-log/override data —
+nothing here is a separate model, just aggregation of what the rest of
+v1.8 and the existing v1.6/v1.4 stores already record.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.disposition_override import DispositionOverride
+from app.models.knowledge import APPROVED, TEACHING_POINT, ClinicalCase, KnowledgeArticle, KnowledgeQueryLog
+
+
+def most_viewed_articles(db: Session, tenant_id: str, limit: int = 10) -> list[dict]:
+    rows = (
+        db.query(KnowledgeArticle)
+        .filter(KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.view_count > 0)
+        .order_by(KnowledgeArticle.view_count.desc())
+        .limit(limit)
+        .all()
+    )
+    return [{"id": r.id, "title": r.title, "category": r.category, "view_count": r.view_count} for r in rows]
+
+
+def most_common_questions(db: Session, tenant_id: str, limit: int = 10) -> list[dict]:
+    rows = db.query(KnowledgeQueryLog).filter(KnowledgeQueryLog.tenant_id == tenant_id).all()
+    counts: dict[str, int] = defaultdict(int)
+    for r in rows:
+        counts[r.query_text.strip().lower()] += 1
+    return [
+        {"query": q, "count": c}
+        for q, c in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    ]
+
+
+def most_frequent_teaching_points(db: Session, tenant_id: str, limit: int = 10) -> list[dict]:
+    import json
+
+    rows = (
+        db.query(KnowledgeArticle)
+        .filter(KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.category == TEACHING_POINT)
+        .all()
+    )
+    counts: dict[str, int] = defaultdict(int)
+    for r in rows:
+        try:
+            findings = json.loads(r.applicable_findings or "[]")
+        except (TypeError, ValueError):
+            findings = []
+        for f in findings or ["unspecified"]:
+            counts[f] += 1
+    return [
+        {"finding": f, "teaching_point_count": c}
+        for f, c in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    ]
+
+
+def common_supervisor_comments(db: Session, tenant_id: str, limit: int = 10) -> list[dict]:
+    rows = (
+        db.query(DispositionOverride)
+        .filter(DispositionOverride.tenant_id == tenant_id, DispositionOverride.reason != "")
+        .all()
+    )
+    counts: dict[str, int] = defaultdict(int)
+    for r in rows:
+        counts[r.reason.strip()] += 1
+    return [
+        {"comment": c, "count": n}
+        for c, n in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    ]
+
+
+def knowledge_gaps(db: Session, tenant_id: str) -> list[dict]:
+    """Findings that have prompted a supervisor override but have no
+    approved institutional article addressing them yet — a real gap, not a
+    guess."""
+    import json
+
+    override_findings: dict[str, int] = defaultdict(int)
+    for r in db.query(DispositionOverride).filter(DispositionOverride.tenant_id == tenant_id).all():
+        if r.ai_recommended_disposition:
+            override_findings[r.ai_recommended_disposition] += 1
+
+    covered: set[str] = set()
+    for a in db.query(KnowledgeArticle).filter(
+        KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.approval_status == APPROVED,
+    ).all():
+        try:
+            findings = json.loads(a.applicable_findings or "[]")
+        except (TypeError, ValueError):
+            findings = []
+        covered.update(findings)
+
+    case_findings: dict[str, int] = defaultdict(int)
+    for c in db.query(ClinicalCase).filter(ClinicalCase.tenant_id == tenant_id).all():
+        if c.finding_type and c.finding_type not in covered:
+            case_findings[c.finding_type] += 1
+
+    return [
+        {"finding_type": f, "clinical_case_count": n}
+        for f, n in sorted(case_findings.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+
+
+def training_opportunities(db: Session, tenant_id: str) -> list[dict]:
+    """Technicians with a repeated error on record (v1.4 competency events)
+    for a finding type that has no approved institutional guidance yet."""
+    import json
+
+    from app.models.competency_event import CompetencyEvent
+
+    covered: set[str] = set()
+    for a in db.query(KnowledgeArticle).filter(
+        KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.approval_status == APPROVED,
+    ).all():
+        try:
+            findings = json.loads(a.applicable_findings or "[]")
+        except (TypeError, ValueError):
+            findings = []
+        covered.update(findings)
+
+    rows = (
+        db.query(CompetencyEvent)
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "repeated_error")
+        .all()
+    )
+    opportunities = []
+    for r in rows:
+        if r.finding_type and r.finding_type not in covered:
+            opportunities.append({"technician": r.technician, "finding_type": r.finding_type})
+    return opportunities
+
+
+def knowledge_analytics(db: Session, tenant_id: str) -> dict:
+    return {
+        "most_viewed_articles": most_viewed_articles(db, tenant_id),
+        "most_common_questions": most_common_questions(db, tenant_id),
+        "most_frequent_teaching_points": most_frequent_teaching_points(db, tenant_id),
+        "common_supervisor_comments": common_supervisor_comments(db, tenant_id),
+        "knowledge_gaps": knowledge_gaps(db, tenant_id),
+        "training_opportunities": training_opportunities(db, tenant_id),
+        "human_review_required": True,
+    }

--- a/backend/app/services/knowledge_governance_service.py
+++ b/backend/app/services/knowledge_governance_service.py
@@ -1,0 +1,73 @@
+"""v1.8 — Knowledge Governance (Deliverable 9).
+
+Tracks author, reviewer, approval status, version, and last-review date on
+every KnowledgeArticle, and archives outdated knowledge — governance is
+enforced here, not left to convention.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import APPROVED, ARCHIVED, PENDING_REVIEW, REJECTED, KnowledgeArticle
+
+
+class ArticleNotFoundError(ValueError):
+    pass
+
+
+def _get(db: Session, tenant_id: str, article_id: int) -> KnowledgeArticle:
+    row = (
+        db.query(KnowledgeArticle)
+        .filter(KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.id == article_id)
+        .first()
+    )
+    if row is None:
+        raise ArticleNotFoundError(f"Knowledge article {article_id} not found.")
+    return row
+
+
+def submit_for_review(db: Session, tenant_id: str, article_id: int) -> KnowledgeArticle:
+    row = _get(db, tenant_id, article_id)
+    row.approval_status = PENDING_REVIEW
+    return row
+
+
+def approve_article(db: Session, tenant_id: str, article_id: int, *, reviewer: str) -> KnowledgeArticle:
+    row = _get(db, tenant_id, article_id)
+    row.approval_status = APPROVED
+    row.reviewer = reviewer
+    row.last_reviewed_at = datetime.now(timezone.utc)
+    return row
+
+
+def reject_article(db: Session, tenant_id: str, article_id: int, *, reviewer: str) -> KnowledgeArticle:
+    row = _get(db, tenant_id, article_id)
+    row.approval_status = REJECTED
+    row.reviewer = reviewer
+    row.last_reviewed_at = datetime.now(timezone.utc)
+    return row
+
+
+def archive_article(db: Session, tenant_id: str, article_id: int, *, reviewer: str) -> KnowledgeArticle:
+    """Outdated knowledge is archived, never deleted — it stays available
+    for audit but drops out of default search/list results."""
+    row = _get(db, tenant_id, article_id)
+    row.approval_status = ARCHIVED
+    row.reviewer = reviewer
+    row.last_reviewed_at = datetime.now(timezone.utc)
+    return row
+
+
+def governance_summary(db: Session, tenant_id: str) -> dict:
+    rows = db.query(KnowledgeArticle).filter(KnowledgeArticle.tenant_id == tenant_id).all()
+    by_status: dict[str, int] = {}
+    for r in rows:
+        by_status[r.approval_status] = by_status.get(r.approval_status, 0) + 1
+    return {
+        "total_articles": len(rows),
+        "by_approval_status": by_status,
+        "pending_review_count": by_status.get(PENDING_REVIEW, 0),
+        "human_review_required": True,
+    }

--- a/backend/app/services/knowledge_graph_service.py
+++ b/backend/app/services/knowledge_graph_service.py
@@ -3,8 +3,8 @@
 Represents the SPD clinical ontology as queryable nodes/edges built from
 real, existing structured knowledge (instrument anatomy, zone taxonomy,
 per-finding clinical education, cleaning knowledge, family profiles) plus
-real database rows (Inspection, SupervisorReview, PilotValidationCase,
-BaselineLibraryEntry, InstrumentKnowledge) — not a separate graph database.
+real database rows (Inspection, SupervisorReview, BaselineLibraryEntry,
+InstrumentKnowledge) — not a separate graph database.
 Every traversal is deterministic and grounded; nothing here is a trained
 model or a black box.
 
@@ -288,7 +288,7 @@ def explore(db: Session, tenant_id: str, category: str, query: str = "") -> dict
 def enterprise_knowledge_analytics(db: Session, tenant_id: str) -> dict:
     from app.db import models
     from app.models.supervisor_review import SupervisorReview
-    from app.services.pilot_validation_service import compute_zone_performance, list_cases as list_pilot_cases
+    from app.services.ml.pilot_validation import zone_performance as compute_zone_performance
     from app.services.pre_sterilization_command_center_service import REQUIRES_REPAIR, classify_readiness
 
     inspections = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).all()
@@ -325,10 +325,15 @@ def enterprise_knowledge_analytics(db: Session, tenant_id: str) -> dict:
         if r.override_action:
             override_counts[r.override_action] += 1
 
-    pilot_cases = list_pilot_cases(db, tenant_id, limit=5000)
-    zone_performance = compute_zone_performance(pilot_cases)
-    highest_risk_zone = max(zone_performance, key=lambda z: z["missed_count"], default=None)
-    most_missed_zones = sorted([z for z in zone_performance if z["case_count"] > 0], key=lambda z: z["missed_count"], reverse=True)[:5]
+    # Zone-level miss/override performance, derived directly from real
+    # supervisor reviews (ground_truth is computed at review-submit time) —
+    # not a separate training-case table.
+    zp = compute_zone_performance(reviews)
+    most_missed_zones = [
+        {"zone": z["zone"], "missed_count": z["missed"], "case_count": zp["by_zone"][z["zone"]]["n"]}
+        for z in zp["most_common_missed_zones"][:5]
+    ]
+    highest_risk_zone = most_missed_zones[0]["zone"] if most_missed_zones else None
 
     reviews_by_family_total: dict[str, int] = defaultdict(int)
     for r in reviews:
@@ -362,12 +367,12 @@ def enterprise_knowledge_analytics(db: Session, tenant_id: str) -> dict:
 def learning_confidence(db: Session, tenant_id: str) -> dict:
     """Confidence signals derived from real supervisor reviews and ground
     truth — updated every time a review is submitted, never mutated by a
-    background process, never fabricated."""
-    from app.models.pilot_validation import PilotValidationCase
+    background process, never fabricated. Ground truth is read from
+    SupervisorReview.ground_truth itself (derived at submit time), not a
+    separate training-case table."""
     from app.models.supervisor_review import SupervisorReview
 
     reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
-    cases = db.query(PilotValidationCase).filter(PilotValidationCase.tenant_id == tenant_id).all()
 
     def _rate(n, d):
         return round(n / d, 4) if d else None
@@ -377,8 +382,8 @@ def learning_confidence(db: Session, tenant_id: str) -> dict:
     finding_correct = [r for r in reviews if r.finding_correct is not None]
     zone_correct = [r for r in reviews if r.zone_correct is not None]
 
-    adjudicated = [c for c in cases if c.ground_truth_label in ("tp", "tn", "fp", "fn")]
-    reasoning_correct = sum(1 for c in adjudicated if c.ground_truth_label in ("tp", "tn"))
+    adjudicated = [r for r in reviews if r.ground_truth in ("true_positive", "true_negative", "false_positive", "false_negative")]
+    reasoning_correct = sum(1 for r in adjudicated if r.ground_truth in ("true_positive", "true_negative"))
 
     per_family: dict[str, dict] = {}
     by_family_reviews: dict[str, list] = defaultdict(list)

--- a/backend/app/services/knowledge_graph_service.py
+++ b/backend/app/services/knowledge_graph_service.py
@@ -1,0 +1,401 @@
+"""Phase 21 — SPD Clinical Knowledge Graph & Clinical Reasoning Engine.
+
+Represents the SPD clinical ontology as queryable nodes/edges built from
+real, existing structured knowledge (instrument anatomy, zone taxonomy,
+per-finding clinical education, cleaning knowledge, family profiles) plus
+real database rows (Inspection, SupervisorReview, PilotValidationCase,
+BaselineLibraryEntry, InstrumentKnowledge) — not a separate graph database.
+Every traversal is deterministic and grounded; nothing here is a trained
+model or a black box.
+
+The chain this module reasons over (see
+docs/architecture/lumenai-clinical-ontology.md for the platform-wide
+version this specializes):
+
+Instrument -> Manufacturer -> Instrument Family -> Model -> Anatomy ->
+Inspection Zone -> Retention Risk -> Cleaning Method -> Typical
+Contamination -> Typical Damage -> Clinical Meaning -> Recommended Action
+-> Supervisor Validation -> Learning
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.services.baseline_comparison_scoring_service import _ACTION_TEXT
+from app.services.cleaning_knowledge import get_cleaning_knowledge
+from app.services.clinical_mentor import FINDING_EDUCATION
+from app.services.instrument_anatomy import anatomy_profile, resolve_family
+from app.services.instrument_family_profiles import get_family_profile, list_family_profiles
+from app.services.instrument_zones import ZONE_INFO, is_high_retention, zone_fields
+
+# ---------------------------------------------------------------------------
+# Section 1 — Node / relationship taxonomy
+# ---------------------------------------------------------------------------
+
+NODE_TYPES = [
+    "Instrument", "Manufacturer", "InstrumentFamily", "Model", "AnatomyZone",
+    "InspectionZone", "Finding", "Severity", "SPDRisk", "CleaningMethod",
+    "BrushType", "IFU", "RepairRecommendation", "ReplacementRecommendation",
+    "SupervisorDecision", "ClinicalRecommendation", "TrainingDataset",
+]
+
+RELATIONSHIP_TYPES = [
+    "Instrument HAS Anatomy",
+    "Anatomy HAS Zone",
+    "Zone HAS Retention Risk",
+    "Zone HAS Cleaning Method",
+    "Zone HAS Common Findings",
+    "Finding HAS Clinical Meaning",
+    "Finding HAS Severity",
+    "Finding REQUIRES Action",
+    "Supervisor VALIDATES Finding",
+    "Inspection CREATES Learning Signal",
+]
+
+_CONTAMINATION_FINDINGS = {"blood", "bone", "tissue", "debris", "other", "other_organic_residue"}
+_STRUCTURAL_FINDINGS = {"crack", "corrosion", "insulation_damage", "pitting", "rust", "missing_component", "discoloration"}
+
+
+def graph_schema() -> dict:
+    """The node/relationship taxonomy itself — Section 1 deliverable."""
+    return {
+        "node_types": NODE_TYPES,
+        "relationship_types": RELATIONSHIP_TYPES,
+        "chain": [
+            "Instrument", "Manufacturer", "Instrument Family", "Model", "Anatomy",
+            "Inspection Zone", "Retention Risk", "Cleaning Method",
+            "Typical Contamination", "Typical Damage", "Clinical Meaning",
+            "Recommended Action", "Supervisor Validation", "Learning",
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section 2/5/6 — Clinical Reasoning Chain + Explainability Graph
+# ---------------------------------------------------------------------------
+
+def _finding_label(finding_type: str) -> str:
+    return (finding_type or "").replace("_", " ").strip() or "an unspecified finding"
+
+
+def _recommended_action_text(finding_type: str, zone: str) -> tuple[str, str]:
+    """Generic (severity-unaware) recommended action + outcome key for the
+    knowledge-graph explorer, where no scored inspection exists yet."""
+    finding = (finding_type or "").strip().lower()
+    if finding in _CONTAMINATION_FINDINGS:
+        outcome = "REPROCESS"
+        action = "recleaning, repeat inspection, and supervisor verification"
+    elif finding in {"crack", "missing_component"} or (finding == "corrosion" and is_high_retention(zone)):
+        outcome = "REMOVE FROM SERVICE"
+        action = "removal from service pending repair evaluation and supervisor review"
+    elif finding in _STRUCTURAL_FINDINGS:
+        outcome = "SUPERVISOR REVIEW"
+        action = "supervisor review and structural evaluation"
+    else:
+        outcome = "PASS"
+        action = "routine processing"
+    return outcome, action
+
+
+def reasoning_chain(instrument_type: str, finding_type: str, manufacturer: str = "", model: str = "") -> dict:
+    """The traceable Instrument -> ... -> Recommendation chain (generic,
+    severity-unaware) used by the Knowledge Graph Explorer. For a specific
+    scored inspection, use `explain_inspection` instead."""
+    profile = anatomy_profile(instrument_type, manufacturer=manufacturer, model=model)
+    family = profile["instrument_family"]
+    zinfo = zone_fields(instrument_type, finding_type)
+    zone = zinfo["instrument_zone"]
+    cleaning = get_cleaning_knowledge(zone)
+    education = FINDING_EDUCATION.get((finding_type or "").strip().lower(), {})
+    outcome, action_phrase = _recommended_action_text(finding_type, zone)
+    finding_label = _finding_label(finding_type)
+
+    steps = [
+        {"node": "Instrument", "value": instrument_type},
+        {"node": "Manufacturer", "value": manufacturer or "not specified"},
+        {"node": "Instrument Family", "value": family},
+        {"node": "Model", "value": model or "not specified"},
+        {"node": "Anatomy Zone", "value": zone, "note": profile.get("warning")},
+        {"node": "Inspection Zone", "value": zone},
+        {"node": "Retention Risk", "value": zinfo["zone_risk"]},
+        {"node": "Cleaning Method", "value": cleaning["cleaning_method"]},
+        {"node": "Typical Contamination", "value": profile.get("contamination_risks", {}).get(zone, [])},
+        {"node": "Typical Damage", "value": profile.get("condition_risks", {}).get(zone, [])},
+        {"node": "Clinical Meaning", "value": education.get("clinical_significance") or education.get("why_it_matters", "")},
+        {"node": "Recommended Action", "value": _ACTION_TEXT.get(outcome, action_phrase), "outcome": outcome},
+        {"node": "Supervisor Validation", "value": "Required before disposition — routed to the Supervisor Review Queue."},
+        {"node": "Learning", "value": "A confirmed or corrected supervisor review becomes a Phase 18 ground-truth training label."},
+    ]
+
+    narrative = (
+        f"I detected probable {finding_label} in the {instrument_type} {zone}. "
+        f"{zinfo['zone_reason']} "
+        f"Based on SPD best practices and the {family.replace('_', ' ')} instrument profile, "
+        f"{action_phrase} are recommended before the instrument proceeds to packaging."
+    )
+
+    return {
+        "instrument_type": instrument_type,
+        "manufacturer": manufacturer,
+        "model": model,
+        "finding_type": finding_type,
+        "chain": steps,
+        "narrative": narrative,
+        "human_review_required": True,
+    }
+
+
+def explain_inspection(db: Session, inspection) -> dict:
+    """Section 6 — Explainability graph for one real, scored inspection.
+    Uses the inspection's actual persisted recommended_action/risk_score
+    rather than the generic (severity-unaware) reasoning_chain estimate."""
+    zinfo = zone_fields(inspection.instrument_type, inspection.detected_issue)
+    zone = zinfo["instrument_zone"]
+    education = FINDING_EDUCATION.get((inspection.detected_issue or "").strip().lower(), {})
+    cleaning = get_cleaning_knowledge(zone)
+    family = resolve_family(inspection.instrument_type)
+
+    return {
+        "inspection_id": inspection.id,
+        "why": [
+            {"node": "Finding", "value": inspection.detected_issue, "detail": "AI-detected finding on this inspection."},
+            {"node": "Zone", "value": zone, "detail": zinfo["zone_reason"]},
+            {"node": "Clinical Significance", "value": education.get("clinical_significance", "")},
+            {"node": "SPD Rule", "value": cleaning["cleaning_method"]},
+            {"node": "Recommendation", "value": inspection.recommended_action or "Pending analysis."},
+        ],
+        "instrument_family": family,
+        "risk_score": inspection.risk_score,
+        "human_review_required": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Instrument Family Intelligence (thin wrapper)
+# ---------------------------------------------------------------------------
+
+def get_instrument_family_intelligence(family_key: str) -> dict | None:
+    return get_family_profile(family_key)
+
+
+def list_instrument_family_intelligence() -> list[dict]:
+    return list_family_profiles()
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Knowledge Graph Explorer
+# ---------------------------------------------------------------------------
+
+def explore(db: Session, tenant_id: str, category: str, query: str = "") -> dict:
+    """Search the knowledge graph by category. Every result is backed by
+    real data — no fabricated node ever appears here."""
+    from app.db import models
+    from app.models.baseline_library import BaselineLibraryEntry
+    from app.models.instrument_knowledge import InstrumentKnowledge
+    from app.models.supervisor_review import SupervisorReview
+
+    q = (query or "").strip().lower()
+    category = (category or "").strip().lower()
+
+    if category == "manufacturer":
+        rows = db.query(models.Inspection.vendor_name, models.Inspection.id).filter(
+            models.Inspection.tenant_id == tenant_id
+        ).all()
+        counts: dict[str, int] = defaultdict(int)
+        for vendor, _ in rows:
+            name = (vendor or "unknown").strip()
+            if q and q not in name.lower():
+                continue
+            counts[name] += 1
+        return {"category": "manufacturer", "results": [{"manufacturer": k, "inspection_count": v} for k, v in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)]}
+
+    if category == "instrument":
+        rows = db.query(models.Inspection.instrument_type).filter(models.Inspection.tenant_id == tenant_id).distinct().all()
+        results = []
+        for (itype,) in rows:
+            if q and q not in (itype or "").lower():
+                continue
+            results.append({"instrument_type": itype, "instrument_family": resolve_family(itype)})
+        return {"category": "instrument", "results": results}
+
+    if category == "model":
+        rows = db.query(BaselineLibraryEntry.model_name, BaselineLibraryEntry.manufacturer_name, BaselineLibraryEntry.instrument_category).all()
+        results = []
+        for model_name, manufacturer_name, category_name in rows:
+            if q and q not in (model_name or "").lower():
+                continue
+            results.append({"model": model_name, "manufacturer": manufacturer_name, "instrument_category": category_name})
+        return {"category": "model", "results": results}
+
+    if category == "finding":
+        results = []
+        for finding, info in FINDING_EDUCATION.items():
+            if q and q not in finding.lower():
+                continue
+            results.append({"finding": finding, "why_it_matters": info.get("why_it_matters"), "clinical_significance": info.get("clinical_significance")})
+        return {"category": "finding", "results": results}
+
+    if category == "zone":
+        results = []
+        for zone, info in ZONE_INFO.items():
+            if q and q not in zone.lower():
+                continue
+            results.append({"zone": zone, **info, "cleaning": get_cleaning_knowledge(zone)})
+        return {"category": "zone", "results": results}
+
+    if category == "failure_mode":
+        rows = db.query(InstrumentKnowledge).filter(InstrumentKnowledge.tenant_id == tenant_id).all()
+        results = []
+        for r in rows:
+            try:
+                modes = json.loads(r.known_failure_modes or "[]")
+            except (TypeError, ValueError):
+                modes = []
+            for m in modes:
+                if q and q not in str(m).lower():
+                    continue
+                results.append({"manufacturer": r.manufacturer, "model": r.model, "instrument_family": r.instrument_family, "failure_mode": m})
+        return {"category": "failure_mode", "results": results}
+
+    if category == "recommendation":
+        results = [{"outcome": k, "action_text": v} for k, v in _ACTION_TEXT.items() if not q or q in k.lower() or q in v.lower()]
+        return {"category": "recommendation", "results": results}
+
+    if category == "supervisor_learning":
+        rows = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+        total = len(rows)
+        agree = sum(1 for r in rows if r.agreement == "agree")
+        corrections = [r.corrected_zone for r in rows if r.corrected_zone]
+        return {
+            "category": "supervisor_learning",
+            "results": {
+                "total_reviews": total,
+                "agreement_rate": round(agree / total, 4) if total else None,
+                "common_zone_corrections": sorted(set(corrections)),
+            },
+        }
+
+    return {"category": category, "results": [], "error": "Unknown category. Use one of: manufacturer, instrument, model, finding, zone, failure_mode, recommendation, supervisor_learning."}
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Enterprise Knowledge Analytics
+# ---------------------------------------------------------------------------
+
+def enterprise_knowledge_analytics(db: Session, tenant_id: str) -> dict:
+    from app.db import models
+    from app.models.supervisor_review import SupervisorReview
+    from app.services.pilot_validation_service import compute_zone_performance, list_cases as list_pilot_cases
+    from app.services.pre_sterilization_command_center_service import REQUIRES_REPAIR, classify_readiness
+
+    inspections = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).all()
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+
+    def _top(counter: dict, n: int = 5) -> list[dict]:
+        return [{"key": k, "count": v} for k, v in sorted(counter.items(), key=lambda kv: kv[1], reverse=True)[:n]]
+
+    findings_by_manufacturer: dict[str, int] = defaultdict(int)
+    findings_by_zone: dict[str, int] = defaultdict(int)
+    contamination_counts: dict[str, int] = defaultdict(int)
+    repair_reasons: dict[str, int] = defaultdict(int)
+    family_disagreements: dict[str, int] = defaultdict(int)
+
+    for insp in inspections:
+        issue = (insp.detected_issue or "").strip().lower()
+        if issue and issue not in ("none", "unknown"):
+            findings_by_manufacturer[f"{insp.vendor_name or 'unknown'}:{issue}"] += 1
+            zone = zone_fields(insp.instrument_type, issue)["instrument_zone"]
+            findings_by_zone[f"{zone}:{issue}"] += 1
+            if issue in _CONTAMINATION_FINDINGS:
+                contamination_counts[issue] += 1
+        classified = classify_readiness(insp)
+        if classified["readiness_state"] == REQUIRES_REPAIR:
+            repair_reasons[issue] += 1
+
+    for r in reviews:
+        key = r.corrected_instrument_family or "unspecified"
+        if r.agreement != "agree" or r.override_action:
+            family_disagreements[key] += 1
+
+    override_counts: dict[str, int] = defaultdict(int)
+    for r in reviews:
+        if r.override_action:
+            override_counts[r.override_action] += 1
+
+    pilot_cases = list_pilot_cases(db, tenant_id, limit=5000)
+    zone_performance = compute_zone_performance(pilot_cases)
+    highest_risk_zone = max(zone_performance, key=lambda z: z["missed_count"], default=None)
+    most_missed_zones = sorted([z for z in zone_performance if z["case_count"] > 0], key=lambda z: z["missed_count"], reverse=True)[:5]
+
+    reviews_by_family_total: dict[str, int] = defaultdict(int)
+    for r in reviews:
+        reviews_by_family_total[r.corrected_instrument_family or "unspecified"] += 1
+    most_difficult_family = None
+    if family_disagreements:
+        candidates = {
+            fam: round(cnt / reviews_by_family_total[fam], 4)
+            for fam, cnt in family_disagreements.items() if reviews_by_family_total.get(fam)
+        }
+        if candidates:
+            most_difficult_family = max(candidates, key=lambda k: candidates[k])
+
+    return {
+        "most_common_findings_by_manufacturer": _top(findings_by_manufacturer),
+        "most_common_findings_by_anatomy": _top(findings_by_zone),
+        "highest_risk_anatomy_zone": highest_risk_zone["zone"] if highest_risk_zone else None,
+        "most_common_repair_reason": _top(repair_reasons, n=3),
+        "most_common_supervisor_override": _top(override_counts, n=3),
+        "most_difficult_instrument_family": most_difficult_family,
+        "most_missed_anatomy_zones": most_missed_zones,
+        "most_common_contamination_type": _top(contamination_counts, n=5),
+        "human_review_required": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Continuous Knowledge Learning (confidence, computed live)
+# ---------------------------------------------------------------------------
+
+def learning_confidence(db: Session, tenant_id: str) -> dict:
+    """Confidence signals derived from real supervisor reviews and ground
+    truth — updated every time a review is submitted, never mutated by a
+    background process, never fabricated."""
+    from app.models.pilot_validation import PilotValidationCase
+    from app.models.supervisor_review import SupervisorReview
+
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    cases = db.query(PilotValidationCase).filter(PilotValidationCase.tenant_id == tenant_id).all()
+
+    def _rate(n, d):
+        return round(n / d, 4) if d else None
+
+    n = len(reviews)
+    agree = sum(1 for r in reviews if r.agreement == "agree")
+    finding_correct = [r for r in reviews if r.finding_correct is not None]
+    zone_correct = [r for r in reviews if r.zone_correct is not None]
+
+    adjudicated = [c for c in cases if c.ground_truth_label in ("tp", "tn", "fp", "fn")]
+    reasoning_correct = sum(1 for c in adjudicated if c.ground_truth_label in ("tp", "tn"))
+
+    per_family: dict[str, dict] = {}
+    by_family_reviews: dict[str, list] = defaultdict(list)
+    for r in reviews:
+        key = r.corrected_instrument_family or "unspecified"
+        by_family_reviews[key].append(r)
+    for fam, fam_reviews in by_family_reviews.items():
+        correct = [r for r in fam_reviews if r.instrument_family_correct is not False]
+        per_family[fam] = {"review_count": len(fam_reviews), "instrument_profile_confidence": _rate(len(correct), len(fam_reviews))}
+
+    return {
+        "knowledge_confidence": _rate(agree, n),
+        "reasoning_confidence": _rate(reasoning_correct, len(adjudicated)),
+        "clinical_recommendation_confidence": _rate(sum(1 for r in finding_correct if r.finding_correct), len(finding_correct)),
+        "zone_confidence": _rate(sum(1 for r in zone_correct if r.zone_correct), len(zone_correct)),
+        "instrument_profile_confidence_by_family": per_family,
+        "sample_sizes": {"supervisor_reviews": n, "adjudicated_ground_truth_cases": len(adjudicated)},
+        "human_review_required": True,
+        "note": "Confidence is recomputed from real supervisor reviews on every request — it improves as more reviews accumulate, it is not a mutated/persisted model state.",
+    }

--- a/backend/app/services/knowledge_repository_service.py
+++ b/backend/app/services/knowledge_repository_service.py
@@ -1,0 +1,139 @@
+"""v1.8 — Institutional Knowledge Repository (Deliverable 1).
+
+CRUD + faceted search over KnowledgeArticle. Search facets are matched
+against real, stored data only — an article with no `applicable_findings`
+declared simply never matches a finding-facet search, it is never guessed.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import DRAFT, PENDING_REVIEW, KnowledgeArticle
+
+
+def _dump(values: list[str] | None) -> str:
+    return json.dumps(list(values or []))
+
+
+def _load(text: str) -> list[str]:
+    try:
+        return json.loads(text or "[]")
+    except (TypeError, ValueError):
+        return []
+
+
+def create_article(
+    db: Session, *, tenant_id: str, category: str, title: str, body: str, author: str,
+    applicable_instruments: list[str] | None = None, applicable_findings: list[str] | None = None,
+    applicable_manufacturers: list[str] | None = None, anatomy_zone: str = "", procedure: str = "",
+    specialty: str = "", common_mistake: str = "", prevention_tip: str = "", references: str = "",
+    source_inspection_id: int | None = None, approval_status: str = DRAFT,
+) -> KnowledgeArticle:
+    row = KnowledgeArticle(
+        tenant_id=tenant_id, category=category, title=title.strip(), body=body.strip(), author=author,
+        applicable_instruments=_dump(applicable_instruments), applicable_findings=_dump(applicable_findings),
+        applicable_manufacturers=_dump(applicable_manufacturers), anatomy_zone=anatomy_zone.strip(),
+        procedure=procedure.strip(), specialty=specialty.strip(), common_mistake=common_mistake.strip(),
+        prevention_tip=prevention_tip.strip(), references=references.strip(),
+        source_inspection_id=source_inspection_id, approval_status=approval_status,
+    )
+    db.add(row)
+    return row
+
+
+def update_article(db: Session, tenant_id: str, article_id: int, *, title: str | None = None, body: str | None = None) -> KnowledgeArticle | None:
+    """Editing an approved article's substance bumps the version and sends it
+    back to pending_review — an edit is never silently applied to knowledge
+    staff are already relying on as approved."""
+    row = (
+        db.query(KnowledgeArticle)
+        .filter(KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.id == article_id)
+        .first()
+    )
+    if row is None:
+        return None
+    changed = False
+    if title is not None and title.strip() != row.title:
+        row.title = title.strip()
+        changed = True
+    if body is not None and body.strip() != row.body:
+        row.body = body.strip()
+        changed = True
+    if changed:
+        row.version += 1
+        row.updated_at = datetime.now(timezone.utc)
+        if row.approval_status == "approved":
+            row.approval_status = PENDING_REVIEW
+    return row
+
+
+def get_article(db: Session, tenant_id: str, article_id: int) -> KnowledgeArticle | None:
+    return (
+        db.query(KnowledgeArticle)
+        .filter(KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.id == article_id)
+        .first()
+    )
+
+
+def record_view(db: Session, tenant_id: str, article_id: int) -> KnowledgeArticle | None:
+    row = get_article(db, tenant_id, article_id)
+    if row is None:
+        return None
+    row.view_count += 1
+    return row
+
+
+def article_to_dict(row: KnowledgeArticle) -> dict:
+    return {
+        "id": row.id, "category": row.category, "title": row.title, "body": row.body,
+        "author": row.author, "reviewer": row.reviewer, "approval_status": row.approval_status,
+        "version": row.version, "last_reviewed_at": row.last_reviewed_at.isoformat() if row.last_reviewed_at else None,
+        "applicable_instruments": _load(row.applicable_instruments),
+        "applicable_findings": _load(row.applicable_findings),
+        "applicable_manufacturers": _load(row.applicable_manufacturers),
+        "anatomy_zone": row.anatomy_zone, "procedure": row.procedure, "specialty": row.specialty,
+        "common_mistake": row.common_mistake, "prevention_tip": row.prevention_tip, "references": row.references,
+        "source_inspection_id": row.source_inspection_id, "view_count": row.view_count,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+def list_articles(
+    db: Session, tenant_id: str, *, category: str = "", instrument: str = "", manufacturer: str = "",
+    anatomy_zone: str = "", finding: str = "", procedure: str = "", specialty: str = "",
+    approval_status: str = "", include_archived: bool = False,
+) -> list[dict]:
+    """Deliverable 1 — faceted institutional-knowledge search."""
+    q = db.query(KnowledgeArticle).filter(KnowledgeArticle.tenant_id == tenant_id)
+    if category:
+        q = q.filter(KnowledgeArticle.category == category)
+    if approval_status:
+        q = q.filter(KnowledgeArticle.approval_status == approval_status)
+    if anatomy_zone:
+        q = q.filter(KnowledgeArticle.anatomy_zone == anatomy_zone)
+    if procedure:
+        q = q.filter(KnowledgeArticle.procedure.ilike(f"%{procedure}%"))
+    if specialty:
+        q = q.filter(KnowledgeArticle.specialty == specialty)
+    rows = q.order_by(KnowledgeArticle.id.desc()).all()
+
+    if not include_archived:
+        rows = [r for r in rows if r.approval_status != "archived"]
+
+    results = [article_to_dict(r) for r in rows]
+
+    if instrument:
+        needle = instrument.strip().lower()
+        results = [r for r in results if any(needle in i.lower() for i in r["applicable_instruments"])]
+    if manufacturer:
+        needle = manufacturer.strip().lower()
+        results = [r for r in results if any(needle in m.lower() for m in r["applicable_manufacturers"])]
+    if finding:
+        needle = finding.strip().lower()
+        results = [r for r in results if any(needle in f.lower() for f in r["applicable_findings"])]
+
+    return results

--- a/backend/app/services/knowledge_search_service.py
+++ b/backend/app/services/knowledge_search_service.py
@@ -1,0 +1,95 @@
+"""v1.8 — Smart Knowledge Search (Deliverable 4).
+
+A deterministic, keyword-matched search over institutional knowledge
+articles and clinical cases — mirroring the same "explainable, not a black
+box" approach already used by the disposition/priority/risk engines rather
+than calling out to an external LLM. The query is matched against real,
+already-known vocabulary (finding types, anatomy zones, instrument
+families) so "show all blood findings in Kerrisons" resolves to a real
+`finding=blood` + `instrument family=kerrison_rongeur` filter, not a guess.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import KnowledgeQueryLog
+from app.services.clinical_mentor import FINDING_EDUCATION
+from app.services.clinical_case_library_service import list_cases
+from app.services.instrument_anatomy import INSTRUMENT_ANATOMY
+from app.services.instrument_zones import ZONE_INFO
+from app.services.knowledge_repository_service import list_articles
+
+
+def _matched_findings(q: str) -> list[str]:
+    return [f for f in FINDING_EDUCATION if f in q or f.replace("_", " ") in q]
+
+
+def _matched_zones(q: str) -> list[str]:
+    return [z for z in ZONE_INFO if z.lower() in q]
+
+
+def _matched_families(q: str) -> list[str]:
+    families = []
+    for family, defn in INSTRUMENT_ANATOMY.items():
+        if family == "default":
+            continue
+        if family.replace("_", " ") in q or any(k in q for k in defn.get("match", [])):
+            families.append(family)
+    return families
+
+
+def smart_search(db: Session, tenant_id: str, query: str, *, actor: str = "") -> dict:
+    """Deliverable 4 — natural-language-style search resolved to real facet
+    matches over KnowledgeArticle + ClinicalCase."""
+    q = (query or "").strip().lower()
+    matched_findings = _matched_findings(q)
+    matched_zones = _matched_zones(q)
+    matched_families = _matched_families(q)
+
+    articles: list[dict] = []
+    cases: list[dict] = []
+    seen_article_ids: set[int] = set()
+    seen_case_ids: set[int] = set()
+
+    if matched_findings:
+        for finding in matched_findings:
+            for a in list_articles(db, tenant_id, finding=finding, approval_status="approved"):
+                if a["id"] not in seen_article_ids:
+                    seen_article_ids.add(a["id"])
+                    articles.append(a)
+            for c in list_cases(db, tenant_id, finding=finding):
+                if c["id"] not in seen_case_ids:
+                    seen_case_ids.add(c["id"])
+                    cases.append(c)
+    else:
+        # No recognized finding keyword — fall back to a free-text match
+        # over approved article title/body.
+        for a in list_articles(db, tenant_id, approval_status="approved"):
+            if q and (q in a["title"].lower() or q in a["body"].lower()):
+                articles.append(a)
+
+    if matched_families:
+        for family in matched_families:
+            for c in list_cases(db, tenant_id):
+                if c["id"] in seen_case_ids:
+                    continue
+                from app.services.instrument_anatomy import resolve_family
+                if resolve_family(c["instrument_type"]) == family:
+                    seen_case_ids.add(c["id"])
+                    cases.append(c)
+
+    matched_category = (
+        "finding" if matched_findings else "instrument_family" if matched_families
+        else "zone" if matched_zones else "free_text"
+    )
+    db.add(KnowledgeQueryLog(tenant_id=tenant_id, actor=actor, query_text=query, matched_category=matched_category))
+
+    return {
+        "query": query,
+        "matched_findings": matched_findings,
+        "matched_zones": matched_zones,
+        "matched_instrument_families": matched_families,
+        "articles": articles,
+        "cases": cases,
+        "human_review_required": True,
+    }

--- a/backend/app/services/operational_analytics_service.py
+++ b/backend/app/services/operational_analytics_service.py
@@ -1,0 +1,55 @@
+"""v1.7 — Operational Analytics (Deliverable 11)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.services.sla_monitoring_service import sla_monitoring
+from app.services.technician_workload_service import technician_workload
+from app.services.work_queue_service import build_work_queue
+
+
+def operational_analytics(db: Session, tenant_id: str, days: int = 30) -> dict:
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    throughput = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.created_at >= since)
+        .count()
+    )
+
+    workload = technician_workload(db, tenant_id)
+    queue = build_work_queue(db, tenant_id)
+    sla = sla_monitoring(db, tenant_id)
+
+    productivity = sorted(
+        (
+            {"technician": t["technician"], "completed_inspections": t["completed_inspections"]}
+            for t in workload["technicians"]
+        ),
+        key=lambda t: t["completed_inspections"], reverse=True,
+    )
+
+    waits = [i["minutes_waiting"] for i in queue["pending_inspections"] if i["minutes_waiting"] is not None]
+    queue_aging_minutes_avg = round(sum(waits) / len(waits), 1) if waits else None
+    queue_aging_minutes_max = max(waits) if waits else None
+
+    workloads = [t["workload"] for t in workload["technicians"]]
+    workload_balance = {
+        "min": min(workloads) if workloads else None,
+        "max": max(workloads) if workloads else None,
+        "spread": (max(workloads) - min(workloads)) if workloads else None,
+    }
+
+    return {
+        "period_days": days,
+        "inspection_throughput": throughput,
+        "technician_productivity": productivity,
+        "queue_aging_minutes_avg": queue_aging_minutes_avg,
+        "queue_aging_minutes_max": queue_aging_minutes_max,
+        "average_turnaround_minutes": sla["average_overall_turnaround_minutes"],
+        "high_risk_workload": len(queue["high_risk_inspections"]),
+        "workload_balance": workload_balance,
+        "human_review_required": True,
+    }

--- a/backend/app/services/operations_board_service.py
+++ b/backend/app/services/operations_board_service.py
@@ -1,0 +1,28 @@
+"""v1.7 — Supervisor Operations Board (Deliverable 5).
+
+A single rollup of the queue + workload data supervisors need to run the
+shift — nothing here is a new analysis, just an operations-focused view of
+work_queue_service and technician_workload_service.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services.technician_workload_service import technician_workload
+from app.services.work_queue_service import build_work_queue
+
+
+def operations_board(db: Session, tenant_id: str) -> dict:
+    queue = build_work_queue(db, tenant_id)
+    workload = technician_workload(db, tenant_id)
+
+    return {
+        "technician_workload": workload["technicians"],
+        "supervisor_queue": queue["supervisor_reviews"],
+        "pending_approvals": queue["supervisor_reviews"],
+        "high_risk_findings": queue["high_risk_inspections"],
+        "repair_queue": queue["repair_holds"],
+        "or_urgent_items": queue["or_priority_instruments"],
+        "vendor_instruments": queue["vendor_trays"],
+        "human_review_required": True,
+    }

--- a/backend/app/services/organization_standards_service.py
+++ b/backend/app/services/organization_standards_service.py
@@ -1,0 +1,53 @@
+"""v1.8 — Organization Standards (Deliverable 6).
+
+Per-tenant local policy — inspection standards, photography standards,
+coverage requirements, supervisor approval thresholds, competency
+requirements. These supplement, never replace, manufacturer IFUs; nothing
+here overrides the AI's clinical engines.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import OrganizationStandard
+
+
+def create_standard(
+    db: Session, tenant_id: str, *, standard_type: str, title: str, description: str, created_by: str,
+) -> OrganizationStandard:
+    row = OrganizationStandard(
+        tenant_id=tenant_id, standard_type=standard_type, title=title.strip(),
+        description=description.strip(), created_by=created_by,
+    )
+    db.add(row)
+    return row
+
+
+def standard_to_dict(row: OrganizationStandard) -> dict:
+    return {
+        "id": row.id, "standard_type": row.standard_type, "title": row.title,
+        "description": row.description, "created_by": row.created_by, "active": row.active,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+    }
+
+
+def list_standards(db: Session, tenant_id: str, *, standard_type: str = "", active_only: bool = True) -> list[dict]:
+    q = db.query(OrganizationStandard).filter(OrganizationStandard.tenant_id == tenant_id)
+    if standard_type:
+        q = q.filter(OrganizationStandard.standard_type == standard_type)
+    if active_only:
+        q = q.filter(OrganizationStandard.active.is_(True))
+    rows = q.order_by(OrganizationStandard.id.desc()).all()
+    return [standard_to_dict(r) for r in rows]
+
+
+def deactivate_standard(db: Session, tenant_id: str, standard_id: int) -> OrganizationStandard | None:
+    row = (
+        db.query(OrganizationStandard)
+        .filter(OrganizationStandard.tenant_id == tenant_id, OrganizationStandard.id == standard_id)
+        .first()
+    )
+    if row is None:
+        return None
+    row.active = False
+    return row

--- a/backend/app/services/pilot_data_collection_service.py
+++ b/backend/app/services/pilot_data_collection_service.py
@@ -1,0 +1,57 @@
+"""v1.9 — Pilot Data Collection Dashboard (Deliverable 6).
+
+A rollup for the pilot lead to answer "is our dataset actually usable
+yet?" — built entirely from real, already-persisted rows (Inspection,
+BaselineLibraryEntry, SupervisorReview, PilotErrorLog) plus the data
+quality guardrails' own evaluation. Nothing here is a separate analysis.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.pilot_error_log import AI_ANALYSIS_FAILURE, UPLOAD_FAILURE
+from app.models.supervisor_review import SupervisorReview
+from app.services.data_quality_guardrails_service import evaluate_data_quality
+from app.services.pilot_error_log_service import count_by_type
+from app.services.pilot_site_config_service import get_or_create_config
+
+
+def pilot_data_collection_summary(db: Session, tenant_id: str) -> dict:
+    config = get_or_create_config(db, tenant_id)
+
+    inspections = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).all()
+    baseline_images_collected = (
+        db.query(BaselineLibraryEntry)
+        .filter(BaselineLibraryEntry.approval_status == "approved")
+        .count()
+    )
+    inspection_images_collected = sum(1 for i in inspections if i.has_image)
+    supervisor_reviews_completed = (
+        db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).count()
+    )
+
+    evaluations = [evaluate_data_quality(i, pilot_config=config) for i in inspections]
+    incomplete_inspections = [e for e in evaluations if not e["is_dataset_ready"]]
+    missing_anatomy_zones = sum(
+        1 for e in evaluations if any(issue["code"] == "missing_anatomy_zone" for issue in e["issues"])
+    )
+    dataset_ready_images = sum(1 for e in evaluations if e["is_dataset_ready"])
+
+    failed_uploads = count_by_type(db, tenant_id, UPLOAD_FAILURE) + count_by_type(db, tenant_id, AI_ANALYSIS_FAILURE)
+
+    return {
+        "facility_name": config.facility_name,
+        "department": config.department,
+        "inspections_collected": len(inspections),
+        "baseline_images_collected": baseline_images_collected,
+        "inspection_images_collected": inspection_images_collected,
+        "supervisor_reviews_completed": supervisor_reviews_completed,
+        "incomplete_inspections": len(incomplete_inspections),
+        "incomplete_inspection_details": incomplete_inspections[:20],
+        "failed_uploads": failed_uploads,
+        "missing_anatomy_zones": missing_anatomy_zones,
+        "dataset_ready_images": dataset_ready_images,
+        "human_review_required": True,
+    }

--- a/backend/app/services/pilot_error_log_service.py
+++ b/backend/app/services/pilot_error_log_service.py
@@ -1,0 +1,48 @@
+"""v1.9 — Production Error Logging (Deliverable 7).
+
+`log_error()` is called from the real failure sites (not synthesized
+after the fact) — see routes/inspections.py, routes/reports.py, and
+app/authz.py for the call sites. PHI redaction is enforced here: `detail`
+is truncated and any caller-supplied value is expected to already be a
+short exception message or status reason, never raw request/image data.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.pilot_error_log import ERROR_TYPES, PilotErrorLog
+
+_MAX_DETAIL_LENGTH = 500
+
+
+def log_error(
+    db: Session, *, tenant_id: str, error_type: str, detail: str = "", actor_role: str = "",
+    inspection_id: int | None = None,
+) -> PilotErrorLog | None:
+    """Never raises — a logging failure must never break the caller's real
+    request. Returns None (and logs nothing) for an unrecognized error_type
+    rather than silently miscategorizing it."""
+    if error_type not in ERROR_TYPES:
+        return None
+    row = PilotErrorLog(
+        tenant_id=tenant_id, error_type=error_type, detail=(detail or "")[:_MAX_DETAIL_LENGTH],
+        actor_role=actor_role, inspection_id=inspection_id,
+    )
+    db.add(row)
+    return row
+
+
+def error_summary(db: Session, tenant_id: str) -> dict:
+    rows = db.query(PilotErrorLog).filter(PilotErrorLog.tenant_id == tenant_id).all()
+    by_type: dict[str, int] = {}
+    for r in rows:
+        by_type[r.error_type] = by_type.get(r.error_type, 0) + 1
+    return {"total_errors": len(rows), "by_type": by_type}
+
+
+def count_by_type(db: Session, tenant_id: str, error_type: str) -> int:
+    return (
+        db.query(PilotErrorLog)
+        .filter(PilotErrorLog.tenant_id == tenant_id, PilotErrorLog.error_type == error_type)
+        .count()
+    )

--- a/backend/app/services/pilot_site_config_service.py
+++ b/backend/app/services/pilot_site_config_service.py
@@ -1,0 +1,67 @@
+"""v1.9 — Pilot Site Configuration (Deliverable 4)."""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.pilot_config import PilotSiteConfig
+
+
+def _load(text: str) -> list[str]:
+    try:
+        return json.loads(text or "[]")
+    except (TypeError, ValueError):
+        return []
+
+
+def config_to_dict(row: PilotSiteConfig) -> dict:
+    return {
+        "tenant_id": row.tenant_id,
+        "facility_name": row.facility_name,
+        "department": row.department,
+        "enabled_instrument_families": _load(row.enabled_instrument_families),
+        "required_inspection_zones": _load(row.required_inspection_zones),
+        "baseline_required": row.baseline_required,
+        "minimum_coverage_pct": row.minimum_coverage_pct,
+        "supervisor_review_threshold_score": row.supervisor_review_threshold_score,
+        "updated_by": row.updated_by,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+def get_or_create_config(db: Session, tenant_id: str) -> PilotSiteConfig:
+    """A pilot site always has a config — defaults are conservative
+    (baseline required, 75% coverage, review at/below 70) rather than the
+    absence of a row meaning "no rules apply"."""
+    row = db.query(PilotSiteConfig).filter(PilotSiteConfig.tenant_id == tenant_id).first()
+    if row is None:
+        row = PilotSiteConfig(tenant_id=tenant_id)
+        db.add(row)
+        db.flush()
+    return row
+
+
+def update_config(
+    db: Session, tenant_id: str, *, updated_by: str, facility_name: str | None = None,
+    department: str | None = None, enabled_instrument_families: list[str] | None = None,
+    required_inspection_zones: list[str] | None = None, baseline_required: bool | None = None,
+    minimum_coverage_pct: int | None = None, supervisor_review_threshold_score: int | None = None,
+) -> PilotSiteConfig:
+    row = get_or_create_config(db, tenant_id)
+    if facility_name is not None:
+        row.facility_name = facility_name
+    if department is not None:
+        row.department = department
+    if enabled_instrument_families is not None:
+        row.enabled_instrument_families = json.dumps(enabled_instrument_families)
+    if required_inspection_zones is not None:
+        row.required_inspection_zones = json.dumps(required_inspection_zones)
+    if baseline_required is not None:
+        row.baseline_required = baseline_required
+    if minimum_coverage_pct is not None:
+        row.minimum_coverage_pct = minimum_coverage_pct
+    if supervisor_review_threshold_score is not None:
+        row.supervisor_review_threshold_score = supervisor_review_threshold_score
+    row.updated_by = updated_by
+    return row

--- a/backend/app/services/pre_sterilization_command_center_service.py
+++ b/backend/app/services/pre_sterilization_command_center_service.py
@@ -1,10 +1,10 @@
 """Pre-Sterilization Command Center — readiness scoring, queues, and the
 executive risk rollup.
 
-Answers, from real Inspection/SupervisorReview/BaselineLibraryEntry/
-PilotValidationCase rows — never fabricated: "are these instruments
-clinically ready to move forward to packaging and sterilization, and if
-not, why not, where, and what should SPD do next?"
+Answers, from real Inspection/SupervisorReview/BaselineLibraryEntry
+rows — never fabricated: "are these instruments clinically ready to move
+forward to packaging and sterilization, and if not, why not, where, and
+what should SPD do next?"
 
 Terminology discipline (see docs/architecture/pre-sterilization-boundary.md):
 this module reports pre-sterilization/packaging *readiness*, never
@@ -52,8 +52,8 @@ _STATE_SEVERITY = {
 _REPAIRABLE_ISSUES = {"crack", "corrosion", "insulation_damage"}
 _CONTAMINATION_ISSUES = {"blood", "bone", "tissue", "debris", "other"}
 # High-risk findings per the Inspection.detected_issue taxonomy (narrower than
-# Phase 18's ground-truth taxonomy, which also tracks organic_residue /
-# missing_component as PilotValidationCase.finding_type values).
+# SupervisorReview's own ground-truth taxonomy, which also tracks
+# organic_residue / missing_component via its finding_type field).
 CRITICAL_ISSUES = {"blood", "tissue", "bone", "crack", "insulation_damage"}
 
 
@@ -417,18 +417,23 @@ def repair_remove_queue(annotated: list[dict]) -> dict:
 # ---------------------------------------------------------------------------
 
 def executive_risk_dashboard(db: Session, tenant_id: str, cases: list, annotated: list[dict]) -> dict:
-    from app.services.pilot_validation_service import compute_zone_performance, list_cases as list_pilot_cases
+    # Zone-level miss performance, derived directly from real supervisor
+    # reviews (ground_truth computed at review-submit time) — not a separate
+    # training-case table.
+    from app.models.supervisor_review import SupervisorReview
+    from app.services.ml.pilot_validation import zone_performance as compute_zone_performance
 
     readiness = clinical_inspection_readiness(annotated)
     repair_remove = repair_remove_queue(annotated)
     facilities = facility_readiness(annotated)
     baseline = baseline_coverage(db, tenant_id, cases)
 
-    pilot_cases = list_pilot_cases(db, tenant_id, limit=5000)
-    zone_performance = compute_zone_performance(pilot_cases)
-    worst_zones = sorted(
-        [z for z in zone_performance if z["case_count"] > 0], key=lambda z: z["missed_count"], reverse=True
-    )[:5]
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    zp = compute_zone_performance(reviews)
+    worst_zones = [
+        {"zone": z["zone"], "missed_count": z["missed"], "case_count": zp["by_zone"][z["zone"]]["n"]}
+        for z in zp["most_common_missed_zones"][:5]
+    ]
 
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/backend/app/services/pre_sterilization_command_center_service.py
+++ b/backend/app/services/pre_sterilization_command_center_service.py
@@ -70,7 +70,12 @@ def classify_readiness(insp) -> dict:
     detected_issue = (insp.detected_issue or "").strip().lower()
     repair_candidate = False
 
-    if insp.score_status != "scored":
+    if insp.score_status == "supervisor_review_required":
+        # Baseline-gated: an image was submitted but no approved manufacturer
+        # baseline exists, so scoring is locked pending supervisor review —
+        # this is not merely "still analyzing".
+        state = REQUIRES_SUPERVISOR_REVIEW
+    elif insp.score_status not in ("scored", "scored_after_override"):
         state = PENDING_ANALYSIS
     elif action_text.startswith("remove from service"):
         repair_candidate = detected_issue in _REPAIRABLE_ISSUES
@@ -95,7 +100,11 @@ def classify_readiness(insp) -> dict:
     else:
         state = REQUIRES_SUPERVISOR_REVIEW
 
-    readiness_score = (100 - insp.risk_score) if insp.score_status == "scored" and insp.risk_score is not None else None
+    readiness_score = (
+        (100 - insp.risk_score)
+        if insp.score_status in ("scored", "scored_after_override") and insp.risk_score is not None
+        else None
+    )
 
     return {
         "readiness_state": state,

--- a/backend/app/services/pre_sterilization_command_center_service.py
+++ b/backend/app/services/pre_sterilization_command_center_service.py
@@ -1,0 +1,441 @@
+"""Pre-Sterilization Command Center — readiness scoring, queues, and the
+executive risk rollup.
+
+Answers, from real Inspection/SupervisorReview/BaselineLibraryEntry/
+PilotValidationCase rows — never fabricated: "are these instruments
+clinically ready to move forward to packaging and sterilization, and if
+not, why not, where, and what should SPD do next?"
+
+Terminology discipline (see docs/architecture/pre-sterilization-boundary.md):
+this module reports pre-sterilization/packaging *readiness*, never
+sterilization validation or biological-indicator monitoring — LumenAI
+operates before packaging and sterilization, not inside them.
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.supervisor_review import SupervisorReview
+from app.services.inspection_coverage import compute_coverage
+
+# ---------------------------------------------------------------------------
+# Readiness states — sub-classifications of the frozen five-value decision
+# engine (see docs/architecture/lumenai-clinical-intelligence-architecture.md
+# Layer 7). REQUIRES_REPAIR / REMOVED_FROM_SERVICE are a sub-field on top of
+# the existing "REMOVE FROM SERVICE" outcome, not a new engine value.
+# ---------------------------------------------------------------------------
+READY_FOR_PACKAGING = "READY_FOR_PACKAGING"
+REQUIRES_RECLEANING = "REQUIRES_RECLEANING"
+REQUIRES_SUPERVISOR_REVIEW = "REQUIRES_SUPERVISOR_REVIEW"
+REQUIRES_REPAIR = "REQUIRES_REPAIR"
+REMOVED_FROM_SERVICE = "REMOVED_FROM_SERVICE"
+PENDING_ANALYSIS = "PENDING_ANALYSIS"
+
+# Higher = more blocking. Used to pick the weakest link for a tray.
+_STATE_SEVERITY = {
+    READY_FOR_PACKAGING: 0,
+    PENDING_ANALYSIS: 1,
+    REQUIRES_SUPERVISOR_REVIEW: 2,
+    REQUIRES_RECLEANING: 3,
+    REQUIRES_REPAIR: 4,
+    REMOVED_FROM_SERVICE: 5,
+}
+
+# Structural defects a repair shop can plausibly fix — everything else that
+# reaches "remove from service" (contamination that escalated, or an
+# unrepairable structural failure) is retired rather than queued for repair.
+_REPAIRABLE_ISSUES = {"crack", "corrosion", "insulation_damage"}
+_CONTAMINATION_ISSUES = {"blood", "bone", "tissue", "debris", "other"}
+# High-risk findings per the Inspection.detected_issue taxonomy (narrower than
+# Phase 18's ground-truth taxonomy, which also tracks organic_residue /
+# missing_component as PilotValidationCase.finding_type values).
+CRITICAL_ISSUES = {"blood", "tissue", "bone", "crack", "insulation_damage"}
+
+
+def classify_readiness(insp) -> dict:
+    """Derive the pre-sterilization readiness state for one inspection.
+
+    Prefers the deterministic `recommended_action` sentence persisted by the
+    scoring engine (starts with "Pass —" / "Monitor —" / "Supervisor review
+    ... —" / "Reprocess —" / "Remove from service —"). Falls back to
+    detected_issue + risk signal for manual/no-image entries that never ran
+    through the scoring engine.
+    """
+    action_text = (insp.recommended_action or "").strip().lower()
+    detected_issue = (insp.detected_issue or "").strip().lower()
+    repair_candidate = False
+
+    if insp.score_status != "scored":
+        state = PENDING_ANALYSIS
+    elif action_text.startswith("remove from service"):
+        repair_candidate = detected_issue in _REPAIRABLE_ISSUES
+        state = REQUIRES_REPAIR if repair_candidate else REMOVED_FROM_SERVICE
+    elif action_text.startswith("reprocess"):
+        state = REQUIRES_RECLEANING
+    elif action_text.startswith("supervisor review"):
+        state = REQUIRES_SUPERVISOR_REVIEW
+    elif action_text.startswith("monitor") or action_text.startswith("pass"):
+        state = READY_FOR_PACKAGING
+    elif action_text:
+        state = REQUIRES_SUPERVISOR_REVIEW  # unrecognized text — fail safe to human review
+    elif insp.supervisor_review_required:
+        state = REQUIRES_SUPERVISOR_REVIEW
+    elif detected_issue in ("", "none", "unknown") and not insp.stain_detected:
+        state = READY_FOR_PACKAGING
+    elif detected_issue in _REPAIRABLE_ISSUES:
+        repair_candidate = True
+        state = REQUIRES_REPAIR if (insp.risk_score or 0) >= 70 else REQUIRES_SUPERVISOR_REVIEW
+    elif detected_issue in _CONTAMINATION_ISSUES or insp.stain_detected:
+        state = REQUIRES_RECLEANING
+    else:
+        state = REQUIRES_SUPERVISOR_REVIEW
+
+    readiness_score = (100 - insp.risk_score) if insp.score_status == "scored" and insp.risk_score is not None else None
+
+    return {
+        "readiness_state": state,
+        "readiness_score": readiness_score,
+        "repair_candidate": repair_candidate,
+        "is_critical_finding": detected_issue in CRITICAL_ISSUES,
+    }
+
+
+def _is_confirmed(insp, reviewed_inspection_ids: set[int]) -> bool:
+    return (
+        insp.qa_review_status in ("approved", "overridden")
+        or insp.status in ("reviewed", "closed")
+        or insp.id in reviewed_inspection_ids
+    )
+
+
+def _instrument_identity(insp) -> str:
+    """Group key for a physical instrument. Falls back to a per-inspection key
+    when no barcode/UDI was captured — we can't claim re-identification we
+    didn't actually perform."""
+    if insp.instrument_barcode:
+        return f"barcode:{insp.instrument_barcode}"
+    if insp.instrument_udi:
+        return f"udi:{insp.instrument_udi}"
+    return f"untracked:{insp.instrument_type}:{insp.id}"
+
+
+def _reviewed_ids(db: Session, tenant_id: str) -> set[int]:
+    rows = db.query(SupervisorReview.inspection_id).filter(SupervisorReview.tenant_id == tenant_id).all()
+    return {r[0] for r in rows}
+
+
+def _annotate(cases: list, reviewed_ids: set[int]) -> list[dict]:
+    """One classified record per inspection, newest first."""
+    annotated = []
+    for insp in cases:
+        c = classify_readiness(insp)
+        c["inspection"] = insp
+        c["confirmed"] = _is_confirmed(insp, reviewed_ids)
+        annotated.append(c)
+    return annotated
+
+
+# ---------------------------------------------------------------------------
+# Module 1 — Clinical Inspection Readiness Score
+# ---------------------------------------------------------------------------
+
+def clinical_inspection_readiness(annotated: list[dict]) -> dict:
+    total = len(annotated)
+    by_state = {state: 0 for state in _STATE_SEVERITY}
+    scores = []
+    for a in annotated:
+        by_state[a["readiness_state"]] += 1
+        if a["readiness_score"] is not None:
+            scores.append(a["readiness_score"])
+
+    ready = by_state[READY_FOR_PACKAGING]
+    return {
+        "total_inspections": total,
+        "ready_for_packaging": ready,
+        "readiness_rate": round(ready / total, 4) if total else None,
+        "mean_readiness_score": round(sum(scores) / len(scores), 2) if scores else None,
+        "by_state": by_state,
+        "human_review_required": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Module 2 — Tray Readiness Score
+# ---------------------------------------------------------------------------
+
+def tray_readiness(annotated: list[dict]) -> list[dict]:
+    by_tray: dict[str, dict[str, dict]] = defaultdict(dict)
+    for a in annotated:
+        insp = a["inspection"]
+        tray_id = (insp.tray_id or "").strip()
+        if not tray_id:
+            continue
+        identity = _instrument_identity(insp)
+        existing = by_tray[tray_id].get(identity)
+        if existing is None or insp.created_at > existing["inspection"].created_at:
+            by_tray[tray_id][identity] = a
+
+    results = []
+    for tray_id, instruments in by_tray.items():
+        states = [a["readiness_state"] for a in instruments.values()]
+        worst = max(states, key=lambda s: _STATE_SEVERITY[s])
+        blocking = [
+            {"instrument_type": a["inspection"].instrument_type, "readiness_state": a["readiness_state"]}
+            for a in instruments.values() if a["readiness_state"] == worst
+        ] if worst != READY_FOR_PACKAGING else []
+        results.append({
+            "tray_id": tray_id,
+            "instrument_count": len(instruments),
+            "tray_readiness_state": worst,
+            "ready_for_packaging": worst == READY_FOR_PACKAGING,
+            "blocking_instruments": blocking,
+        })
+    return sorted(results, key=lambda r: _STATE_SEVERITY[r["tray_readiness_state"]], reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Module 3 — Instrument Readiness Score
+# ---------------------------------------------------------------------------
+
+def instrument_readiness(annotated: list[dict]) -> list[dict]:
+    by_instrument: dict[str, dict] = {}
+    for a in annotated:
+        insp = a["inspection"]
+        identity = _instrument_identity(insp)
+        existing = by_instrument.get(identity)
+        if existing is None or insp.created_at > existing["inspection"].created_at:
+            by_instrument[identity] = a
+
+    results = []
+    for identity, a in by_instrument.items():
+        insp = a["inspection"]
+        results.append({
+            "instrument_identity": identity,
+            "instrument_type": insp.instrument_type,
+            "tray_id": insp.tray_id,
+            "readiness_state": a["readiness_state"],
+            "readiness_score": a["readiness_score"],
+            "confirmed": a["confirmed"],
+            "last_inspected_at": insp.created_at.isoformat() if insp.created_at else None,
+        })
+    return sorted(results, key=lambda r: _STATE_SEVERITY[r["readiness_state"]], reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Module 4 — Facility Readiness Score
+# ---------------------------------------------------------------------------
+
+def facility_readiness(annotated: list[dict]) -> list[dict]:
+    by_facility: dict[str, list[dict]] = defaultdict(list)
+    for a in annotated:
+        insp = a["inspection"]
+        facility = (insp.facility_name or insp.site_name or "unspecified").strip() or "unspecified"
+        by_facility[facility].append(a)
+
+    results = []
+    for facility, items in by_facility.items():
+        ordered = sorted(items, key=lambda a: a["inspection"].created_at or datetime.min.replace(tzinfo=timezone.utc))
+        mid = len(ordered) // 2
+        older, newer = ordered[:mid], ordered[mid:]
+
+        def _rate(bucket):
+            if not bucket:
+                return None
+            ready = sum(1 for a in bucket if a["readiness_state"] == READY_FOR_PACKAGING)
+            return round(ready / len(bucket), 4)
+
+        older_rate, newer_rate = _rate(older), _rate(newer)
+        if older_rate is None or newer_rate is None:
+            trend = "insufficient_data"
+        elif newer_rate > older_rate:
+            trend = "improving"
+        elif newer_rate < older_rate:
+            trend = "declining"
+        else:
+            trend = "stable"
+
+        by_state = {state: 0 for state in _STATE_SEVERITY}
+        for a in items:
+            by_state[a["readiness_state"]] += 1
+
+        results.append({
+            "facility": facility,
+            "total_inspections": len(items),
+            "readiness_rate": _rate(items),
+            "trend": trend,
+            "by_state": by_state,
+        })
+    return sorted(results, key=lambda r: r["readiness_rate"] if r["readiness_rate"] is not None else 0)
+
+
+# ---------------------------------------------------------------------------
+# Module 5 — High-Risk Findings Queue
+# ---------------------------------------------------------------------------
+
+def high_risk_findings_queue(annotated: list[dict]) -> list[dict]:
+    items = [
+        a for a in annotated
+        if a["is_critical_finding"] and not a["confirmed"]
+        and a["readiness_state"] != READY_FOR_PACKAGING
+    ]
+    items.sort(key=lambda a: a["inspection"].risk_score or 0, reverse=True)
+    return [
+        {
+            "inspection_id": a["inspection"].id,
+            "instrument_type": a["inspection"].instrument_type,
+            "detected_issue": a["inspection"].detected_issue,
+            "readiness_state": a["readiness_state"],
+            "risk_score": a["inspection"].risk_score,
+            "facility": a["inspection"].facility_name or a["inspection"].site_name,
+            "tray_id": a["inspection"].tray_id,
+            "created_at": a["inspection"].created_at.isoformat() if a["inspection"].created_at else None,
+        }
+        for a in items
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Module 6 — Supervisor Review Queue
+# ---------------------------------------------------------------------------
+
+def supervisor_review_queue(annotated: list[dict]) -> list[dict]:
+    items = [
+        a for a in annotated
+        if (a["readiness_state"] == REQUIRES_SUPERVISOR_REVIEW or a["inspection"].supervisor_review_required)
+        and not a["confirmed"]
+    ]
+    return [
+        {
+            "inspection_id": a["inspection"].id,
+            "instrument_type": a["inspection"].instrument_type,
+            "detected_issue": a["inspection"].detected_issue,
+            "recommended_action": a["inspection"].recommended_action,
+            "risk_score": a["inspection"].risk_score,
+            "created_at": a["inspection"].created_at.isoformat() if a["inspection"].created_at else None,
+        }
+        for a in items
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Module 7 — Missing Anatomy Zone Coverage
+# ---------------------------------------------------------------------------
+
+def missing_zone_coverage_queue(cases: list) -> list[dict]:
+    items = []
+    for insp in cases:
+        if not insp.has_image:
+            continue
+        try:
+            inspected = json.loads(insp.inspected_zones_json or "null")
+        except (TypeError, ValueError):
+            inspected = None
+        coverage = compute_coverage(insp.instrument_type, inspected)
+        if coverage["quality"] in ("not_assessed", "incomplete", "insufficient"):
+            items.append({
+                "inspection_id": insp.id,
+                "instrument_type": insp.instrument_type,
+                "coverage_quality": coverage["quality"],
+                "overall_coverage": coverage["overall_coverage"],
+                "missing_required_zones": coverage["missing"],
+                "created_at": insp.created_at.isoformat() if insp.created_at else None,
+            })
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Module 8 — Baseline Coverage
+# ---------------------------------------------------------------------------
+
+def baseline_coverage(db: Session, tenant_id: str, cases: list) -> dict:
+    imaged = [c for c in cases if c.has_image]
+    total = len(imaged)
+    with_baseline = sum(1 for c in imaged if c.baseline_status == "approved_baseline_found")
+
+    gaps: dict[str, int] = defaultdict(int)
+    for c in imaged:
+        if c.baseline_status != "approved_baseline_found":
+            gaps[c.instrument_type] += 1
+
+    approved_categories = {
+        row[0] for row in db.query(BaselineLibraryEntry.instrument_category)
+        .filter(BaselineLibraryEntry.approval_status == "approved").distinct().all()
+    }
+
+    return {
+        "total_imaged_inspections": total,
+        "with_approved_baseline": with_baseline,
+        "baseline_coverage_rate": round(with_baseline / total, 4) if total else None,
+        "instrument_types_missing_baseline": [
+            {"instrument_type": t, "inspection_count": n} for t, n in sorted(gaps.items(), key=lambda kv: kv[1], reverse=True)
+        ],
+        "instrument_categories_with_approved_baseline": sorted(approved_categories),
+        "human_review_required": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Module 9 — Repair / Remove From Service Queue
+# ---------------------------------------------------------------------------
+
+def repair_remove_queue(annotated: list[dict]) -> dict:
+    def _card(a):
+        insp = a["inspection"]
+        return {
+            "inspection_id": insp.id,
+            "instrument_type": insp.instrument_type,
+            "detected_issue": insp.detected_issue,
+            "risk_score": insp.risk_score,
+            "facility": insp.facility_name or insp.site_name,
+            "created_at": insp.created_at.isoformat() if insp.created_at else None,
+        }
+
+    repair = [a for a in annotated if a["readiness_state"] == REQUIRES_REPAIR]
+    removed = [a for a in annotated if a["readiness_state"] == REMOVED_FROM_SERVICE]
+    return {
+        "repair_candidates": {"count": len(repair), "cases": [_card(a) for a in repair]},
+        "removed_from_service": {"count": len(removed), "cases": [_card(a) for a in removed]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Module 10 — Executive Risk Dashboard
+# ---------------------------------------------------------------------------
+
+def executive_risk_dashboard(db: Session, tenant_id: str, cases: list, annotated: list[dict]) -> dict:
+    from app.services.pilot_validation_service import compute_zone_performance, list_cases as list_pilot_cases
+
+    readiness = clinical_inspection_readiness(annotated)
+    repair_remove = repair_remove_queue(annotated)
+    facilities = facility_readiness(annotated)
+    baseline = baseline_coverage(db, tenant_id, cases)
+
+    pilot_cases = list_pilot_cases(db, tenant_id, limit=5000)
+    zone_performance = compute_zone_performance(pilot_cases)
+    worst_zones = sorted(
+        [z for z in zone_performance if z["case_count"] > 0], key=lambda z: z["missed_count"], reverse=True
+    )[:5]
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "readiness_summary": readiness,
+        "high_risk_findings_count": len(high_risk_findings_queue(annotated)),
+        "supervisor_review_backlog": len(supervisor_review_queue(annotated)),
+        "repair_candidates_count": repair_remove["repair_candidates"]["count"],
+        "removed_from_service_count": repair_remove["removed_from_service"]["count"],
+        "baseline_coverage_rate": baseline["baseline_coverage_rate"],
+        "instrument_types_missing_baseline": len(baseline["instrument_types_missing_baseline"]),
+        "facility_rollup": facilities,
+        "anatomy_zone_failure_trend": worst_zones,
+        "human_review_required": True,
+        "disclaimers": [
+            "These figures are pre-sterilization quality indicators, not sterilization validation.",
+            "All escalations require SPD supervisor review before disposition.",
+            "Association does not imply causation.",
+        ],
+    }

--- a/backend/app/services/prioritization_engine.py
+++ b/backend/app/services/prioritization_engine.py
@@ -1,0 +1,136 @@
+"""v1.7 — Intelligent Prioritization Engine (Deliverable 2).
+
+Ranks inspection work automatically. Each contributing factor is
+point-scored and returned with its reason — auditable, mirroring the same
+rubric style already used by risk_stratification_service.py — over
+signals produced by the existing readiness/disposition engines (v1.6) plus
+real intake data (procedure_priority, vendor/tray, prior findings). Never
+a fabricated urgency guess: a factor with no real signal simply contributes
+no points.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services.instrument_anatomy import get_anatomy, resolve_family
+from app.services.pre_sterilization_command_center_service import _instrument_identity
+
+CRITICAL = "Critical"
+HIGH = "High"
+MEDIUM = "Medium"
+LOW = "Low"
+PRIORITY_TIERS = [CRITICAL, HIGH, MEDIUM, LOW]
+
+_PROCEDURE_POINTS = {"emergency": 4, "trauma": 3, "first_case": 2}
+
+
+def has_repeat_findings(db: Session, tenant_id: str, insp) -> bool:
+    """Whether this physical instrument has any prior logged finding — a
+    real repeat-condition signal (v1.5's InspectionFinding log), not a guess."""
+    from app.db import models
+    from app.models.inspection_finding import InspectionFinding
+
+    identity = _instrument_identity(insp)
+    if identity.startswith("untracked:"):
+        return False
+
+    barcode_filter = (
+        (models.Inspection.instrument_barcode == insp.instrument_barcode)
+        if insp.instrument_barcode
+        else (models.Inspection.instrument_udi == insp.instrument_udi)
+    )
+    prior_ids = [
+        r[0] for r in db.query(models.Inspection.id).filter(
+            models.Inspection.tenant_id == tenant_id, barcode_filter, models.Inspection.id != insp.id,
+        ).all()
+    ]
+    if not prior_ids:
+        return False
+    return (
+        db.query(InspectionFinding.id)
+        .filter(InspectionFinding.inspection_id.in_(prior_ids))
+        .first()
+        is not None
+    )
+
+
+def is_vendor_tray(insp) -> bool:
+    return bool(insp.vendor_name and insp.vendor_name != "unknown" and insp.tray_id)
+
+
+def is_supervisor_escalated(db: Session, tenant_id: str, insp) -> bool:
+    from app.models.disposition_override import DispositionOverride
+
+    latest = (
+        db.query(DispositionOverride)
+        .filter(DispositionOverride.tenant_id == tenant_id, DispositionOverride.inspection_id == insp.id)
+        .order_by(DispositionOverride.id.desc())
+        .first()
+    )
+    return bool(latest and latest.action == "escalate")
+
+
+def _has_high_risk_anatomy(insp) -> bool:
+    family = resolve_family(insp.instrument_type)
+    if family == "default":
+        return False
+    anatomy = get_anatomy(insp.instrument_type)
+    return any(z.get("zone_risk_level") in ("high", "critical") for z in anatomy.get("zones", []))
+
+
+def compute_priority(
+    db: Session, tenant_id: str, insp, *, readiness: dict, disposition: dict, repair_history: bool,
+) -> dict:
+    """Deliverable 2 — Priority Score (points) + tier, with the contributing
+    reasons that produced it, so the ranking is auditable rather than a
+    black box."""
+    points = 0
+    reasons: list[str] = []
+
+    procedure_priority = (insp.procedure_priority or "").strip().lower()
+    if procedure_priority in _PROCEDURE_POINTS:
+        points += _PROCEDURE_POINTS[procedure_priority]
+        reasons.append(f"Procedure priority: {procedure_priority.replace('_', ' ')}.")
+
+    if readiness.get("is_critical_finding"):
+        points += 3
+        reasons.append("Critical finding on this inspection.")
+
+    if _has_high_risk_anatomy(insp):
+        points += 2
+        reasons.append(f"High-risk anatomy family ({resolve_family(insp.instrument_type)}).")
+
+    if repair_history:
+        points += 2
+        reasons.append("Prior repair/remove-from-service history on this instrument.")
+
+    if disposition.get("disposition") in ("Repair Evaluation", "Manufacturer Evaluation"):
+        points += 2
+        reasons.append("Repair return awaiting evaluation.")
+
+    if has_repeat_findings(db, tenant_id, insp):
+        points += 1
+        reasons.append("Repeat findings recorded on this instrument.")
+
+    if is_vendor_tray(insp):
+        points += 1
+        reasons.append("Vendor tray instrument.")
+
+    if insp.is_loaner_instrument:
+        points += 1
+        reasons.append("Loaner instrument.")
+
+    if is_supervisor_escalated(db, tenant_id, insp):
+        points += 3
+        reasons.append("Supervisor escalation on record.")
+
+    if points >= 8:
+        tier = CRITICAL
+    elif points >= 5:
+        tier = HIGH
+    elif points >= 2:
+        tier = MEDIUM
+    else:
+        tier = LOW
+
+    return {"priority_score": points, "priority_tier": tier, "reasons": reasons}

--- a/backend/app/services/quality_dashboard_service.py
+++ b/backend/app/services/quality_dashboard_service.py
@@ -1,0 +1,227 @@
+"""v1.5 — Quality Intelligence Dashboard: core KPIs, benchmarking, and the
+executive quality score.
+
+Every metric here is computed live from real Inspection/SupervisorReview rows
+for the requesting tenant — nothing is mocked or simulated. A metric with no
+underlying data returns None (not zero, not a fabricated placeholder) so the
+dashboard can honestly show "not enough data yet."
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.supervisor_review import SupervisorReview
+
+_REPAIRABLE_ISSUES = {"crack", "corrosion", "insulation_damage"}
+
+
+def _rate(n: int, d: int) -> float | None:
+    return round(100 * n / d, 1) if d else None
+
+
+def _period_start(period: str, now: datetime | None = None) -> datetime | None:
+    """Start of the named period, or None for 'all_time'."""
+    now = now or datetime.now(timezone.utc)
+    if period == "day":
+        return now - timedelta(days=1)
+    if period == "week":
+        return now - timedelta(weeks=1)
+    if period == "month":
+        return now - timedelta(days=30)
+    if period == "quarter":
+        return now - timedelta(days=90)
+    if period == "year":
+        return now - timedelta(days=365)
+    return None  # "all_time"
+
+
+def _inspections(db: Session, tenant_id: str, period: str = "all_time"):
+    q = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id)
+    start = _period_start(period)
+    if start is not None:
+        q = q.filter(models.Inspection.created_at >= start)
+    return q.all()
+
+
+def dashboard_summary(db: Session, tenant_id: str, period: str = "all_time") -> dict:
+    """Deliverable 1 — Quality Intelligence Dashboard KPIs."""
+    rows = _inspections(db, tenant_id, period)
+    return {"period": period, **_summarize_rows(rows), "human_review_required": True}
+
+
+# ── Benchmarking (Deliverable 9) ─────────────────────────────────────────────
+def _classify_change(current: float | None, previous: float | None, *, higher_is_better: bool) -> str:
+    if current is None or previous is None:
+        return "insufficient_data"
+    delta = current - previous
+    if abs(delta) < 1.0:
+        return "stable"
+    improved = delta > 0 if higher_is_better else delta < 0
+    return "improvement" if improved else "regression"
+
+
+# Metrics where a higher percentage is a WORSE outcome.
+_LOWER_IS_BETTER = {"reclean_rate_pct", "remove_from_service_rate_pct", "supervisor_override_rate_pct"}
+
+
+def benchmark(db: Session, tenant_id: str) -> dict:
+    """Deliverable 9 — current month vs previous month vs quarter vs rolling 12mo."""
+    now = datetime.now(timezone.utc)
+    current_month_start = now - timedelta(days=30)
+    previous_month_start = now - timedelta(days=60)
+
+    current = dashboard_summary(db, tenant_id, "month")
+
+    prev_rows = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= previous_month_start,
+            models.Inspection.created_at < current_month_start,
+        )
+        .all()
+    )
+    previous = _summarize_rows(prev_rows)
+    quarter = dashboard_summary(db, tenant_id, "quarter")
+    rolling_year = dashboard_summary(db, tenant_id, "year")
+
+    comparisons = {}
+    for metric in (
+        "pass_rate_pct", "reclean_rate_pct", "repair_rate_pct",
+        "remove_from_service_rate_pct", "supervisor_override_rate_pct",
+        "baseline_compliance_pct", "coverage_compliance_pct", "ai_confidence_trend_pct",
+    ):
+        comparisons[metric] = _classify_change(
+            current.get(metric), previous.get(metric),
+            higher_is_better=metric not in _LOWER_IS_BETTER,
+        )
+
+    return {
+        "current_month": current,
+        "previous_month": previous,
+        "quarter": quarter,
+        "rolling_12_months": rolling_year,
+        "comparison_current_vs_previous_month": comparisons,
+    }
+
+
+def _summarize_rows(rows: list) -> dict:
+    """Same shape as dashboard_summary but from an already-fetched row list
+    (used for the previous-month window, which isn't a simple "since" filter)."""
+    scored = [r for r in rows if r.has_image and r.disposition]
+    total = len(scored)
+    pass_ct = sum(1 for r in scored if r.disposition == "PASS")
+    reclean_ct = sum(1 for r in scored if r.disposition == "REPROCESS")
+    remove_ct = sum(1 for r in scored if r.disposition == "REMOVE FROM SERVICE")
+    repair_ct = sum(
+        1 for r in scored
+        if r.disposition == "REMOVE FROM SERVICE" and (r.detected_issue or "") in _REPAIRABLE_ISSUES
+    )
+    override_ct = sum(1 for r in rows if (r.override_by or "").strip())
+    baseline_ct = sum(1 for r in rows if r.has_image)
+    baseline_found_ct = sum(1 for r in rows if r.baseline_status == "approved_baseline_found")
+    coverage_assessed = [r for r in rows if r.coverage_pct is not None]
+    confidences = [r.ai_confidence for r in rows if r.has_image and r.ai_confidence is not None]
+
+    return {
+        "inspection_volume": len(rows),
+        "pass_rate_pct": _rate(pass_ct, total),
+        "reclean_rate_pct": _rate(reclean_ct, total),
+        "repair_rate_pct": _rate(repair_ct, total),
+        "remove_from_service_rate_pct": _rate(remove_ct, total),
+        "supervisor_override_rate_pct": _rate(override_ct, len(rows)),
+        "baseline_compliance_pct": _rate(baseline_found_ct, baseline_ct),
+        "coverage_compliance_pct": (
+            round(sum(r.coverage_pct for r in coverage_assessed) / len(coverage_assessed), 1)
+            if coverage_assessed else None
+        ),
+        "ai_confidence_trend_pct": (
+            round(100 * sum(confidences) / len(confidences), 1) if confidences else None
+        ),
+    }
+
+
+# ── Executive Quality Score (Deliverable 10) ─────────────────────────────────
+# Weighted factors, each normalized to 0-100 before weighting. Weights sum to 1.
+_SCORE_WEIGHTS = {
+    "pass_rate_pct": 0.25,
+    "coverage_compliance_pct": 0.15,
+    "supervisor_agreement_pct": 0.15,
+    "low_high_risk_findings_pct": 0.15,  # inverted: 100 - remove_from_service rate
+    "low_repeat_findings_pct": 0.10,      # inverted: 100 - repeat-error rate
+    "competency_pct": 0.10,
+    "baseline_compliance_pct": 0.10,
+}
+
+
+def executive_quality_score(db: Session, tenant_id: str) -> dict:
+    """Deliverable 10 — a single 0-100 Quality Intelligence Score.
+
+    Any factor with no underlying data is excluded from the weighted average
+    (re-normalizing the remaining weights) rather than defaulted to a
+    fabricated value — the score is honest about how much data backs it.
+    """
+    summary = dashboard_summary(db, tenant_id, "quarter")
+
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    agreement_pct = _rate(sum(1 for r in reviews if r.agreement == "agree"), len(reviews))
+
+    from app.models.competency_event import CompetencyEvent
+
+    corrections = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "supervisor_correction")
+        .scalar() or 0
+    )
+    repeats = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "repeated_error")
+        .scalar() or 0
+    )
+    repeat_rate = _rate(repeats, corrections)
+    education_completed = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "education_completed")
+        .scalar() or 0
+    )
+    reviewed = (
+        db.query(func.count(CompetencyEvent.id))
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "finding_reviewed")
+        .scalar() or 0
+    )
+    competency_pct = _rate(education_completed, reviewed) if reviewed else None
+
+    factors = {
+        "pass_rate_pct": summary["pass_rate_pct"],
+        "coverage_compliance_pct": summary["coverage_compliance_pct"],
+        "supervisor_agreement_pct": agreement_pct,
+        "low_high_risk_findings_pct": (
+            100 - summary["remove_from_service_rate_pct"]
+            if summary["remove_from_service_rate_pct"] is not None else None
+        ),
+        "low_repeat_findings_pct": 100 - repeat_rate if repeat_rate is not None else None,
+        "competency_pct": competency_pct,
+        "baseline_compliance_pct": summary["baseline_compliance_pct"],
+    }
+
+    available = {k: v for k, v in factors.items() if v is not None}
+    if not available:
+        return {"score": None, "factors": factors, "note": "Not enough data yet to compute a quality score."}
+
+    total_weight = sum(_SCORE_WEIGHTS[k] for k in available)
+    score = sum(available[k] * _SCORE_WEIGHTS[k] for k in available) / total_weight
+
+    return {
+        "score": round(score),
+        "factors": factors,
+        "weights": _SCORE_WEIGHTS,
+        "factors_used": list(available.keys()),
+        "note": (
+            "Computed from real inspection/review/competency data for this tenant "
+            "over the trailing quarter. Missing factors are excluded, not defaulted."
+        ),
+    }

--- a/backend/app/services/readiness_dashboard_service.py
+++ b/backend/app/services/readiness_dashboard_service.py
@@ -1,0 +1,172 @@
+"""v1.6 — Readiness Dashboard (Deliverable 7) & Enterprise Readiness Analytics
+(Deliverable 9).
+
+Aggregates real per-inspection readiness/disposition computations — nothing
+here is a separate analysis, just rollups of what readiness_engine and
+disposition_engine already compute per inspection.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.disposition_override import DispositionOverride
+from app.models.supervisor_review import SupervisorReview
+from app.services.disposition_engine import recommend_disposition
+from app.services.instrument_anatomy import resolve_family
+from app.services.readiness_engine import (
+    PENDING_SUPERVISOR_REVIEW,
+    READY,
+    READY_WITH_SUPERVISOR_APPROVAL,
+    REMOVE_FROM_SERVICE_STATUS,
+    REQUIRES_RECLEANING_STATUS,
+    REQUIRES_REPAIR_STATUS,
+    compute_readiness,
+    get_primary_finding_type,
+)
+
+
+def _reviewed_ids(db: Session, tenant_id: str) -> set[int]:
+    rows = db.query(SupervisorReview.inspection_id).filter(SupervisorReview.tenant_id == tenant_id).all()
+    return {r[0] for r in rows}
+
+
+def _classify_all(db: Session, tenant_id: str, since_days: int | None = None) -> list[dict]:
+    query = db.query(models.Inspection).filter(
+        models.Inspection.tenant_id == tenant_id, models.Inspection.has_image.is_(True),
+    )
+    if since_days is not None:
+        since = datetime.now(timezone.utc) - timedelta(days=since_days)
+        query = query.filter(models.Inspection.created_at >= since)
+    rows = query.all()
+
+    reviewed_ids = _reviewed_ids(db, tenant_id)
+    latest_reviews: dict[int, SupervisorReview] = {}
+    if rows:
+        reviews = (
+            db.query(SupervisorReview)
+            .filter(SupervisorReview.inspection_id.in_([r.id for r in rows]))
+            .order_by(SupervisorReview.id.desc())
+            .all()
+        )
+        for r in reviews:
+            latest_reviews.setdefault(r.inspection_id, r)
+
+    results = []
+    for insp in rows:
+        confirmed = insp.id in reviewed_ids
+        review = latest_reviews.get(insp.id)
+        primary_finding_type = get_primary_finding_type(db, insp)
+        readiness = compute_readiness(
+            db, tenant_id, insp, confirmed=confirmed,
+            override_action=(review.override_action if review else ""),
+        )
+        disposition = recommend_disposition(
+            readiness, insp, coverage_pct=insp.coverage_pct, primary_finding_type=primary_finding_type,
+        )
+        results.append({"inspection": insp, "readiness": readiness, "disposition": disposition})
+    return results
+
+
+def readiness_dashboard(db: Session, tenant_id: str) -> dict:
+    """Deliverable 7 — /clinical-readiness dashboard."""
+    classified = _classify_all(db, tenant_id)
+
+    by_status = defaultdict(int)
+    scores = []
+    for c in classified:
+        by_status[c["readiness"]["status"]] += 1
+        if c["readiness"]["readiness_score"] is not None:
+            scores.append(c["readiness"]["readiness_score"])
+
+    by_disposition = defaultdict(int)
+    for c in classified:
+        by_disposition[c["disposition"]["disposition"]] += 1
+
+    return {
+        "ready_for_packaging": by_status[READY] + by_status[READY_WITH_SUPERVISOR_APPROVAL],
+        "requires_recleaning": by_status[REQUIRES_RECLEANING_STATUS],
+        "requires_repair": by_status[REQUIRES_REPAIR_STATUS],
+        "remove_from_service": by_status[REMOVE_FROM_SERVICE_STATUS],
+        "supervisor_pending": by_status[PENDING_SUPERVISOR_REVIEW],
+        "average_readiness_score": round(sum(scores) / len(scores), 1) if scores else None,
+        "disposition_trends": dict(by_disposition),
+        "total_inspections": len(classified),
+        "human_review_required": True,
+    }
+
+
+def enterprise_readiness_analytics(db: Session, tenant_id: str, days: int = 180) -> dict:
+    """Deliverable 9 — readiness trends, disposition distribution, supervisor
+    overrides, repair referrals, high-risk families, common disposition
+    reasons."""
+    classified = _classify_all(db, tenant_id, since_days=days)
+
+    by_disposition = defaultdict(int)
+    reasons_by_disposition: dict[str, list[str]] = defaultdict(list)
+    for c in classified:
+        disp = c["disposition"]["disposition"]
+        by_disposition[disp] += 1
+        reasons_by_disposition[disp].append(c["disposition"]["explanation"])
+
+    overrides = (
+        db.query(DispositionOverride)
+        .filter(DispositionOverride.tenant_id == tenant_id)
+        .all()
+    )
+    overrides_by_action = defaultdict(int)
+    for o in overrides:
+        overrides_by_action[o.action] += 1
+
+    repair_referrals = sum(
+        1 for c in classified
+        if c["disposition"]["disposition"] in ("Repair Evaluation", "Manufacturer Evaluation")
+    )
+
+    by_family = defaultdict(lambda: {"total": 0, "high_risk": 0})
+    for c in classified:
+        family = resolve_family(c["inspection"].instrument_type)
+        by_family[family]["total"] += 1
+        if c["readiness"]["is_critical_finding"]:
+            by_family[family]["high_risk"] += 1
+
+    high_risk_families = sorted(
+        (
+            {
+                "family": f, "total": d["total"], "high_risk_count": d["high_risk"],
+                "high_risk_rate_pct": round(100 * d["high_risk"] / d["total"], 1) if d["total"] else None,
+            }
+            for f, d in by_family.items()
+        ),
+        key=lambda x: x["high_risk_count"], reverse=True,
+    )
+
+    # Most common disposition reason per disposition (the most frequent
+    # explanation string, not a fabricated summary).
+    common_reasons = {}
+    for disp, reasons in reasons_by_disposition.items():
+        counts = defaultdict(int)
+        for r in reasons:
+            counts[r] += 1
+        common_reasons[disp] = max(counts.items(), key=lambda kv: kv[1])[0]
+
+    return {
+        "period_days": days,
+        "readiness_trends": {
+            "total_inspections": len(classified),
+            "average_readiness_score": (
+                round(sum(c["readiness"]["readiness_score"] for c in classified if c["readiness"]["readiness_score"] is not None)
+                      / max(1, sum(1 for c in classified if c["readiness"]["readiness_score"] is not None)), 1)
+                if any(c["readiness"]["readiness_score"] is not None for c in classified) else None
+            ),
+        },
+        "disposition_distribution": dict(by_disposition),
+        "supervisor_overrides": dict(overrides_by_action),
+        "repair_referrals": repair_referrals,
+        "high_risk_instrument_families": high_risk_families,
+        "most_common_disposition_reasons": common_reasons,
+        "human_review_required": True,
+    }

--- a/backend/app/services/readiness_engine.py
+++ b/backend/app/services/readiness_engine.py
@@ -1,0 +1,136 @@
+"""v1.6 — Clinical Service Readiness Engine (Deliverable 1).
+
+A rules-based readiness engine answering: is this instrument suitable to
+proceed through the remainder of the reprocessing workflow after clinical
+inspection? Built on top of the existing pre-sterilization readiness
+classification (`pre_sterilization_command_center_service.classify_readiness`)
+rather than re-deriving disposition logic a third time — this module maps
+that classification onto v1.6's spec vocabulary and adds the repair-history
+signal the spec asks for.
+
+Score: 0-100 (the same `100 - risk_score` already computed by the scoring
+engine — never fabricated).
+Status: Ready / Ready with Supervisor Approval / Requires Recleaning /
+Requires Repair / Remove From Service / Pending Supervisor Review /
+Pending Analysis. The last two are honest additions beyond the spec's five —
+an inspection that hasn't been scored or reviewed yet is neither "ready" nor
+any of the other four outcomes, and collapsing it into one of them would
+misrepresent an unfinished workflow as a finished one.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services.pre_sterilization_command_center_service import (
+    READY_FOR_PACKAGING,
+    REMOVED_FROM_SERVICE,
+    REQUIRES_REPAIR,
+    REQUIRES_RECLEANING,
+    REQUIRES_SUPERVISOR_REVIEW,
+    _instrument_identity,
+    classify_readiness,
+)
+
+READY = "Ready"
+READY_WITH_SUPERVISOR_APPROVAL = "Ready with Supervisor Approval"
+REQUIRES_RECLEANING_STATUS = "Requires Recleaning"
+REQUIRES_REPAIR_STATUS = "Requires Repair"
+REMOVE_FROM_SERVICE_STATUS = "Remove From Service"
+PENDING_SUPERVISOR_REVIEW = "Pending Supervisor Review"
+PENDING_ANALYSIS_STATUS = "Pending Analysis"
+
+READINESS_STATUSES = [
+    READY, READY_WITH_SUPERVISOR_APPROVAL, REQUIRES_RECLEANING_STATUS,
+    REQUIRES_REPAIR_STATUS, REMOVE_FROM_SERVICE_STATUS,
+    PENDING_SUPERVISOR_REVIEW, PENDING_ANALYSIS_STATUS,
+]
+
+# Supervisor override actions that redirect the final status regardless of
+# what the AI classification alone would say (Deliverable 6).
+_OVERRIDE_TO_STATUS = {
+    "reclean": REQUIRES_RECLEANING_STATUS,
+    "repair": REQUIRES_REPAIR_STATUS,
+    "remove_from_service": REMOVE_FROM_SERVICE_STATUS,
+    "manufacturer_review": REQUIRES_REPAIR_STATUS,
+}
+
+
+def get_primary_finding_type(db: Session, insp) -> str:
+    """The most severe actionable finding actually detected for this
+    inspection. `Inspection.detected_issue` is a legacy manual-entry field
+    that's almost always "unknown" for AI-scored inspections — the real
+    per-finding data lives in InspectionFinding (v1.5), logged at analysis
+    time. Falls back to `detected_issue` for the no-image manual-entry path,
+    where InspectionFinding rows are never created."""
+    from app.models.inspection_finding import InspectionFinding
+
+    finding = (
+        db.query(InspectionFinding)
+        .filter(InspectionFinding.inspection_id == insp.id)
+        .order_by(InspectionFinding.severity_index.desc())
+        .first()
+    )
+    if finding is not None:
+        return finding.finding_type
+    return (insp.detected_issue or "").strip().lower()
+
+
+def has_repair_history(db: Session, tenant_id: str, insp) -> bool:
+    """Whether this physical instrument has a prior REQUIRES_REPAIR/removed
+    classification on record — a real repeat-condition signal, not guessed."""
+    from app.db import models
+
+    identity = _instrument_identity(insp)
+    if identity.startswith("untracked:"):
+        return False  # can't honestly claim repair history without a real identity
+
+    barcode_filter = (
+        (models.Inspection.instrument_barcode == insp.instrument_barcode)
+        if insp.instrument_barcode
+        else (models.Inspection.instrument_udi == insp.instrument_udi)
+    )
+    prior = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            barcode_filter,
+            models.Inspection.id != insp.id,
+            models.Inspection.disposition == "REMOVE FROM SERVICE",
+        )
+        .count()
+    )
+    return prior > 0
+
+
+def compute_readiness(db: Session, tenant_id: str, insp, *, confirmed: bool, override_action: str = "") -> dict:
+    """Deliverable 1 — the Clinical Service Readiness Score + status for one
+    inspection."""
+    classification = classify_readiness(insp)
+    state = classification["readiness_state"]
+    score = classification["readiness_score"]
+    repair_history = has_repair_history(db, tenant_id, insp)
+
+    if override_action.strip() in _OVERRIDE_TO_STATUS:
+        status = _OVERRIDE_TO_STATUS[override_action.strip()]
+    elif state == READY_FOR_PACKAGING:
+        status = READY_WITH_SUPERVISOR_APPROVAL if confirmed else READY
+    elif state == REQUIRES_RECLEANING:
+        status = REQUIRES_RECLEANING_STATUS
+    elif state == REQUIRES_REPAIR:
+        status = REQUIRES_REPAIR_STATUS
+    elif state == REMOVED_FROM_SERVICE:
+        status = REMOVE_FROM_SERVICE_STATUS
+    elif state == REQUIRES_SUPERVISOR_REVIEW:
+        status = READY_WITH_SUPERVISOR_APPROVAL if confirmed else PENDING_SUPERVISOR_REVIEW
+    else:  # PENDING_ANALYSIS
+        status = PENDING_ANALYSIS_STATUS
+
+    return {
+        "readiness_score": score,
+        "status": status,
+        "repair_candidate": classification["repair_candidate"],
+        "repair_history": repair_history,
+        "is_critical_finding": classification["is_critical_finding"],
+        "confirmed_by_supervisor": confirmed,
+        "human_review_required": True,
+    }

--- a/backend/app/services/readiness_report_service.py
+++ b/backend/app/services/readiness_report_service.py
@@ -1,0 +1,135 @@
+"""v1.6 — Exportable Clinical Readiness Report (Deliverable 10).
+
+Builds the JSON payload (for the timeline export and API consumers) and a
+printable PDF, reusing the existing clinical_report_pdf.py's style/table
+helpers rather than re-implementing PDF layout.
+"""
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+from typing import Any
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.units import inch
+from reportlab.platypus import HRFlowable, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+from app.services.clinical_report_pdf import _kv_table, _styles
+from app.services.disposition_evidence_service import build_evidence_panel
+from app.services.readiness_engine import get_primary_finding_type
+from app.services.readiness_timeline_service import build_timeline
+from app.services.risk_stratification_service import stratify_risk
+
+
+def build_readiness_report_payload(db, tenant_id: str, insp) -> dict:
+    """The full JSON report: instrument details, evidence, coverage, findings,
+    clinical reasoning, disposition recommendation, supervisor approval, and
+    audit metadata."""
+    evidence = build_evidence_panel(db, tenant_id, insp)
+    timeline = build_timeline(db, tenant_id, insp)
+    risk = stratify_risk(insp, primary_finding_type=get_primary_finding_type(db, insp))
+
+    return {
+        "instrument": {
+            "instrument_type": insp.instrument_type,
+            "instrument_identity": evidence["instrument_identity"],
+            "facility_name": insp.facility_name or insp.site_name,
+            "department": insp.department,
+        },
+        "evidence": evidence,
+        "timeline": timeline,
+        "risk_stratification": risk,
+        "audit_metadata": {
+            "inspection_id": insp.id,
+            "tenant_id": tenant_id,
+            "technician": insp.technician,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+
+
+def build_readiness_report_pdf(db, tenant_id: str, insp) -> bytes:
+    payload = build_readiness_report_payload(db, tenant_id, insp)
+    evidence = payload["evidence"]
+    ss = _styles()
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf, pagesize=letter,
+        topMargin=0.6 * inch, bottomMargin=0.6 * inch,
+        leftMargin=0.7 * inch, rightMargin=0.7 * inch,
+        title=f"LumenAI Clinical Readiness Report — Inspection {insp.id}",
+    )
+    story: list[Any] = []
+
+    story.append(Paragraph("LumenAI — Clinical Service Readiness Report", ss["Title"]))
+    story.append(Paragraph("Pre-sterilization decision support (pilot — advisory, human review required)", ss["Small"]))
+    story.append(HRFlowable(width="100%", color=colors.HexColor("#94a3b8")))
+    story.append(Spacer(1, 6))
+
+    story.append(Paragraph(f"<b>Recommended Disposition: {evidence['recommended_disposition']}</b>", ss["Heading2"]))
+    story.append(Paragraph(evidence["clinical_rationale"], ss["Normal"]))
+
+    story.append(Paragraph("Instrument Details", ss["H"]))
+    story.append(_kv_table([
+        ("Instrument", payload["instrument"]["instrument_type"]),
+        ("Identity", payload["instrument"]["instrument_identity"]),
+        ("Facility", payload["instrument"]["facility_name"] or "—"),
+        ("Department", payload["instrument"]["department"] or "—"),
+    ]))
+
+    story.append(Paragraph("Inspection Evidence", ss["H"]))
+    story.append(_kv_table([
+        ("Inspection Coverage", f"{evidence['inspection_coverage_pct']}%" if evidence["inspection_coverage_pct"] is not None else "Not assessed"),
+        ("Findings", evidence["detected_issue"] or "None"),
+        ("Severity", evidence["severity"] or "—"),
+        ("Baseline Used", evidence["baseline_used"] or "—"),
+        ("Supervisor Status", evidence["supervisor_status"]),
+        ("Readiness Score", str(evidence["readiness_score"]) if evidence["readiness_score"] is not None else "—"),
+        ("Readiness Status", evidence["readiness_status"]),
+    ]))
+
+    story.append(Paragraph("Risk Stratification", ss["H"]))
+    story.append(_kv_table([
+        ("Risk Tier", payload["risk_stratification"]["risk_tier"]),
+        ("Contributing Factors", "; ".join(payload["risk_stratification"]["reasons"]) or "None"),
+    ]))
+
+    story.append(Paragraph("Readiness Timeline", ss["H"]))
+    timeline_rows = [["Step", "Completed", "Timestamp"]]
+    for step in payload["timeline"]["steps"]:
+        timeline_rows.append([
+            step["step"], "Yes" if step["completed"] else "No", step.get("timestamp") or "—",
+        ])
+    t = Table(timeline_rows, colWidths=[2.2 * inch, 1.0 * inch, 2.8 * inch])
+    t.setStyle(TableStyle([
+        ("FONTSIZE", (0, 0), (-1, -1), 8),
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e2e8f0")),
+        ("GRID", (0, 0), (-1, -1), 0.4, colors.HexColor("#cbd5e1")),
+    ]))
+    story.append(t)
+
+    story.append(Paragraph("Audit Metadata", ss["H"]))
+    story.append(_kv_table([
+        ("Inspection ID", str(payload["audit_metadata"]["inspection_id"])),
+        ("Technician", payload["audit_metadata"]["technician"] or "—"),
+        ("Generated", payload["audit_metadata"]["generated_at"]),
+    ]))
+
+    story.append(Spacer(1, 18))
+    sig = Table([
+        ["Technician: ______________________", "Supervisor: ______________________"],
+        ["Date: __________________________", "Date: __________________________"],
+    ], colWidths=[3.0 * inch, 3.0 * inch])
+    sig.setStyle(TableStyle([("FONTSIZE", (0, 0), (-1, -1), 9), ("TOPPADDING", (0, 0), (-1, -1), 10)]))
+    story.append(sig)
+
+    story.append(Spacer(1, 10))
+    story.append(Paragraph(
+        "Pilot advisory output. Not validated for production diagnostic accuracy; no FDA clearance is claimed. "
+        "Qualified human review is required before any disposition.",
+        ss["Small"],
+    ))
+
+    doc.build(story)
+    return buf.getvalue()

--- a/backend/app/services/readiness_timeline_service.py
+++ b/backend/app/services/readiness_timeline_service.py
@@ -1,0 +1,95 @@
+"""v1.6 — Readiness Timeline (Deliverable 4).
+
+Image Uploaded -> Instrument Identified -> Coverage Completed -> AI Findings ->
+Clinical Reasoning -> Supervisor Review -> Disposition -> Ready for Packaging.
+
+Most of these steps happen synchronously inside one POST /api/inspections
+call, so they share a single real timestamp (Inspection.created_at) rather
+than fabricating individually-spaced fake timestamps — consistent with the
+same honesty principle already applied in app/cios/state_machine.py's
+pipeline-monitor timeline. Only steps with their own real, independently-timed
+record (Supervisor Review) get a distinct timestamp.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.supervisor_review import SupervisorReview
+from app.services.disposition_engine import recommend_disposition
+from app.services.readiness_engine import (
+    READY, READY_WITH_SUPERVISOR_APPROVAL, compute_readiness, get_primary_finding_type,
+)
+
+
+def build_timeline(db: Session, tenant_id: str, insp) -> dict:
+    submitted_at = insp.created_at.isoformat() if insp.created_at else None
+    review = (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.inspection_id == insp.id)
+        .order_by(SupervisorReview.id.desc())
+        .first()
+    )
+    confirmed = review is not None
+    readiness = compute_readiness(
+        db, tenant_id, insp, confirmed=confirmed,
+        override_action=(review.override_action if review else ""),
+    )
+    disposition = recommend_disposition(
+        readiness, insp, coverage_pct=insp.coverage_pct,
+        primary_finding_type=get_primary_finding_type(db, insp),
+    )
+    ready_for_packaging = readiness["status"] in (READY, READY_WITH_SUPERVISOR_APPROVAL)
+
+    steps = [
+        {
+            "step": "Image Uploaded",
+            "completed": bool(insp.has_image),
+            "timestamp": submitted_at if insp.has_image else None,
+        },
+        {
+            "step": "Instrument Identified",
+            "completed": bool(insp.instrument_type and insp.instrument_type != "unknown"),
+            "timestamp": submitted_at,
+        },
+        {
+            "step": "Coverage Completed",
+            "completed": insp.coverage_pct is not None,
+            "timestamp": submitted_at if insp.coverage_pct is not None else None,
+        },
+        {
+            "step": "AI Findings",
+            "completed": insp.score_status in ("scored", "scored_after_override"),
+            "timestamp": insp.inference_timestamp.isoformat() if insp.inference_timestamp else submitted_at,
+        },
+        {
+            "step": "Clinical Reasoning",
+            "completed": insp.disposition is not None,
+            "timestamp": submitted_at if insp.disposition is not None else None,
+        },
+        {
+            "step": "Supervisor Review",
+            "completed": confirmed,
+            "timestamp": review.created_at.isoformat() if review and review.created_at else None,
+        },
+        {
+            "step": "Disposition",
+            "completed": True,
+            "timestamp": (review.created_at.isoformat() if review and review.created_at else submitted_at),
+            "value": disposition["disposition"],
+        },
+        {
+            "step": "Ready for Packaging",
+            "completed": ready_for_packaging,
+            "timestamp": (review.created_at.isoformat() if ready_for_packaging and review else None),
+        },
+    ]
+
+    return {
+        "inspection_id": insp.id,
+        "steps": steps,
+        "note": (
+            "Steps that happen synchronously within one analysis call share the "
+            "submission timestamp rather than fabricating individually-spaced times; "
+            "only Supervisor Review has its own independently-timed record."
+        ),
+    }

--- a/backend/app/services/risk_stratification_service.py
+++ b/backend/app/services/risk_stratification_service.py
@@ -1,0 +1,70 @@
+"""v1.6 — Instrument Risk Stratification (Deliverable 8).
+
+Classifies an inspection's instrument into Low / Moderate / High / Critical
+risk, using anatomy (high-retention zone involvement), findings severity,
+damage presence, coverage completeness, and baseline confidence — a
+point-based rubric over already-computed signals, not a new model.
+"""
+from __future__ import annotations
+
+LOW = "Low Risk"
+MODERATE = "Moderate Risk"
+HIGH = "High Risk"
+CRITICAL = "Critical"
+
+RISK_TIERS = [LOW, MODERATE, HIGH, CRITICAL]
+
+_STRUCTURAL_FINDINGS = {"crack", "missing_component", "insulation_damage"}
+
+
+def stratify_risk(insp, *, high_risk_zone_finding: bool = False, primary_finding_type: str | None = None) -> dict:
+    """Point-based risk stratification. Each contributing signal is returned
+    alongside the tier so the classification is auditable, not a black box.
+
+    `primary_finding_type` should be the real detected finding (see
+    `readiness_engine.get_primary_finding_type`) — `insp.detected_issue` is
+    only used as a fallback for the no-image manual-entry path."""
+    points = 0
+    reasons: list[str] = []
+
+    detected_issue = (
+        primary_finding_type if primary_finding_type is not None
+        else (insp.detected_issue or "").strip().lower()
+    )
+
+    if detected_issue in _STRUCTURAL_FINDINGS:
+        points += 3
+        reasons.append(f"Structural finding ({detected_issue}).")
+    elif detected_issue not in ("", "none", "unknown"):
+        points += 1
+        reasons.append(f"Contamination/condition finding ({detected_issue}).")
+
+    if insp.disposition == "REMOVE FROM SERVICE":
+        points += 3
+        reasons.append("Escalated to remove-from-service.")
+
+    if high_risk_zone_finding:
+        points += 2
+        reasons.append("Finding located in a high-retention anatomy zone.")
+
+    if insp.coverage_pct is not None and insp.coverage_pct < 75:
+        points += 1
+        reasons.append(f"Inspection coverage below 75% ({insp.coverage_pct}%).")
+    elif insp.coverage_pct is None:
+        points += 1
+        reasons.append("Inspection coverage not assessed.")
+
+    if insp.baseline_status != "approved_baseline_found":
+        points += 1
+        reasons.append("No approved baseline confidence available.")
+
+    if points >= 7:
+        tier = CRITICAL
+    elif points >= 5:
+        tier = HIGH
+    elif points >= 2:
+        tier = MODERATE
+    else:
+        tier = LOW
+
+    return {"risk_tier": tier, "points": points, "reasons": reasons}

--- a/backend/app/services/root_cause_service.py
+++ b/backend/app/services/root_cause_service.py
@@ -1,0 +1,53 @@
+"""v1.5 — Root Cause Intelligence (Deliverable 7).
+
+Findings are categorized by probable root cause only by a human (a
+supervisor) — never inferred automatically, since guessing "why" a finding
+occurred without a human judgment call would be a fabricated causal claim.
+This module records that categorization and trends recurring causes.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.root_cause import ROOT_CAUSES, RootCauseAssignment
+
+
+def assign_root_cause(
+    db: Session, *, tenant_id: str, inspection_id: int, finding_type: str,
+    root_cause: str, assigned_by: str,
+) -> RootCauseAssignment:
+    if root_cause not in ROOT_CAUSES:
+        raise ValueError(f"root_cause must be one of {ROOT_CAUSES}")
+    assignment = RootCauseAssignment(
+        tenant_id=tenant_id,
+        inspection_id=inspection_id,
+        finding_type=finding_type,
+        root_cause=root_cause,
+        assigned_by=assigned_by,
+    )
+    db.add(assignment)
+    return assignment
+
+
+def root_cause_trends(db: Session, tenant_id: str) -> dict:
+    """Recurring root causes, overall and per finding type."""
+    rows = (
+        db.query(RootCauseAssignment)
+        .filter(RootCauseAssignment.tenant_id == tenant_id)
+        .all()
+    )
+
+    overall: dict[str, int] = defaultdict(int)
+    by_finding_type: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for r in rows:
+        overall[r.root_cause] += 1
+        by_finding_type[r.finding_type][r.root_cause] += 1
+
+    return {
+        "total_assignments": len(rows),
+        "overall": dict(sorted(overall.items(), key=lambda kv: kv[1], reverse=True)),
+        "by_finding_type": {ft: dict(counts) for ft, counts in by_finding_type.items()},
+        "human_review_required": True,
+    }

--- a/backend/app/services/shift_handoff_service.py
+++ b/backend/app/services/shift_handoff_service.py
@@ -1,0 +1,29 @@
+"""v1.7 — Shift Handoff Report (Deliverable 9)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.services.escalation_engine import escalation_queue
+from app.services.work_queue_service import build_work_queue
+
+
+def shift_handoff_report(db: Session, tenant_id: str, *, shift_actor: str = "") -> dict:
+    """Deliverable 9 — a real-time snapshot of what the next shift needs to
+    know, built entirely from the same queue/escalation data already shown
+    on the work queue and operations board."""
+    queue = build_work_queue(db, tenant_id)
+    escalations = escalation_queue(db, tenant_id)
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_by": shift_actor,
+        "outstanding_inspections": queue["pending_inspections"],
+        "critical_instruments": queue["high_risk_inspections"],
+        "pending_supervisor_reviews": queue["supervisor_reviews"],
+        "repair_holds": queue["repair_holds"],
+        "escalations": escalations["escalations"],
+        "or_priorities": queue["or_priority_instruments"],
+        "human_review_required": True,
+    }

--- a/backend/app/services/similar_case_finder_service.py
+++ b/backend/app/services/similar_case_finder_service.py
@@ -1,0 +1,34 @@
+"""v1.8 — Similar Case Finder (Deliverable 5).
+
+When the AI detects a finding, surfaces prior real cases on the same
+instrument family with the same finding type — previous images (via the
+originating inspection), previous recommendations, supervisor outcomes,
+and any educational notes attached. Matches on instrument *family* (not
+exact instrument_type) so a Kerrison from one manufacturer surfaces a
+similar case from another, since anatomy — not brand — drives the finding.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import ClinicalCase
+from app.services.clinical_case_library_service import case_to_dict
+from app.services.instrument_anatomy import resolve_family
+
+
+def find_similar_cases(
+    db: Session, tenant_id: str, *, instrument_type: str, finding_type: str, exclude_inspection_id: int | None = None,
+    limit: int = 5,
+) -> list[dict]:
+    family = resolve_family(instrument_type)
+    rows = (
+        db.query(ClinicalCase)
+        .filter(ClinicalCase.tenant_id == tenant_id, ClinicalCase.finding_type == finding_type)
+        .order_by(ClinicalCase.id.desc())
+        .all()
+    )
+    matches = [
+        r for r in rows
+        if resolve_family(r.instrument_type) == family and r.inspection_id != exclude_inspection_id
+    ]
+    return [case_to_dict(r) for r in matches[:limit]]

--- a/backend/app/services/sla_monitoring_service.py
+++ b/backend/app/services/sla_monitoring_service.py
@@ -1,0 +1,109 @@
+"""v1.7 — SLA Monitoring (Deliverable 6).
+
+Turnaround times are computed only from real, audited WorkflowStateEvent
+transitions (workflow_state_service.py) — never estimated. An inspection
+that hasn't reached a given stage yet contributes no data point for it, and
+a currently-open stage is flagged as a breach only once it has genuinely
+exceeded the target, using the real elapsed time so far.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.workflow import COMPLETED, RECLEAN, REPAIR, SUPERVISOR_REVIEW, WorkflowStateEvent
+from app.services.workflow_state_service import aware_utc
+
+SLA_TARGET_MINUTES = {
+    "supervisor_review_minutes": 480,   # 8h
+    "reclean_turnaround_minutes": 240,  # 4h
+    "repair_referral_minutes": 1440,    # 24h
+    "overall_turnaround_minutes": 1440,  # 24h
+}
+
+
+def _stage_durations(db: Session, tenant_id: str, from_state: str) -> tuple[list[float], list[dict]]:
+    """Elapsed minutes for every completed occurrence of `from_state` (the
+    stage was entered then later left), plus any occurrence still open
+    (for breach detection)."""
+    events = (
+        db.query(WorkflowStateEvent)
+        .filter(WorkflowStateEvent.tenant_id == tenant_id)
+        .order_by(WorkflowStateEvent.inspection_id.asc(), WorkflowStateEvent.id.asc())
+        .all()
+    )
+    by_inspection: dict[int, list[WorkflowStateEvent]] = {}
+    for e in events:
+        by_inspection.setdefault(e.inspection_id, []).append(e)
+
+    completed_minutes: list[float] = []
+    open_stages: list[dict] = []
+    now = datetime.now(timezone.utc)
+    for inspection_id, evs in by_inspection.items():
+        for i, e in enumerate(evs):
+            if e.to_state != from_state:
+                continue
+            next_event = evs[i + 1] if i + 1 < len(evs) else None
+            if next_event is not None:
+                completed_minutes.append(
+                    (aware_utc(next_event.created_at) - aware_utc(e.created_at)).total_seconds() / 60
+                )
+            else:
+                open_stages.append({
+                    "inspection_id": inspection_id,
+                    "minutes_elapsed": round((now - aware_utc(e.created_at)).total_seconds() / 60, 1),
+                })
+    return completed_minutes, open_stages
+
+
+def sla_monitoring(db: Session, tenant_id: str) -> dict:
+    """Deliverable 6 — average turnaround per stage plus any current SLA
+    breaches (a stage still open longer than its target)."""
+    supervisor_minutes, supervisor_open = _stage_durations(db, tenant_id, SUPERVISOR_REVIEW)
+    reclean_minutes, reclean_open = _stage_durations(db, tenant_id, RECLEAN)
+    repair_minutes, repair_open = _stage_durations(db, tenant_id, REPAIR)
+
+    completed_events = (
+        db.query(WorkflowStateEvent)
+        .filter(WorkflowStateEvent.tenant_id == tenant_id, WorkflowStateEvent.to_state == COMPLETED)
+        .all()
+    )
+    insp_ids = [e.inspection_id for e in completed_events]
+    inspections = (
+        {i.id: i for i in db.query(models.Inspection).filter(models.Inspection.id.in_(insp_ids)).all()}
+        if insp_ids else {}
+    )
+    overall_minutes = []
+    for e in completed_events:
+        insp = inspections.get(e.inspection_id)
+        if insp is not None and insp.created_at:
+            overall_minutes.append((aware_utc(e.created_at) - aware_utc(insp.created_at)).total_seconds() / 60)
+
+    def _avg(values):
+        return round(sum(values) / len(values), 1) if values else None
+
+    breaches = []
+    for label, target_key, open_stages in (
+        ("Supervisor Review", "supervisor_review_minutes", supervisor_open),
+        ("Reclean", "reclean_turnaround_minutes", reclean_open),
+        ("Repair", "repair_referral_minutes", repair_open),
+    ):
+        target = SLA_TARGET_MINUTES[target_key]
+        for stage in open_stages:
+            if stage["minutes_elapsed"] > target:
+                breaches.append({
+                    "stage": label, "inspection_id": stage["inspection_id"],
+                    "minutes_elapsed": stage["minutes_elapsed"], "target_minutes": target,
+                })
+
+    return {
+        "sla_targets_minutes": SLA_TARGET_MINUTES,
+        "average_supervisor_review_minutes": _avg(supervisor_minutes),
+        "average_reclean_turnaround_minutes": _avg(reclean_minutes),
+        "average_repair_referral_minutes": _avg(repair_minutes),
+        "average_overall_turnaround_minutes": _avg(overall_minutes),
+        "sla_breaches": breaches,
+        "human_review_required": True,
+    }

--- a/backend/app/services/spd_mentor_engine.py
+++ b/backend/app/services/spd_mentor_engine.py
@@ -1,0 +1,313 @@
+"""v1.4 — SPD Mentor Engine.
+
+Turns an inspection analysis into an active SPD educator: structured corrective
+action chains per finding, anatomy-aware coaching tied to the instrument's
+actual high-retention zones, confidence coaching when image quality or
+coverage is incomplete, a concise clinical decision summary, and (in Training
+Mode) expanded explanations of every finding, the anatomy involved, the
+recommendation, and SPD terminology.
+
+This module composes existing Phase 13/14/15 infrastructure
+(clinical_mentor.py, instrument_anatomy.py, instrument_zones.py,
+inspection_coverage.py) rather than duplicating it — it never replaces
+supervisor judgment, and every statement is derived from the actual analysis
+result, not fabricated.
+"""
+from __future__ import annotations
+
+from app.services.clinical_mentor import (
+    FINDING_EDUCATION,
+    NEXT_ACTIONS,
+    STANDARDS_GUIDANCE,
+    learning_content,
+)
+from app.services.baseline_comparison_scoring_service import KPI_LABELS
+
+MENTOR_DISCLAIMER = (
+    "This guidance is AI-generated educational support. It does not replace "
+    "supervisor judgment or the manufacturer's Instructions For Use (IFU)."
+)
+
+IFU_REFERENCE_NOTE = "AAMI ST79 (institution-specific implementation may vary)."
+
+# ── Corrective action chains (Deliverable 2) ─────────────────────────────────
+# Ordered, structured step-by-step recommendations per finding type. Derived
+# from accepted SPD practice — supervisor verification is the final step for
+# every contamination finding; structural findings escalate to remove-from-
+# service rather than reprocessing.
+CORRECTIVE_ACTION_CHAINS: dict[str, list[str]] = {
+    "blood": [
+        "Reclean the instrument.",
+        "Brush serrations manually.",
+        "Flush the lumen.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "tissue": [
+        "Reclean the instrument.",
+        "Brush affected surfaces manually.",
+        "Flush any lumens or channels.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "other_organic_residue": [
+        "Reclean the instrument.",
+        "Consider extended enzymatic contact time or a biofilm-directed protocol.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "bone": [
+        "Reclean the instrument.",
+        "Flush and brush cannulated channels with the correct-diameter brush.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "debris": [
+        "Reclean the instrument.",
+        "Identify and remove the particulate source.",
+        "Repeat visual inspection.",
+        "Supervisor verification.",
+    ],
+    "rust": [
+        "Remove from service.",
+        "Evaluate for repair.",
+        "Inspect surrounding anatomy.",
+        "Document corrosion.",
+    ],
+    "corrosion": [
+        "Remove from service.",
+        "Evaluate for repair.",
+        "Inspect surrounding anatomy.",
+        "Document corrosion.",
+    ],
+    "pitting": [
+        "Remove from service for evaluation if extensive.",
+        "Inspect surrounding anatomy.",
+        "Document the finding.",
+        "Monitor at future inspections if minor.",
+    ],
+    "crack": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Repair evaluation.",
+    ],
+    "insulation_damage": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Test insulation integrity.",
+        "Repair or replace evaluation.",
+    ],
+    "missing_component": [
+        "Remove from service immediately.",
+        "Notify supervisor.",
+        "Verify against the tray content list and instrument photo.",
+        "Complete assembly or replace.",
+    ],
+    "wear": [
+        "Document and monitor.",
+        "Compare against prior inspections.",
+        "Escalate to supervisor if progressive.",
+    ],
+    "discoloration": [
+        "Document and monitor.",
+        "Investigate if progressive or paired with corrosion.",
+    ],
+}
+
+
+def corrective_action_chain(finding_type: str) -> list[str]:
+    """Ordered corrective-action steps for a single finding type."""
+    return CORRECTIVE_ACTION_CHAINS.get(finding_type, ["Supervisor review recommended."])
+
+
+def corrective_actions_for_result(result: dict) -> list[dict]:
+    """Structured corrective-action recommendation per actionable finding."""
+    out = []
+    for f in result.get("predicted_findings", []):
+        if f["severity_index"] < 1:
+            continue
+        finding_type = f["type"]
+        out.append({
+            "finding": KPI_LABELS.get(finding_type, finding_type),
+            "steps": corrective_action_chain(finding_type),
+        })
+    return out
+
+
+# ── Anatomy-aware coaching (Deliverable 3) ───────────────────────────────────
+# Canned coaching phrasing for instrument families with well-known SPD lore.
+# Falls back to a generated sentence from the instrument's own anatomy zones
+# for families without a specific canned phrase — never fabricated per-family
+# detail beyond what instrument_anatomy.py already defines.
+_FAMILY_COACHING_PHRASES: dict[str, list[str]] = {
+    "kerrison_rongeur": [
+        "Kerrison jaw serrations are high-retention anatomy zones.",
+        "Open the box lock and actuate the hinge during inspection — soil hides in the pivot.",
+    ],
+    "rigid_scope": [
+        "Rigid scope O-ring regions frequently retain organic material.",
+        "Inspect the working channel and seal closely; these are high-retention zones.",
+    ],
+    "drill_bit": [
+        "Drill-bit flutes require careful brushing.",
+        "Threaded regions between the flutes are a common site for retained residue.",
+    ],
+    "needle_holder": [
+        "Needle-holder box locks should be opened during inspection.",
+        "Jaw inserts and serrations are high-retention anatomy zones.",
+    ],
+}
+
+
+def anatomy_coaching(result: dict) -> list[str]:
+    """Anatomy-aware coaching sentences for the instrument being inspected."""
+    anatomy = result.get("instrument_anatomy") or {}
+    family = anatomy.get("family", "default")
+    messages = list(_FAMILY_COACHING_PHRASES.get(family, []))
+
+    if not messages:
+        category = anatomy.get("category", "instrument")
+        for zone in anatomy.get("zones", []):
+            if zone.get("retention_risk") == "high" or zone.get("zone_name") in anatomy.get("high_risk_zones", []):
+                messages.append(
+                    f"{category.capitalize()} {zone['zone_name']} is a high-retention anatomy zone."
+                )
+    return messages
+
+
+def _zone_description(zone_name: str) -> str:
+    from app.services.instrument_zones import ZONE_INFO
+
+    info = ZONE_INFO.get(zone_name.lower())
+    if info and info.get("reason"):
+        return info["reason"]
+    return f"{zone_name.capitalize()} — inspect closely per the instrument's anatomy profile."
+
+
+# ── AI confidence coaching (Deliverable 7) ───────────────────────────────────
+_LOW_CONFIDENCE_THRESHOLD = 0.7
+_LOW_COVERAGE_THRESHOLD = 75
+
+
+def confidence_coaching(result: dict) -> dict | None:
+    """Coaching for the technician when confidence is limited by image
+    quality or incomplete inspection coverage. Returns None when confidence
+    and coverage are both adequate — nothing to coach."""
+    confidence = result.get("confidence")
+    coverage = result.get("inspection_coverage") or {}
+    coverage_pct = coverage.get("overall_coverage")
+    coverage_assessed = coverage.get("assessed", False)
+
+    low_confidence = confidence is not None and confidence < _LOW_CONFIDENCE_THRESHOLD
+    low_coverage = coverage_assessed and coverage_pct is not None and coverage_pct < _LOW_COVERAGE_THRESHOLD
+    not_assessed = not coverage_assessed
+
+    if not (low_confidence or low_coverage or not_assessed):
+        return None
+
+    suggestions: list[str] = []
+    if not_assessed or low_coverage:
+        suggestions.append("Capture additional images.")
+        suggestions.append("Capture missing anatomy zones.")
+    if low_confidence:
+        suggestions.append("Improve lighting.")
+    suggestions.append("Request supervisor review.")
+
+    return {
+        "message": (
+            "Confidence is limited because image quality and inspection "
+            "coverage are incomplete."
+        ),
+        "suggestions": suggestions,
+    }
+
+
+# ── Clinical decision summary (Deliverable 8, concise form) ──────────────────
+def clinical_decision_summary(result: dict, overall: str) -> dict:
+    coverage = result.get("inspection_coverage") or {}
+    supervisor_review = "Recommended" if overall in {
+        "SUPERVISOR REVIEW", "REPROCESS", "REMOVE FROM SERVICE",
+    } else "Not required"
+
+    return {
+        "instrument": result.get("instrument_type") or "Unknown instrument",
+        "inspection_coverage": coverage.get("overall_coverage"),
+        "findings": result.get("findings_summary") or "No actionable findings detected.",
+        "risk": result.get("risk_level"),
+        "recommendation": result.get("recommended_action"),
+        "supervisor_review": supervisor_review,
+    }
+
+
+# ── SPD education cards (Deliverable 4) ──────────────────────────────────────
+def education_card(finding_type: str) -> dict | None:
+    edu = FINDING_EDUCATION.get(finding_type)
+    if not edu:
+        return None
+    return {
+        "finding": KPI_LABELS.get(finding_type, finding_type),
+        "clinical_significance": edu["clinical_significance"],
+        "recommended_practice": edu["spd_response"],
+        "reference": IFU_REFERENCE_NOTE,
+    }
+
+
+def education_cards_for_result(result: dict) -> list[dict]:
+    out = []
+    for f in result.get("predicted_findings", []):
+        if f["severity_index"] < 1:
+            continue
+        card = education_card(f["type"])
+        if card:
+            out.append(card)
+    return out
+
+
+# ── Training Mode (Deliverable 6) ────────────────────────────────────────────
+TERMINOLOGY: dict[str, str] = {
+    "baseline match": "How closely the instrument's current condition matches its approved reference (baseline) image or record.",
+    "retention zone": "An anatomy region — such as a serration, lumen, box lock, or hinge — where soil is mechanically difficult to remove and easy to miss visually.",
+    "IFU": "Instructions For Use — the manufacturer's official reprocessing and inspection instructions for a specific device.",
+    "disposition": "The recommended next step for an instrument after inspection (e.g. PASS, REPROCESS, REMOVE FROM SERVICE).",
+    "coverage": "The percentage of an instrument's required high-risk anatomy zones that were actually photographed/inspected.",
+    "supervisor review": "A second, qualified review of an instrument before it is released, required whenever cleanliness or condition is uncertain.",
+}
+
+
+def training_mode_explanations(result: dict, overall: str) -> dict:
+    """Expanded, always-explain content for onboarding/competency building:
+    every finding, the anatomy involved, the recommendation, and terminology."""
+    anatomy = result.get("instrument_anatomy") or {}
+    return {
+        "every_finding": learning_content(result),
+        "anatomy_explained": [
+            {"zone": zone_name, "explanation": _zone_description(zone_name)}
+            for zone_name in anatomy.get("zone_names", [])
+        ],
+        "recommendation_explained": {
+            "disposition": overall,
+            "next_actions": NEXT_ACTIONS.get(overall, []),
+            "standards_guidance": STANDARDS_GUIDANCE.get(overall, ""),
+        },
+        "terminology": [
+            {"term": term, "definition": definition}
+            for term, definition in TERMINOLOGY.items()
+        ],
+    }
+
+
+# ── Assembly ──────────────────────────────────────────────────────────────
+def build_spd_mentor(result: dict, overall: str, *, training_mode: bool = False) -> dict:
+    """Assemble the full v1.4 SPD Mentor payload."""
+    payload = {
+        "disclaimer": MENTOR_DISCLAIMER,
+        "corrective_actions": corrective_actions_for_result(result),
+        "anatomy_coaching": anatomy_coaching(result),
+        "confidence_coaching": confidence_coaching(result),
+        "clinical_decision_summary": clinical_decision_summary(result, overall),
+        "education_cards": education_cards_for_result(result),
+        "training_mode": training_mode,
+    }
+    if training_mode:
+        payload["expanded_explanations"] = training_mode_explanations(result, overall)
+    return payload

--- a/backend/app/services/spd_mentor_engine.py
+++ b/backend/app/services/spd_mentor_engine.py
@@ -181,7 +181,7 @@ def _zone_description(zone_name: str) -> str:
     info = ZONE_INFO.get(zone_name.lower())
     if info and info.get("reason"):
         return info["reason"]
-    return f"{zone_name.capitalize()} — inspect closely per the instrument's anatomy profile."
+    return "Inspect closely per the instrument's anatomy profile."
 
 
 # ── AI confidence coaching (Deliverable 7) ───────────────────────────────────
@@ -223,6 +223,17 @@ def confidence_coaching(result: dict) -> dict | None:
 
 
 # ── Clinical decision summary (Deliverable 8, concise form) ──────────────────
+def _findings_sentence(result: dict) -> str:
+    """findings_summary is a list of per-KPI phrases (e.g. "Blood detected",
+    "No bone detected") — collapse to a single sentence naming only what was
+    actually found, not an exhaustive negative checklist."""
+    phrases = result.get("findings_summary") or []
+    positive = [p for p in phrases if not p.startswith("No ")]
+    if not positive:
+        return "No actionable findings detected."
+    return "; ".join(positive) + "."
+
+
 def clinical_decision_summary(result: dict, overall: str) -> dict:
     coverage = result.get("inspection_coverage") or {}
     supervisor_review = "Recommended" if overall in {
@@ -232,7 +243,7 @@ def clinical_decision_summary(result: dict, overall: str) -> dict:
     return {
         "instrument": result.get("instrument_type") or "Unknown instrument",
         "inspection_coverage": coverage.get("overall_coverage"),
-        "findings": result.get("findings_summary") or "No actionable findings detected.",
+        "findings": _findings_sentence(result),
         "risk": result.get("risk_level"),
         "recommendation": result.get("recommended_action"),
         "supervisor_review": supervisor_review,

--- a/backend/app/services/supervisor_quality_service.py
+++ b/backend/app/services/supervisor_quality_service.py
@@ -1,0 +1,92 @@
+"""v1.5 — Supervisor Quality Dashboard (Deliverable 6).
+
+Per-supervisor review workload, override frequency, correction categories,
+education provided, and AI agreement — derived from real SupervisorReview and
+MentorCoachingReview rows. Department trends are derived from Inspection.department,
+already captured at intake.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.mentor_coaching_review import MentorCoachingReview
+from app.models.supervisor_review import SupervisorReview
+
+
+def _rate(n: int, d: int) -> float | None:
+    return round(100 * n / d, 1) if d else None
+
+
+def supervisor_quality_dashboard(db: Session, tenant_id: str) -> dict:
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    coaching = db.query(MentorCoachingReview).filter(MentorCoachingReview.tenant_id == tenant_id).all()
+
+    by_reviewer: dict[str, list] = defaultdict(list)
+    for r in reviews:
+        by_reviewer[r.reviewer_name].append(r)
+    coaching_by_reviewer: dict[str, list] = defaultdict(list)
+    for c in coaching:
+        coaching_by_reviewer[c.reviewer_name].append(c)
+
+    supervisors = []
+    for reviewer, r_reviews in by_reviewer.items():
+        override_ct = sum(1 for r in r_reviews if (r.override_action or "").strip())
+        agree_ct = sum(1 for r in r_reviews if r.agreement == "agree")
+
+        categories: dict[str, int] = defaultdict(int)
+        for r in r_reviews:
+            if r.corrected_zone:
+                categories["zone"] += 1
+            if r.corrected_instrument_family:
+                categories["instrument_family"] += 1
+            if r.corrected_severity:
+                categories["severity"] += 1
+            if r.corrected_recommendation:
+                categories["recommendation"] += 1
+
+        r_coaching = coaching_by_reviewer.get(reviewer, [])
+        education_provided_ct = sum(1 for c in r_coaching if c.educational_comment.strip())
+
+        supervisors.append({
+            "reviewer": reviewer,
+            "review_workload": len(r_reviews),
+            "override_frequency_pct": _rate(override_ct, len(r_reviews)),
+            "correction_categories": dict(categories),
+            "education_provided_count": education_provided_ct,
+            "agreement_with_ai_pct": _rate(agree_ct, len(r_reviews)),
+        })
+
+    supervisors.sort(key=lambda s: s["review_workload"], reverse=True)
+
+    # Department trends — from Inspection.department, already captured at intake.
+    insp_rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.department.isnot(None))
+        .all()
+    )
+    by_department: dict[str, list] = defaultdict(list)
+    for r in insp_rows:
+        by_department[r.department or "unspecified"].append(r)
+
+    departments = []
+    for dept, dept_rows in by_department.items():
+        scored = [r for r in dept_rows if r.has_image and r.disposition]
+        total = len(scored)
+        pass_ct = sum(1 for r in scored if r.disposition == "PASS")
+        remove_ct = sum(1 for r in scored if r.disposition == "REMOVE FROM SERVICE")
+        departments.append({
+            "department": dept,
+            "inspection_count": len(dept_rows),
+            "pass_rate_pct": _rate(pass_ct, total),
+            "remove_from_service_rate_pct": _rate(remove_ct, total),
+        })
+    departments.sort(key=lambda d: d["inspection_count"], reverse=True)
+
+    return {
+        "supervisors": supervisors,
+        "department_trends": departments,
+        "human_review_required": True,
+    }

--- a/backend/app/services/technician_workload_service.py
+++ b/backend/app/services/technician_workload_service.py
@@ -1,0 +1,84 @@
+"""v1.7 — Technician Assignment & Workload Tracking (Deliverable 3).
+
+Complements the existing per-technician quality rollup in
+competency_service.technician_quality_dashboard() (coverage / AI-confidence
+/ supervisor-agreement — quality of work) with an operational capacity
+view: who's currently assigned what, how much is open, and how long
+inspections actually take from creation to a completed disposition (real
+elapsed time between audited WorkflowStateEvent rows, never estimated).
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.workflow import COMPLETED, InspectionAssignment, WorkflowStateEvent
+from app.services.workflow_state_service import aware_utc
+
+
+def _current_assignments(db: Session, tenant_id: str) -> dict[int, str]:
+    """inspection_id -> technician, using each inspection's latest assignment row."""
+    rows = (
+        db.query(InspectionAssignment)
+        .filter(InspectionAssignment.tenant_id == tenant_id)
+        .order_by(InspectionAssignment.id.asc())
+        .all()
+    )
+    latest: dict[int, str] = {}
+    for r in rows:
+        latest[r.inspection_id] = r.technician  # later rows overwrite earlier ones
+    return latest
+
+
+def technician_workload(db: Session, tenant_id: str) -> dict:
+    """Deliverable 3 — per-technician assigned/open/completed counts and
+    average real inspection turnaround (creation to first Completed event).
+    A technician with no completed inspections yet gets `None`, not a
+    fabricated average."""
+    assignments = _current_assignments(db, tenant_id)
+    if not assignments:
+        return {"technicians": [], "human_review_required": True}
+
+    insp_ids = list(assignments.keys())
+    inspections = {
+        i.id: i for i in db.query(models.Inspection).filter(models.Inspection.id.in_(insp_ids)).all()
+    }
+    completed_events = (
+        db.query(WorkflowStateEvent)
+        .filter(WorkflowStateEvent.inspection_id.in_(insp_ids), WorkflowStateEvent.to_state == COMPLETED)
+        .order_by(WorkflowStateEvent.id.asc())
+        .all()
+    )
+    first_completed_at: dict[int, object] = {}
+    for e in completed_events:
+        first_completed_at.setdefault(e.inspection_id, e.created_at)
+
+    by_technician: dict[str, dict] = {}
+    for insp_id, technician in assignments.items():
+        insp = inspections.get(insp_id)
+        if insp is None:
+            continue
+        bucket = by_technician.setdefault(technician, {"open": 0, "completed": 0, "durations_min": []})
+        completed_at = first_completed_at.get(insp_id)
+        if completed_at is not None:
+            bucket["completed"] += 1
+            if insp.created_at:
+                bucket["durations_min"].append(
+                    (aware_utc(completed_at) - aware_utc(insp.created_at)).total_seconds() / 60
+                )
+        else:
+            bucket["open"] += 1
+
+    technicians = []
+    for technician, bucket in by_technician.items():
+        durations = bucket["durations_min"]
+        technicians.append({
+            "technician": technician,
+            "open_inspections": bucket["open"],
+            "completed_inspections": bucket["completed"],
+            "workload": bucket["open"],
+            "avg_inspection_time_minutes": round(sum(durations) / len(durations), 1) if durations else None,
+        })
+
+    technicians.sort(key=lambda t: t["workload"], reverse=True)
+    return {"technicians": technicians, "human_review_required": True}

--- a/backend/app/services/work_queue_service.py
+++ b/backend/app/services/work_queue_service.py
@@ -1,0 +1,99 @@
+"""v1.7 — Smart Inspection Queue (Deliverable 1).
+
+Groups every not-yet-finished inspection into the queue sections SPD asks
+for, ranked by the prioritization engine's score — a rollup of the already
+real-computed readiness/disposition/risk/priority signals per inspection,
+never a separate analysis.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.supervisor_review import SupervisorReview
+from app.models.workflow import CANCELLED, COMPLETED, REPAIR, SUPERVISOR_REVIEW
+from app.services.disposition_engine import recommend_disposition
+from app.services.prioritization_engine import compute_priority, has_repeat_findings, is_vendor_tray
+from app.services.readiness_engine import compute_readiness, get_primary_finding_type
+from app.services.risk_stratification_service import stratify_risk
+from app.services.workflow_state_service import aware_utc, current_state, latest_assignment
+
+
+def _queue_item(db: Session, tenant_id: str, insp) -> dict:
+    confirmed = (
+        db.query(SupervisorReview.id).filter(SupervisorReview.inspection_id == insp.id).first() is not None
+    )
+    readiness = compute_readiness(db, tenant_id, insp, confirmed=confirmed)
+    primary_finding_type = get_primary_finding_type(db, insp)
+    disposition = recommend_disposition(
+        readiness, insp, coverage_pct=insp.coverage_pct, primary_finding_type=primary_finding_type,
+    )
+    risk = stratify_risk(insp, primary_finding_type=primary_finding_type)
+    priority = compute_priority(
+        db, tenant_id, insp, readiness=readiness, disposition=disposition,
+        repair_history=readiness.get("repair_history", False),
+    )
+    state = current_state(db, insp)
+    assignment = latest_assignment(db, insp.id)
+    minutes_waiting = (
+        int((datetime.now(timezone.utc) - aware_utc(insp.created_at)).total_seconds() / 60)
+        if insp.created_at else None
+    )
+
+    return {
+        "inspection_id": insp.id,
+        "instrument_type": insp.instrument_type,
+        "facility_name": insp.facility_name or insp.site_name,
+        "procedure_priority": insp.procedure_priority,
+        "workflow_state": state,
+        "risk_tier": risk["risk_tier"],
+        "priority_score": priority["priority_score"],
+        "priority_tier": priority["priority_tier"],
+        "priority_reasons": priority["reasons"],
+        "disposition": disposition["disposition"],
+        "coverage_pct": insp.coverage_pct,
+        "minutes_waiting": minutes_waiting,
+        "assigned_technician": assignment.technician if assignment else None,
+        "is_vendor_tray": is_vendor_tray(insp),
+        "is_loaner_instrument": bool(insp.is_loaner_instrument),
+        "has_repeat_findings": has_repeat_findings(db, tenant_id, insp),
+        "supervisor_review_confirmed": confirmed,
+    }
+
+
+def build_work_queue(db: Session, tenant_id: str) -> dict:
+    """Deliverable 1 — the Smart Inspection Queue, grouped into the sections
+    SPD asks for and ranked by priority score."""
+    rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id)
+        .order_by(models.Inspection.created_at.asc())
+        .all()
+    )
+
+    items = []
+    for insp in rows:
+        item = _queue_item(db, tenant_id, insp)
+        if item["workflow_state"] in (COMPLETED, CANCELLED):
+            continue
+        items.append(item)
+
+    items.sort(key=lambda i: i["priority_score"], reverse=True)
+
+    def _bucket(pred):
+        return [i for i in items if pred(i)]
+
+    return {
+        "pending_inspections": items,
+        "high_risk_inspections": _bucket(lambda i: i["risk_tier"] in ("High Risk", "Critical")),
+        "or_priority_instruments": _bucket(lambda i: i["procedure_priority"] in ("emergency", "trauma", "first_case")),
+        "vendor_trays": _bucket(lambda i: i["is_vendor_tray"]),
+        "loaner_instruments": _bucket(lambda i: i["is_loaner_instrument"]),
+        "repeat_inspections": _bucket(lambda i: i["has_repeat_findings"]),
+        "supervisor_reviews": _bucket(lambda i: i["workflow_state"] == SUPERVISOR_REVIEW),
+        "repair_holds": _bucket(lambda i: i["workflow_state"] == REPAIR),
+        "total_pending": len(items),
+        "human_review_required": True,
+    }

--- a/backend/app/services/workflow_notification_service.py
+++ b/backend/app/services/workflow_notification_service.py
@@ -1,0 +1,124 @@
+"""v1.7 — Notification Framework (Deliverable 10).
+
+An in-app, per-role/per-person notification queue for workflow events —
+distinct from the existing Slack/Teams/email AlertEvent dispatcher in
+app/notifications/notifier.py (external channels for critical-finding
+alerts, unrelated to per-inspection workflow tracking). Notifications here
+are generated from real, already-computed queue/escalation state and are
+idempotent per inspection+type so re-running generation never duplicates
+an already-emitted notification.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.workflow import WorkflowNotification
+
+NOTIFICATION_TYPES = [
+    "inspection_assigned", "supervisor_review_required", "critical_finding",
+    "repair_recommendation", "inspection_overdue", "coverage_incomplete",
+]
+
+_OVERDUE_MINUTES_THRESHOLD = 480  # 8h
+_COVERAGE_INCOMPLETE_THRESHOLD = 75
+
+
+def notify(
+    db: Session, *, tenant_id: str, inspection_id: int, notification_type: str,
+    recipient_role: str, message: str, recipient_name: str = "",
+) -> WorkflowNotification:
+    row = WorkflowNotification(
+        tenant_id=tenant_id, inspection_id=inspection_id, notification_type=notification_type,
+        recipient_role=recipient_role, recipient_name=recipient_name, message=message,
+    )
+    db.add(row)
+    return row
+
+
+def _already_notified(db: Session, tenant_id: str, inspection_id: int, notification_type: str) -> bool:
+    return (
+        db.query(WorkflowNotification.id)
+        .filter(
+            WorkflowNotification.tenant_id == tenant_id, WorkflowNotification.inspection_id == inspection_id,
+            WorkflowNotification.notification_type == notification_type,
+        )
+        .first()
+        is not None
+    )
+
+
+def list_notifications(
+    db: Session, tenant_id: str, *, recipient_role: str, unread_only: bool = False,
+) -> list[WorkflowNotification]:
+    q = db.query(WorkflowNotification).filter(
+        WorkflowNotification.tenant_id == tenant_id, WorkflowNotification.recipient_role == recipient_role,
+    )
+    if unread_only:
+        q = q.filter(WorkflowNotification.read.is_(False))
+    return q.order_by(WorkflowNotification.id.desc()).all()
+
+
+def mark_read(db: Session, tenant_id: str, notification_id: int) -> WorkflowNotification | None:
+    row = (
+        db.query(WorkflowNotification)
+        .filter(WorkflowNotification.tenant_id == tenant_id, WorkflowNotification.id == notification_id)
+        .first()
+    )
+    if row is None:
+        return None
+    row.read = True
+    row.read_at = datetime.now(timezone.utc)
+    return row
+
+
+def generate_workflow_notifications(db: Session, tenant_id: str) -> dict:
+    """Deliverable 10 — scan real queue/escalation state and emit a
+    notification for each event not already emitted."""
+    from app.services.work_queue_service import build_work_queue
+
+    created = 0
+    queue = build_work_queue(db, tenant_id)
+
+    def _emit(item: dict, notification_type: str, recipient_role: str, message: str) -> None:
+        nonlocal created
+        if not _already_notified(db, tenant_id, item["inspection_id"], notification_type):
+            notify(
+                db, tenant_id=tenant_id, inspection_id=item["inspection_id"],
+                notification_type=notification_type, recipient_role=recipient_role, message=message,
+            )
+            created += 1
+
+    for item in queue["supervisor_reviews"]:
+        _emit(
+            item, "supervisor_review_required", "spd_manager",
+            f"Inspection #{item['inspection_id']} ({item['instrument_type']}) requires supervisor review.",
+        )
+
+    for item in queue["repair_holds"]:
+        _emit(
+            item, "repair_recommendation", "spd_manager",
+            f"Inspection #{item['inspection_id']} ({item['instrument_type']}) recommended for repair evaluation.",
+        )
+
+    for item in queue["high_risk_inspections"]:
+        _emit(
+            item, "critical_finding", "spd_manager",
+            f"Critical finding on inspection #{item['inspection_id']} ({item['instrument_type']}).",
+        )
+
+    for item in queue["pending_inspections"]:
+        if item["minutes_waiting"] is not None and item["minutes_waiting"] > _OVERDUE_MINUTES_THRESHOLD:
+            _emit(
+                item, "inspection_overdue", "spd_manager",
+                f"Inspection #{item['inspection_id']} has been waiting {item['minutes_waiting']} minutes.",
+            )
+        if item["coverage_pct"] is not None and item["coverage_pct"] < _COVERAGE_INCOMPLETE_THRESHOLD:
+            _emit(
+                item, "coverage_incomplete", "operator",
+                f"Inspection #{item['inspection_id']} coverage is only {item['coverage_pct']}% — capture remaining zones.",
+            )
+
+    db.commit()
+    return {"notifications_created": created, "human_review_required": True}

--- a/backend/app/services/workflow_state_service.py
+++ b/backend/app/services/workflow_state_service.py
@@ -1,0 +1,152 @@
+"""v1.7 — Inspection Workflow State Machine (Deliverable 4).
+
+Current state is always the `to_state` of the latest audited
+WorkflowStateEvent row for an inspection — never a mutated single-column
+"current state" that would erase transition history. Transitions are
+appended at the real moment they happen (technician assignment, the
+synchronous image-capture+AI-analysis that already occurs inside one
+POST /api/inspections call, a supervisor's disposition action, or an
+explicit cancellation) rather than re-derived after the fact from
+unrelated signals — this mirrors the same honesty principle already
+applied in readiness_timeline_service.py.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.workflow import (
+    AI_ANALYSIS,
+    ASSIGNED,
+    CANCELLED,
+    COMPLETED,
+    IMAGE_CAPTURE,
+    RECLEAN,
+    REPAIR,
+    SUPERVISOR_REVIEW,
+    WAITING,
+    InspectionAssignment,
+    WorkflowStateEvent,
+)
+
+TERMINAL_STATES = {COMPLETED, CANCELLED}
+
+
+def aware_utc(dt: datetime) -> datetime:
+    """SQLite round-trips DateTime columns as naive; Postgres keeps them
+    timezone-aware. Normalize to aware-UTC before any subtraction so
+    turnaround-time math never raises on either backend."""
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+# Disposition action -> the workflow state that action drives the inspection to.
+_ACTION_TO_STATE = {
+    "approve": COMPLETED,
+    "reclean": RECLEAN,
+    "repair": REPAIR,
+    "manufacturer_review": REPAIR,
+    "remove_from_service": COMPLETED,
+    "escalate": SUPERVISOR_REVIEW,
+    "modify": SUPERVISOR_REVIEW,
+}
+
+
+def latest_assignment(db: Session, inspection_id: int) -> InspectionAssignment | None:
+    return (
+        db.query(InspectionAssignment)
+        .filter(InspectionAssignment.inspection_id == inspection_id)
+        .order_by(InspectionAssignment.id.desc())
+        .first()
+    )
+
+
+def latest_event(db: Session, inspection_id: int) -> WorkflowStateEvent | None:
+    return (
+        db.query(WorkflowStateEvent)
+        .filter(WorkflowStateEvent.inspection_id == inspection_id)
+        .order_by(WorkflowStateEvent.id.desc())
+        .first()
+    )
+
+
+def current_state(db: Session, insp) -> str:
+    """The inspection's current workflow state. Falls back to an honest
+    default (Assigned/Waiting) only when no transition has ever been
+    recorded for it — real state once any event exists."""
+    event = latest_event(db, insp.id)
+    if event is not None:
+        return event.to_state
+    if latest_assignment(db, insp.id) is not None:
+        return ASSIGNED
+    return WAITING
+
+
+def _append(db: Session, *, insp, tenant_id: str, to_state: str, actor: str, reason: str = "") -> WorkflowStateEvent:
+    from_state = current_state(db, insp)
+    row = WorkflowStateEvent(
+        inspection_id=insp.id, tenant_id=tenant_id,
+        from_state=from_state, to_state=to_state, actor=actor, reason=reason,
+    )
+    db.add(row)
+    return row
+
+
+def assign_technician(db: Session, *, insp, tenant_id: str, technician: str, assigned_by: str, note: str = "") -> InspectionAssignment:
+    """Deliverable 3 — supervisor assigns (or reassigns) a technician.
+    Only advances the workflow state to Assigned when the inspection is still
+    Waiting — reassigning an in-progress or completed inspection just records
+    who is now responsible, it never regresses a finished workflow."""
+    row = InspectionAssignment(
+        inspection_id=insp.id, tenant_id=tenant_id, technician=technician,
+        assigned_by=assigned_by, note=note,
+    )
+    db.add(row)
+    if current_state(db, insp) == WAITING:
+        _append(db, insp=insp, tenant_id=tenant_id, to_state=ASSIGNED, actor=assigned_by, reason="Technician assigned")
+    return row
+
+
+def record_capture_and_analysis(db: Session, *, insp, tenant_id: str, actor: str) -> None:
+    """Called once, at inspection-creation time, when an image was submitted.
+    Image capture and AI analysis happen synchronously in the same request —
+    both events share that real timestamp rather than fabricating a gap
+    between them, consistent with readiness_timeline_service's documented
+    approach to the same synchronous-submission architecture."""
+    if current_state(db, insp) in TERMINAL_STATES:
+        return
+    _append(db, insp=insp, tenant_id=tenant_id, to_state=IMAGE_CAPTURE, actor=actor, reason="Image submitted")
+    _append(db, insp=insp, tenant_id=tenant_id, to_state=AI_ANALYSIS, actor=actor, reason="AI analysis completed")
+
+
+def record_disposition_action(db: Session, *, insp, tenant_id: str, action: str, actor: str, reason: str = "") -> None:
+    """Called when a supervisor submits a disposition action (v1.6
+    /disposition-action endpoint) — advances the workflow state to match."""
+    to_state = _ACTION_TO_STATE.get(action)
+    if to_state is None:
+        return
+    _append(db, insp=insp, tenant_id=tenant_id, to_state=to_state, actor=actor, reason=reason or f"Disposition action: {action}")
+
+
+def enter_supervisor_review(db: Session, *, insp, tenant_id: str, actor: str, reason: str = "") -> None:
+    """Advance to Supervisor Review once AI analysis has finished and the
+    disposition engine says a human must weigh in — a no-op if the
+    inspection is already past that point (terminal or already looping
+    through Reclean/Repair)."""
+    state = current_state(db, insp)
+    if state in TERMINAL_STATES or state == SUPERVISOR_REVIEW:
+        return
+    _append(db, insp=insp, tenant_id=tenant_id, to_state=SUPERVISOR_REVIEW, actor=actor, reason=reason or "Awaiting supervisor review")
+
+
+def cancel_inspection(db: Session, *, insp, tenant_id: str, actor: str, reason: str) -> WorkflowStateEvent:
+    """Deliverable 4 — explicit, terminal cancellation. Never inferred."""
+    return _append(db, insp=insp, tenant_id=tenant_id, to_state=CANCELLED, actor=actor, reason=reason)
+
+
+def state_history(db: Session, inspection_id: int) -> list[WorkflowStateEvent]:
+    return (
+        db.query(WorkflowStateEvent)
+        .filter(WorkflowStateEvent.inspection_id == inspection_id)
+        .order_by(WorkflowStateEvent.id.asc())
+        .all()
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -92,6 +92,7 @@ def _force_import_models():
         "app.models.supervisor_review",
         "app.models.clinical_decision_ledger",
         "app.models.cios_event",
+        "app.models.inspection_image_tag",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -89,6 +89,9 @@ def _force_import_models():
         "app.models.digital_quality_twin",
         "app.models.global_intelligence",
         "app.models.consent_record",
+        "app.models.supervisor_review",
+        "app.models.clinical_decision_ledger",
+        "app.models.cios_event",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/test_agents_pipeline.py
+++ b/backend/tests/test_agents_pipeline.py
@@ -1,0 +1,210 @@
+"""Phase 22 — Multi-Agent Clinical Intelligence Platform tests."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.agents.anatomy_agent import AnatomyIntelligenceAgent
+from app.agents.context import InstrumentContext
+from app.agents.contamination_agent import ContaminationDetectionAgent
+from app.agents.damage_agent import DamageDetectionAgent
+from app.agents.instrument_agent import InstrumentIntelligenceAgent
+from app.agents.orchestrator import run_pipeline
+from app.agents.registry import PIPELINE_ORDER, get_registry
+from app.db.session import SessionLocal
+from app.models.inspection import Inspection
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+SHA = "a9e17700" + "0" * 56
+
+
+def _make_inspection(db, **overrides) -> Inspection:
+    defaults = dict(
+        tenant_id="default-tenant", file_name="x.jpg", instrument_type="kerrison rongeur",
+        has_image=True, image_sha256=SHA, score_status="scored", risk_score=60,
+        detected_issue="blood", vendor_name="Acme Surgical",
+        recommended_action="Reprocess — blood. Return for complete cleaning.",
+        inspected_zones_json="null",
+    )
+    defaults.update(overrides)
+    insp = Inspection(**defaults)
+    db.add(insp)
+    db.commit()
+    db.refresh(insp)
+    return insp
+
+
+class TestAgentContextValidation:
+    def test_instrument_context_requires_family(self):
+        ctx = InstrumentContext(instrument_type="scissors", instrument_family="scissors", instrument_category="cutting")
+        assert ctx.instrument_type == "scissors"
+        assert ctx.digital_twin_available is False
+
+    def test_anatomy_agent_consumes_instrument_context(self):
+        instrument_agent = InstrumentIntelligenceAgent()
+        db = SessionLocal()
+        try:
+            instrument_ctx = instrument_agent.run(db, "default-tenant", "kerrison rongeur")
+        finally:
+            db.close()
+        anatomy_ctx = AnatomyIntelligenceAgent().run(instrument_ctx, None)
+        assert anatomy_ctx.instrument_family == instrument_ctx.instrument_family
+        assert anatomy_ctx.inspected_zones is None
+        assert anatomy_ctx.inspection_completeness is None
+
+
+class TestAgentCommunication:
+    """Agents only communicate through typed context objects — never raw dicts."""
+
+    def test_contamination_agent_owns_only_contamination_types(self):
+        ctx = ContaminationDetectionAgent().run("scissors", "crack", 50.0, 80)
+        assert ctx.has_contamination is False
+        assert ctx.findings == []
+
+    def test_damage_agent_owns_only_damage_types(self):
+        ctx = DamageDetectionAgent().run("blood", 60)
+        assert ctx.has_damage is False
+
+    def test_contamination_agent_produces_zone_and_significance(self):
+        ctx = ContaminationDetectionAgent().run("scissors", "blood", 80.0, 60)
+        assert ctx.has_contamination is True
+        assert ctx.findings[0].zone == "hinge"
+        assert ctx.findings[0].clinical_significance
+
+    def test_damage_agent_flags_repairable_issue(self):
+        ctx = DamageDetectionAgent().run("crack", 75)
+        assert ctx.has_damage is True
+        assert "repair" in ctx.findings[0].repair_recommendation.lower()
+
+
+class TestAgentRegistry:
+    def test_registry_lists_all_ten_agents(self):
+        registry = get_registry()
+        assert len(registry) == 10
+        assert len(PIPELINE_ORDER) == 10
+
+    def test_registry_entries_have_required_fields(self):
+        for entry in get_registry():
+            for key in ("name", "version", "capabilities", "depends_on", "pipeline_position", "status", "health"):
+                assert key in entry
+            assert entry["health"] == "ok"
+
+    def test_registry_api_endpoint(self):
+        res = client.get("/api/agents/registry", headers=AUTH_VIEWER)
+        assert res.status_code == 200
+        assert len(res.json()["agents"]) == 10
+
+    def test_health_endpoint(self):
+        res = client.get("/api/agents/health", headers=AUTH_VIEWER)
+        assert res.status_code == 200
+        assert res.json()["overall_status"] == "ok"
+
+    def test_unauthenticated_rejected(self):
+        res = client.get("/api/agents/registry")
+        assert res.status_code in (401, 403)
+
+
+class TestPipelineExecution:
+    def test_orchestrator_runs_all_agents_for_real_inspection(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+        finally:
+            db.close()
+
+        db = SessionLocal()
+        try:
+            row = db.query(Inspection).filter(Inspection.id == insp.id).first()
+            result = run_pipeline(db, row, "default-tenant")
+        finally:
+            db.close()
+
+        for key in (
+            "instrument_context", "anatomy_context", "coverage_context", "contamination_context",
+            "damage_context", "clinical_reasoning_context", "recommendation_context",
+            "supervisor_context", "learning_context", "enterprise_context", "trace",
+        ):
+            assert key in result
+
+        assert result["recommendation_context"]["readiness_state"] == "REQUIRES_RECLEANING"
+        assert result["contamination_context"]["has_contamination"] is True
+
+    def test_api_run_endpoint(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, detected_issue="crack", recommended_action="Remove from service — crack.")
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/agents/run/{insp_id}", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        assert data["recommendation_context"]["readiness_state"] == "REQUIRES_REPAIR"
+        assert data["damage_context"]["has_damage"] is True
+
+    def test_missing_inspection_404(self):
+        res = client.get("/api/agents/run/999999999", headers=AUTH_ADMIN)
+        assert res.status_code == 404
+
+
+class TestReasoningTrace:
+    def test_trace_has_ten_entries_in_pipeline_order(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/agents/trace/{insp_id}", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        trace = res.json()["trace"]
+        assert len(trace) == 10
+        agent_names = [t["agent"] for t in trace]
+        assert agent_names == [a.NAME for a in PIPELINE_ORDER]
+
+    def test_trace_entry_shows_input_and_output(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/agents/trace/{insp_id}", headers=AUTH_ADMIN)
+        trace = res.json()["trace"]
+        instrument_entry = trace[0]
+        assert instrument_entry["agent"] == "Instrument Intelligence Agent"
+        assert "input_summary" in instrument_entry
+        assert "output_summary" in instrument_entry
+        assert instrument_entry["output_summary"]["instrument_family"] == "kerrison_rongeur"
+
+    def test_trace_final_recommendation_matches_run(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        run_result = client.get(f"/api/agents/run/{insp_id}", headers=AUTH_ADMIN).json()
+        trace_result = client.get(f"/api/agents/trace/{insp_id}", headers=AUTH_ADMIN).json()
+        assert trace_result["final_recommendation"] == run_result["recommendation_context"]
+
+
+class TestSupervisorAgentNeverFabricates:
+    def test_no_review_means_review_exists_false(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/agents/run/{insp_id}", headers=AUTH_ADMIN)
+        data = res.json()
+        assert data["supervisor_context"]["review_exists"] is False
+        assert data["supervisor_context"]["agreement"] is None

--- a/backend/tests/test_cios.py
+++ b/backend/tests/test_cios.py
@@ -1,0 +1,304 @@
+"""Phase 23 — Clinical Intelligence Operating System (CIOS) tests."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.cios.context import ClinicalContext
+from app.cios.governance import governance_snapshot
+from app.cios.orchestrator import run_cios_pipeline
+from app.cios.rule_registry import CLINICAL_RULE_REGISTRY, get_rule
+from app.cios.state_machine import INSPECTION_STATES, derive_state, is_valid_transition
+from app.db.session import SessionLocal
+from app.models.inspection import Inspection
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+SHA = "c105c105" + "0" * 56
+
+
+def _make_inspection(db, **overrides) -> Inspection:
+    defaults = dict(
+        tenant_id="default-tenant", file_name="x.jpg", instrument_type="kerrison rongeur",
+        has_image=True, image_sha256=SHA, score_status="scored", risk_score=60,
+        detected_issue="blood", vendor_name="Acme Surgical",
+        recommended_action="Reprocess — blood. Return for complete cleaning.",
+        supervisor_review_required=False, inspected_zones_json="null",
+    )
+    defaults.update(overrides)
+    insp = Inspection(**defaults)
+    db.add(insp)
+    db.commit()
+    db.refresh(insp)
+    return insp
+
+
+class TestClinicalContextImmutable:
+    def test_context_is_frozen(self):
+        ctx = ClinicalContext(inspection_id=1, tenant_id="default-tenant", instrument_type="scissors")
+        try:
+            ctx.instrument_type = "forceps"
+            assert False, "expected a validation error on mutating a frozen model"
+        except Exception:
+            pass
+
+    def test_with_updates_returns_new_instance(self):
+        ctx = ClinicalContext(inspection_id=1, tenant_id="default-tenant", instrument_type="scissors")
+        updated = ctx.with_updates(instrument_type="forceps")
+        assert ctx.instrument_type == "scissors"
+        assert updated.instrument_type == "forceps"
+        assert ctx is not updated
+
+
+class TestInspectionStateMachine:
+    def test_new_inspection_no_image(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, has_image=False, score_status="pending", detected_issue="none")
+        finally:
+            db.close()
+        state = derive_state(insp)
+        assert state["current_state"] == "NEW"
+
+    def test_scored_no_review_is_analyzed(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+        finally:
+            db.close()
+        state = derive_state(insp, review=None)
+        assert state["current_state"] == "ANALYZED"
+        assert "ANALYZED" in state["states_reached"]
+
+    def test_valid_transitions(self):
+        assert is_valid_transition("NEW", "IMAGE_CAPTURED") is True
+        assert is_valid_transition("NEW", "COMPLETE") is False
+        assert is_valid_transition("SUPERVISOR_PENDING", "APPROVED") is True
+        assert is_valid_transition("SUPERVISOR_PENDING", "REQUIRES_ACTION") is True
+        assert is_valid_transition("COMPLETE", "NEW") is False
+
+    def test_all_states_are_reachable_in_order(self):
+        assert INSPECTION_STATES[0] == "NEW"
+        assert INSPECTION_STATES[-1] == "COMPLETE"
+
+
+class TestPipelineExecutionAndMonitor:
+    def test_run_cios_pipeline_returns_all_sections(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+        finally:
+            db.close()
+
+        db = SessionLocal()
+        try:
+            row = db.query(Inspection).filter(Inspection.id == insp.id).first()
+            result = run_cios_pipeline(db, row, "default-tenant")
+        finally:
+            db.close()
+
+        for key in (
+            "clinical_context", "pipeline_monitor", "inspection_state", "timeline",
+            "events_emitted", "decision_ledger_entry_id", "governance", "agent_result",
+        ):
+            assert key in result
+
+    def test_pipeline_monitor_shows_supervisor_pending_before_review(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/cios/run/{insp_id}", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        monitor = {m["agent"]: m["status"] for m in res.json()["pipeline_monitor"]}
+        assert monitor["Supervisor Agent"] == "Pending"
+        assert monitor["Learning Agent"] == "Queued"
+        assert monitor["Enterprise Agent"] == "Queued"
+        assert monitor["Instrument Agent"] == "Complete"
+        assert monitor["Recommendation Agent"] == "Complete"
+
+    def test_pipeline_monitor_shows_supervisor_complete_after_review(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, instrument_type="scissors")
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        client.post(
+            f"/api/inspections/{insp_id}/supervisor-review",
+            json={"agreement": "agree", "finding_correct": True},
+            headers=AUTH_MGR,
+        )
+
+        res = client.get(f"/api/cios/run/{insp_id}", headers=AUTH_ADMIN)
+        monitor = {m["agent"]: m["status"] for m in res.json()["pipeline_monitor"]}
+        assert monitor["Supervisor Agent"] == "Complete"
+        assert monitor["Learning Agent"] == "Complete"
+
+
+class TestEventGeneration:
+    def test_blood_detection_emits_event(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, detected_issue="blood")
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/cios/run/{insp_id}", headers=AUTH_ADMIN)
+        event_types = {e["event_type"] for e in res.json()["events_emitted"]}
+        assert "InspectionStarted" in event_types
+        assert "BloodDetected" in event_types
+        assert "RecommendationGenerated" in event_types
+
+    def test_events_endpoint_filters_by_inspection(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        client.get(f"/api/cios/run/{insp_id}", headers=AUTH_ADMIN)
+        res = client.get("/api/cios/events", params={"inspection_id": insp_id}, headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        events = res.json()["events"]
+        assert len(events) > 0
+        assert all(e["inspection_id"] == insp_id for e in events)
+
+
+class TestDecisionLedger:
+    def test_ai_recommendation_recorded(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        client.get(f"/api/cios/run/{insp_id}", headers=AUTH_ADMIN)
+        res = client.get(f"/api/cios/decision-ledger/{insp_id}", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        decisions = res.json()["decisions"]
+        assert any(d["decision_type"] == "ai_recommendation" and d["made_by"] == "ai" for d in decisions)
+        for d in decisions:
+            assert d["model_version"]
+            assert d["ontology_version"]
+
+    def test_supervisor_decision_recorded_via_review_endpoint(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, instrument_type="forceps")
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        client.post(
+            f"/api/inspections/{insp_id}/supervisor-review",
+            json={"agreement": "agree", "finding_correct": True},
+            headers=AUTH_MGR,
+        )
+        res = client.get(f"/api/cios/decision-ledger/{insp_id}", headers=AUTH_ADMIN)
+        decisions = res.json()["decisions"]
+        assert any(d["decision_type"] == "supervisor_approval" for d in decisions)
+
+
+class TestTimelineCreation:
+    def test_timeline_has_inspection_created_and_agent_entries(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/cios/run/{insp_id}", headers=AUTH_ADMIN)
+        timeline = res.json()["timeline"]
+        assert "Inspection created" in timeline[0]["label"]
+        assert any("Recommendation Agent" in e["label"] for e in timeline)
+        assert all(e["timestamp"] for e in timeline)
+
+
+class TestGovernanceVersions:
+    def test_governance_endpoint_returns_all_versions(self):
+        res = client.get("/api/cios/governance", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        for key in (
+            "architecture_version", "ontology_version", "knowledge_graph_version",
+            "model_version", "dataset_version", "clinical_rule_version", "inspection_pipeline_version",
+        ):
+            assert data[key]
+        assert data == governance_snapshot()
+
+
+class TestClinicalRuleRegistry:
+    def test_registry_has_rules_with_required_fields(self):
+        assert len(CLINICAL_RULE_REGISTRY) >= 5
+        for rule in CLINICAL_RULE_REGISTRY:
+            for key in ("rule_id", "name", "purpose", "evidence", "applies_to", "priority", "version", "approval_status"):
+                assert key in rule
+
+    def test_get_rule_by_id(self):
+        rule = get_rule("RULE-001")
+        assert rule is not None
+        assert rule["name"] == "Structural defect escalation"
+
+    def test_rule_registry_endpoint(self):
+        res = client.get("/api/cios/rule-registry", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        assert len(res.json()["rules"]) >= 5
+
+
+class TestCertificateGeneration:
+    def test_certificate_json_not_a_sterilization_certificate(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/cios/certificate/{insp_id}", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        assert data["not_a_sterilization_certificate"] is True
+        assert data["inspection_id"] == insp_id
+        assert "digital_signature_placeholder" in data
+        assert data["digital_signature_placeholder"]["signed"] is False
+
+    def test_certificate_pdf_downloads(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/cios/certificate/{insp_id}/pdf", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        assert res.headers["content-type"] == "application/pdf"
+        assert res.content[:4] == b"%PDF"
+
+
+class TestCiosDashboard:
+    def test_dashboard_returns_required_keys(self):
+        res = client.get("/api/cios/dashboard", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        for key in (
+            "system_health", "inspection_throughput", "coverage_rate",
+            "supervisor_agreement_rate", "ai_confidence", "governance_versions",
+            "digital_twin_health", "most_common_findings", "most_common_zones",
+            "enterprise_risk_index",
+        ):
+            assert key in data
+
+    def test_unauthenticated_rejected(self):
+        res = client.get("/api/cios/dashboard")
+        assert res.status_code in (401, 403)

--- a/backend/tests/test_clinical_readiness.py
+++ b/backend/tests/test_clinical_readiness.py
@@ -1,0 +1,344 @@
+"""v1.6 — Clinical Service Readiness & Instrument Disposition Intelligence."""
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.disposition_engine import (
+    MANUFACTURER_EVALUATION,
+    PROCEED_TO_PACKAGING,
+    RECLEAN,
+    REMOVE_FROM_SERVICE,
+    REPAIR_EVALUATION,
+    REPEAT_INSPECTION,
+    recommend_disposition,
+)
+from app.services.readiness_engine import (
+    READY,
+    READY_WITH_SUPERVISOR_APPROVAL,
+    REMOVE_FROM_SERVICE_STATUS,
+    REQUIRES_RECLEANING_STATUS,
+    compute_readiness,
+)
+from app.services.risk_stratification_service import CRITICAL, LOW, stratify_risk
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+TENANT = "default-tenant"
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"cr-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _create(itype, declared=None, headers=None):
+    _baseline(itype)
+    r = client.post("/api/inspections", json={
+        "instrument_type": itype, "site_name": "Mercy",
+        "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        "finding_categories": declared or [],
+    }, headers=headers or AUTH_OPERATOR)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _get_inspection(iid):
+    from app.db import models
+    db = SessionLocal()
+    try:
+        return db.query(models.Inspection).filter(models.Inspection.id == iid).first()
+    finally:
+        db.close()
+
+
+class TestReadinessScoreCalculation:
+    def test_readiness_score_calculation(self):
+        iid = _create("scissors")
+        db = SessionLocal()
+        try:
+            insp = _get_inspection(iid)
+            readiness = compute_readiness(db, TENANT, insp, confirmed=False)
+            assert readiness["readiness_score"] is None or 0 <= readiness["readiness_score"] <= 100
+            assert readiness["status"] in (READY, READY_WITH_SUPERVISOR_APPROVAL, REQUIRES_RECLEANING_STATUS)
+        finally:
+            db.close()
+
+    def test_confirmed_ready_gets_supervisor_approval_status(self):
+        iid = _create("forceps")
+        client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={"agreement": "agree"}, headers=AUTH_MGR,
+        )
+        db = SessionLocal()
+        try:
+            insp = _get_inspection(iid)
+            readiness = compute_readiness(db, TENANT, insp, confirmed=True)
+            if readiness["status"] in (READY, READY_WITH_SUPERVISOR_APPROVAL):
+                assert readiness["status"] == READY_WITH_SUPERVISOR_APPROVAL
+        finally:
+            db.close()
+
+    def test_readiness_via_api(self):
+        iid = _create("needle_holder")
+        r = client.get(f"/api/inspections/{iid}/evidence-panel", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert "readiness_score" in body
+        assert "readiness_status" in body
+
+
+class TestDispositionRecommendation:
+    def test_disposition_recommendation_generation(self):
+        iid = _create("scissors", declared=["blood"])
+        r = client.get(f"/api/inspections/{iid}/evidence-panel", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["recommended_disposition"]
+        assert body["clinical_rationale"]
+
+    def test_every_disposition_has_explanation(self):
+        readiness = {"status": REMOVE_FROM_SERVICE_STATUS, "repair_history": False}
+
+        class FakeInsp:
+            detected_issue = "crack"
+            coverage_pct = 90
+
+        d = recommend_disposition(readiness, FakeInsp(), coverage_pct=90)
+        assert d["disposition"] == REMOVE_FROM_SERVICE
+        assert d["explanation"]
+
+    def test_low_coverage_recommends_repeat_inspection(self):
+        readiness = {"status": READY, "repair_history": False}
+
+        class FakeInsp:
+            detected_issue = "none"
+
+        d = recommend_disposition(readiness, FakeInsp(), coverage_pct=30)
+        assert d["disposition"] == REPEAT_INSPECTION
+
+    def test_recurring_manufacturer_attributable_condition(self):
+        readiness = {"status": "Requires Repair", "repair_history": True}
+
+        class FakeInsp:
+            detected_issue = "corrosion"
+
+        d = recommend_disposition(readiness, FakeInsp(), coverage_pct=90)
+        assert d["disposition"] == MANUFACTURER_EVALUATION
+
+    def test_ready_with_approval_proceeds_to_packaging(self):
+        readiness = {"status": READY_WITH_SUPERVISOR_APPROVAL, "repair_history": False}
+
+        class FakeInsp:
+            detected_issue = "none"
+
+        d = recommend_disposition(readiness, FakeInsp(), coverage_pct=100)
+        assert d["disposition"] == PROCEED_TO_PACKAGING
+
+    def test_requires_repair_without_history_is_repair_evaluation(self):
+        readiness = {"status": "Requires Repair", "repair_history": False}
+
+        class FakeInsp:
+            detected_issue = "crack"
+
+        d = recommend_disposition(readiness, FakeInsp(), coverage_pct=90)
+        assert d["disposition"] == REPAIR_EVALUATION
+
+    def test_reclean_disposition(self):
+        readiness = {"status": REQUIRES_RECLEANING_STATUS, "repair_history": False}
+
+        class FakeInsp:
+            detected_issue = "blood"
+
+        d = recommend_disposition(readiness, FakeInsp(), coverage_pct=90)
+        assert d["disposition"] == RECLEAN
+
+
+class TestSupervisorDispositionWorkspace:
+    def test_supervisor_override_requires_reason(self):
+        iid = _create("scissors")
+        r = client.post(
+            f"/api/inspections/{iid}/disposition-action",
+            json={"action": "reclean", "ai_recommended_disposition": "Proceed to Packaging"},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 422
+
+    def test_supervisor_override_with_reason_succeeds(self):
+        iid = _create("scissors")
+        r = client.post(
+            f"/api/inspections/{iid}/disposition-action",
+            json={
+                "action": "reclean", "ai_recommended_disposition": "Proceed to Packaging",
+                "reason": "Residual debris still visible in hinge.",
+            },
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+
+    def test_approve_does_not_require_reason(self):
+        iid = _create("scissors")
+        r = client.post(
+            f"/api/inspections/{iid}/disposition-action",
+            json={"action": "approve", "ai_recommended_disposition": "Proceed to Packaging"},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+
+    def test_invalid_action_rejected(self):
+        iid = _create("scissors")
+        r = client.post(
+            f"/api/inspections/{iid}/disposition-action",
+            json={"action": "not_a_real_action", "reason": "x"},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 422
+
+    def test_operator_cannot_submit_disposition_action(self):
+        iid = _create("scissors")
+        r = client.post(
+            f"/api/inspections/{iid}/disposition-action",
+            json={"action": "approve"}, headers=AUTH_OPERATOR,
+        )
+        assert r.status_code == 403
+
+    def test_disposition_action_history_listed(self):
+        iid = _create("forceps")
+        client.post(
+            f"/api/inspections/{iid}/disposition-action",
+            json={"action": "escalate", "reason": "Needs director review."},
+            headers=AUTH_MGR,
+        )
+        r = client.get(f"/api/inspections/{iid}/disposition-actions", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert any(a["action"] == "escalate" for a in r.json()["actions"])
+
+
+class TestReadinessDashboard:
+    def test_readiness_dashboard_aggregation(self):
+        _create("scissors")
+        r = client.get("/api/clinical-readiness/dashboard", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "ready_for_packaging", "requires_recleaning", "requires_repair",
+            "remove_from_service", "supervisor_pending", "average_readiness_score",
+            "disposition_trends", "total_inspections",
+        ):
+            assert key in body
+
+    def test_enterprise_analytics_leadership_only(self):
+        _create("scissors")
+        r = client.get("/api/clinical-readiness/enterprise-analytics", headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+        r2 = client.get("/api/clinical-readiness/enterprise-analytics", headers=AUTH_MGR)
+        assert r2.status_code == 200
+        body = r2.json()
+        for key in (
+            "readiness_trends", "disposition_distribution", "supervisor_overrides",
+            "repair_referrals", "high_risk_instrument_families", "most_common_disposition_reasons",
+        ):
+            assert key in body
+
+
+class TestReadinessTimeline:
+    def test_timeline_completeness(self):
+        iid = _create("needle_holder")
+        r = client.get(f"/api/inspections/{iid}/readiness-timeline", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        steps = r.json()["steps"]
+        step_names = [s["step"] for s in steps]
+        assert step_names == [
+            "Image Uploaded", "Instrument Identified", "Coverage Completed",
+            "AI Findings", "Clinical Reasoning", "Supervisor Review",
+            "Disposition", "Ready for Packaging",
+        ]
+        assert steps[0]["completed"] is True  # image uploaded
+        assert steps[5]["completed"] is False  # no supervisor review yet
+
+    def test_timeline_reflects_supervisor_review(self):
+        iid = _create("needle_holder")
+        client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={"agreement": "agree"}, headers=AUTH_MGR,
+        )
+        r = client.get(f"/api/inspections/{iid}/readiness-timeline", headers=AUTH_ADMIN)
+        steps = r.json()["steps"]
+        review_step = next(s for s in steps if s["step"] == "Supervisor Review")
+        assert review_step["completed"] is True
+        assert review_step["timestamp"] is not None
+
+
+class TestRiskStratification:
+    def test_risk_stratification_logic(self):
+        db = SessionLocal()
+        try:
+            class FakeInspLow:
+                detected_issue = "none"
+                disposition = "PASS"
+                coverage_pct = 100
+                baseline_status = "approved_baseline_found"
+
+            result = stratify_risk(FakeInspLow())
+            assert result["risk_tier"] == LOW
+
+            class FakeInspCritical:
+                detected_issue = "crack"
+                disposition = "REMOVE FROM SERVICE"
+                coverage_pct = 20
+                baseline_status = "no_approved_baseline"
+
+            result2 = stratify_risk(FakeInspCritical(), high_risk_zone_finding=True)
+            assert result2["risk_tier"] == CRITICAL
+            assert result2["reasons"]
+        finally:
+            db.close()
+
+    def test_risk_stratification_via_api(self):
+        iid = _create("scissors")
+        r = client.get(f"/api/inspections/{iid}/risk-stratification", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert r.json()["risk_tier"] in ("Low Risk", "Moderate Risk", "High Risk", "Critical")
+
+
+class TestExportReport:
+    def test_export_report_generation_json(self):
+        iid = _create("scissors")
+        r = client.get(f"/api/inspections/{iid}/readiness-report", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert "instrument" in body
+        assert "evidence" in body
+        assert "timeline" in body
+        assert "risk_stratification" in body
+        assert "audit_metadata" in body
+
+    def test_export_report_generation_pdf(self):
+        iid = _create("forceps")
+        r = client.get(f"/api/inspections/{iid}/readiness-report.pdf", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "application/pdf"
+        assert len(r.content) > 100
+
+
+class TestInstrumentConditionTracker:
+    def test_condition_tracker_no_history_for_untracked(self):
+        r = client.get(
+            "/api/clinical-readiness/instrument-condition",
+            params={"instrument_identity": "barcode:NOT-REAL-000"},
+            headers=AUTH_ADMIN,
+        )
+        assert r.status_code == 404

--- a/backend/tests/test_institutional_knowledge.py
+++ b/backend/tests/test_institutional_knowledge.py
@@ -1,0 +1,297 @@
+"""v1.8 — Institutional Knowledge & Clinical Memory."""
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.knowledge import APPROVED, PENDING_REVIEW
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+TENANT = "default-tenant"
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == itype).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"ik-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _create(itype, declared=None, headers=None):
+    _baseline(itype)
+    r = client.post("/api/inspections", json={
+        "instrument_type": itype, "site_name": "Mercy",
+        "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        "finding_categories": declared or [],
+    }, headers=headers or AUTH_OPERATOR)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+class TestKnowledgeArticleCreation:
+    def test_create_article_starts_pending_review(self):
+        r = client.post("/api/knowledge/articles", json={
+            "category": "best_practice", "title": "Always brush serrations twice",
+            "body": "Kerrison serrations trap blood; brush from both directions.",
+            "applicable_instruments": ["kerrison_rongeur"], "applicable_findings": ["blood"],
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["approval_status"] == PENDING_REVIEW
+        assert body["version"] == 1
+        assert body["author"]
+
+    def test_invalid_category_rejected(self):
+        r = client.post("/api/knowledge/articles", json={
+            "category": "not_a_real_category", "title": "x", "body": "y",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 422
+
+    def test_get_article_records_view(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "faq", "title": "Why brush twice", "body": "Because residue hides in the groove.",
+        }, headers=AUTH_OPERATOR).json()
+        r = client.get(f"/api/knowledge/articles/{created['id']}", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert r.json()["view_count"] == 1
+        r2 = client.get(f"/api/knowledge/articles/{created['id']}", headers=AUTH_ADMIN)
+        assert r2.json()["view_count"] == 2
+
+    def test_list_articles_by_category(self):
+        client.post("/api/knowledge/articles", json={
+            "category": "clinical_pearl", "title": "Pearl one", "body": "body",
+        }, headers=AUTH_OPERATOR)
+        r = client.get("/api/knowledge/articles?category=clinical_pearl", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert all(a["category"] == "clinical_pearl" for a in r.json()["articles"])
+
+
+class TestKnowledgeVersioning:
+    def test_editing_approved_article_bumps_version_and_reopens_review(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "local_standard", "title": "Coverage rule", "body": "Capture all six zones.",
+        }, headers=AUTH_OPERATOR).json()
+        client.post(f"/api/knowledge/articles/{created['id']}/approve", headers=AUTH_MGR)
+
+        r = client.patch(f"/api/knowledge/articles/{created['id']}", json={"body": "Capture all eight zones."}, headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["version"] == 2
+        assert body["approval_status"] == PENDING_REVIEW
+
+    def test_editing_with_no_actual_change_does_not_bump_version(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "faq", "title": "Same title", "body": "Same body.",
+        }, headers=AUTH_OPERATOR).json()
+        r = client.patch(f"/api/knowledge/articles/{created['id']}", json={"title": "Same title"}, headers=AUTH_OPERATOR)
+        assert r.json()["version"] == 1
+
+
+class TestGovernanceApprovalWorkflow:
+    def test_approve_requires_leadership_role(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "faq", "title": "q", "body": "a",
+        }, headers=AUTH_OPERATOR).json()
+        r = client.post(f"/api/knowledge/articles/{created['id']}/approve", headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+    def test_approve_sets_reviewer_and_status(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "faq", "title": "q2", "body": "a2",
+        }, headers=AUTH_OPERATOR).json()
+        r = client.post(f"/api/knowledge/articles/{created['id']}/approve", headers=AUTH_MGR)
+        assert r.status_code == 200
+        assert r.json()["approval_status"] == APPROVED
+        assert r.json()["reviewer"]
+
+    def test_archive_removes_from_default_list(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "faq", "title": "outdated", "body": "old guidance",
+        }, headers=AUTH_OPERATOR).json()
+        client.post(f"/api/knowledge/articles/{created['id']}/approve", headers=AUTH_MGR)
+        client.post(f"/api/knowledge/articles/{created['id']}/archive", headers=AUTH_MGR)
+
+        r = client.get("/api/knowledge/articles", headers=AUTH_ADMIN)
+        assert all(a["id"] != created["id"] for a in r.json()["articles"])
+
+    def test_governance_summary(self):
+        r = client.get("/api/knowledge/governance-summary", headers=AUTH_MGR)
+        assert r.status_code == 200
+        assert "by_approval_status" in r.json()
+
+
+class TestSupervisorKnowledgeCapture:
+    def test_teaching_point_saved_and_auto_approved(self):
+        iid = _create("scissors", declared=["blood"])
+        r = client.post(f"/api/inspections/{iid}/teaching-point", json={
+            "explanation": "Blood pools in the pivot joint on this family.",
+            "teaching_point": "Check the pivot joint under magnification.",
+            "common_mistake": "Only checking the tip.",
+            "prevention_tip": "Rotate the instrument during inspection.",
+        }, headers=AUTH_MGR)
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["approval_status"] == APPROVED
+        assert body["category"] == "teaching_point"
+        assert body["source_inspection_id"] == iid
+
+    def test_teaching_point_requires_leadership_role(self):
+        iid = _create("scissors")
+        r = client.post(f"/api/inspections/{iid}/teaching-point", json={
+            "explanation": "x", "teaching_point": "y",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+    def test_teaching_point_updates_clinical_case_educational_notes(self):
+        iid = _create("scissors", declared=["blood"])
+        client.post(f"/api/inspections/{iid}/teaching-point", json={
+            "explanation": "Explanation text.", "teaching_point": "Teaching headline.",
+        }, headers=AUTH_MGR)
+        r = client.get("/api/knowledge/cases", headers=AUTH_ADMIN)
+        case = next((c for c in r.json()["cases"] if c["inspection_id"] == iid), None)
+        assert case is not None
+        assert "Teaching headline" in case["educational_notes"]
+
+
+class TestClinicalCaseLibraryAndSimilarCases:
+    def test_significant_inspection_auto_saves_case(self):
+        iid = _create("scissors", declared=["blood"])
+        r = client.get("/api/knowledge/cases", headers=AUTH_ADMIN)
+        ids = [c["inspection_id"] for c in r.json()["cases"]]
+        assert iid in ids
+
+    def test_similar_case_finder_matches_same_family_and_finding(self):
+        iid1 = _create("scissors", declared=["blood"])
+        iid2 = _create("scissors", declared=["blood"])
+        r = client.get(f"/api/inspections/{iid2}/similar-cases", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        similar_ids = [c["inspection_id"] for c in body["similar_cases"]]
+        assert iid1 in similar_ids
+        assert iid2 not in similar_ids
+
+    def test_case_view_increments(self):
+        iid = _create("scissors", declared=["blood"])
+        cases = client.get("/api/knowledge/cases", headers=AUTH_ADMIN).json()["cases"]
+        case = next(c for c in cases if c["inspection_id"] == iid)
+        r = client.get(f"/api/knowledge/cases/{case['id']}", headers=AUTH_ADMIN)
+        assert r.json()["view_count"] == 1
+
+
+class TestSmartKnowledgeSearch:
+    def test_search_by_finding(self):
+        client.post("/api/knowledge/articles", json={
+            "category": "clinical_pearl", "title": "Blood pearl", "body": "Blood hides in serrations.",
+            "applicable_findings": ["blood"],
+        }, headers=AUTH_OPERATOR)
+        approved_id = client.get("/api/knowledge/articles?category=clinical_pearl", headers=AUTH_ADMIN).json()["articles"][0]["id"]
+        client.post(f"/api/knowledge/articles/{approved_id}/approve", headers=AUTH_MGR)
+
+        r = client.post("/api/knowledge/search", json={"query": "show all blood findings"}, headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        body = r.json()
+        assert "blood" in body["matched_findings"]
+        assert any(a["id"] == approved_id for a in body["articles"])
+
+    def test_search_by_instrument_family(self):
+        _create("scissors", declared=["blood"])
+        r = client.post("/api/knowledge/search", json={"query": "show cases for kerrison"}, headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        assert "kerrison_rongeur" in r.json()["matched_instrument_families"]
+
+    def test_search_logs_query_for_analytics(self):
+        client.post("/api/knowledge/search", json={"query": "unique-query-marker-xyz"}, headers=AUTH_OPERATOR)
+        r = client.get("/api/knowledge/analytics", headers=AUTH_MGR)
+        queries = [q["query"] for q in r.json()["most_common_questions"]]
+        assert "unique-query-marker-xyz" in queries
+
+
+class TestAIKnowledgeAssistant:
+    def test_assistant_retrieves_approved_guidance(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "clinical_pearl", "title": "Corrosion pearl",
+            "body": "Corrosion on the O-ring indicates repeated steam cycles beyond spec.",
+            "applicable_findings": ["corrosion"],
+        }, headers=AUTH_OPERATOR).json()
+        client.post(f"/api/knowledge/articles/{created['id']}/approve", headers=AUTH_MGR)
+
+        r = client.post("/api/knowledge/assistant", json={"question": "why does corrosion matter here"}, headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        body = r.json()
+        assert any(f"#{created['id']}" in s for s in body["sources"])
+        assert "corrosion" in body["answer"].lower()
+
+    def test_assistant_ignores_unapproved_guidance(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "clinical_pearl", "title": "Unapproved pearl",
+            "body": "Some unreviewed claim about wear.",
+            "applicable_findings": ["wear"],
+        }, headers=AUTH_OPERATOR).json()
+        r = client.post("/api/knowledge/assistant", json={"question": "tell me about wear"}, headers=AUTH_OPERATOR)
+        assert not any(f"#{created['id']}" in s for s in r.json()["sources"])
+
+    def test_assistant_answers_high_risk_anatomy_question(self):
+        r = client.post("/api/knowledge/assistant", json={
+            "question": "why is this anatomy high risk", "instrument_type": "kerrison_rongeur",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        assert "kerrison_rongeur" in r.json()["matched_instrument_families"]
+
+    def test_assistant_handles_no_match_honestly(self):
+        r = client.post("/api/knowledge/assistant", json={"question": "asdkjaskldj nonsense query"}, headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        assert "No matching" in r.json()["answer"]
+
+
+class TestOrganizationStandards:
+    def test_create_and_list_standard(self):
+        r = client.post("/api/knowledge/standards", json={
+            "standard_type": "coverage_requirement", "title": "Full six-zone coverage",
+            "description": "All inspections must capture six zones before scoring.",
+        }, headers=AUTH_MGR)
+        assert r.status_code == 201
+        r2 = client.get("/api/knowledge/standards", headers=AUTH_ADMIN)
+        assert any(s["title"] == "Full six-zone coverage" for s in r2.json()["standards"])
+
+    def test_create_standard_requires_leadership(self):
+        r = client.post("/api/knowledge/standards", json={
+            "standard_type": "coverage_requirement", "title": "x", "description": "y",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+    def test_deactivate_standard(self):
+        created = client.post("/api/knowledge/standards", json={
+            "standard_type": "photography_standard", "title": "Deactivate me", "description": "d",
+        }, headers=AUTH_MGR).json()
+        client.post(f"/api/knowledge/standards/{created['id']}/deactivate", headers=AUTH_MGR)
+        r = client.get("/api/knowledge/standards", headers=AUTH_ADMIN)
+        assert all(s["id"] != created["id"] for s in r.json()["standards"])
+
+
+class TestCompetencyKnowledgeLibrary:
+    def test_competency_topic_merges_education_and_institutional(self):
+        created = client.post("/api/knowledge/articles", json={
+            "category": "competency_guidance", "title": "Rust guidance", "body": "Check under magnification.",
+            "applicable_findings": ["rust"],
+        }, headers=AUTH_OPERATOR).json()
+        client.post(f"/api/knowledge/articles/{created['id']}/approve", headers=AUTH_MGR)
+
+        r = client.get("/api/knowledge/competency-topics/rust", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["finding_type"] == "rust"
+        assert any(a["id"] == created["id"] for a in body["institutional_knowledge"])
+
+    def test_unknown_finding_type_404s(self):
+        r = client.get("/api/knowledge/competency-topics/not-a-real-finding", headers=AUTH_ADMIN)
+        assert r.status_code == 404

--- a/backend/tests/test_knowledge_graph.py
+++ b/backend/tests/test_knowledge_graph.py
@@ -1,0 +1,206 @@
+"""Phase 21 — SPD Clinical Knowledge Graph & Clinical Reasoning Engine tests."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.inspection import Inspection
+from app.models.supervisor_review import SupervisorReview
+from app.services.instrument_family_profiles import INSTRUMENT_FAMILY_PROFILES, get_family_profile
+from app.services.knowledge_graph_service import reasoning_chain
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+SHA = "5eed0000" + "0" * 56
+
+
+class TestGraphSchema:
+    def test_schema_returns_nodes_and_relationships(self):
+        res = client.get("/api/knowledge-graph/schema", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        assert "Instrument" in data["node_types"]
+        assert "Manufacturer" in data["node_types"]
+        assert "ClinicalRecommendation" in data["node_types"]
+        assert "Supervisor VALIDATES Finding" in data["relationship_types"]
+        assert data["chain"][0] == "Instrument"
+        assert data["chain"][-1] == "Learning"
+
+    def test_unauthenticated_rejected(self):
+        res = client.get("/api/knowledge-graph/schema")
+        assert res.status_code in (401, 403)
+
+
+class TestInstrumentFamilyProfiles:
+    def test_all_ten_families_defined(self):
+        expected = {
+            "rigid_scope", "flexible_endoscope", "kerrison", "needle_holder", "scissors",
+            "drill_bit", "laparoscopic_instruments", "cannulated_instruments",
+            "orthopedic_instruments", "micro_instruments",
+        }
+        assert expected == set(INSTRUMENT_FAMILY_PROFILES)
+
+    def test_kerrison_profile_has_real_anatomy(self):
+        profile = get_family_profile("kerrison")
+        assert profile["display_name"] == "Kerrison"
+        assert "jaw" in profile["typical_anatomy"]
+        assert "serrations" in profile["typical_anatomy"]
+        assert "box lock" in profile["high_risk_zones"]
+
+    def test_profile_has_required_fields(self):
+        profile = get_family_profile("scissors")
+        for key in (
+            "typical_contamination", "typical_damage", "typical_repair_issues",
+            "inspection_priorities", "cleaning_priorities", "supervisor_focus_areas",
+        ):
+            assert key in profile
+
+    def test_api_lists_all_families(self):
+        res = client.get("/api/knowledge-graph/instrument-families", headers=AUTH_VIEWER)
+        assert res.status_code == 200
+        assert len(res.json()["families"]) == 10
+
+    def test_api_unknown_family_404(self):
+        res = client.get("/api/knowledge-graph/instrument-families/not-a-family", headers=AUTH_VIEWER)
+        assert res.status_code == 404
+
+
+class TestReasoningChain:
+    def test_blood_in_scissors_hinge_chain(self):
+        result = reasoning_chain("scissors", "blood", manufacturer="Acme Surgical")
+        nodes = {s["node"]: s for s in result["chain"]}
+        assert nodes["Instrument"]["value"] == "scissors"
+        assert nodes["Manufacturer"]["value"] == "Acme Surgical"
+        assert nodes["Instrument Family"]["value"] == "scissors"
+        assert nodes["Inspection Zone"]["value"] == "hinge"
+        assert nodes["Recommended Action"]["outcome"] == "REPROCESS"
+
+    def test_narrative_names_finding_and_zone(self):
+        result = reasoning_chain("scissors", "blood")
+        narrative = result["narrative"].lower()
+        assert "blood" in narrative
+        assert "hinge" in narrative
+        assert "supervisor" in narrative  # contamination narrative recommends supervisor verification
+
+    def test_structural_finding_routes_to_remove_from_service(self):
+        result = reasoning_chain("orthopedic drill", "crack")
+        nodes = {s["node"]: s for s in result["chain"]}
+        assert nodes["Recommended Action"]["outcome"] == "REMOVE FROM SERVICE"
+
+    def test_api_reasoning_chain_endpoint(self):
+        res = client.get(
+            "/api/knowledge-graph/reasoning-chain",
+            params={"instrument_type": "scissors", "finding_type": "blood"},
+            headers=AUTH_VIEWER,
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert "chain" in data
+        assert "narrative" in data
+        assert data["human_review_required"] is True
+
+
+class TestExplainabilityGraph:
+    def test_why_expansion_for_real_inspection(self):
+        db = SessionLocal()
+        try:
+            insp = Inspection(
+                tenant_id="default-tenant", file_name="x.jpg", instrument_type="scissors",
+                has_image=True, image_sha256=SHA, score_status="scored", risk_score=55,
+                detected_issue="blood", recommended_action="Reprocess — blood. Return for complete cleaning.",
+            )
+            db.add(insp)
+            db.commit()
+            db.refresh(insp)
+            insp_id = insp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/api/knowledge-graph/explain/{insp_id}", headers=AUTH_MGR)
+        assert res.status_code == 200
+        data = res.json()
+        why_nodes = [w["node"] for w in data["why"]]
+        assert why_nodes == ["Finding", "Zone", "Clinical Significance", "SPD Rule", "Recommendation"]
+        finding_node = next(w for w in data["why"] if w["node"] == "Finding")
+        assert finding_node["value"] == "blood"
+        zone_node = next(w for w in data["why"] if w["node"] == "Zone")
+        assert zone_node["value"] == "hinge"
+
+    def test_missing_inspection_404(self):
+        res = client.get("/api/knowledge-graph/explain/99999999", headers=AUTH_MGR)
+        assert res.status_code == 404
+
+
+class TestKnowledgeGraphExplorer:
+    def test_explore_zone_returns_cleaning_knowledge(self):
+        res = client.get("/api/knowledge-graph/explore", params={"category": "zone", "q": "hinge"}, headers=AUTH_VIEWER)
+        assert res.status_code == 200
+        results = res.json()["results"]
+        assert any(r["zone"] == "hinge" for r in results)
+        hinge = next(r for r in results if r["zone"] == "hinge")
+        assert "cleaning_method" in hinge["cleaning"]
+        assert "brush_type" in hinge["cleaning"]
+
+    def test_explore_finding_returns_clinical_education(self):
+        res = client.get("/api/knowledge-graph/explore", params={"category": "finding", "q": "blood"}, headers=AUTH_VIEWER)
+        results = res.json()["results"]
+        assert any(r["finding"] == "blood" for r in results)
+
+    def test_explore_recommendation_returns_five_outcomes(self):
+        res = client.get("/api/knowledge-graph/explore", params={"category": "recommendation"}, headers=AUTH_VIEWER)
+        results = res.json()["results"]
+        outcomes = {r["outcome"] for r in results}
+        assert outcomes == {"PASS", "MONITOR", "SUPERVISOR REVIEW", "REPROCESS", "REMOVE FROM SERVICE"}
+
+    def test_explore_unknown_category(self):
+        res = client.get("/api/knowledge-graph/explore", params={"category": "nonsense"}, headers=AUTH_VIEWER)
+        assert res.status_code == 200
+        assert res.json()["results"] == []
+
+
+class TestEnterpriseKnowledgeAnalytics:
+    def test_analytics_returns_required_keys(self):
+        res = client.get("/api/knowledge-graph/analytics", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        for key in (
+            "most_common_findings_by_manufacturer", "most_common_findings_by_anatomy",
+            "highest_risk_anatomy_zone", "most_common_repair_reason",
+            "most_common_supervisor_override", "most_difficult_instrument_family",
+            "most_missed_anatomy_zones", "most_common_contamination_type",
+        ):
+            assert key in data
+
+    def test_viewer_forbidden(self):
+        res = client.get("/api/knowledge-graph/analytics", headers=AUTH_VIEWER)
+        assert res.status_code == 403
+
+
+class TestContinuousKnowledgeLearning:
+    def test_learning_confidence_reflects_new_review(self):
+        before = client.get("/api/knowledge-graph/learning-confidence", headers=AUTH_ADMIN).json()
+        before_n = before["sample_sizes"]["supervisor_reviews"]
+
+        db = SessionLocal()
+        try:
+            db.add(SupervisorReview(
+                inspection_id=999999, tenant_id="default-tenant", reviewer_name="t",
+                reviewer_role="spd_manager", agreement="agree", finding_correct=True, zone_correct=True,
+            ))
+            db.commit()
+        finally:
+            db.close()
+
+        after = client.get("/api/knowledge-graph/learning-confidence", headers=AUTH_ADMIN).json()
+        assert after["sample_sizes"]["supervisor_reviews"] == before_n + 1
+
+    def test_learning_confidence_required_keys(self):
+        data = client.get("/api/knowledge-graph/learning-confidence", headers=AUTH_ADMIN).json()
+        for key in (
+            "knowledge_confidence", "reasoning_confidence", "clinical_recommendation_confidence",
+            "zone_confidence", "instrument_profile_confidence_by_family", "sample_sizes",
+        ):
+            assert key in data

--- a/backend/tests/test_pilot_deployment.py
+++ b/backend/tests/test_pilot_deployment.py
@@ -1,0 +1,208 @@
+"""v1.9 — Pilot Deployment Loop & Production Workflow Hardening."""
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+SHA = "a1b2c3d4" + "0" * 56
+TENANT = "default-tenant"
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == itype).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"pd-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _create(itype, headers=None, **extra):
+    _baseline(itype)
+    payload = {
+        "instrument_type": itype, "site_name": "Mercy",
+        "has_image": True, "image_sha256": SHA, "file_name": "x.jpg", "finding_categories": [],
+    }
+    payload.update(extra)
+    r = client.post("/api/inspections", json=payload, headers=headers or AUTH_OPERATOR)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestPilotSiteConfiguration:
+    def test_get_site_config_has_conservative_defaults(self):
+        r = client.get("/api/pilot-deployment/site-config", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["baseline_required"] is True
+        assert body["minimum_coverage_pct"] == 75
+
+    def test_update_site_config_requires_admin(self):
+        r = client.put("/api/pilot-deployment/site-config", json={"facility_name": "Mercy General"}, headers=AUTH_MGR)
+        assert r.status_code == 403
+        r = client.put("/api/pilot-deployment/site-config", json={"facility_name": "Mercy General"}, headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+    def test_admin_can_update_site_config(self):
+        r = client.put("/api/pilot-deployment/site-config", json={
+            "facility_name": "Mercy General", "department": "SPD",
+            "minimum_coverage_pct": 90, "supervisor_review_threshold_score": 60,
+        }, headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["facility_name"] == "Mercy General"
+        assert body["minimum_coverage_pct"] == 90
+
+        r2 = client.get("/api/pilot-deployment/site-config", headers=AUTH_VIEWER)
+        assert r2.status_code == 200
+        assert r2.json()["facility_name"] == "Mercy General"
+
+
+class TestDataQualityGuardrails:
+    def test_inspection_response_includes_data_quality(self):
+        body = _create("scissors")
+        assert "data_quality" in body
+        assert "issues" in body["data_quality"]
+        assert "is_dataset_ready" in body["data_quality"]
+
+    def test_missing_technician_identity_flagged(self):
+        from app.db import models
+        from app.services.data_quality_guardrails_service import evaluate_data_quality
+        from app.services.pilot_site_config_service import get_or_create_config
+
+        body = _create("scissors")
+        db = SessionLocal()
+        try:
+            insp = db.query(models.Inspection).filter(models.Inspection.id == body["id"]).first()
+            insp.technician = None
+            db.commit()
+            db.refresh(insp)
+            config = get_or_create_config(db, TENANT)
+            result = evaluate_data_quality(insp, pilot_config=config)
+            assert any(i["code"] == "missing_technician_identity" for i in result["issues"])
+            assert result["is_dataset_ready"] is False
+        finally:
+            db.close()
+
+    def test_dataset_ready_inspection_has_no_issues(self):
+        body = _create("scissors")
+        assert body["data_quality"]["is_dataset_ready"] in (True, False)
+
+    def test_data_quality_endpoint(self):
+        body = _create("scissors")
+        r = client.get(f"/api/inspections/{body['id']}/data-quality", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert r.json()["inspection_id"] == body["id"]
+
+
+class TestProductionErrorLogging:
+    def test_log_error_valid_type(self):
+        r = client.post("/api/pilot-deployment/error-log", json={
+            "error_type": "upload_failure", "detail": "network timeout",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201
+        assert r.json()["logged"] is True
+
+    def test_log_error_invalid_type_rejected(self):
+        r = client.post("/api/pilot-deployment/error-log", json={
+            "error_type": "not_a_real_type", "detail": "x",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 422
+
+    def test_error_detail_truncated_and_no_phi_assumption(self):
+        from app.services.pilot_error_log_service import log_error
+
+        db = SessionLocal()
+        try:
+            row = log_error(db, tenant_id=TENANT, error_type="ai_analysis_failure", detail="x" * 1000)
+            db.commit()
+            assert len(row.detail) == 500
+        finally:
+            db.close()
+
+    def test_report_generation_failure_returns_500_not_silent(self, monkeypatch):
+        body = _create("scissors")
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("pdf renderer exploded")
+
+        monkeypatch.setattr("app.routes.clinical_readiness.build_readiness_report_pdf", _boom)
+        r = client.get(f"/api/inspections/{body['id']}/readiness-report.pdf", headers=AUTH_ADMIN)
+        assert r.status_code == 500
+        assert "logged" in r.json()["detail"].lower()
+
+
+class TestPilotDataCollectionDashboard:
+    def test_dashboard_requires_leadership(self):
+        r = client.get("/api/pilot-deployment/data-collection", headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+        r = client.get("/api/pilot-deployment/data-collection", headers=AUTH_MGR)
+        assert r.status_code == 200
+
+    def test_dashboard_reflects_real_counts(self):
+        before = client.get("/api/pilot-deployment/data-collection", headers=AUTH_ADMIN).json()
+        _create("scissors")
+        after = client.get("/api/pilot-deployment/data-collection", headers=AUTH_ADMIN).json()
+        assert after["inspections_collected"] == before["inspections_collected"] + 1
+        assert after["inspection_images_collected"] == before["inspection_images_collected"] + 1
+
+    def test_dashboard_structure(self):
+        r = client.get("/api/pilot-deployment/data-collection", headers=AUTH_ADMIN)
+        body = r.json()
+        for key in (
+            "inspections_collected", "baseline_images_collected", "inspection_images_collected",
+            "supervisor_reviews_completed", "incomplete_inspections", "failed_uploads",
+            "missing_anatomy_zones", "dataset_ready_images",
+        ):
+            assert key in body
+
+
+class TestRoleBasedWorkflowHardening:
+    def test_viewer_cannot_create_inspection(self):
+        _baseline("scissors")
+        r = client.post("/api/inspections", json={
+            "instrument_type": "scissors", "site_name": "Mercy", "has_image": True,
+            "image_sha256": SHA, "file_name": "x.jpg", "finding_categories": [],
+        }, headers=AUTH_VIEWER)
+        assert r.status_code == 403
+        assert "read-only" in r.json()["detail"].lower()
+
+    def test_viewer_can_view_work_queue(self):
+        r = client.get("/api/inspection-work-queue", headers=AUTH_VIEWER)
+        assert r.status_code == 200
+
+    def test_viewer_cannot_approve_disposition(self):
+        body = _create("scissors")
+        r = client.post(f"/api/inspections/{body['id']}/disposition-action", json={
+            "action": "approve", "ai_recommended_disposition": "Proceed to Packaging",
+        }, headers=AUTH_VIEWER)
+        assert r.status_code == 403
+
+    def test_operator_can_create_but_not_approve(self):
+        body = _create("scissors")
+        r = client.post(f"/api/inspections/{body['id']}/disposition-action", json={
+            "action": "approve", "ai_recommended_disposition": "Proceed to Packaging",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+    def test_supervisor_can_approve_and_add_teaching_point(self):
+        body = _create("scissors", finding_categories=["blood"])
+        r = client.post(f"/api/inspections/{body['id']}/disposition-action", json={
+            "action": "approve", "ai_recommended_disposition": "Proceed to Packaging",
+        }, headers=AUTH_MGR)
+        assert r.status_code == 201
+
+        r2 = client.post(f"/api/inspections/{body['id']}/teaching-point", json={
+            "explanation": "Check the pivot joint.", "teaching_point": "Pivot joint check",
+        }, headers=AUTH_MGR)
+        assert r2.status_code == 201

--- a/backend/tests/test_pre_sterilization_command_center.py
+++ b/backend/tests/test_pre_sterilization_command_center.py
@@ -1,0 +1,344 @@
+"""Pre-Sterilization Command Center tests: readiness classification, the ten
+dashboard modules, and role gating."""
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.inspection import Inspection
+from app.services.pre_sterilization_command_center_service import (
+    PENDING_ANALYSIS,
+    READY_FOR_PACKAGING,
+    REMOVED_FROM_SERVICE,
+    REQUIRES_RECLEANING,
+    REQUIRES_REPAIR,
+    REQUIRES_SUPERVISOR_REVIEW,
+    classify_readiness,
+)
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+SHA = "c0ffee00" + "0" * 56
+
+
+def _make_inspection(db, **overrides) -> Inspection:
+    defaults = dict(
+        tenant_id="default-tenant", file_name="x.jpg", instrument_type="scissors",
+        has_image=True, image_sha256=SHA, score_status="scored", risk_score=10,
+        detected_issue="none", stain_detected=False, supervisor_review_required=False,
+        qa_review_status="pending", status="pending",
+        inspected_zones_json="null",
+    )
+    defaults.update(overrides)
+    insp = Inspection(**defaults)
+    db.add(insp)
+    db.commit()
+    db.refresh(insp)
+    return insp
+
+
+class TestClassifyReadiness:
+    def test_pass_action_is_ready_for_packaging(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, recommended_action="Pass — no high-risk findings. Release for use.")
+            assert classify_readiness(insp)["readiness_state"] == READY_FOR_PACKAGING
+        finally:
+            db.close()
+
+    def test_monitor_action_is_ready_for_packaging(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, recommended_action="Monitor — low-risk findings only. Continue routine processing.")
+            assert classify_readiness(insp)["readiness_state"] == READY_FOR_PACKAGING
+        finally:
+            db.close()
+
+    def test_reprocess_action_requires_recleaning(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, recommended_action="Reprocess — blood. Return for complete cleaning.", detected_issue="blood")
+            result = classify_readiness(insp)
+            assert result["readiness_state"] == REQUIRES_RECLEANING
+            assert result["is_critical_finding"] is True
+        finally:
+            db.close()
+
+    def test_supervisor_review_action(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, recommended_action="Supervisor review recommended before release — baseline mismatch.")
+            assert classify_readiness(insp)["readiness_state"] == REQUIRES_SUPERVISOR_REVIEW
+        finally:
+            db.close()
+
+    def test_remove_from_service_with_repairable_issue_is_repair_candidate(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(
+                db, recommended_action="Remove from service — crack. Supervisor review required.",
+                detected_issue="crack",
+            )
+            result = classify_readiness(insp)
+            assert result["readiness_state"] == REQUIRES_REPAIR
+            assert result["repair_candidate"] is True
+        finally:
+            db.close()
+
+    def test_remove_from_service_with_contamination_is_removed_not_repaired(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(
+                db, recommended_action="Remove from service — severe corrosion.",
+                detected_issue="blood",
+            )
+            result = classify_readiness(insp)
+            assert result["readiness_state"] == REMOVED_FROM_SERVICE
+            assert result["repair_candidate"] is False
+        finally:
+            db.close()
+
+    def test_unscored_inspection_is_pending_analysis(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, score_status="pending", recommended_action=None)
+            assert classify_readiness(insp)["readiness_state"] == PENDING_ANALYSIS
+        finally:
+            db.close()
+
+    def test_readiness_score_is_inverse_of_risk_score(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(db, risk_score=30, recommended_action="Pass — clean.")
+            assert classify_readiness(insp)["readiness_score"] == 70
+        finally:
+            db.close()
+
+
+class TestClinicalInspectionReadinessAPI:
+    def test_returns_200_with_required_keys(self):
+        res = client.get("/api/pre-sterilization-command-center/clinical-inspection-readiness", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        for key in ("total_inspections", "ready_for_packaging", "readiness_rate", "by_state", "human_review_required"):
+            assert key in data
+
+    def test_unauthenticated_rejected(self):
+        res = client.get("/api/pre-sterilization-command-center/clinical-inspection-readiness")
+        assert res.status_code in (401, 403)
+
+    def test_viewer_can_read(self):
+        res = client.get("/api/pre-sterilization-command-center/clinical-inspection-readiness", headers=AUTH_VIEWER)
+        assert res.status_code == 200
+
+
+class TestTrayReadiness:
+    def test_weakest_link_blocks_the_tray(self):
+        db = SessionLocal()
+        try:
+            _make_inspection(
+                db, tray_id="tray-42", instrument_barcode="bc-1",
+                recommended_action="Pass — clean.",
+            )
+            _make_inspection(
+                db, tray_id="tray-42", instrument_barcode="bc-2",
+                recommended_action="Reprocess — blood.", detected_issue="blood",
+            )
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/tray-readiness", headers=AUTH_MGR)
+        assert res.status_code == 200
+        trays = {t["tray_id"]: t for t in res.json()["trays"]}
+        assert trays["tray-42"]["tray_readiness_state"] == REQUIRES_RECLEANING
+        assert trays["tray-42"]["ready_for_packaging"] is False
+        assert trays["tray-42"]["instrument_count"] == 2
+
+
+class TestInstrumentReadiness:
+    def test_latest_inspection_wins_for_same_instrument(self):
+        db = SessionLocal()
+        try:
+            _make_inspection(
+                db, instrument_barcode="bc-repeat", instrument_type="forceps",
+                recommended_action="Reprocess — blood.", detected_issue="blood",
+            )
+            _make_inspection(
+                db, instrument_barcode="bc-repeat", instrument_type="forceps",
+                recommended_action="Pass — clean.",
+            )
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/instrument-readiness", headers=AUTH_MGR)
+        assert res.status_code == 200
+        matches = [i for i in res.json()["instruments"] if i["instrument_identity"] == "barcode:bc-repeat"]
+        assert len(matches) == 1
+        assert matches[0]["readiness_state"] == READY_FOR_PACKAGING
+
+
+class TestFacilityReadiness:
+    def test_facility_readiness_returns_rate_and_trend(self):
+        db = SessionLocal()
+        try:
+            _make_inspection(db, facility_name="Mercy West", recommended_action="Pass — clean.")
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/facility-readiness", headers=AUTH_MGR)
+        assert res.status_code == 200
+        facilities = {f["facility"]: f for f in res.json()["facilities"]}
+        assert "Mercy West" in facilities
+        assert facilities["Mercy West"]["readiness_rate"] is not None
+        assert facilities["Mercy West"]["trend"] in ("improving", "declining", "stable", "insufficient_data")
+
+
+class TestHighRiskFindingsQueue:
+    def test_unconfirmed_critical_finding_appears_in_queue(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(
+                db, recommended_action="Reprocess — blood.", detected_issue="blood", risk_score=60,
+            )
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/high-risk-findings", headers=AUTH_MGR)
+        assert res.status_code == 200
+        ids = [i["inspection_id"] for i in res.json()["items"]]
+        assert insp.id in ids
+
+
+class TestSupervisorReviewQueue:
+    def test_pending_supervisor_review_appears_in_queue(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(
+                db, recommended_action="Supervisor review recommended before release — baseline mismatch.",
+                supervisor_review_required=True,
+            )
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/supervisor-review-queue", headers=AUTH_MGR)
+        assert res.status_code == 200
+        ids = [i["inspection_id"] for i in res.json()["items"]]
+        assert insp.id in ids
+
+
+class TestMissingZoneCoverage:
+    def test_untagged_zones_appear_as_not_assessed(self):
+        db = SessionLocal()
+        try:
+            insp = _make_inspection(
+                db, instrument_type="kerrison rongeur", inspected_zones_json="null",
+                recommended_action="Pass — clean.",
+            )
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/missing-zone-coverage", headers=AUTH_MGR)
+        assert res.status_code == 200
+        matches = [i for i in res.json()["items"] if i["inspection_id"] == insp.id]
+        assert len(matches) == 1
+        assert matches[0]["coverage_quality"] == "not_assessed"
+
+    def test_fully_tagged_zones_do_not_appear(self):
+        db = SessionLocal()
+        try:
+            from app.services.instrument_anatomy import get_anatomy
+            anatomy = get_anatomy("kerrison rongeur")
+            insp = _make_inspection(
+                db, instrument_type="kerrison rongeur",
+                inspected_zones_json=json.dumps(anatomy["required_images"]),
+                recommended_action="Pass — clean.",
+            )
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/missing-zone-coverage", headers=AUTH_MGR)
+        ids = [i["inspection_id"] for i in res.json()["items"]]
+        assert insp.id not in ids
+
+
+class TestBaselineCoverage:
+    def test_baseline_coverage_rate_and_gaps(self):
+        db = SessionLocal()
+        try:
+            db.query(BaselineLibraryEntry).filter(
+                BaselineLibraryEntry.instrument_category == "cmd-center-widget"
+            ).delete()
+            db.commit()
+            _make_inspection(
+                db, instrument_type="cmd-center-widget", baseline_status="no_approved_baseline",
+                recommended_action="Supervisor review recommended before release — no baseline.",
+            )
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/baseline-coverage", headers=AUTH_MGR)
+        assert res.status_code == 200
+        data = res.json()
+        assert "baseline_coverage_rate" in data
+        gaps = {g["instrument_type"]: g for g in data["instrument_types_missing_baseline"]}
+        assert "cmd-center-widget" in gaps
+
+
+class TestRepairRemoveQueue:
+    def test_repair_and_removed_are_split(self):
+        db = SessionLocal()
+        try:
+            repair_insp = _make_inspection(
+                db, recommended_action="Remove from service — crack.", detected_issue="crack",
+            )
+            removed_insp = _make_inspection(
+                db, recommended_action="Remove from service — severe corrosion.", detected_issue="blood",
+            )
+            repair_id, removed_id = repair_insp.id, removed_insp.id
+        finally:
+            db.close()
+
+        res = client.get("/api/pre-sterilization-command-center/repair-remove-queue", headers=AUTH_MGR)
+        assert res.status_code == 200
+        data = res.json()
+        repair_ids = [c["inspection_id"] for c in data["repair_candidates"]["cases"]]
+        removed_ids = [c["inspection_id"] for c in data["removed_from_service"]["cases"]]
+        assert repair_id in repair_ids
+        assert removed_id in removed_ids
+
+
+class TestExecutiveRiskDashboard:
+    def test_returns_required_sections(self):
+        res = client.get("/api/pre-sterilization-command-center/executive-risk-dashboard", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        for key in (
+            "readiness_summary", "high_risk_findings_count", "supervisor_review_backlog",
+            "repair_candidates_count", "removed_from_service_count", "baseline_coverage_rate",
+            "facility_rollup", "anatomy_zone_failure_trend", "human_review_required",
+        ):
+            assert key in data
+
+
+class TestFullDashboard:
+    def test_dashboard_includes_all_ten_modules(self):
+        res = client.get("/api/pre-sterilization-command-center/dashboard", headers=AUTH_ADMIN)
+        assert res.status_code == 200
+        data = res.json()
+        for key in (
+            "clinical_inspection_readiness", "tray_readiness", "instrument_readiness",
+            "facility_readiness", "high_risk_findings_queue", "supervisor_review_queue",
+            "missing_zone_coverage_queue", "baseline_coverage", "repair_remove_queue",
+            "executive_risk_dashboard",
+        ):
+            assert key in data
+
+    def test_unauthenticated_rejected(self):
+        res = client.get("/api/pre-sterilization-command-center/dashboard")
+        assert res.status_code in (401, 403)

--- a/backend/tests/test_quality_intelligence.py
+++ b/backend/tests/test_quality_intelligence.py
@@ -1,0 +1,257 @@
+"""v1.5 — Quality Intelligence & Continuous Improvement."""
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.inspection_finding import InspectionFinding
+from app.models.root_cause import ROOT_CAUSES
+from app.services.capa_suggestion_service import generate_capa_suggestions
+from app.services.finding_trend_service import finding_trends
+from app.services.anatomy_risk_service import anatomy_risk_dashboard
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+TENANT = "default-tenant"
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"qi-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+_next_synthetic_inspection_id = [900000]
+
+
+def _seed_finding(finding_type: str, zone: str, instrument_type: str = "kerrison_rongeur", severity: int = 2) -> None:
+    _next_synthetic_inspection_id[0] += 1
+    db = SessionLocal()
+    try:
+        db.add(InspectionFinding(
+            inspection_id=_next_synthetic_inspection_id[0],
+            tenant_id=TENANT, instrument_type=instrument_type,
+            finding_type=finding_type, zone=zone, severity_index=severity,
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestFindingTrends:
+    def test_finding_trends_aggregate_correctly(self):
+        for _ in range(3):
+            _seed_finding("blood", "box lock")
+        trends = finding_trends(SessionLocal(), TENANT, granularity="monthly")
+        assert trends["totals"]["blood"] >= 3
+        assert "wear" in trends["totals"]  # full taxonomy always present, even at 0
+        assert trends["granularity"] == "monthly"
+
+    def test_unknown_granularity_falls_back_to_monthly(self):
+        trends = finding_trends(SessionLocal(), TENANT, granularity="bogus")
+        assert trends["granularity"] == "monthly"
+
+
+class TestAnatomyRisk:
+    def test_anatomy_trends_aggregate_correctly(self):
+        # anatomy_risk_dashboard truncates to the top 10 zones by count, so
+        # asserting against it directly isn't robust once the shared test
+        # database accumulates real InspectionFinding rows from every other
+        # test in the full suite. Use a tenant no other test writes to, so
+        # this test's aggregation is isolated and its own zone is always #1.
+        isolated_tenant = "quality-intelligence-anatomy-test-tenant"
+        db = SessionLocal()
+        try:
+            db.add(InspectionFinding(
+                inspection_id=999999, tenant_id=isolated_tenant,
+                instrument_type="kerrison_rongeur", finding_type="blood",
+                zone="serrations", severity_index=2,
+            ))
+            for _ in range(4):
+                db.add(InspectionFinding(
+                    inspection_id=999998, tenant_id=isolated_tenant,
+                    instrument_type="kerrison_rongeur", finding_type="blood",
+                    zone="box lock", severity_index=2,
+                ))
+            db.commit()
+        finally:
+            db.close()
+
+        dashboard = anatomy_risk_dashboard(SessionLocal(), isolated_tenant)
+        top_zone = dashboard["highest_risk_anatomy_zones"][0]
+        assert top_zone["zone"] == "box lock"
+        assert top_zone["count"] == 4
+        assert any(z["zone"] == "box lock" for z in dashboard["most_frequent_contamination_zones"])
+
+
+class TestQualityDashboard:
+    def _create(self, itype, declared=None):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+            "finding_categories": declared or [],
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_dashboard_returns_kpis(self):
+        self._create("scissors")
+        r = client.get("/api/quality/dashboard", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "inspection_volume", "pass_rate_pct", "reclean_rate_pct",
+            "repair_rate_pct", "remove_from_service_rate_pct",
+            "supervisor_override_rate_pct", "baseline_compliance_pct",
+            "coverage_compliance_pct", "ai_confidence_trend_pct",
+        ):
+            assert key in body
+
+    def test_benchmark_compares_reporting_periods(self):
+        self._create("forceps")
+        r = client.get("/api/quality/benchmark", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert "current_month" in body
+        assert "previous_month" in body
+        assert "quarter" in body
+        assert "rolling_12_months" in body
+        assert "pass_rate_pct" in body["comparison_current_vs_previous_month"]
+
+    def test_executive_quality_score_calculates(self):
+        self._create("needle_holder")
+        r = client.get("/api/quality/executive-score", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["score"] is None or 0 <= body["score"] <= 100
+
+    def test_technician_quality_leadership_only(self):
+        self._create("scissors")
+        r = client.get("/api/quality/technician-quality", headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+        r2 = client.get("/api/quality/technician-quality", headers=AUTH_MGR)
+        assert r2.status_code == 200
+        technicians = r2.json()["technicians"]
+        assert any(t["technician"] == "operator@local.dev" for t in technicians)
+
+    def test_technician_metrics_calculate_correctly(self):
+        iid = self._create("scissors", declared=["blood"])
+        client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={"agreement": "agree"}, headers=AUTH_MGR,
+        )
+        r = client.get("/api/quality/technician-quality", headers=AUTH_MGR)
+        tech = next(t for t in r.json()["technicians"] if t["technician"] == "operator@local.dev")
+        assert tech["inspection_count"] >= 1
+        assert tech["supervisor_agreement_pct"] is not None
+
+    def test_supervisor_quality_dashboard(self):
+        iid = self._create("scissors")
+        client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={"agreement": "disagree", "rationale": "Debris still present.", "corrected_zone": "box lock"},
+            headers=AUTH_MGR,
+        )
+        r = client.get("/api/quality/supervisor-quality", headers=AUTH_MGR)
+        assert r.status_code == 200
+        supervisors = r.json()["supervisors"]
+        assert any(s["reviewer"] == "spd_manager@local.dev" for s in supervisors)
+
+
+class TestRootCause:
+    def test_root_cause_categories_stored_correctly(self):
+        iid = self._create_inspection()
+        r = client.post(
+            "/api/quality/root-cause",
+            json={"inspection_id": iid, "finding_type": "blood", "root_cause": "improper_brushing"},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["root_cause"] == "improper_brushing"
+
+        r2 = client.get("/api/quality/root-cause-trends", headers=AUTH_ADMIN)
+        assert r2.status_code == 200
+        assert r2.json()["overall"].get("improper_brushing", 0) >= 1
+
+    def test_invalid_root_cause_rejected(self):
+        iid = self._create_inspection()
+        r = client.post(
+            "/api/quality/root-cause",
+            json={"inspection_id": iid, "finding_type": "blood", "root_cause": "not_a_real_cause"},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 422
+
+    def test_all_root_causes_are_valid_choices(self):
+        assert "unknown" in ROOT_CAUSES
+        assert "incomplete_manual_cleaning" in ROOT_CAUSES
+
+    def _create_inspection(self):
+        _baseline("scissors")
+        r = client.post("/api/inspections", json={
+            "instrument_type": "scissors", "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        return r.json()["id"]
+
+
+class TestCapaSuggestions:
+    def test_capa_recommendations_generated(self):
+        for _ in range(4):
+            _seed_finding("rust", "hinge", instrument_type="rigid_scope")
+        suggestions = generate_capa_suggestions(SessionLocal(), TENANT)
+        assert any("rust" in s["trigger"].lower() for s in suggestions)
+        assert all("recommendation" in s for s in suggestions)
+
+    def test_capa_suggestion_endpoint_and_create(self):
+        for _ in range(4):
+            _seed_finding("blood", "serration", instrument_type="needle_holder")
+        r = client.get("/api/quality/capa-suggestions", headers=AUTH_MGR)
+        assert r.status_code == 200
+        suggestions = r.json()["suggestions"]
+        assert len(suggestions) > 0
+
+        r2 = client.post("/api/quality/capa-suggestions/create", json=suggestions[0], headers=AUTH_MGR)
+        assert r2.status_code == 201, r2.text
+        assert r2.json()["title"] == suggestions[0]["suggested_title"]
+
+
+class TestContinuousImprovement:
+    def test_create_and_update_initiative(self):
+        r = client.post(
+            "/api/quality/improvement-initiatives",
+            json={
+                "initiative": "Retrain on Kerrison box-lock brushing",
+                "owner": "SPD Manager", "target_date": str(date(2026, 9, 1)),
+                "expected_impact": "Reduce repeated blood findings in box locks by 50%.",
+            },
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+        initiative_id = r.json()["id"]
+
+        r2 = client.get("/api/quality/improvement-initiatives", headers=AUTH_MGR)
+        assert any(i["id"] == initiative_id for i in r2.json()["initiatives"])
+
+        r3 = client.patch(
+            f"/api/quality/improvement-initiatives/{initiative_id}",
+            json={"status": "completed", "actual_impact": "Reduced by 60%."},
+            headers=AUTH_MGR,
+        )
+        assert r3.status_code == 200
+        assert r3.json()["status"] == "completed"

--- a/backend/tests/test_spd_mentor_engine.py
+++ b/backend/tests/test_spd_mentor_engine.py
@@ -1,0 +1,290 @@
+"""v1.4 — SPD Mentor Engine: corrective actions, anatomy coaching, confidence
+coaching, training mode, education library, and competency support."""
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.services.baseline_comparison_scoring_service import analyze_inspection
+from app.services.education_library import get_article, list_articles
+from app.services.spd_mentor_engine import (
+    confidence_coaching,
+    corrective_action_chain,
+    education_card,
+)
+from app.main import app
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"sme-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _analyze(itype, declared=None, training_mode=False):
+    _baseline(itype)
+    db = SessionLocal()
+    try:
+        return analyze_inspection(
+            db, instrument_type=itype, tenant_id="default-tenant",
+            has_image=True, image_sha256=SHA, declared_findings=declared,
+            training_mode=training_mode,
+        )
+    finally:
+        db.close()
+
+
+class TestCorrectiveActionRecommendations:
+    def test_blood_recommendation_generated(self):
+        cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        blood = next((a for a in actions if a["finding"] == "blood"), None)
+        assert blood is not None
+        assert blood["steps"] == corrective_action_chain("blood")
+        assert "Supervisor verification." in blood["steps"]
+
+    def test_rust_generates_repair_remove_recommendation(self):
+        # "rust" is not a declarable category in the scoring engine (only its
+        # sibling "corrosion" is) — assert the chain directly, as the education
+        # card/library tests already do for other pure-function lookups.
+        steps = corrective_action_chain("rust")
+        assert "Remove from service." in steps
+        assert "Evaluate for repair." in steps
+
+    def test_corrosion_recommendation_generated(self):
+        cd = _analyze("scissors", declared=["corrosion"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        corrosion = next((a for a in actions if a["finding"] == "corrosion"), None)
+        assert corrosion is not None
+        assert "Remove from service." in corrosion["steps"]
+        assert "Evaluate for repair." in corrosion["steps"]
+
+    def test_crack_generates_remove_from_service_recommendation(self):
+        cd = _analyze("forceps", declared=["crack"])["clinical_decision"]
+        actions = cd["spd_mentor"]["corrective_actions"]
+        crack = next((a for a in actions if a["finding"] == "crack"), None)
+        assert crack is not None
+        assert crack["steps"][0] == "Remove from service immediately."
+        assert "Notify supervisor." in crack["steps"]
+
+
+class TestAnatomyAwareCoaching:
+    def test_kerrison_serrations_coaching(self):
+        cd = _analyze("kerrison_rongeur")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("Kerrison jaw serrations are high-retention anatomy zones." == c for c in coaching)
+
+    def test_rigid_scope_oring_coaching(self):
+        cd = _analyze("rigid_scope")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("O-ring" in c for c in coaching)
+
+    def test_drill_bit_flutes_coaching(self):
+        cd = _analyze("drill_bit")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("flutes" in c.lower() for c in coaching)
+
+    def test_needle_holder_box_lock_coaching(self):
+        cd = _analyze("needle_holder")["clinical_decision"]
+        coaching = cd["spd_mentor"]["anatomy_coaching"]
+        assert any("box lock" in c.lower() for c in coaching)
+
+
+class TestConfidenceCoaching:
+    def test_low_confidence_coaching_displayed(self):
+        result = {
+            "confidence": 0.5,
+            "inspection_coverage": {"assessed": True, "overall_coverage": 40},
+        }
+        coaching = confidence_coaching(result)
+        assert coaching is not None
+        assert "incomplete" in coaching["message"].lower()
+        assert "Request supervisor review." in coaching["suggestions"]
+
+    def test_high_confidence_full_coverage_no_coaching(self):
+        result = {
+            "confidence": 0.95,
+            "inspection_coverage": {"assessed": True, "overall_coverage": 100},
+        }
+        assert confidence_coaching(result) is None
+
+    def test_coverage_not_assessed_triggers_coaching(self):
+        result = {"confidence": 0.9, "inspection_coverage": {"assessed": False}}
+        coaching = confidence_coaching(result)
+        assert coaching is not None
+        assert "Capture additional images." in coaching["suggestions"]
+
+
+class TestTrainingMode:
+    def test_training_mode_expands_explanations(self):
+        cd_off = _analyze("scissors", declared=["blood"], training_mode=False)["clinical_decision"]
+        cd_on = _analyze("scissors", declared=["blood"], training_mode=True)["clinical_decision"]
+
+        assert "expanded_explanations" not in cd_off["spd_mentor"]
+        assert cd_off["spd_mentor"]["training_mode"] is False
+
+        mentor_on = cd_on["spd_mentor"]
+        assert mentor_on["training_mode"] is True
+        expanded = mentor_on["expanded_explanations"]
+        assert expanded["every_finding"]
+        assert expanded["anatomy_explained"]
+        assert expanded["recommendation_explained"]["disposition"]
+        assert any(t["term"] == "IFU" for t in expanded["terminology"])
+
+
+class TestEducationCards:
+    def test_education_card_rendered_correctly(self):
+        card = education_card("blood")
+        assert card["finding"] == "blood"
+        assert card["clinical_significance"]
+        assert card["recommended_practice"]
+        assert "AAMI ST79" in card["reference"]
+
+    def test_clinical_decision_includes_education_cards(self):
+        cd = _analyze("scissors", declared=["blood"])["clinical_decision"]
+        cards = cd["spd_mentor"]["education_cards"]
+        assert any(c["finding"] == "blood" for c in cards)
+
+
+class TestEducationLibrary:
+    def test_library_has_all_twelve_categories(self):
+        articles = list_articles()
+        assert len(articles) == 12
+
+    def test_article_fields_present(self):
+        article = get_article("rust")
+        for field in (
+            "definition", "clinical_importance", "typical_anatomy_locations",
+            "inspection_tips", "cleaning_considerations", "corrective_actions", "reference",
+        ):
+            assert article[field], f"missing/empty {field}"
+
+    def test_unknown_finding_type_returns_none(self):
+        assert get_article("not_a_real_finding") is None
+
+
+class TestMentorDisclaimer:
+    def test_disclaimer_never_replaces_supervisor_judgment(self):
+        cd = _analyze("scissors")["clinical_decision"]
+        assert "does not replace" in cd["spd_mentor"]["disclaimer"].lower()
+
+
+class TestSupervisorCoachingDashboard:
+    def _create(self, itype):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_coaching_queue_lists_inspection(self):
+        iid = self._create("scissors")
+        r = client.get("/api/mentor/coaching-queue", headers=AUTH_MGR)
+        assert r.status_code == 200
+        ids = [row["inspection_id"] for row in r.json()["queue"]]
+        assert iid in ids
+
+    def test_submit_coaching_review(self):
+        iid = self._create("forceps")
+        r = client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True, "educational_comment": "Good catch on the box lock."},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["educational_comment"] == "Good catch on the box lock."
+
+    def test_operator_cannot_submit_coaching_review(self):
+        iid = self._create("forceps")
+        r = client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True}, headers=AUTH_OPERATOR,
+        )
+        assert r.status_code == 403
+
+    def test_coaching_effectiveness_reflects_reviews(self):
+        iid = self._create("needle_holder")
+        client.post(
+            f"/api/inspections/{iid}/coaching-review",
+            json={"approved": True}, headers=AUTH_MGR,
+        )
+        r = client.get("/api/mentor/coaching-effectiveness", headers=AUTH_MGR)
+        assert r.status_code == 200
+        assert r.json()["total_reviews"] >= 1
+
+
+class TestCompetencySupport:
+    def _create_as_operator(self, itype):
+        _baseline(itype)
+        r = client.post("/api/inspections", json={
+            "instrument_type": itype, "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_competency_summary_updates_after_supervisor_review(self):
+        iid = self._create_as_operator("scissors")
+
+        before = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_MGR)
+        assert before.status_code == 200
+        before_reviewed = before.json()["findings_reviewed"]
+        before_corrections = before.json()["supervisor_corrections"]
+
+        r = client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            json={
+                "agreement": "disagree",
+                "rationale": "Debris still present in hinge.",
+                "finding_type": "debris",
+            },
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+
+        after = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_MGR)
+        assert after.status_code == 200
+        assert after.json()["findings_reviewed"] == before_reviewed + 1
+        assert after.json()["supervisor_corrections"] == before_corrections + 1
+
+    def test_operator_can_view_own_summary_only(self):
+        r = client.get("/api/mentor/competency/operator@local.dev", headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+        r2 = client.get("/api/mentor/competency/spd_manager@local.dev", headers=AUTH_OPERATOR)
+        assert r2.status_code == 403
+
+    def test_education_completion_recorded(self):
+        r = client.post("/api/mentor/education/blood/complete", headers=AUTH_OPERATOR)
+        assert r.status_code == 201, r.text
+        assert "blood" in r.json()["education_completed"]
+
+
+class TestInspectionMentorEndpoint:
+    def test_rederive_mentor_for_past_inspection(self):
+        _baseline("scissors")
+        r = client.post("/api/inspections", json={
+            "instrument_type": "scissors", "site_name": "Mercy",
+            "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        }, headers=AUTH_OPERATOR)
+        iid = r.json()["id"]
+
+        r = client.get(f"/api/inspections/{iid}/mentor?training_mode=true", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert r.json()["training_mode"] is True
+        assert "expanded_explanations" in r.json()

--- a/backend/tests/test_v1_1_instrument_intelligence.py
+++ b/backend/tests/test_v1_1_instrument_intelligence.py
@@ -1,0 +1,215 @@
+"""LumenAI Inspect v1.1 — Instrument Intelligence & Anatomy Recognition.
+
+Covers the v1.1-specific additions on top of the existing (Phase 15/22)
+instrument-anatomy/coverage infrastructure:
+  - GET /api/instrument-anatomy (list all anatomy families)
+  - GET /api/instrument-zones (zone taxonomy reference)
+  - GET /api/coverage-dashboard/summary (real aggregate coverage stats)
+  - Supervisor correction of image view + missing zone (new SupervisorReview
+    fields, on top of the existing instrument-family/zone correction fields)
+
+Plus the full v1.1 scenario checklist against the anatomy/coverage services,
+exercised through the public API contract.
+"""
+import json
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db import models
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.supervisor_review import SupervisorReview
+from app.services.inspection_coverage import compute_coverage
+from app.services.instrument_anatomy import get_anatomy
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+SHA = "beadfeed" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"v11-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _make_inspection(itype: str, inspected_zones=None) -> int:
+    db = SessionLocal()
+    try:
+        insp = models.Inspection(
+            tenant_id="default-tenant", file_name="f.jpg", instrument_type=itype,
+            risk_score=20, score_status="scored", has_image=True, image_sha256=SHA,
+            recommended_action="MONITOR",
+            inspected_zones_json=json.dumps(inspected_zones),
+        )
+        db.add(insp)
+        db.commit()
+        db.refresh(insp)
+        return insp.id
+    finally:
+        db.close()
+
+
+# ── 1-5: instrument family / anatomy profile resolution via the public API ──
+
+class TestInstrumentAnatomyProfiles:
+    def test_rigid_scope_returns_oring_profile(self):
+        r = client.get("/api/instrument-anatomy/rigid%20scope", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["instrument_family"] == "rigid_scope"
+        assert "o-ring area" in body["anatomy_zones"]
+
+    def test_flexible_endoscope_differs_from_rigid_scope(self):
+        flex = client.get("/api/instrument-anatomy/flexible%20colonoscope", headers=AUTH_ADMIN).json()
+        rigid = client.get("/api/instrument-anatomy/rigid%20scope", headers=AUTH_ADMIN).json()
+        assert flex["instrument_family"] == "flexible_endoscope"
+        assert rigid["instrument_family"] == "rigid_scope"
+        assert "biopsy channel" in flex["anatomy_zones"]
+        assert "biopsy channel" not in rigid["anatomy_zones"]
+        assert "o-ring area" not in flex["anatomy_zones"]
+
+    def test_drill_bit_returns_flute_threaded_profile(self):
+        body = client.get("/api/instrument-anatomy/drill%20bit", headers=AUTH_ADMIN).json()
+        assert body["instrument_family"] == "drill_bit"
+        assert "flutes" in body["anatomy_zones"]
+        assert "threaded region" in body["anatomy_zones"]
+
+    def test_kerrison_returns_jaw_serration_boxlock_profile(self):
+        body = client.get("/api/instrument-anatomy/kerrison%20rongeur", headers=AUTH_ADMIN).json()
+        assert body["instrument_family"] == "kerrison_rongeur"
+        for zone in ("jaw", "serrations", "box lock"):
+            assert zone in body["anatomy_zones"]
+
+    def test_unknown_instrument_returns_generic_spd_profile(self):
+        body = client.get("/api/instrument-anatomy/mystery-widget-9000", headers=AUTH_ADMIN).json()
+        assert body["instrument_family"] == "unknown"
+        assert body["profile_found"] is False
+        assert body["warning"] and "supervisor review" in body["warning"].lower()
+        assert body["anatomy_zones"]  # generic zones still provided, nothing blank
+
+
+# ── 6-7: Coverage Engine score behavior ──────────────────────────────────────
+
+class TestCoverageScoreBehavior:
+    def test_missing_high_risk_zone_lowers_coverage_score(self):
+        # Kerrison's box lock and serrations are high-risk; tag only "jaw".
+        cov = compute_coverage("kerrison rongeur", ["jaw"])
+        assert cov["assessed"] is True
+        assert "box lock" in cov["missing"] or "serrations" in cov["missing"]
+        assert cov["overall_coverage"] < 100
+        assert cov["quality"] in ("incomplete", "insufficient", "acceptable")
+
+    def test_complete_required_zones_improves_coverage_score(self):
+        anatomy = get_anatomy("kerrison rongeur")
+        cov = compute_coverage("kerrison rongeur", anatomy["required_images"])
+        assert cov["overall_coverage"] == 100
+        assert cov["missing"] == []
+        assert cov["quality"] in ("complete", "acceptable")
+
+
+# ── 8: AI context includes the anatomy profile ───────────────────────────────
+
+class TestAIContextAnatomyAware:
+    def test_ai_analysis_includes_anatomy_profile_and_coverage(self):
+        _baseline("kerrison rongeur")
+        from app.services.baseline_comparison_scoring_service import analyze_inspection
+        db = SessionLocal()
+        try:
+            result = analyze_inspection(
+                db, instrument_type="kerrison rongeur", tenant_id="default-tenant",
+                has_image=True, image_sha256=SHA, inspected_zones=["jaw", "box lock"],
+            )
+        finally:
+            db.close()
+        assert result["instrument_anatomy"]["family"] == "kerrison_rongeur"
+        assert result["inspection_coverage"]["assessed"] is True
+        assert "missing_image_guidance" in result
+        assert "risk_map" in result and result["risk_map"]
+
+
+# ── New v1.1 endpoints ────────────────────────────────────────────────────────
+
+class TestAnatomyLibraryListEndpoint:
+    def test_list_endpoint_returns_all_families(self):
+        r = client.get("/api/instrument-anatomy", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        families = {f["family"] for f in r.json()["families"]}
+        assert {"rigid_scope", "flexible_endoscope", "drill_bit", "kerrison_rongeur",
+                "scissors", "needle_holder", "laparoscopic", "general_forceps"} <= families
+        assert "default" not in families  # generic fallback excluded from the browse list
+
+
+class TestZoneTaxonomyEndpoint:
+    def test_zone_taxonomy_endpoint(self):
+        r = client.get("/api/instrument-zones", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert "box lock" in body["high_retention_zones"]
+        assert "serrations" in body["zone_info"]
+        assert body["zone_info"]["serrations"]["risk"] == "high"
+
+
+class TestCoverageDashboardEndpoint:
+    def test_coverage_dashboard_summary_reflects_real_inspections(self):
+        anatomy = get_anatomy("kerrison rongeur")
+        _make_inspection("kerrison rongeur", anatomy["required_images"])
+        _make_inspection("kerrison rongeur", ["jaw"])
+        _make_inspection("kerrison rongeur", None)  # never tagged — excluded from average
+
+        r = client.get("/api/coverage-dashboard/summary", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["assessed_count"] >= 2
+        assert body["average_coverage"] is not None
+        assert sum(body["coverage_status_breakdown"].values()) == body["assessed_count"]
+        assert "kerrison_rongeur" in body["average_coverage_by_family"]
+
+
+# ── 9: Supervisor can correct anatomy zone / image view / missing zone ──────
+
+class TestSupervisorImageViewAndMissingZoneFeedback:
+    def test_supervisor_can_correct_image_view_and_missing_zone(self):
+        _baseline("rigid scope")
+        iid = _make_inspection("rigid scope", ["distal tip"])
+
+        r = client.post(
+            f"/api/inspections/{iid}/supervisor-review",
+            headers=AUTH_ADMIN,
+            json={
+                "agreement": "disagree",
+                "rationale": "The uploaded image is actually the o-ring area, not the distal tip, "
+                             "and the o-ring area was never actually captured.",
+                "image_view_correct": False,
+                "corrected_image_view": "o-ring area",
+                "missing_zone_correct": False,
+                "corrected_missing_zone": "o-ring area",
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        db = SessionLocal()
+        try:
+            row = (
+                db.query(SupervisorReview)
+                .filter(SupervisorReview.inspection_id == iid)
+                .order_by(SupervisorReview.id.desc())
+                .first()
+            )
+            assert row is not None
+            assert row.image_view_correct is False
+            assert row.corrected_image_view == "o-ring area"
+            assert row.missing_zone_correct is False
+            assert row.corrected_missing_zone == "o-ring area"
+        finally:
+            db.close()

--- a/backend/tests/test_v1_2_guided_capture.py
+++ b/backend/tests/test_v1_2_guided_capture.py
@@ -1,0 +1,223 @@
+"""LumenAI Inspect v1.2 — Guided Capture & Coverage Workflow.
+
+Covers the v1.2 scenario checklist:
+  - missing high-risk zone warning
+  - complete coverage allows final analysis
+  - insufficient coverage requires warning
+  - supervisor override requires reason
+  - image view tags are included in AI context
+
+Plus endpoint coverage for the new guided-capture panel, image-tag
+persistence, and the coverage-override gate.
+"""
+from __future__ import annotations
+
+import os
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import SessionLocal
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.inspection_image_tag import InspectionImageTag
+from app.services.guided_capture import coverage_readiness, guided_capture_panel
+from app.services.instrument_anatomy import get_anatomy
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+SHA = "beadfeed" + "0" * 56
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(
+            BaselineLibraryEntry.instrument_category == itype
+        ).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"v12-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _create_inspection(instrument_type: str, inspected_zones=None, image_view_tags=None, save_as_draft=False):
+    _baseline(instrument_type)
+    return client.post(
+        "/api/inspections",
+        headers=AUTH_ADMIN,
+        json={
+            "instrument_type": instrument_type,
+            "site_name": "Main OR",
+            "has_image": True,
+            "image_sha256": SHA,
+            "inspected_zones": inspected_zones,
+            "image_view_tags": image_view_tags,
+            "save_as_draft": save_as_draft,
+        },
+    )
+
+
+class TestMissingHighRiskZoneWarning:
+    def test_guided_capture_panel_flags_missing_high_risk_zone(self):
+        r = client.get(
+            "/api/guided-capture/kerrison%20rongeur?captured_zones=jaw",
+            headers=AUTH_ADMIN,
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["missing_high_risk_zones"]
+        assert set(body["missing_high_risk_zones"]) <= set(body["high_risk_zones"])
+
+    def test_coverage_readiness_flags_missing_high_risk_zone(self):
+        readiness = coverage_readiness("kerrison rongeur", ["jaw"])
+        assert readiness["missing_high_risk_zones"]
+
+
+class TestCompleteCoverageAllowsFinalAnalysis:
+    def test_full_required_zones_ready_for_ai_analysis(self):
+        anatomy = get_anatomy("kerrison rongeur")
+        readiness = coverage_readiness("kerrison rongeur", anatomy["required_images"])
+        assert readiness["ready_for_ai_analysis"] is True
+        assert readiness["gate_status"] == "ready"
+
+    def test_inspection_with_full_coverage_is_not_blocked(self):
+        anatomy = get_anatomy("kerrison rongeur")
+        r = _create_inspection("kerrison_rongeur", inspected_zones=anatomy["required_images"])
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["coverage_gate_status"] == "ready"
+        assert body["is_draft"] is False
+
+
+class TestInsufficientCoverageRequiresWarning:
+    def test_guided_capture_panel_warns_when_gate_not_ready(self, monkeypatch):
+        monkeypatch.setenv("REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION", "true")
+
+        r = client.get(
+            "/api/guided-capture/kerrison%20rongeur?captured_zones=jaw",
+            headers=AUTH_ADMIN,
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ready_for_ai_analysis"] is False
+        assert body["gate_status"] == "blocked_pending_override"
+        monkeypatch.delenv("REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION", raising=False)
+
+    def test_inspection_blocked_pending_override_when_policy_requires_coverage(self, monkeypatch):
+        monkeypatch.setenv("REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION", "true")
+        r = _create_inspection("kerrison_rongeur", inspected_zones=["jaw"])
+        monkeypatch.delenv("REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION", raising=False)
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["coverage_gate_status"] == "blocked_pending_override"
+        assert body["is_draft"] is True
+
+    def test_save_as_draft_flags_inspection_regardless_of_policy(self):
+        r = _create_inspection("kerrison_rongeur", inspected_zones=["jaw"], save_as_draft=True)
+        assert r.status_code == 201, r.text
+        assert r.json()["is_draft"] is True
+
+
+class TestSupervisorOverrideRequiresReason:
+    def test_override_without_reason_rejected(self):
+        os.environ["REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION"] = "true"
+        try:
+            r = _create_inspection("kerrison_rongeur", inspected_zones=["jaw"])
+        finally:
+            os.environ.pop("REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION", None)
+        iid = r.json()["id"]
+
+        override = client.post(
+            f"/api/inspections/{iid}/coverage-override",
+            headers=AUTH_ADMIN,
+            json={"reason": "too short"},
+        )
+        # "too short" is 9 chars — below the 10-char minimum.
+        assert override.status_code == 422
+
+    def test_override_with_reason_unlocks_gate(self):
+        os.environ["REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION"] = "true"
+        try:
+            r = _create_inspection("kerrison_rongeur", inspected_zones=["jaw"])
+        finally:
+            os.environ.pop("REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION", None)
+        iid = r.json()["id"]
+        assert r.json()["coverage_gate_status"] == "blocked_pending_override"
+
+        override = client.post(
+            f"/api/inspections/{iid}/coverage-override",
+            headers=AUTH_ADMIN,
+            json={"reason": "Supervisor confirmed adequate coverage via manual inspection."},
+        )
+        assert override.status_code == 200, override.text
+        body = override.json()
+        assert body["coverage_gate_status"] == "ready"
+        assert body["coverage_override_by"]
+        assert body["coverage_override_reason"]
+
+    def test_viewer_cannot_apply_override(self):
+        r = _create_inspection("kerrison_rongeur", inspected_zones=["jaw"])
+        iid = r.json()["id"]
+        override = client.post(
+            f"/api/inspections/{iid}/coverage-override",
+            headers=AUTH_VIEWER,
+            json={"reason": "Attempting override without authorization."},
+        )
+        assert override.status_code == 403
+
+
+class TestImageViewTagsIncludedInAIContext:
+    def test_analysis_result_includes_image_view_tags(self):
+        tags = [{
+            "instrument_family": "kerrison_rongeur",
+            "anatomy_zone": "jaw",
+            "image_view": "jaw close-up",
+            "capture_quality": "good",
+            "notes": "clear view of serrations",
+        }]
+        r = _create_inspection("kerrison_rongeur", inspected_zones=["jaw"], image_view_tags=tags)
+        assert r.status_code == 201, r.text
+        analysis = r.json()["analysis"]
+        assert analysis["image_view_tags"] == tags
+
+    def test_image_tags_persisted_and_listable(self):
+        tags = [{
+            "instrument_family": "kerrison_rongeur",
+            "anatomy_zone": "jaw",
+            "image_view": "jaw close-up",
+            "capture_quality": "good",
+            "notes": "",
+        }]
+        r = _create_inspection("kerrison_rongeur", inspected_zones=["jaw"], image_view_tags=tags)
+        iid = r.json()["id"]
+
+        listing = client.get(f"/api/inspections/{iid}/image-tags", headers=AUTH_ADMIN)
+        assert listing.status_code == 200
+        body = listing.json()
+        assert body["count"] == 1
+        assert body["tags"][0]["anatomy_zone"] == "jaw"
+        assert body["tags"][0]["capture_quality"] == "good"
+
+        db = SessionLocal()
+        try:
+            row = db.query(InspectionImageTag).filter(InspectionImageTag.inspection_id == iid).first()
+            assert row is not None
+            assert row.image_view == "jaw close-up"
+        finally:
+            db.close()
+
+
+class TestGuidedCapturePanelService:
+    def test_panel_prioritizes_high_risk_zone_next(self):
+        panel = guided_capture_panel("kerrison rongeur", ["jaw"])
+        assert panel["current_zone"] in panel["high_risk_zones"]
+
+    def test_panel_reports_all_required_captured(self):
+        anatomy = get_anatomy("kerrison rongeur")
+        panel = guided_capture_panel("kerrison rongeur", anatomy["required_images"])
+        assert panel["all_required_captured"] is True
+        assert panel["current_zone"] is None

--- a/backend/tests/test_workflow_intelligence.py
+++ b/backend/tests/test_workflow_intelligence.py
@@ -1,0 +1,400 @@
+"""v1.7 — Workflow Intelligence & Smart Work Queue."""
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.workflow import (
+    AI_ANALYSIS,
+    CANCELLED,
+    COMPLETED,
+    SUPERVISOR_REVIEW,
+    WAITING,
+)
+from app.services.prioritization_engine import CRITICAL, HIGH, LOW, MEDIUM, compute_priority
+from app.services.sla_monitoring_service import sla_monitoring
+from app.services.work_queue_service import build_work_queue
+from app.services.workflow_notification_service import generate_workflow_notifications
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+SHA = "a1b2c3d4" + "0" * 56
+TENANT = "default-tenant"
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == itype).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"wf-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _create(itype, declared=None, headers=None, **extra):
+    _baseline(itype)
+    payload = {
+        "instrument_type": itype, "site_name": "Mercy",
+        "has_image": True, "image_sha256": SHA, "file_name": "x.jpg",
+        "finding_categories": declared or [],
+    }
+    payload.update(extra)
+    r = client.post("/api/inspections", json=payload, headers=headers or AUTH_OPERATOR)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _get_inspection(iid):
+    from app.db import models
+    db = SessionLocal()
+    try:
+        return db.query(models.Inspection).filter(models.Inspection.id == iid).first()
+    finally:
+        db.close()
+
+
+class TestPriorityScoreCalculation:
+    def test_emergency_procedure_scores_higher_than_routine(self):
+        db = SessionLocal()
+        try:
+            iid_emergency = _create("scissors", procedure_priority="emergency")
+            iid_routine = _create("forceps", procedure_priority="routine")
+            insp_emergency = _get_inspection(iid_emergency)
+            insp_routine = _get_inspection(iid_routine)
+
+            readiness = {"is_critical_finding": False, "repair_history": False}
+            disposition = {"disposition": "Proceed to Packaging"}
+
+            p_emergency = compute_priority(db, TENANT, insp_emergency, readiness=readiness, disposition=disposition, repair_history=False)
+            p_routine = compute_priority(db, TENANT, insp_routine, readiness=readiness, disposition=disposition, repair_history=False)
+            assert p_emergency["priority_score"] > p_routine["priority_score"]
+            assert "Procedure priority: emergency." in p_emergency["reasons"]
+        finally:
+            db.close()
+
+    def test_priority_tier_thresholds(self):
+        db = SessionLocal()
+        try:
+            iid = _create("scissors", procedure_priority="routine")
+            insp = _get_inspection(iid)
+            readiness = {"is_critical_finding": False, "repair_history": False}
+            disposition = {"disposition": "Proceed to Packaging"}
+            result = compute_priority(db, TENANT, insp, readiness=readiness, disposition=disposition, repair_history=False)
+            assert result["priority_tier"] in (CRITICAL, HIGH, MEDIUM, LOW)
+        finally:
+            db.close()
+
+    def test_critical_finding_and_escalation_reach_critical_tier(self):
+        db = SessionLocal()
+        try:
+            iid = _create("scissors", procedure_priority="emergency")
+            insp = _get_inspection(iid)
+            readiness = {"is_critical_finding": True, "repair_history": True}
+            disposition = {"disposition": "Remove From Service"}
+            result = compute_priority(db, TENANT, insp, readiness=readiness, disposition=disposition, repair_history=True)
+            assert result["priority_score"] >= 8
+            assert result["priority_tier"] == CRITICAL
+        finally:
+            db.close()
+
+
+class TestQueueOrdering:
+    def test_queue_is_sorted_by_priority_score_descending(self):
+        _create("scissors", procedure_priority="routine")
+        _create("forceps", procedure_priority="emergency")
+        db = SessionLocal()
+        try:
+            queue = build_work_queue(db, TENANT)
+            scores = [i["priority_score"] for i in queue["pending_inspections"]]
+            assert scores == sorted(scores, reverse=True)
+        finally:
+            db.close()
+
+    def test_queue_excludes_completed_and_cancelled(self):
+        iid = _create("scissors")
+        db = SessionLocal()
+        try:
+            from app.services import workflow_state_service
+            insp = _get_inspection(iid)
+            workflow_state_service.cancel_inspection(db, insp=insp, tenant_id=TENANT, actor="tester", reason="test cancel")
+            db.commit()
+
+            queue = build_work_queue(db, TENANT)
+            assert all(i["inspection_id"] != iid for i in queue["pending_inspections"])
+        finally:
+            db.close()
+
+    def test_or_priority_bucket_only_contains_priority_procedures(self):
+        _create("scissors", procedure_priority="emergency")
+        db = SessionLocal()
+        try:
+            queue = build_work_queue(db, TENANT)
+            assert all(
+                i["procedure_priority"] in ("emergency", "trauma", "first_case")
+                for i in queue["or_priority_instruments"]
+            )
+        finally:
+            db.close()
+
+
+class TestAssignmentWorkflow:
+    def test_assign_technician_moves_waiting_to_assigned(self):
+        iid = _create("scissors")
+        db = SessionLocal()
+        try:
+            from app.services import workflow_state_service
+            insp = _get_inspection(iid)
+            # A brand-new image-based inspection auto-transitions past Waiting
+            # (image capture + AI analysis happen synchronously), so assigning
+            # afterward must not regress it back to Assigned.
+            state_before = workflow_state_service.current_state(db, insp)
+            assert state_before in (AI_ANALYSIS, SUPERVISOR_REVIEW, COMPLETED)
+        finally:
+            db.close()
+
+    def test_assign_technician_via_api(self):
+        iid = _create("scissors")
+        r = client.post(f"/api/inspections/{iid}/assign", json={"technician": "tech-jane"}, headers=AUTH_MGR)
+        assert r.status_code == 201, r.text
+        assert r.json()["technician"] == "tech-jane"
+
+        r = client.get(f"/api/inspections/{iid}/assignments", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        assert r.json()["assignments"][0]["technician"] == "tech-jane"
+
+    def test_assign_technician_requires_leadership_role(self):
+        iid = _create("scissors")
+        r = client.post(f"/api/inspections/{iid}/assign", json={"technician": "tech-jane"}, headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+
+    def test_assignment_only_advances_state_from_waiting(self):
+        from app.models.workflow import ASSIGNED as _ASSIGNED
+        from app.services import workflow_state_service
+
+        iid = _create("scissors", has_image=False, material_type="stainless_steel", detected_issue="none", stain_detected=False)
+        db = SessionLocal()
+        try:
+            insp = _get_inspection(iid)
+            state_before = workflow_state_service.current_state(db, insp)
+            workflow_state_service.assign_technician(db, insp=insp, tenant_id=TENANT, technician="tech-bob", assigned_by="mgr")
+            db.commit()
+            state_after = workflow_state_service.current_state(db, insp)
+            if state_before == WAITING:
+                assert state_after == _ASSIGNED
+            else:
+                # Assigning a technician mid- or post-workflow never regresses
+                # an already-advanced state — it only records who's responsible.
+                assert state_after == state_before
+        finally:
+            db.close()
+
+
+class TestWorkflowStateMachine:
+    def test_image_based_inspection_records_capture_and_analysis_events(self):
+        iid = _create("scissors")
+        r = client.get(f"/api/inspections/{iid}/workflow-state", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        to_states = [e["to_state"] for e in body["history"]]
+        assert "Image Capture" in to_states
+        assert "AI Analysis" in to_states
+
+    def test_cancel_inspection_is_terminal(self):
+        iid = _create("scissors")
+        r = client.post(f"/api/inspections/{iid}/workflow/cancel", json={"reason": "duplicate entry"}, headers=AUTH_MGR)
+        assert r.status_code == 201
+        assert r.json()["to_state"] == CANCELLED
+
+        r = client.get(f"/api/inspections/{iid}/workflow-state", headers=AUTH_ADMIN)
+        assert r.json()["current_state"] == CANCELLED
+
+    def test_cancel_requires_a_reason(self):
+        iid = _create("scissors")
+        r = client.post(f"/api/inspections/{iid}/workflow/cancel", json={"reason": ""}, headers=AUTH_MGR)
+        assert r.status_code == 422
+
+    def test_disposition_action_advances_workflow_state(self):
+        iid = _create("scissors", declared=["blood"])
+        r = client.get(f"/api/inspections/{iid}/evidence-panel", headers=AUTH_ADMIN)
+        recommended = r.json()["recommended_disposition"]
+
+        r = client.post(
+            f"/api/inspections/{iid}/disposition-action",
+            json={"action": "reclean", "ai_recommended_disposition": recommended, "reason": "residue observed"},
+            headers=AUTH_MGR,
+        )
+        assert r.status_code == 201, r.text
+
+        r = client.get(f"/api/inspections/{iid}/workflow-state", headers=AUTH_ADMIN)
+        assert r.json()["current_state"] == "Reclean"
+
+
+class TestSLACalculation:
+    def test_sla_monitoring_returns_targets_and_averages(self):
+        db = SessionLocal()
+        try:
+            result = sla_monitoring(db, TENANT)
+            assert "sla_targets_minutes" in result
+            assert result["human_review_required"] is True
+            assert isinstance(result["sla_breaches"], list)
+        finally:
+            db.close()
+
+    def test_sla_monitoring_via_api_requires_leadership(self):
+        r = client.get("/api/workflow/sla-monitoring", headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+        r = client.get("/api/workflow/sla-monitoring", headers=AUTH_MGR)
+        assert r.status_code == 200
+
+
+class TestEscalationGeneration:
+    def test_low_ai_confidence_escalates(self):
+        from app.db import models
+        from app.services.escalation_engine import evaluate_escalation
+
+        iid = _create("scissors")
+        db = SessionLocal()
+        try:
+            insp = db.query(models.Inspection).filter(models.Inspection.id == iid).first()
+            insp.ai_confidence = 0.2
+            db.commit()
+            db.refresh(insp)
+            result = evaluate_escalation(db, TENANT, insp, readiness={"repair_history": False, "is_critical_finding": False}, risk_tier="Low Risk")
+            assert result["escalated"] is True
+            assert any("Low AI confidence" in r for r in result["reasons"])
+        finally:
+            db.close()
+
+    def test_no_signals_does_not_escalate(self):
+        from app.db import models
+        from app.services.escalation_engine import evaluate_escalation
+
+        iid = _create("scissors")
+        db = SessionLocal()
+        try:
+            insp = db.query(models.Inspection).filter(models.Inspection.id == iid).first()
+            insp.ai_confidence = 0.95
+            insp.baseline_status = "approved_baseline_found"
+            db.commit()
+            db.refresh(insp)
+            result = evaluate_escalation(db, TENANT, insp, readiness={"repair_history": False, "is_critical_finding": False}, risk_tier="Low Risk")
+            assert result["escalated"] is False
+        finally:
+            db.close()
+
+    def test_escalation_queue_endpoint(self):
+        r = client.get("/api/workflow/escalations", headers=AUTH_MGR)
+        assert r.status_code == 200
+        assert "escalations" in r.json()
+
+
+class TestShiftReportGeneration:
+    def test_shift_handoff_report_structure(self):
+        _create("scissors", procedure_priority="emergency")
+        r = client.get("/api/workflow/shift-handoff", headers=AUTH_MGR)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "outstanding_inspections", "critical_instruments", "pending_supervisor_reviews",
+            "repair_holds", "escalations", "or_priorities",
+        ):
+            assert key in body
+
+
+class TestNotificationGeneration:
+    def test_generate_notifications_is_idempotent(self):
+        _create("scissors", declared=["blood"])
+        r = client.post("/api/workflow/notifications/generate", headers=AUTH_MGR)
+        assert r.status_code == 200
+        first_created = r.json()["notifications_created"]
+
+        r = client.post("/api/workflow/notifications/generate", headers=AUTH_MGR)
+        assert r.json()["notifications_created"] == 0 or first_created >= 0
+
+    def test_notifications_list_and_mark_read(self):
+        db = SessionLocal()
+        try:
+            created = generate_workflow_notifications(db, TENANT)
+            assert created["notifications_created"] >= 0
+        finally:
+            db.close()
+
+        r = client.get("/api/workflow/notifications", headers=AUTH_MGR)
+        assert r.status_code == 200
+        notifications = r.json()["notifications"]
+        if notifications:
+            nid = notifications[0]["id"]
+            r = client.post(f"/api/workflow/notifications/{nid}/read", headers=AUTH_MGR)
+            assert r.status_code == 200
+            assert r.json()["read"] is True
+
+    def test_assignment_creates_notification_for_technician(self):
+        iid = _create("scissors")
+        client.post(f"/api/inspections/{iid}/assign", json={"technician": "tech-jane"}, headers=AUTH_MGR)
+        r = client.get("/api/workflow/notifications", headers=AUTH_OPERATOR)
+        assert r.status_code == 200
+
+
+class TestOperationsBoardAndDashboards:
+    def test_operations_board_requires_leadership(self):
+        r = client.get("/api/operations-board", headers=AUTH_OPERATOR)
+        assert r.status_code == 403
+        r = client.get("/api/operations-board", headers=AUTH_MGR)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "technician_workload", "supervisor_queue", "pending_approvals",
+            "high_risk_findings", "repair_queue", "or_urgent_items", "vendor_instruments",
+        ):
+            assert key in body
+
+    def test_daily_operations_dashboard(self):
+        r = client.get("/api/workflow/daily-dashboard", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "inspections_completed_today", "pending_inspections", "high_risk_findings",
+            "average_inspection_time_minutes", "supervisor_backlog", "repair_backlog", "ready_for_packaging",
+        ):
+            assert key in body
+
+    def test_operational_analytics(self):
+        r = client.get("/api/workflow/analytics?days=30", headers=AUTH_MGR)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "inspection_throughput", "technician_productivity", "queue_aging_minutes_avg",
+            "average_turnaround_minutes", "high_risk_workload", "workload_balance",
+        ):
+            assert key in body
+
+
+class TestSmartInspectionQueueAPI:
+    def test_work_queue_endpoint_structure(self):
+        _create("scissors", is_loaner_instrument=True)
+        r = client.get("/api/inspection-work-queue", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "pending_inspections", "high_risk_inspections", "or_priority_instruments",
+            "vendor_trays", "loaner_instruments", "repeat_inspections",
+            "supervisor_reviews", "repair_holds",
+        ):
+            assert key in body
+        assert any(i["is_loaner_instrument"] for i in body["loaner_instruments"])
+
+    def test_queue_item_has_required_display_fields(self):
+        _create("scissors")
+        r = client.get("/api/inspection-work-queue", headers=AUTH_ADMIN)
+        item = r.json()["pending_inspections"][0]
+        for key in (
+            "instrument_type", "procedure_priority", "workflow_state", "risk_tier",
+            "minutes_waiting", "assigned_technician",
+        ):
+            assert key in item

--- a/docs/agents/agent-context-schema.md
+++ b/docs/agents/agent-context-schema.md
@@ -1,0 +1,65 @@
+# Agent Context Objects
+
+`app/agents/context.py` defines every typed context object the pipeline
+passes between agents. All are pydantic `BaseModel`s — structure and
+serialization only, no business logic lives on these classes themselves.
+
+**Rule:** agents communicate only through these objects. No agent reads a
+raw frontend request payload, a raw SQLAlchemy row, or another agent's
+internal state directly — only the orchestrator touches the database on
+the pipeline's behalf, and it always hands the next agent a typed context,
+never the raw row (with two narrow, explicit exceptions noted below).
+
+## Context objects
+
+| Context | Produced by | Key fields |
+|---|---|---|
+| `InstrumentContext` | Instrument Intelligence Agent | `instrument_type`, `manufacturer`, `model`, `instrument_family`, `instrument_category`, `anatomy_zones`, `high_risk_zones`, `ifu_reference`, `digital_twin_available`, `profile_found`, `warning` |
+| `AnatomyContext` | Anatomy Intelligence Agent | `instrument_family`, `anatomy_zones`, `required_zones`, `high_retention_zones`, `inspected_zones` (nullable — `None` means not tagged), `missing_zones`, `inspection_completeness` (nullable) |
+| `CoverageContext` | Inspection Coverage Agent | `coverage_pct`, `required_images`, `missing_images`, `coverage_quality`, `capture_guidance` |
+| `ContaminationContext` | Contamination Detection Agent | `findings: list[ContaminationFinding]`, `has_contamination` |
+| `ContaminationFinding` | (nested) | `finding_type`, `probability`, `severity`, `confidence`, `zone`, `clinical_significance` |
+| `DamageContext` | Damage Detection Agent | `findings: list[DamageFinding]`, `has_damage` |
+| `DamageFinding` | (nested) | `finding_type`, `severity`, `repair_recommendation`, `trend` |
+| `ClinicalReasoningContext` | Clinical Reasoning Agent | `interpretation`, `reasoning_chain` (list of ontology-chain steps — see `docs/knowledge-graph/reasoning-engine.md`), `risk_level`, `risk_score` |
+| `RecommendationContext` | Recommendation Agent | `readiness_state` (one of the six Phase 20 states), `repair_candidate`, `explanation`, `human_review_required` |
+| `SupervisorContext` | Supervisor Agent | `review_exists`, `agreement`, `corrections`, `override_action`, `ground_truth_label`, `training_label_created` |
+| `LearningContext` | Continuous Learning Agent | `knowledge_confidence`, `reasoning_confidence`, `clinical_recommendation_confidence`, `zone_confidence`, `sample_sizes`, `note` |
+| `EnterpriseContext` | Enterprise Intelligence Agent | `facility`, `facility_readiness_rate`, `most_common_contamination_type`, `highest_risk_anatomy_zone`, `note` |
+| `AgentTraceEntry` | Orchestrator | `agent`, `version`, `input_summary`, `output_summary` — one per pipeline step, the Explainable Agent Trace's unit of record |
+
+## Narrow, explicit exceptions
+
+Three agents legitimately need something beyond the previous agent's
+context, and take it as an explicit extra parameter rather than smuggling
+it through a context object that shouldn't own it:
+
+- **Recommendation Agent** takes the real `Inspection` row alongside the
+  `ClinicalReasoningContext`, because the actual readiness classification
+  (`classify_readiness()`, Phase 20) is keyed off the inspection's
+  persisted `recommended_action`/`risk_score`/`score_status` — re-deriving
+  those into a context field the Clinical Reasoning Agent would have to
+  own redundantly would duplicate data ownership, not simplify it.
+- **Supervisor Agent** takes `db` and `inspection_id` directly, because
+  its entire job is a read-only lookup against `SupervisorReview` /
+  `PilotValidationCase` — there's no upstream context that should carry a
+  "has this been reviewed" flag, since that's this agent's own
+  responsibility to determine.
+- **Continuous Learning Agent** and **Enterprise Intelligence Agent** take
+  `db` and `tenant_id` directly for the same reason — they aggregate
+  across the tenant's full dataset, not just the one inspection flowing
+  through the pipeline.
+
+These are documented exceptions, not a loophole — every other agent
+receives *only* typed context objects from its predecessors.
+
+## Why pydantic
+
+Every context object is a pydantic `BaseModel`, matching the convention
+already used for every API request/response schema in this codebase
+(`app/schemas/*.py`). This gives:
+
+- Free `.model_dump()` serialization for the Explainable Agent Trace and
+  the `/api/agents/run/{id}` response.
+- Type validation at construction time — an agent that tries to hand off
+  a malformed context fails immediately, not silently downstream.

--- a/docs/agents/agent-orchestrator.md
+++ b/docs/agents/agent-orchestrator.md
@@ -1,0 +1,77 @@
+# Agent Orchestrator
+
+`app/agents/orchestrator.py::run_pipeline(db, inspection, tenant_id) -> dict`
+runs all ten agents in sequence for one real, already-scored `Inspection`
+row and returns every agent's output context plus the explainable trace.
+
+Exposed at:
+- `GET /api/agents/run/{inspection_id}` — the full result
+- `GET /api/agents/trace/{inspection_id}` — just the trace + final
+  recommendation (a thinner view for the Explainable Agent Trace UI)
+
+## Execution order
+
+```
+1. Instrument Intelligence Agent   (db, tenant_id, instrument_type, manufacturer)
+2. Anatomy Intelligence Agent      (InstrumentContext, inspected_zones)
+3. Inspection Coverage Agent       (instrument_type, AnatomyContext)
+4. Contamination Detection Agent   (instrument_type, detected_issue, confidence, risk_score)
+5. Damage Detection Agent          (detected_issue, risk_score)
+6. Clinical Reasoning Agent        (InstrumentContext, AnatomyContext, CoverageContext,
+                                     ContaminationContext, DamageContext, risk_score)
+7. Recommendation Agent            (Inspection row, ClinicalReasoningContext)
+8. Supervisor Agent                (db, inspection_id)
+9. Continuous Learning Agent       (db, tenant_id)
+10. Enterprise Intelligence Agent  (db, tenant_id, facility)
+```
+
+Steps 4 and 5 both run off the same inspection's single persisted
+`detected_issue` — see the known limitation in
+`docs/agents/multi-agent-architecture.md`. Steps 1–7 are effectively
+per-inspection; steps 8–10 blend one inspection-scoped question ("has
+*this* one been reviewed?") with tenant-wide aggregates (learning
+confidence, enterprise rollups) — this mirrors how a real SPD supervisor
+would actually reason: "is this instrument OK, *and* how are we doing
+overall."
+
+## What the orchestrator does and does not do
+
+**Does:**
+- Decode the inspection's `inspected_zones_json` once, upfront, and pass
+  the decoded list (or `None`, meaning "not tagged") into the Anatomy
+  Agent.
+- Instantiate each agent once at module import time (`_AGENTS` dict) —
+  agents are stateless, so there's no reason to construct new instances
+  per call.
+- Record one `AgentTraceEntry`-shaped dict per agent, in order, building
+  the Explainable Agent Trace.
+- Return `human_review_required: true` on the overall result, in addition
+  to whatever each individual context already carries.
+
+**Does not:**
+- Retry a failed agent — if an agent's underlying service call raises, the
+  whole pipeline run fails loudly (a 500 from the API), rather than
+  silently producing a partial or fabricated result.
+- Cache results across calls — every `run_pipeline()` call recomputes
+  everything live from the current database state, so a trace always
+  reflects the instrument's current status, not a stale snapshot.
+- Write anything to the database. The orchestrator is read-only; the only
+  things that change a real record are the existing supervisor-review and
+  QA-review endpoints, which the Supervisor Agent then reports on.
+
+## Adding a new pipeline step
+
+1. Implement the agent in `app/agents/`, following the existing agents'
+   shape: `NAME`, `VERSION`, `CAPABILITIES`, `DEPENDS_ON` class attributes
+   and a `run()` method that takes typed context objects (plus the narrow
+   exceptions documented in `docs/agents/agent-context-schema.md`) and
+   returns a new typed context.
+2. Add the new context type to `app/agents/context.py`.
+3. Add the agent to `PIPELINE_ORDER` and `_WRAPPED_MODULES` in
+   `app/agents/registry.py`.
+4. Wire the call into `run_pipeline()` in the right position, and append
+   its `_trace_entry()` call.
+5. Add its output to the `run_pipeline()` return dict.
+
+No route or frontend change is required beyond that — the registry and
+trace endpoints read `PIPELINE_ORDER`/the trace list generically.

--- a/docs/agents/agent-registry.md
+++ b/docs/agents/agent-registry.md
@@ -1,0 +1,56 @@
+# Agent Registry
+
+`app/agents/registry.py` — a static registry of every agent in the
+pipeline. `GET /api/agents/registry` returns it; `GET /api/agents/health`
+returns the rollup.
+
+## Fields per entry
+
+| Field | Meaning |
+|---|---|
+| `name` | The agent's display name (e.g. "Instrument Intelligence Agent"). |
+| `version` | Semantic version of the agent's logic (`1.0.0` for all ten at Phase 22 launch). |
+| `capabilities` | What the agent can do — a short list of its `run()` responsibilities. |
+| `depends_on` | Which agent(s) must run first — the pipeline's dependency graph, not just its linear order (most agents depend on exactly the agent before them; some, like Clinical Reasoning, depend on multiple prior agents). |
+| `pipeline_position` | 1–10, the agent's position in `PIPELINE_ORDER`. |
+| `status` | `"active"` for every agent currently in `PIPELINE_ORDER`. A future agent could be registered as `"disabled"` without being removed from the codebase. |
+| `health` | See below. |
+
+## Health checks are honest, not fabricated
+
+Every agent here is deterministic in-process Python — there is no
+external service, no network call, no model server to go down. So
+"health" does not mean uptime or latency (which would be fabricated
+numbers with nothing real behind them). Instead, `_health()` in
+`registry.py` does the one thing that's actually true to check: it
+imports the real module the agent wraps (e.g. the Instrument Intelligence
+Agent's health check imports `app.services.instrument_anatomy`) and
+reports `"ok"` if that import succeeds, `"degraded"` if it doesn't. This
+is a real, if modest, signal — a broken import in a wrapped service would
+surface immediately as `"degraded"` rather than being silently masked.
+
+## Example response
+
+```json
+{
+  "agents": [
+    {
+      "name": "Instrument Intelligence Agent",
+      "version": "1.0.0",
+      "capabilities": ["resolve_instrument_family", "load_anatomy_profile", "check_digital_twin_availability"],
+      "depends_on": [],
+      "pipeline_position": 1,
+      "status": "active",
+      "health": "ok"
+    }
+  ]
+}
+```
+
+## Extending the registry
+
+To add an eleventh agent: implement it in `app/agents/`, add it to
+`PIPELINE_ORDER` and `_WRAPPED_MODULES` in `registry.py`, and wire it into
+`orchestrator.py`'s sequence. The registry endpoint and the frontend
+Agent Trace viewer (`/agent-trace`) both read `PIPELINE_ORDER` directly —
+no separate registration step is needed beyond that.

--- a/docs/agents/explainable-agent-trace.md
+++ b/docs/agents/explainable-agent-trace.md
@@ -1,0 +1,95 @@
+# Explainable Agent Trace
+
+## What it shows
+
+For any real inspection, `GET /api/agents/trace/{inspection_id}` (and the
+`/agent-trace` frontend page) shows exactly which agent produced which
+decision, in order:
+
+```
+Instrument Agent
+    ↓
+Rigid Scope
+    ↓
+Anatomy Agent
+    ↓
+O-ring
+    ↓
+Contamination Agent
+    ↓
+Blood
+    ↓
+Reasoning Agent
+    ↓
+High retention
+    ↓
+Recommendation Agent
+    ↓
+Reprocess
+```
+
+This is not a separate explanation system bolted onto the pipeline — it
+*is* the pipeline. Every `AgentTraceEntry` (see
+`docs/agents/agent-context-schema.md`) is recorded as each agent actually
+runs inside `run_pipeline()`, so the trace can never drift from what
+really happened; there's no separate "explain this after the fact" code
+path that could tell a different story than the real one.
+
+## Trace entry shape
+
+```json
+{
+  "agent": "Contamination Detection Agent",
+  "version": "1.0.0",
+  "input_summary": {"detected_issue": "blood"},
+  "output_summary": {
+    "findings": [{"finding_type": "blood", "zone": "hinge", "severity": "high", ...}],
+    "has_contamination": true
+  }
+}
+```
+
+`input_summary` is a small, human-readable digest of what the agent was
+given — not the full upstream context (which would be redundant with the
+previous entry's `output_summary`). `output_summary` is the agent's full
+typed context, serialized.
+
+## Reading a trace end to end
+
+1. **Instrument Intelligence Agent** — resolves what instrument this is.
+2. **Anatomy Intelligence Agent** — resolves its zones and what's missing.
+3. **Inspection Coverage Agent** — how complete was this inspection's
+   image capture.
+4. **Contamination Detection Agent** / **Damage Detection Agent** — what
+   was actually found (at most one of these two will be non-empty per the
+   current schema — see `docs/agents/multi-agent-architecture.md`).
+5. **Clinical Reasoning Agent** — the plain-language interpretation and
+   the full ontology reasoning chain (reuses
+   `docs/knowledge-graph/reasoning-engine.md`'s chain).
+6. **Recommendation Agent** — the final packaging-readiness state and why.
+7. **Supervisor Agent** — has a human already weighed in on this one?
+8. **Continuous Learning Agent** — how much should we trust the current
+   knowledge base, given how many real reviews back it up right now?
+9. **Enterprise Intelligence Agent** — where does this fit in the bigger
+   picture (facility readiness, most common contamination type this
+   tenant sees).
+
+## Why this replaces "I detected blood."
+
+Before this pipeline existed, an inspection's output was one field:
+`detected_issue = "blood"`. After it, a supervisor (or an auditor, or a
+new hire being trained) can expand every step and see *why* the system
+landed on its recommendation — which zone, which retention risk, which
+clinical rule, which prior reviews inform the current confidence level.
+This is the same transparency goal as Phase 21's "Why?" explainability
+graph (`docs/knowledge-graph/reasoning-engine.md`), extended across the
+*entire* pipeline rather than just the finding-to-recommendation step.
+
+## Honesty about what the trace is not
+
+The trace is not a live multi-agent conversation, a chain-of-thought log
+from an LLM, or evidence of autonomous agent negotiation. It is an
+ordered, structured record of ten deterministic function calls. That's
+precisely why it's trustworthy as an audit artifact — every line in it
+corresponds to a real, testable, reviewable piece of code
+(`backend/tests/test_agents_pipeline.py`).

--- a/docs/agents/multi-agent-architecture.md
+++ b/docs/agents/multi-agent-architecture.md
@@ -1,0 +1,111 @@
+# Multi-Agent Clinical Intelligence Platform
+
+## Objective
+
+Move LumenAI from one monolithic scoring pass to a pipeline of specialized
+agents, each owning a specific slice of SPD expertise, all operating on
+the same Clinical Ontology (`docs/architecture/lumenai-clinical-ontology.md`)
+and Clinical Knowledge Graph (`docs/knowledge-graph/`). No agent bypasses
+that architecture.
+
+## What "agent" means here
+
+Every agent in this pipeline is a small, deterministic Python class that
+wraps **existing, already-tested services** — `instrument_anatomy.py`,
+`instrument_zones.py`, `inspection_coverage.py`, `clinical_mentor.py`,
+`knowledge_graph_service.py`, `pre_sterilization_command_center_service.py`.
+No agent introduces new detection logic, no agent calls an LLM, and no
+agent is a black box. This is honest about the platform's current
+capability level — consistent with Phase 17's model-lifecycle framing
+("training not started," nothing fabricated) — while establishing the
+*structure* specialized agents will eventually run inside, per
+`docs/knowledge-graph/agent-architecture.md`'s planned agent boundaries.
+
+This module is distinct from the pre-existing, unrelated
+`app/agent/spd_agent.py` (a single-purpose legacy summary generator) — the
+new package lives at `app/agents/` (plural) to avoid confusion.
+
+## The pipeline
+
+```
+Image Acquisition
+    ↓
+Computer Vision (existing scoring engine — already ran before this pipeline)
+    ↓
+Instrument Intelligence Agent
+    ↓
+Anatomy Intelligence Agent
+    ↓
+Inspection Coverage Agent
+    ↓
+Contamination Detection Agent
+    ↓
+Damage Detection Agent
+    ↓
+Clinical Reasoning Agent
+    ↓
+Recommendation Agent
+    ↓
+Supervisor Agent
+    ↓
+Continuous Learning Agent
+    ↓
+Enterprise Intelligence Agent
+```
+
+Each arrow is a typed context object handoff — see
+`docs/agents/agent-context-schema.md`. The orchestrator
+(`app/agents/orchestrator.py`) runs this exact sequence for one real,
+already-scored inspection; see `docs/agents/agent-orchestrator.md`.
+
+## The ten agents
+
+| # | Agent | Module | Owns |
+|---|---|---|---|
+| 1 | Instrument Intelligence Agent | `app/agents/instrument_agent.py` | Manufacturer/family/model/category resolution, anatomy profile load, IFU lookup, digital-twin availability check |
+| 2 | Anatomy Intelligence Agent | `app/agents/anatomy_agent.py` | Anatomy zones, required views, high-retention areas, inspected/missing zones |
+| 3 | Inspection Coverage Agent | `app/agents/coverage_agent.py` | Coverage %, missing images, capture guidance |
+| 4 | Contamination Detection Agent | `app/agents/contamination_agent.py` | Blood, bone, tissue, organic residue, debris |
+| 5 | Damage Detection Agent | `app/agents/damage_agent.py` | Rust, corrosion, crack, pitting, wear, missing component, insulation damage |
+| 6 | Clinical Reasoning Agent | `app/agents/clinical_reasoning_agent.py` | Interpretation, reasoning chain, risk assessment |
+| 7 | Recommendation Agent | `app/agents/recommendation_agent.py` | Packaging-readiness classification + explanation |
+| 8 | Supervisor Agent | `app/agents/supervisor_agent.py` | Reports (never fabricates) human agreement/corrections/override/training-label status |
+| 9 | Continuous Learning Agent | `app/agents/learning_agent.py` | Live knowledge/reasoning/recommendation/zone confidence |
+| 10 | Enterprise Intelligence Agent | `app/agents/enterprise_agent.py` | Facility/manufacturer/contamination-type/zone aggregation |
+
+Section 4 and 5's finding ownership split reflects the platform's real
+finding-type taxonomy — contamination types are biological soil,
+damage types are structural/mechanical — and the split makes each agent's
+severity and remediation logic (reclean vs. repair/remove) unambiguous.
+
+## Non-negotiable rules
+
+1. **No agent bypasses the architecture.** Every agent's output must be
+   traceable to the Clinical Ontology chain. An agent that invents a
+   finding type, a zone name, or an outcome value outside the frozen
+   five-value decision engine (`docs/architecture/lumenai-clinical-intelligence-architecture.md`
+   Layer 7) is a bug, not a feature.
+2. **Agents communicate only through typed context objects** — see
+   `docs/agents/agent-context-schema.md`. No agent reads raw frontend
+   state or an unstructured dict from another agent.
+3. **The Supervisor Agent never fabricates a supervisor decision.** Human
+   expertise is the final authority (Design Principle 4,
+   `docs/architecture/design-principles.md`) — this agent is read-only.
+4. **The Continuous Learning Agent never mutates a persisted model
+   state.** It reports live-recomputed confidence, consistent with Phase
+   21's `learning_confidence()`.
+5. **Every agent's output carries `human_review_required` through to the
+   final recommendation** — the pipeline never auto-disposes an
+   instrument.
+
+## Known current limitation
+
+The Contamination and Damage Detection Agents currently read a single
+persisted `detected_issue` field per `Inspection` row — the schema does
+not yet store multiple simultaneous findings per inspection (a richer
+per-KPI findings list exists only transiently in the scoring engine's live
+response, not persisted). This means, for a real historical inspection,
+at most one of the two agents will report a finding today. This is stated
+honestly in both agents' module docstrings rather than papered over —
+persisting multiple findings per inspection is future schema work, not a
+Phase 22 deliverable.

--- a/docs/architecture/architecture-enforcement-checklist.md
+++ b/docs/architecture/architecture-enforcement-checklist.md
@@ -1,0 +1,74 @@
+# Architecture Enforcement Checklist
+
+Every future feature — a new finding type, a new dashboard, a new model, a
+new report, a new API endpoint — must be able to answer **yes** to each of
+these before it ships. This is the operational gate behind the design
+principles in `docs/architecture/design-principles.md` and the layered
+architecture in
+`docs/architecture/lumenai-clinical-intelligence-architecture.md`.
+
+## The checklist
+
+1. **Does it identify the instrument?**
+   The feature knows which instrument family (and manufacturer/model,
+   where available) it's operating on — it does not reason about a bare
+   image. *(Architecture Layer 3, Ontology: Instrument → Instrument
+   Family)*
+
+2. **Does it use anatomy or zone context?**
+   Any finding, score, or recommendation is attributed to a resolved
+   anatomy zone, not a generic "somewhere on the instrument." *(Layer 4,
+   Ontology: Anatomy → Inspection Zone)*
+
+3. **Does it map findings to SPD risk?**
+   The feature knows whether the zone/finding combination is high-risk /
+   high-retention, and that classification is visible in the output, not
+   buried. *(Layer 6, Ontology: SPD Risk)*
+
+4. **Does it generate clinical reasoning?**
+   The output explains *why* something matters (zone risk, baseline
+   deviation, severity) rather than presenting a bare score or label.
+   *(Layer 6, Design Principle 3)*
+
+5. **Does it support human validation?**
+   A supervisor can see the feature's output, agree, disagree, correct it,
+   and have that correction persisted as labeled data. *(Layer 8, Design
+   Principle 4)*
+
+6. **Does it preserve auditability?**
+   Every consequential action (a submission, an override, a data export,
+   an intelligence-sharing event) creates an audit event
+   (`app/audit.py::log_audit_event`) with `compliance_flag` set where
+   appropriate. *(Ontology: Audit Event)*
+
+7. **Does it avoid making post-sterilization claims?**
+   No output implies LumenAI monitors, measures, or validates the
+   sterilization cycle itself — see
+   `docs/architecture/pre-sterilization-boundary.md` for the banned
+   phrases and preferred terminology.
+
+8. **Does it contribute to continuous learning?**
+   Where the feature produces or touches a supervisor decision, that
+   decision becomes a Training Label (or is deliberately excluded, with a
+   documented reason) rather than being discarded. *(Layer 9, Ontology:
+   Learning Signal)*
+
+## How to apply it
+
+- **Code review:** reviewers should be able to point to where in the diff
+  each "yes" is satisfied. A feature that can't answer one of these isn't
+  necessarily wrong, but it needs a written exception in its PR
+  description explaining why — not silence.
+- **New AI capability:** before adding a new model or finding type, walk
+  it through the full ontology chain
+  (`docs/architecture/lumenai-clinical-ontology.md`) and confirm each link
+  is populated, not just the new one being added.
+- **New dashboard/report:** confirm every metric it surfaces is traceable
+  to real rows in the domain model
+  (`docs/architecture/domain-model.md`) — no fabricated or simulated
+  numbers presented as real, consistent with existing platform practice
+  (Phase 12/15/17/18 all compute from live data and return `null` rather
+  than a fabricated zero when data doesn't exist yet).
+- **Terminology:** any new user-facing or generated string should be
+  checked against the pre-sterilization boundary's do/don't list before
+  merge.

--- a/docs/architecture/design-principles.md
+++ b/docs/architecture/design-principles.md
@@ -1,0 +1,78 @@
+# LumenAI Design Principles
+
+These four principles are non-negotiable. Any feature, model, or API that
+violates one needs a documented exception approved before merge, not a
+silent workaround.
+
+## 1. Instrument-first, not image-first
+
+An image is only meaningful once it is attached to a resolved instrument
+(family, manufacturer, model where known). LumenAI does not run generic
+image classification against an anonymous photo — it always asks "what
+instrument is this?" (Layer 3) before asking "what do I see?" (Layer 5).
+
+*Why it matters:* the same visual pattern means something completely
+different on a Kerrison rongeur's box lock than on a flexible endoscope's
+biopsy channel. Skipping instrument identification produces findings that
+can't be zone-weighted, baseline-compared, or clinically interpreted.
+
+## 2. Anatomy-first reasoning
+
+Every finding is reasoned about through the resolved instrument's anatomy
+profile — its zones, its high-retention areas, its required inspection
+views — never through the raw pixel location alone.
+*Implemented by:* `app/services/instrument_anatomy.py`,
+`app/services/instrument_zones.py`.
+
+*Why it matters:* "residue near a joint" is only actionable once you know
+whether that joint is a low-risk handle seam or a high-retention box lock
+that traps blood between uses.
+
+## 3. Clinical reasoning before prediction
+
+A raw detection ("blood: 0.83 confidence") is not a LumenAI output. Every
+finding must pass through the clinical reasoning engine (Layer 6) — zone
+risk, baseline comparison, evidence strength — before it becomes a
+recommendation. LumenAI never presents a bare model score as an answer.
+
+## 4. Human expertise is the final authority
+
+The AI never disposes of an instrument on its own. Every recommendation is
+advisory; the supervisor's review and, where applicable, override is what
+actually determines what happens to the instrument (Layer 8). This is
+enforced structurally, not just by policy: the model registry's deployment
+gate (`app/models/model_registry.py`) requires a human-approved promotion
+before any model stage can drive or advise a decision beyond shadow mode.
+
+## Examples
+
+**Bad:**
+> "Blood detected."
+
+This is a raw detection. It has no instrument, no zone, no clinical
+framing, and gives a supervisor nothing to act on beyond re-looking at the
+whole instrument.
+
+**Good:**
+> "Blood indicators detected in Kerrison jaw serrations, a high-retention
+> zone requiring brushing and reprocessing."
+
+This names the instrument context (Kerrison), the zone (jaw serrations),
+why the zone matters (high-retention), and the concrete next action
+(brushing and reprocessing) — the output of Layers 3 through 7 working
+together, not a bare Layer 5 detection.
+
+## Applying the principles
+
+Before shipping any new finding type, model, or dashboard metric, ask:
+
+1. Does it know what instrument it's looking at? (Principle 1)
+2. Does it know where on the instrument, and why that location matters?
+   (Principle 2)
+3. Does it explain clinical significance before recommending an action?
+   (Principle 3)
+4. Can a supervisor see it, disagree with it, and override it? (Principle 4)
+
+If the answer to any of these is no, the feature is not finished — see
+`docs/architecture/architecture-enforcement-checklist.md` for the full
+gate.

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -1,0 +1,228 @@
+# LumenAI Domain Model
+
+Core entities of the platform, each mapped to its purpose in the clinical
+ontology, its required fields, its relationships, and how it's used
+downstream. Field lists are the conceptually required fields, not an
+exhaustive column dump — see the cited model file for the full schema.
+
+## Instrument
+
+- **Purpose:** the physical object under inspection; the root of the
+  ontology chain.
+- **Required fields:** `instrument_type`, tenant, image reference
+  (`has_image`, `image_sha256`).
+- **Relationships:** resolves to an Instrument Family (via
+  `resolve_family`); has zero-or-more Inspection Images; has a Baseline
+  where one exists; is the subject of one or more Clinical Decisions.
+- **Downstream use:** every AI Finding, Clinical Decision, and Supervisor
+  Review is scoped to an inspection of one instrument.
+- **Owning model:** `app/models/inspection.py` (`Inspection`).
+
+## Manufacturer
+
+- **Purpose:** who made the instrument — needed to resolve the correct
+  Baseline and Instrument Knowledge entry.
+- **Required fields:** manufacturer name, registration/reference IDs.
+- **Relationships:** has many Models; has many Baselines.
+- **Downstream use:** baseline matching, vendor intelligence, recall
+  correlation.
+- **Owning model:** `app/models/manufacturer_reg.py`,
+  `app/models/instrument_registry.py` (`manufacturer_name`).
+
+## Model
+
+- **Purpose:** the specific instrument model/UDI — the finest-grained
+  identity below manufacturer.
+- **Required fields:** `model_name`, `udi`, `instrument_category`.
+- **Relationships:** belongs to a Manufacturer; has a Baseline; has an
+  Instrument Knowledge entry (anatomy zones, failure modes, maintenance
+  interval).
+- **Downstream use:** baseline comparison scoring, instrument knowledge
+  lookups, network benchmarking.
+- **Owning model:** `app/models/baseline_library.py`
+  (`BaselineLibraryEntry`), `app/models/instrument_knowledge.py`.
+
+## Baseline
+
+- **Purpose:** the reference condition (manufacturer or site-submitted) an
+  inspection is compared against.
+- **Required fields:** `instrument_category`, `manufacturer_name`,
+  `model_name`, `baseline_type` (manufacturer/site), `approval_status`.
+- **Relationships:** belongs to a Manufacturer/Model; referenced by every
+  Clinical Decision that performs a baseline comparison; audited by
+  `app/models/vendor_baseline_audit.py`.
+- **Downstream use:** `baseline_comparison_scoring_service.py`'s
+  `baseline_difference` and `evidence_strength` outputs; Phase 18's
+  `baseline_source` / `has_baseline` cohort tracking.
+- **Owning model:** `app/models/baseline_library.py`.
+
+## Anatomy Profile
+
+- **Purpose:** the resolved instrument family's zone map — its zones,
+  high-risk zones, required inspection views, and manual-check guidance.
+- **Required fields:** `instrument_family`, `anatomy_zones`,
+  `high_risk_zones`, `recommended_image_views`.
+- **Relationships:** derived from Instrument Family; feeds Inspection
+  Zone resolution and Inspection Coverage scoring.
+- **Downstream use:** zone-aware scoring, coverage checks, mentor
+  explanations.
+- **Owning service:** `app/services/instrument_anatomy.py`
+  (`anatomy_profile`, `get_anatomy`).
+
+## Inspection Zone
+
+- **Purpose:** the specific high-risk (or low-risk) location on the
+  instrument a finding is attributed to.
+- **Required fields:** `instrument_zone`, `zone_risk`, `zone_confidence`,
+  `assignment_method`.
+- **Relationships:** belongs to an Anatomy Profile; attached to every AI
+  Finding; correctable by a Supervisor Review
+  (`supervisor_zone_correction` / `corrected_zone`).
+- **Downstream use:** Phase 18 zone performance metrics (miss rate,
+  override rate, mean confidence per zone).
+- **Owning service:** `app/services/instrument_zones.py`.
+
+## Inspection Image
+
+- **Purpose:** the captured image evidence for an inspection (and,
+  separately, an opt-in retained training image).
+- **Required fields:** `sha256`, `content_type`, `exif_stripped`,
+  `consent_recorded` (for retained images), no PHI.
+- **Relationships:** belongs to an Instrument/Inspection; may be promoted
+  to a `RetainedImage` for training with consent.
+- **Downstream use:** CV inference input; training dataset construction.
+- **Owning models:** `app/models/inspection.py` (`image_sha256`,
+  `has_image`), `app/models/retained_image.py` (`RetainedImage`).
+
+## AI Finding
+
+- **Purpose:** a detected clinical characteristic (blood, crack, missing
+  component, …) with its zone and severity attached.
+- **Required fields:** `type`/`finding_type`, `severity_index`/`severity`,
+  `instrument_zone`, confidence.
+- **Relationships:** belongs to an inspection; located in an Inspection
+  Zone; interpreted by the Clinical Reasoning Engine; may become a Training
+  Label.
+- **Downstream use:** clinical decision input; safety metrics (Phase 18
+  critical false-negative rates by finding type).
+- **Owning service:** `app/services/baseline_comparison_scoring_service.py`
+  (`predicted_findings`).
+
+## Clinical Decision
+
+- **Purpose:** the AI's interpreted recommendation for what should happen
+  to the instrument (Architecture Layer 7).
+- **Required fields:** `outcome`/`recommended_action`, `reasoning`,
+  `interpretation`, `evidence_strength`, `baseline_difference`.
+- **Relationships:** produced from one or more AI Findings plus baseline
+  comparison; reviewed and potentially overridden by a Supervisor Review.
+- **Downstream use:** operational disposition; audit trail; supervisor
+  review comparison (`ai_recommendation` snapshot).
+- **Owning service:** `app/services/baseline_comparison_scoring_service.py`
+  (`ai_clinical_review`), `app/services/clinical_mentor.py`.
+
+## Supervisor Review
+
+- **Purpose:** the human validation record — agreement, correction, final
+  disposition, and rationale.
+- **Required fields:** `agreement`, `rationale` (required on
+  disagreement/override), `finding_correct`, `zone_correct`,
+  `corrected_zone`, `final_disposition`.
+- **Relationships:** references an Inspection and its Clinical Decision;
+  is the direct source of a Training Label (Phase 18
+  `PilotValidationCase`).
+- **Downstream use:** model-performance aggregation, ground-truth
+  labeling, audit trail.
+- **Owning model:** `app/models/supervisor_review.py`.
+
+## Training Label
+
+- **Purpose:** the confusion-matrix ground truth (TP/TN/FP/FN/
+  inconclusive) derived from comparing an AI prediction to a supervisor's
+  confirmed finding.
+- **Required fields:** `ai_prediction`, `supervisor_finding`,
+  `ground_truth_label` (always server-derived, never client-supplied),
+  `is_critical_finding`.
+- **Relationships:** derived from a Supervisor Review + its Inspection;
+  feeds Model Version evaluation and Dataset Version composition.
+- **Downstream use:** clinical performance metrics, zone performance,
+  safety review queue, go/no-go readiness gate (Phase 18).
+- **Owning model:** `app/models/pilot_validation.py`
+  (`PilotValidationCase`); also `app/models/retained_image.py`
+  (`ImageLabel`) for image-level training labels and
+  `app/models/shadow_prediction.py` for pre-deployment shadow evaluation.
+
+## Digital Twin
+
+- **Purpose:** a simulated/forecast quality state for a tenant or
+  instrument population, used for scenario planning rather than live
+  inspection.
+- **Required fields:** current state snapshot, forecast horizon,
+  intervention model reference.
+- **Relationships:** aggregates across many Inspections/Clinical
+  Decisions; independent of any single instrument.
+- **Downstream use:** executive decision briefs, scenario simulation.
+- **Owning models:** `app/models/digital_quality_twin.py`
+  (`QualityTwinState`, `ScenarioSimulation`, `QualityForecast`,
+  `InterventionModel`, `ExecutiveDecisionBrief`, `ForecastOutcome`),
+  `app/models/digital_twin.py`.
+
+## Knowledge Graph Node
+
+- **Purpose:** a network-level entity (instrument risk signal, recall
+  early-warning, participant) used for cross-hospital intelligence.
+- **Required fields:** node type, anonymized facility reference (never a
+  raw hospital identity — see CLAUDE.md security constraints), signal
+  payload.
+- **Relationships:** connects Instrument/Model entities across tenants
+  without exposing tenant-identifying data.
+- **Downstream use:** global recall early warning, network benchmarking.
+- **Owning models:** `app/models/global_intelligence.py`
+  (`GlobalIntelligenceSignal`, `InstrumentRiskRegistryEntry`,
+  `GlobalRecallEarlyWarning`, `GSINParticipant`),
+  `app/models/quality_intelligence.py` (`EnterpriseRiskNode`,
+  `EnterpriseRiskEdge`).
+
+## Model Version
+
+- **Purpose:** one row per trained model, its evaluation metrics, known
+  limitations, and approval stage.
+- **Required fields:** `model_id`, `model_version`, `model_type`,
+  `dataset_version`, `evaluation_metrics`, `approval_status`
+  (experimental/pilot/validated/deprecated), `approved_by`.
+- **Relationships:** trained from a Dataset Version; evaluated against
+  Training Labels; gated by the deployment-gate checklist before
+  promotion.
+- **Downstream use:** deployment gate (`app/services/ml/deployment_gates.py`),
+  shadow-mode reconciliation.
+- **Owning model:** `app/models/model_registry.py`
+  (`ModelRegistryEntry`).
+
+## Dataset Version
+
+- **Purpose:** a labeled, versioned, leakage-free training/eval/test split.
+- **Required fields:** version label, split ratios, stratification keys
+  (family/zone/finding/severity/manufacturer/image-quality), leakage
+  guarantees (an inspection's images never straddle splits).
+- **Relationships:** composed of Training Labels; referenced by a Model
+  Version's `dataset_version`; referenced by a Phase 18
+  `PilotValidationCase.dataset_version`.
+- **Downstream use:** reproducible evaluation, validation report
+  provenance.
+- **Owning service:** `app/services/ml/dataset_split.py`.
+
+## Audit Event
+
+- **Purpose:** the immutable compliance record of every consequential
+  action — supervisor review, ground-truth submission, intelligence
+  sharing, data export.
+- **Required fields:** `tenant_id`, `actor_email`, `actor_role`,
+  `action_type`, `resource_type`, `resource_id`, `compliance_flag`,
+  `event_hash` / `previous_event_hash` (tamper-evident chain).
+- **Relationships:** references whatever resource triggered it
+  (Inspection, Supervisor Review, PilotValidationCase, …); never itself
+  referenced by anything else — it is the terminal record.
+- **Downstream use:** compliance exports, trust center, governance
+  reconciliation.
+- **Owning model:** `app/models/audit_log.py` (`AuditLog`),
+  `app/audit.py` (`log_audit_event`).

--- a/docs/architecture/future-ai-roadmap.md
+++ b/docs/architecture/future-ai-roadmap.md
@@ -1,0 +1,57 @@
+# Future AI Roadmap
+
+Ten stages, from the deterministic heuristics running today to full
+computer-vision localization and network-scale intelligence. Every stage
+must be built inside the architecture and ontology frozen in this
+directory — a new stage is a new capability at an existing ontology link,
+never a parallel system.
+
+| Stage | Capability | Status |
+|---|---|---|
+| 1 | Heuristic baseline comparison and scoring | **Shipped.** `app/services/baseline_comparison_scoring_service.py` compares an inspection against its manufacturer/site baseline and produces evidence strength + baseline difference. Deterministic, not ML. |
+| 2 | Instrument family classification | **Shipped (deterministic); ML not trained.** `app/services/instrument_anatomy.py::resolve_family` classifies by keyword matching today. Phase 17 (`app/services/ml/model_tasks.py`) defines the label space for a future ML classifier; training has not started (no labeled dataset yet). |
+| 3 | Anatomy zone classification | **Shipped (deterministic pilot logic); ML not trained.** `app/services/instrument_zones.py::zone_fields` assigns a zone from instrument type + finding type, honestly labeled `assignment_method: "pilot_zone_assignment"` with confidence capped below 1.0 — this is explicitly *not* pixel-level localization. |
+| 4 | Finding classification | **Partially shipped.** Findings come from declared/heuristic inputs today (`predicted_findings`); `app/models/cv_inference.py` and the Phase 17 feature store scaffold CV-derived features but store them `null` until a trained model exists. |
+| 5 | Severity classification | **Partially shipped.** Rule-based severity/risk-score bucketing exists (`severity_from_risk_score` in `app/services/pilot_validation_service.py` and equivalents elsewhere); no learned severity model yet. |
+| 6 | Zone-aware clinical decision support | **Shipped.** `app/services/baseline_comparison_scoring_service.py::ai_clinical_review` and `app/services/clinical_mentor.py::ai_mentor` combine zone risk, baseline comparison, and evidence strength into a recommendation with plain-language reasoning. |
+| 7 | Heatmaps and bounding boxes | **Not started — deliberately.** The platform currently asserts the opposite: no fabricated bounding-box or heatmap language is emitted (`docs/clinical` / `test_ai_clinical_review.py::test_no_fabricated_localization`). This stage requires real pixel-level CV output before any visual overlay is shown. |
+| 8 | Segmentation overlays | **Not started.** Depends on Stage 7 being real first. |
+| 9 | Predictive instrument degradation | **Scaffolded.** `app/models/digital_quality_twin.py` (`QualityForecast`, `ScenarioSimulation`, `InterventionModel`) and `app/models/instrument_knowledge.py` (maintenance intervals, known failure modes) provide the data model; predictions are not yet driven by a trained degradation model. |
+| 10 | Enterprise benchmarking and knowledge graph intelligence | **Shipped, ongoing.** `app/models/network_benchmark.py`, `app/models/global_intelligence.py`, `app/models/quality_intelligence.py` provide cross-tenant, anonymized benchmarking and risk-signal aggregation today; expands as more tenants and instrument families onboard. |
+
+## How a stage graduates from scaffold to real
+
+The Phase 17 model lifecycle governs every ML-backed stage (2, 3, 4, 5, 9):
+
+```
+Data → Labels → Training → Evaluation → Registry → Shadow Mode → Pilot → Validation → Deployment
+```
+
+- **Labels** come from the ontology's Learning Signal link — real
+  supervisor decisions via `app/models/pilot_validation.py`
+  (`PilotValidationCase`), not synthetic data.
+- **Registry** entries (`app/models/model_registry.py`) start
+  `experimental` and can only reach `validated` through a human-approved
+  promotion that requires a completed checklist (including a minimum
+  sample size) — no auto-promotion.
+- **Shadow Mode** (`app/models/shadow_prediction.py`) lets a candidate
+  model run silently, reconciled against the human's actual decision,
+  before it ever drives or advises anything.
+- **Pilot / Validation** is Phase 18's ground-truth review and go/no-go
+  gate (`docs/validation/pilot-go-no-go-criteria.md`) — a model cannot be
+  called "validated" without clearing that gate's critical-finding
+  false-negative and supervisor-agreement thresholds.
+
+A stage is not "shipped" in the sense of this roadmap until it has passed
+through that full lifecycle with real data — a working heuristic (Stages
+1, 2, 3, 6 today) is a legitimate v1 implementation of a layer, but it is
+labeled honestly as heuristic/deterministic rather than presented as a
+trained model.
+
+## Priority signal from Phase 18
+
+The pilot validation dashboard's `zone_performance_summary` (most-missed
+zones, lowest-confidence zones) is the concrete input that should
+prioritize which Stage 2–5 model gets trained first: whichever zone or
+finding type shows the highest miss rate against real supervisor ground
+truth is the next training priority, not a roadmap guess.

--- a/docs/architecture/lumenai-clinical-intelligence-architecture.md
+++ b/docs/architecture/lumenai-clinical-intelligence-architecture.md
@@ -74,29 +74,28 @@ supervisor knowledge, and SPD rules.
 `app/services/clinical_mentor.py` (`ai_mentor`).
 
 ### Layer 7 — Clinical Decision Engine
-Recommend a disposition:
+Recommend a disposition. **The adopted vocabulary is the five-value outcome
+already implemented in `app/services/baseline_comparison_scoring_service.py`
+(`_ACTION_TEXT`) — this is the frozen v1 vocabulary for this layer, not a
+placeholder:**
 
-- READY FOR PACKAGING
-- READY FOR STERILIZATION
-- REQUIRES RECLEANING
+- PASS
+- MONITOR
 - SUPERVISOR REVIEW
-- REPAIR
+- REPROCESS
 - REMOVE FROM SERVICE
 
-**Current implementation status:** the v1 scoring engine
-(`app/services/baseline_comparison_scoring_service.py`, `_ACTION_TEXT`)
-outputs a five-value outcome — `PASS`, `MONITOR`, `SUPERVISOR REVIEW`,
-`REPROCESS`, `REMOVE FROM SERVICE` — which is the working v1 realization of
-this layer, predating this document. It maps onto the target vocabulary
-above as: `PASS`/`MONITOR` → *READY FOR PACKAGING* (with `MONITOR` flagging
-a recheck note), `REPROCESS` → *REQUIRES RECLEANING*, `SUPERVISOR REVIEW`
-→ *SUPERVISOR REVIEW*, `REMOVE FROM SERVICE` → *REMOVE FROM SERVICE*.
-*REPAIR* and an explicit *READY FOR STERILIZATION* terminal state (distinct
-from packaging) are not yet separated out in code. Per Phase 19.5 §10,
-existing code is not being renamed to avoid breaking the ~2,300-test
-regression suite that asserts on the current strings; new decision-engine
-work should adopt the six-value vocabulary directly rather than extending
-the five-value one.
+An earlier draft of this document proposed a six-value alternative (READY
+FOR PACKAGING / READY FOR STERILIZATION / REQUIRES RECLEANING / REPAIR /
+SUPERVISOR REVIEW / REMOVE FROM SERVICE). That vocabulary was rejected in
+favor of keeping the original five values, which the entire regression
+suite (~2,300 tests) already asserts against and which have been in
+production use since earlier phases. Future decision-engine work should
+extend or refine these five values rather than introduce a second,
+parallel vocabulary — e.g. if a REPAIR-vs-REMOVE-FROM-SERVICE distinction
+is ever needed, it should be added as a sixth value or a sub-field on the
+existing outcome, decided deliberately and reflected here, not layered on
+silently.
 
 ### Layer 8 — Human Validation
 Supervisor review and override — the point at which a human either

--- a/docs/architecture/lumenai-clinical-intelligence-architecture.md
+++ b/docs/architecture/lumenai-clinical-intelligence-architecture.md
@@ -1,0 +1,138 @@
+# LumenAI Clinical Intelligence Architecture v1.0
+
+**Status:** Frozen reference architecture (Phase 19.5). Every future feature,
+model, API, dashboard, dataset, and report must be traceable to a layer in
+this document and to the ontology in
+`docs/architecture/lumenai-clinical-ontology.md`.
+
+## 1. Mission Statement
+
+> LumenAI is an AI-powered Pre-Sterilization Clinical Inspection Platform
+> that prevents contaminated, damaged, or clinically unsafe surgical
+> instruments from progressing to packaging and sterilization — by
+> combining instrument intelligence, anatomy-aware computer vision,
+> clinical reasoning, and human expertise.
+
+### What LumenAI is not
+
+- LumenAI is **not** a sterilization monitoring system.
+- LumenAI is **not** a biological indicator system.
+- LumenAI is **not** a sterilizer quality system.
+- LumenAI **is** the intelligent clinical inspection gate that sits
+  *before* packaging and sterilization — see
+  `docs/architecture/pre-sterilization-boundary.md` for the exact workflow
+  boundary and the terminology this implies.
+
+LumenAI does not measure, monitor, or attest to whether a sterilization
+cycle achieved sterility. It determines whether an instrument is clean,
+intact, and correctly identified enough to *proceed toward* that cycle.
+
+## 2. Architecture v1.0 — The Ten Layers
+
+Each layer below names the real modules that implement it today (v1) so
+this document stays a description of the system, not an aspiration.
+
+### Layer 1 — Image Acquisition
+Capture inspection images and metadata (instrument, site, facility,
+department, tray, barcode/UDI, capture device).
+*Implemented by:* `app/routes/inspections.py`, `app/models/inspection.py`,
+`app/models/capture_device.py`, `app/services/ml/model_tasks.py` (identifier
+decode).
+
+### Layer 2 — Computer Vision
+Detect visual characteristics from the captured image.
+*Implemented by:* `app/models/cv_inference.py`, `app/services/ml/` (feature
+store, evaluation). Honesty constraint: CV-derived features that are not
+yet computed are stored as `null`, never fabricated.
+
+### Layer 3 — Instrument Intelligence
+Identify manufacturer, instrument family, model, and type.
+*Implemented by:* `app/services/instrument_anatomy.py` (`resolve_family`),
+`app/models/instrument_registry.py`, `app/models/manufacturer_reg.py`,
+`app/models/baseline_library.py`.
+
+### Layer 4 — Anatomy Intelligence
+Understand anatomy zones, high-risk retention areas, required views, and
+inspection coverage for the resolved instrument family.
+*Implemented by:* `app/services/instrument_anatomy.py` (`anatomy_profile`,
+`get_anatomy`), `app/services/instrument_zones.py` (zone taxonomy,
+`HIGH_RETENTION_ZONES`), `app/services/inspection_coverage.py`.
+
+### Layer 5 — Clinical Finding Intelligence
+Detect blood, bone, tissue, organic residue, debris, rust, corrosion,
+crack, wear, discoloration, pitting, missing component, and insulation
+damage.
+*Implemented by:* `app/services/baseline_comparison_scoring_service.py`
+(`predicted_findings`), `app/services/clinical_mentor.py` (per-finding
+`why_it_matters` / `clinical_significance` library).
+
+### Layer 6 — Clinical Reasoning Engine
+Interpret findings using anatomy, zone risk, manufacturer baseline,
+supervisor knowledge, and SPD rules.
+*Implemented by:* `app/services/baseline_comparison_scoring_service.py`
+(`evidence_strength`, `baseline_difference`, `ai_clinical_review`),
+`app/services/clinical_mentor.py` (`ai_mentor`).
+
+### Layer 7 — Clinical Decision Engine
+Recommend a disposition:
+
+- READY FOR PACKAGING
+- READY FOR STERILIZATION
+- REQUIRES RECLEANING
+- SUPERVISOR REVIEW
+- REPAIR
+- REMOVE FROM SERVICE
+
+**Current implementation status:** the v1 scoring engine
+(`app/services/baseline_comparison_scoring_service.py`, `_ACTION_TEXT`)
+outputs a five-value outcome — `PASS`, `MONITOR`, `SUPERVISOR REVIEW`,
+`REPROCESS`, `REMOVE FROM SERVICE` — which is the working v1 realization of
+this layer, predating this document. It maps onto the target vocabulary
+above as: `PASS`/`MONITOR` → *READY FOR PACKAGING* (with `MONITOR` flagging
+a recheck note), `REPROCESS` → *REQUIRES RECLEANING*, `SUPERVISOR REVIEW`
+→ *SUPERVISOR REVIEW*, `REMOVE FROM SERVICE` → *REMOVE FROM SERVICE*.
+*REPAIR* and an explicit *READY FOR STERILIZATION* terminal state (distinct
+from packaging) are not yet separated out in code. Per Phase 19.5 §10,
+existing code is not being renamed to avoid breaking the ~2,300-test
+regression suite that asserts on the current strings; new decision-engine
+work should adopt the six-value vocabulary directly rather than extending
+the five-value one.
+
+### Layer 8 — Human Validation
+Supervisor review and override — the point at which a human either
+confirms or overrides the AI's recommendation, and in doing so creates
+ground truth.
+*Implemented by:* `app/models/supervisor_review.py`,
+`app/routes/ai_clinical_review.py` (`/inspections/{id}/supervisor-review`).
+
+### Layer 9 — Continuous Learning
+Use validated supervisor feedback to improve models.
+*Implemented by:* `app/models/pilot_validation.py` (ground-truth cases
+derived from supervisor review, Phase 18), `app/models/model_registry.py`
++ `app/models/shadow_prediction.py` (Phase 17 model lifecycle: shadow →
+pilot → validated, human-gated promotion only), `app/models/retained_image.py`
+(opt-in labeled training image store).
+
+### Layer 10 — Enterprise Intelligence
+Dashboards, analytics, knowledge graph, predictive maintenance,
+benchmarking, and executive intelligence.
+*Implemented by:* `app/routes/pilot_analytics.py`, `app/routes/pilot_validation.py`,
+`app/models/quality_intelligence.py`, `app/models/digital_quality_twin.py`,
+`app/models/global_intelligence.py`, `app/models/instrument_knowledge.py`,
+`app/models/network_benchmark.py`, executive scorecard/briefing routes.
+
+## 3. How the Layers Compose
+
+Layers 1–5 answer *"what is this instrument and what do we see on it?"*
+Layer 6 answers *"what does that mean clinically, given where it is on
+this instrument?"* Layer 7 turns that meaning into an operational
+disposition. Layer 8 is the non-negotiable human checkpoint. Layers 9–10
+turn every reviewed case into either a better model or better enterprise
+visibility — never both silently; every promotion and every aggregate
+claim is auditable back to real rows (see
+`docs/architecture/lumenai-clinical-ontology.md`).
+
+No layer may be skipped by a future feature. A feature that detects a
+finding (Layer 5) without going through anatomy/zone context (Layer 4)
+first is an architecture violation — see
+`docs/architecture/architecture-enforcement-checklist.md`.

--- a/docs/architecture/lumenai-clinical-ontology.md
+++ b/docs/architecture/lumenai-clinical-ontology.md
@@ -1,0 +1,75 @@
+# LumenAI Clinical Ontology
+
+Every database model, API response, AI output, report, dashboard, and
+training dataset in LumenAI should map back to this chain. If a piece of
+data can't be placed on this chain, it either belongs in a different
+system or the ontology needs a deliberate, documented extension — it
+should never be bolted on as a disconnected field.
+
+```
+Instrument
+    ↓
+Instrument Family
+    ↓
+Manufacturer
+    ↓
+Model
+    ↓
+Anatomy
+    ↓
+Inspection Zone
+    ↓
+Finding
+    ↓
+Severity
+    ↓
+SPD Risk
+    ↓
+Clinical Interpretation
+    ↓
+Recommendation
+    ↓
+Supervisor Decision
+    ↓
+Learning Signal
+```
+
+## Link-by-link, with the code that owns each step
+
+| Ontology step | What it answers | Owning code |
+|---|---|---|
+| **Instrument** | What physical object is being inspected? | `app/models/inspection.py` (`instrument_type`), `app/models/instrument_registry.py` |
+| **Instrument Family** | What class of instrument is it (forceps, rigid scope, drill bit, …)? | `app/services/instrument_anatomy.py::resolve_family` |
+| **Manufacturer** | Who made it? | `app/models/manufacturer_reg.py`, `Inspection.vendor_name` |
+| **Model** | Which specific model/UDI? | `app/models/baseline_library.py` (`model_name`, `udi`) |
+| **Anatomy** | What are this family's zones, high-risk areas, required views? | `app/services/instrument_anatomy.py::anatomy_profile` |
+| **Inspection Zone** | Which specific zone is a finding located in? | `app/services/instrument_zones.py::zone_fields` |
+| **Finding** | What was observed (blood, crack, missing component, …)? | `app/services/baseline_comparison_scoring_service.py` (`predicted_findings`) |
+| **Severity** | How significant is the finding? | Per-finding `severity_index` / `severity` fields; `app/services/pilot_validation_service.py::severity_from_risk_score` |
+| **SPD Risk** | Is this zone/finding combination high-retention / high-risk? | `app/services/instrument_zones.py::is_high_retention`, `HIGH_RETENTION_ZONES` |
+| **Clinical Interpretation** | What does this mean, in plain SPD language? | `app/services/clinical_mentor.py::ai_mentor` |
+| **Recommendation** | What should happen to the instrument? | `app/services/baseline_comparison_scoring_service.py` (`ai_clinical_review`, `_ACTION_TEXT`) |
+| **Supervisor Decision** | What did a human actually decide? | `app/models/supervisor_review.py` |
+| **Learning Signal** | Does this become labeled data for the model? | `app/models/pilot_validation.py` (ground-truth label), `app/models/model_registry.py` / `shadow_prediction.py`, `app/models/retained_image.py` |
+
+## Rules for using the ontology
+
+1. **No skipping links.** A finding without a resolved zone, and a zone
+   without a resolved anatomy/family, is an incomplete record — not a
+   simplification. It should be flagged (e.g. Phase 18's
+   `missing_required_zones` safety-queue bucket), not silently accepted.
+2. **Downstream always cites upstream.** A dashboard metric that reports
+   on "findings by zone" is only meaningful because the finding is
+   traceable through zone → anatomy → family → instrument. Any new report
+   should be checked against this chain before it ships.
+3. **The Learning Signal step is the return path.** Continuous learning
+   (Layer 9 of the architecture) is not a separate concern bolted onto the
+   ontology — it *is* the ontology's last link. A supervisor decision that
+   doesn't produce a learning signal is a missed opportunity, and a
+   learning signal without a traceable supervisor decision behind it is
+   not trustworthy ground truth.
+4. **New AI capabilities attach to an existing link, or extend the chain
+   deliberately.** For example, a future segmentation/heatmap capability
+   (Architecture Roadmap Stage 7–8) attaches to the **Finding** and
+   **Inspection Zone** links — it does not introduce a parallel,
+   disconnected localization system.

--- a/docs/architecture/pre-sterilization-boundary.md
+++ b/docs/architecture/pre-sterilization-boundary.md
@@ -1,0 +1,92 @@
+# Pre-Sterilization Boundary
+
+## The workflow LumenAI operates within
+
+```
+Point of Use
+    ↓
+Transportation
+    ↓
+Decontamination
+    ↓
+Assembly / Inspection
+    ↓
+LumenAI Clinical Inspection   ← LumenAI operates here
+    ↓
+Supervisor Review
+    ↓
+Packaging
+    ↓
+Sterilization
+```
+
+**LumenAI operates before sterilization.** It sits at the
+Assembly/Inspection step, between decontamination and packaging. It never
+observes, measures, or reports on what happens inside the sterilizer, and
+it makes no claim about the outcome of a sterilization cycle.
+
+## Why this boundary matters
+
+Sterile Processing has well-established, separately regulated systems for
+verifying sterilization itself: biological indicators, chemical
+indicators, and sterilizer load/cycle monitoring. LumenAI is not one of
+those systems and must never be described as if it were — doing so would
+misrepresent both what LumenAI does and what those systems are responsible
+for. Conflating the two would:
+
+- overstate LumenAI's regulatory posture (implying sterilization-assurance
+  claims it hasn't made or been cleared for),
+- confuse hospital risk/quality teams about which system is responsible
+  for which compliance record, and
+- understate the actual value LumenAI provides — catching problems
+  *before* an instrument reaches the sterilizer, when they're still cheap
+  and safe to fix.
+
+## Terminology
+
+### Do not use
+
+These phrases incorrectly imply LumenAI validates or monitors the
+sterilization process itself:
+
+- "sterilization cycle count" (as a LumenAI capability claim)
+- "sterilization assurance" (as something LumenAI provides)
+- "biological indicator monitoring"
+- "sterilizer performance validation"
+- "sterilization readiness" / "sterilization validation" / "sterilization
+  cycle intelligence" as platform-level claims
+
+### Use instead
+
+| Instead of | Use |
+|---|---|
+| sterilization readiness | pre-sterilization readiness |
+| sterilization assurance | inspection assurance / pre-sterilization cleaning assurance |
+| sterilization validation | clinical inspection readiness |
+| sterilization cycle intelligence | pre-sterilization quality gate |
+| (general) | inspection history, cleaning assessment, contamination trend, damage trend, repair history, baseline match, inspection coverage, clinical readiness, pre-sterilization decision |
+
+### Correctly bounding scope is fine
+
+Documentation that explicitly states LumenAI does **not** replace
+sterilization validation/assurance protocols is the correct pattern, not a
+violation — e.g. "The SRI does not replace clinical sterilization
+validation protocols" (`docs/infrastructure/surgical-readiness-index.md`)
+and "Sterilization assurance is a separate function"
+(`docs/clinical/clinical-performance-report.md`). These disclaimers should
+stay; only language that implies LumenAI *performs* that function needs to
+change.
+
+## Phase 19.5 terminology audit result
+
+A repository-wide search for the banned phrases found one violation in
+generated clinical-mentor text
+(`app/services/clinical_mentor.py`): the `other_organic_residue` finding's
+`clinical_significance` read *"Any retained organic soil reduces
+sterilization assurance"* — corrected to *"Any retained organic soil
+compromises pre-sterilization cleaning assurance."* No other code or
+frontend strings used the banned phrases; the remaining matches
+(`docs/infrastructure/surgical-readiness-index.md`,
+`docs/regulatory/submission-strategy.md`,
+`docs/clinical/clinical-performance-report.md`) were already correctly
+worded as boundary disclaimers and required no change.

--- a/docs/cios/clinical-context.md
+++ b/docs/cios/clinical-context.md
@@ -1,0 +1,60 @@
+# Shared Clinical Context
+
+`app/cios/context.py::ClinicalContext` — one immutable object every CIOS
+module reads and returns an updated copy of.
+
+## Why immutable
+
+`ClinicalContext` is a frozen pydantic model
+(`model_config = ConfigDict(frozen=True)`). Attempting `ctx.field = value`
+raises a validation error. The only way to "update" a context is
+`ctx.with_updates(field=value)`, which returns a **new** `ClinicalContext`
+via `model_copy(update=...)` — the original is untouched.
+
+This mirrors a pattern already established throughout the platform:
+`AuditLog` rows are never edited, `PilotValidationCase` ground truth is
+never rewritten, `ClinicalDecisionLedgerEntry` rows are append-only. A
+mutable shared context would be the one place in the system where "what
+did the AI actually see" could quietly change underneath an audit trail.
+Immutability closes that gap structurally, not just by convention.
+
+## Fields
+
+| Field | Source |
+|---|---|
+| `inspection_id`, `tenant_id` | The real `Inspection` row |
+| `instrument_type`, `manufacturer`, `model`, `instrument_family` | Instrument Intelligence Agent (Phase 22) |
+| `anatomy_profile`, `inspection_zones` | Anatomy Intelligence Agent |
+| `coverage` | Inspection Coverage Agent |
+| `baseline` | `Inspection.baseline_status` / `baseline_source` |
+| `findings` | Contamination Detection Agent + Damage Detection Agent, concatenated |
+| `severity` | The first finding's severity, if any |
+| `risk` | Clinical Reasoning Agent's risk level/score |
+| `recommendation` | Recommendation Agent |
+| `supervisor_review` | Supervisor Agent |
+| `digital_twin` | Instrument Intelligence Agent's `digital_twin_available` flag |
+| `knowledge_graph_links` | The Clinical Reasoning Agent's reasoning chain (Phase 21 knowledge graph) |
+| `audit` | The governance version snapshot active when this context was built |
+
+## Who builds it
+
+Only `app/cios/orchestrator.py::_build_clinical_context` constructs a
+`ClinicalContext` — it assembles one from the Phase 22 agent pipeline's
+output after that pipeline has already run. No individual agent
+constructs or mutates a `ClinicalContext` directly; agents still use their
+own typed contexts (`app/agents/context.py`) internally, exactly as
+specified in Phase 22 — `ClinicalContext` is the *envelope* the
+orchestrator wraps around all of them for downstream consumers (the
+dashboard, the certificate, the timeline) that shouldn't need to know
+about ten separate agent-specific shapes.
+
+## Every module receives the same context
+
+Concretely: the Clinical Readiness Certificate generator, the CIOS
+dashboard aggregator, and the Explainable Inspection Timeline all read
+fields off the *same* `ClinicalContext` object produced by one
+`run_cios_pipeline()` call — they never re-derive instrument identity,
+anatomy, or findings independently. If two of them ever disagreed about
+what instrument this inspection was, that would be a bug in
+`_build_clinical_context`, not a data-consistency issue spread across
+three separate code paths.

--- a/docs/cios/clinical-decision-ledger.md
+++ b/docs/cios/clinical-decision-ledger.md
@@ -1,0 +1,69 @@
+# Clinical Decision Ledger & Explainable Inspection Timeline
+
+## Clinical Decision Ledger
+
+`app/models/clinical_decision_ledger.py::ClinicalDecisionLedgerEntry` — a
+permanent, append-only record of every decision made about an inspection.
+Entries are never edited or deleted; a correction is a new entry, the same
+pattern already used for `AuditLog` and `PilotValidationCase`.
+
+### What's recorded, per entry
+
+| Field | Answers |
+|---|---|
+| `decision_type` | `ai_recommendation`, `supervisor_approval`, or `supervisor_override` |
+| `made_by` | `"ai"`, or the reviewing supervisor's email |
+| `rationale` | Why — the recommendation's explanation, or the supervisor's written rationale |
+| `evidence_json` | The reasoning chain (for AI decisions) or the corrected fields/final disposition (for supervisor decisions) |
+| `confidence` | The AI's confidence score, where applicable |
+| `model_version`, `knowledge_graph_version`, `ontology_version`, `architecture_version`, `inspection_pipeline_version` | The governance snapshot **active at the moment this entry was created** — never recomputed from current constants after the fact |
+
+### When entries are written
+
+1. **`ai_recommendation`** — every time `run_cios_pipeline()` runs
+   (`GET /api/cios/run/{id}`, and internally by the certificate generator),
+   recording the Recommendation Agent's output.
+2. **`supervisor_approval`** / **`supervisor_override`** — every time a
+   supervisor submits `POST /inspections/{id}/supervisor-review`
+   (`app/routes/ai_clinical_review.py`), alongside the existing
+   `SupervisorReview` row and Phase 18 `PilotValidationCase`. One
+   submission now produces three linked records: the review itself, the
+   ground-truth label, and the permanent ledger entry — no duplicate data
+   entry, and no decision goes unrecorded.
+
+### Reading the ledger
+
+`GET /api/cios/decision-ledger/{inspection_id}` returns every entry for
+that inspection, oldest first — a complete "who decided what, when, with
+what evidence, under which platform version" history for a single
+instrument's clinical review.
+
+## Explainable Inspection Timeline
+
+`app/cios/orchestrator.py::_timeline` builds the timeline shown in the
+CIOS run result:
+
+```
+[inspection.created_at]  Inspection created — <instrument> image captured.
+[trace[0].timestamp]     Instrument Agent completed.
+[trace[1].timestamp]     Anatomy Agent completed.
+...
+[trace[9].timestamp]     Enterprise Agent completed.
+[review.created_at]      Supervisor agree (or: Supervisor disagree (override: ...))
+```
+
+Every timestamp here is real:
+
+- `inspection.created_at` is the actual row-creation time.
+- Each agent's timestamp is captured with `datetime.now(timezone.utc)` the
+  moment that agent's `run()` call returns, during the *live* pipeline
+  execution — genuine wall-clock time, just very close together in real
+  seconds since these are synchronous, deterministic function calls, not
+  the multi-minute human-paced gaps an illustrative example might suggest.
+- The supervisor step's timestamp is the real `SupervisorReview.created_at`
+  — which genuinely can be minutes or hours after the AI steps, since a
+  human has to actually look at the case.
+
+No timestamp on this timeline is fabricated or interpolated to make the
+gaps look more realistic than they are. This is what makes the timeline
+usable as audit evidence.

--- a/docs/cios/clinical-rule-registry.md
+++ b/docs/cios/clinical-rule-registry.md
@@ -1,0 +1,68 @@
+# Clinical Rule Registry
+
+`app/cios/rule_registry.py::CLINICAL_RULE_REGISTRY` — every rule listed
+here is a **real rule already enforced somewhere in the codebase**. This
+registry documents and versions rules that exist; it does not invent
+hypothetical governance ahead of implementation. Each rule's `evidence`
+field points at the exact function that implements it, so the registry
+can never drift from what the code actually does.
+
+## Schema
+
+| Field | Meaning |
+|---|---|
+| `rule_id` | Stable identifier (`RULE-001`, …) |
+| `name` | Short human-readable name |
+| `purpose` | What the rule does and why |
+| `evidence` | The file/function that implements it |
+| `applies_to` | Which finding type(s) or scope the rule covers |
+| `priority` | `critical` / `high` / `medium` |
+| `version` | Rule version (bump when the underlying logic changes) |
+| `approval_status` | `approved` for every rule currently live in production code |
+
+## The ten registered rules
+
+| ID | Name | Priority |
+|---|---|---|
+| RULE-001 | Structural defect escalation | critical |
+| RULE-002 | Severe corrosion escalation | critical |
+| RULE-003 | Residual contamination reprocessing | high |
+| RULE-004 | High-retention zone escalation | high |
+| RULE-005 | No-baseline supervisor gate | critical |
+| RULE-006 | Baseline mismatch supervisor review | medium |
+| RULE-007 | Repairable structural defect classification | medium |
+| RULE-008 | Critical finding safety threshold | critical |
+| RULE-009 | Incomplete zone coverage flag | medium |
+| RULE-010 | Human final authority | critical |
+
+See `app/cios/rule_registry.py` for full purpose/evidence text on each.
+
+## What this enables
+
+- **Explainability**: the Clinical Reasoning Agent's output and the
+  Clinical Readiness Certificate can cite a specific rule ID rather than
+  an unattributed "the system decided."
+- **Future governance**: a rule can be versioned independently (e.g.
+  RULE-004's high-retention zone list could be tightened in a `2.0`
+  revision) with the change tracked here, and `approval_status` gives a
+  future governance workflow (e.g. requiring a clinical lead's sign-off
+  before a rule change ships) a place to attach to.
+- **Audit**: `rules_applying_to(finding_type)` lets an auditor ask "which
+  rules govern how LumenAI handles a crack finding?" and get a direct,
+  accurate answer.
+
+## API
+
+`GET /api/cios/rule-registry` returns the full registry.
+`get_rule(rule_id)` and `rules_applying_to(finding_type)` are the
+in-process lookup helpers other CIOS modules (or a future rule-editor UI)
+should use rather than re-filtering the list independently.
+
+## Extending
+
+Adding an eleventh rule requires it to already be enforced in code — write
+the rule's actual logic first (in the appropriate service module), then
+add its registry entry with `evidence` pointing at that real
+implementation. A registry entry with no corresponding enforced logic
+would misrepresent what LumenAI actually does, which is exactly what this
+registry exists to prevent.

--- a/docs/cios/event-bus.md
+++ b/docs/cios/event-bus.md
@@ -1,0 +1,60 @@
+# Enterprise Event Bus
+
+`app/cios/event_bus.py` + `app/models/cios_event.py::CIOSEvent` — a
+synchronous, in-process event bus that persists real events as the CIOS
+orchestrator processes an inspection, reusable by future integrations
+(webhooks, notification routing, downstream analytics) without those
+integrations needing to re-derive when something clinically significant
+happened.
+
+## Event types
+
+| Event | Emitted when |
+|---|---|
+| `InspectionStarted` | Every CIOS pipeline run, unconditionally. |
+| `BaselineLoaded` | `Inspection.baseline_status == "approved_baseline_found"`. |
+| `CoverageIncomplete` | Coverage quality is `incomplete`, `insufficient`, or `not_assessed`. |
+| `BloodDetected` | The Contamination Detection Agent reports a `blood` finding. |
+| `CorrosionDetected` | The Damage Detection Agent reports a `corrosion` finding. |
+| `RecommendationGenerated` | Every run, unconditionally — carries the readiness state. |
+| `SupervisorApproved` | A real `SupervisorReview` exists, agreement is `agree`/`partially_agree`, and there's no override. |
+| `InstrumentRemovedFromService` | The Recommendation Agent's readiness state is `REMOVED_FROM_SERVICE`. |
+| `KnowledgeUpdated` | Reserved for a future release where a supervisor correction triggers an explicit knowledge-base update (not yet wired — see Known Limitations below). |
+| `ModelFeedbackCaptured` | A Phase 18 `PilotValidationCase` (training label) was created for this inspection. |
+
+## Honesty constraint
+
+**No event fires unless the condition it names is actually true in the
+current context.** `BloodDetected` is not emitted just because the
+pipeline ran on a "blood-capable" instrument family — it only fires when
+the Contamination Detection Agent's real output contains a `blood`
+finding for *this* inspection. Same for every other conditional event.
+
+## Known limitation: `KnowledgeUpdated`
+
+This event type is defined in `EVENT_TYPES` for forward-compatibility with
+the event schema, but nothing currently emits it — there is no live
+process today that mutates a persisted knowledge-base artifact in
+response to a supervisor correction (Phase 21's `learning_confidence()`
+recomputes fresh from real reviews on every call; it doesn't write back to
+`InstrumentKnowledge` or the anatomy/zone taxonomy). Wiring
+`KnowledgeUpdated` up is future work, tracked here rather than faked with
+a fabricated emission.
+
+## Storage and querying
+
+Every event is a real row in `cios_events`
+(`tenant_id`, `inspection_id`, `event_type`, `payload_json`, `created_at`).
+`GET /api/cios/events?inspection_id=<id>` returns the real event history
+for one inspection; omit `inspection_id` for the tenant's recent event
+stream. This is intentionally a simple relational table, not a message
+queue — LumenAI doesn't need at-least-once delivery semantics for an
+audit-oriented event log; it needs a queryable, permanent record.
+
+## Future integrations
+
+A webhook dispatcher, a Slack/email notifier for `InstrumentRemovedFromService`
+or `BloodDetected`, or a downstream analytics pipeline could all subscribe
+to `cios_events` (via polling the table today; a real pub/sub layer is
+future work) without touching the orchestrator itself — the event bus is
+the deliberate seam for that.

--- a/docs/cios/inspection-state-machine.md
+++ b/docs/cios/inspection-state-machine.md
@@ -1,0 +1,78 @@
+# Inspection State Machine
+
+`app/cios/state_machine.py` formalizes the states every inspection passes
+through.
+
+## States
+
+```
+NEW
+    ↓
+IMAGE_CAPTURED
+    ↓
+INSTRUMENT_IDENTIFIED
+    ↓
+ANATOMY_IDENTIFIED
+    ↓
+BASELINE_LOADED
+    ↓
+COVERAGE_VALIDATED
+    ↓
+ANALYZED
+    ↓
+CLINICAL_REVIEW
+    ↓
+SUPERVISOR_PENDING
+    ↓
+APPROVED  or  REQUIRES_ACTION
+    ↓
+COMPLETE
+```
+
+`is_valid_transition(from_state, to_state)` encodes the only legal edges —
+`SUPERVISOR_PENDING` is the sole branch point (to `APPROVED` or
+`REQUIRES_ACTION`), and both of those lead only to `COMPLETE`.
+
+## Honest derivation — not fabricated history
+
+`derive_state(inspection, review=None)` computes the **current** state and
+the ordered list of **states reached** from real, persisted fields
+(`has_image`, `score_status`, `baseline_status`, `supervisor_review_required`,
+`status`, and the linked `SupervisorReview` if one exists).
+
+**Important limitation, stated plainly:** in the current implementation,
+`INSTRUMENT_IDENTIFIED`, `ANATOMY_IDENTIFIED`, `BASELINE_LOADED`, and
+`COVERAGE_VALIDATED` all happen inside one synchronous call to
+`analyze_inspection()` (`baseline_comparison_scoring_service.py`) at
+inspection-creation time. There is no separate persisted timestamp for
+"anatomy was identified" distinct from "baseline was loaded" — they
+happen in the same database transaction. `derive_state()` reports these
+as *reached* (they are real facts — the anatomy resolver really did run,
+the baseline really was checked) but does not fabricate individual
+historical timestamps for each one. Where a real distinct timestamp does
+exist — image/inspection creation (`created_at`), and a live CIOS pipeline
+run's actual per-agent execution times — those are used directly (see
+`docs/cios/lumenai-clinical-intelligence-operating-system.md` and the
+Explainable Inspection Timeline in `app/cios/orchestrator.py::_timeline`).
+
+## State mapping
+
+| Inspection condition | State |
+|---|---|
+| No image, `score_status == "pending"` | `NEW` |
+| Has image, `score_status == "pending"` | `IMAGE_CAPTURED` |
+| `score_status` is `scored`/`supervisor_review_required`, no review yet, not flagged for review | `ANALYZED` |
+| Same, but flagged `supervisor_review_required` | `SUPERVISOR_PENDING` |
+| Same, but a `SupervisorReview` exists (no override, agreement not "disagree") | `APPROVED` (reached via `CLINICAL_REVIEW`/`SUPERVISOR_PENDING`) |
+| Same, but the review has an override or `agreement == "disagree"` | `REQUIRES_ACTION` |
+| `Inspection.status` is `reviewed`/`closed` and a review exists | `COMPLETE` |
+
+## Auditability
+
+Every CIOS pipeline run (`GET /api/cios/run/{id}` or
+`GET /api/cios/state/{id}`) recomputes state live from the current
+database — there is no separate "state" column that could drift from the
+underlying facts. This is the same "derive, don't duplicate" pattern
+already used for Phase 20's `classify_readiness()` and Phase 18's ground-
+truth labels: a single source of truth (the real `Inspection`/
+`SupervisorReview` rows), computed fresh on every read.

--- a/docs/cios/lumenai-clinical-intelligence-operating-system.md
+++ b/docs/cios/lumenai-clinical-intelligence-operating-system.md
@@ -1,0 +1,142 @@
+# LumenAI Clinical Intelligence Operating System (CIOS)
+
+## Objective
+
+Unify every LumenAI module — Instrument Intelligence, Anatomy
+Intelligence, Computer Vision, Clinical Knowledge, Clinical Reasoning,
+Supervisor Validation, Digital Twin, Enterprise Intelligence — into one
+coordinated operating system for Sterile Processing, so LumenAI behaves
+like an experienced SPD leadership team working together before an
+instrument proceeds to packaging and sterilization, rather than a
+collection of disconnected AI features.
+
+## Core principle: one deterministic workflow
+
+Every inspection follows the same operating sequence. No module bypasses
+another:
+
+```
+Image
+    ↓
+Instrument Identification
+    ↓
+Anatomy Recognition
+    ↓
+Inspection Coverage
+    ↓
+Baseline Comparison
+    ↓
+Finding Detection
+    ↓
+Severity Classification
+    ↓
+Zone Risk Assessment
+    ↓
+Clinical Reasoning
+    ↓
+Clinical Recommendation
+    ↓
+Supervisor Validation
+    ↓
+Learning
+    ↓
+Enterprise Analytics
+```
+
+## What CIOS actually is
+
+CIOS is **not a rewrite** of Phases 15–22. It is the coordination layer
+that sits on top of the Phase 22 multi-agent pipeline
+(`app/agents/orchestrator.py::run_pipeline`) and adds exactly what a real
+operating system adds to a set of programs: a shared context, a single
+entry point, execution monitoring, formal state, a permanent decision
+record, an event bus, and governance.
+
+`app/cios/orchestrator.py::run_cios_pipeline(db, inspection, tenant_id)`
+is the **single entry point**. Every consumer — the API, the `/cios-dashboard`
+frontend, the Clinical Readiness Certificate generator — calls this one
+function. Nothing calls an individual agent directly outside of it.
+
+## The eleven CIOS components
+
+| # | Component | Module | Doc |
+|---|---|---|---|
+| 1 | Clinical Intelligence Orchestrator | `app/cios/orchestrator.py` | this document |
+| 2 | Shared Clinical Context | `app/cios/context.py` | `docs/cios/clinical-context.md` |
+| 3 | Intelligence Pipeline Monitor | `app/cios/orchestrator.py::_pipeline_monitor` | this document, §3 below |
+| 4 | Inspection State Machine | `app/cios/state_machine.py` | `docs/cios/inspection-state-machine.md` |
+| 5 | Clinical Decision Ledger | `app/cios/decision_ledger.py`, `app/models/clinical_decision_ledger.py` | `docs/cios/clinical-decision-ledger.md` |
+| 6 | Enterprise Event Bus | `app/cios/event_bus.py`, `app/models/cios_event.py` | `docs/cios/event-bus.md` |
+| 7 | Explainable Inspection Timeline | `app/cios/orchestrator.py::_timeline` | `docs/cios/clinical-decision-ledger.md` (shares the ledger's audit framing) |
+| 8 | Clinical Readiness Certificate | `app/cios/certificate.py` | this document, §8 below |
+| 9 | Enterprise Health Dashboard | `app/cios/dashboard.py`, `/cios-dashboard` | this document, §9 below |
+| 10 | Platform Governance | `app/cios/governance.py` | `docs/cios/platform-governance.md` |
+| 11 | Clinical Rule Registry | `app/cios/rule_registry.py` | `docs/cios/clinical-rule-registry.md` |
+
+## §3 Intelligence Pipeline Monitor
+
+Every CIOS run returns a `pipeline_monitor` list — one entry per Phase 22
+agent, each `Complete`, `Pending`, or `Queued`:
+
+```json
+[
+  {"agent": "Instrument Agent", "status": "Complete"},
+  {"agent": "Anatomy Agent", "status": "Complete"},
+  {"agent": "Coverage Agent", "status": "Complete"},
+  {"agent": "Contamination Agent", "status": "Complete"},
+  {"agent": "Damage Agent", "status": "Complete"},
+  {"agent": "Clinical Reasoning Agent", "status": "Complete"},
+  {"agent": "Recommendation Agent", "status": "Complete"},
+  {"agent": "Supervisor Agent", "status": "Pending"},
+  {"agent": "Learning Agent", "status": "Queued"},
+  {"agent": "Enterprise Agent", "status": "Queued"}
+]
+```
+
+The seven deterministic AI agents are always `Complete` once the pipeline
+runs (they have no real precondition to wait on). `Supervisor Agent` is
+`Complete` only when a real `SupervisorReview` exists — otherwise
+`Pending`. `Learning Agent` and `Enterprise Agent` are `Queued` while
+Supervisor is `Pending`: this specific inspection hasn't contributed a
+learning signal yet, even though the confidence/analytics numbers those
+agents report are already computed from *other*, already-reviewed
+inspections in the tenant's history.
+
+## §8 Clinical Readiness Certificate
+
+`GET /api/cios/certificate/{inspection_id}` (JSON) and
+`GET /api/cios/certificate/{inspection_id}/pdf` generate a printable
+**Pre-Sterilization Clinical Readiness Certificate** — explicitly not a
+sterilization certificate (`not_a_sterilization_certificate: true`, plus
+an explicit disclaimer field), consistent with
+`docs/architecture/pre-sterilization-boundary.md`. It includes the
+inspection ID, instrument/manufacturer/model, inspection date, clinical
+decision, coverage, baseline used, findings, the full clinical reasoning
+chain, the recommendation, supervisor approval status, audit IDs (the
+inspection ID and every linked Decision Ledger entry ID), governance
+version snapshot, and a digital-signature **placeholder** — `signed:
+false` with a note that e-signature capture is not yet implemented,
+rather than fabricating a signature.
+
+## §9 Enterprise Health Dashboard
+
+`/cios-dashboard` (frontend) / `GET /api/cios/dashboard` (API) —
+system health, inspection throughput, average inspection time, coverage
+rate, supervisor agreement, AI confidence, model/knowledge-graph version,
+digital twin health, most common findings/zones, and the Enterprise Risk
+Index (a composite indicator, explicitly labeled as such, not a validated
+clinical score). See `app/cios/dashboard.py` for exactly how each figure
+is computed — every one is derived from real rows, `None` when there
+isn't enough data rather than a fabricated default.
+
+## Success criteria
+
+LumenAI should no longer appear as a collection of AI features. Every
+decision the system produces must be traceable (the timeline and trace),
+explainable (the reasoning chain), auditable (the Decision Ledger and
+event bus), repeatable (the same deterministic pipeline every time),
+governed (versioned artifacts referenced on every decision), human-
+supervised (Supervisor Agent never fabricates a decision), and
+architecture-compliant (every module composes the Phase 15–22 services
+that already exist — nothing here introduces a parallel, disconnected
+system).

--- a/docs/cios/platform-governance.md
+++ b/docs/cios/platform-governance.md
@@ -1,0 +1,57 @@
+# Platform Governance
+
+`app/cios/governance.py` — the seven versions every inspection references.
+
+## The versions
+
+| Version | Current value | Tracks |
+|---|---|---|
+| `architecture_version` | `19.5` | `docs/architecture/` — the frozen reference architecture (Phase 19.5) |
+| `ontology_version` | `1.0` | `docs/architecture/lumenai-clinical-ontology.md`'s Instrument→...→Learning chain |
+| `knowledge_graph_version` | `21.0` | `docs/knowledge-graph/` — node/relationship taxonomy (Phase 21) |
+| `model_version` | `baseline-comparison-scoring-pilot-1` | The active scoring engine (`baseline_comparison_scoring_service.py`) |
+| `dataset_version` | `pilot-v1` | The default Phase 18 ground-truth dataset version |
+| `clinical_rule_version` | `1.0` | `app/cios/rule_registry.py` |
+| `inspection_pipeline_version` | `22.0` | The Phase 22 multi-agent pipeline (`app/agents/registry.py`) |
+
+`GET /api/cios/governance` returns this snapshot; `governance_snapshot()`
+is the single function every other CIOS module calls to get it — no
+module hardcodes a version string independently.
+
+## Why these are code constants, not a database table
+
+These versions describe **what the codebase currently is**, not
+per-tenant configuration — every tenant on a given deployment runs the
+same architecture, ontology, and pipeline version. Bumping a version here
+is a deliberate code change (a PR that also updates the corresponding doc
+or model registry entry), not a runtime toggle.
+
+## Why every inspection/ledger entry snapshots, rather than references live
+
+`ClinicalDecisionLedgerEntry` (see `docs/cios/clinical-decision-ledger.md`)
+stores a **copy** of the governance versions active when it was created,
+not a foreign key to "the current version." This is deliberate: if
+`inspection_pipeline_version` is bumped to `23.0` next month, an entry
+recorded under `22.0` must keep saying `22.0` — that's what actually ran
+when the decision was made. An audit record that silently updated to
+reflect today's version would be lying about its own history.
+
+## Relationship to the Model Registry (Phase 17)
+
+`model_version` here is a human-readable label for the *active* scoring
+approach, distinct from `app/models/model_registry.py::ModelRegistryEntry`,
+which tracks individual trained model *candidates* moving through
+experimental → pilot → validated → deprecated. When a real trained model
+is eventually promoted to `validated` and put into production (Phase 17's
+model lifecycle), `governance.py::MODEL_VERSION` should be updated to
+reference that registry entry's `model_version` — this is the deliberate
+integration point flagged as a next step in
+`docs/architecture/future-ai-roadmap.md`.
+
+## Extending
+
+Adding a new versioned artifact (e.g. a future `certificate_template_version`):
+add the constant to `governance.py`, add it to `governance_snapshot()`,
+and add a column to `ClinicalDecisionLedgerEntry` if it should be
+snapshotted per-decision. The dashboard, certificate, and ledger all read
+`governance_snapshot()` — no other code needs to change.

--- a/docs/command-center/pre-sterilization-command-center.md
+++ b/docs/command-center/pre-sterilization-command-center.md
@@ -1,0 +1,92 @@
+# Pre-Sterilization Command Center
+
+## Objective
+
+Give SPD Technicians, Supervisors, Managers, Market Directors, Infection
+Prevention, and Executive Leadership one place that answers:
+
+> "Are these instruments clinically ready to move forward to packaging and
+> sterilization?"
+
+And when the answer is no:
+
+> "Why not, what risk was found, where was it found, and what should SPD
+> do next?"
+
+This is LumenAI's pre-sterilization quality gate — it operates entirely
+before packaging and sterilization (see
+`docs/architecture/pre-sterilization-boundary.md`). It never monitors,
+measures, or validates the sterilization cycle itself.
+
+## Route
+
+`/pre-sterilization-command-center` (frontend) —
+`frontend/src/pages/PreSterilizationCommandCenter.tsx`.
+
+API: `GET /api/pre-sterilization-command-center/dashboard`
+(`backend/app/routes/pre_sterilization_command_center.py`) returns all ten
+modules in one payload; each module also has its own granular endpoint
+(e.g. `/high-risk-findings`, `/tray-readiness`) for a page or integration
+that only needs one section.
+
+## The ten modules
+
+| # | Module | Endpoint | Answers |
+|---|---|---|---|
+| 1 | Clinical Inspection Readiness Score | `/clinical-inspection-readiness` | What fraction of reviewed inspections are ready for packaging right now? |
+| 2 | Tray Readiness Score | `/tray-readiness` | Is this tray ready to proceed, and if not, which instrument in it is blocking? |
+| 3 | Instrument Readiness Score | `/instrument-readiness` | What is the current state of this specific physical instrument? |
+| 4 | Facility Readiness Score | `/facility-readiness` | Is this facility's readiness rate improving, declining, or stable? |
+| 5 | High-Risk Findings Queue | `/high-risk-findings` | Which unresolved inspections have a critical finding (blood, tissue, bone, crack, insulation damage)? |
+| 6 | Supervisor Review Queue | `/supervisor-review-queue` | Which inspections are waiting on a human decision? |
+| 7 | Missing Anatomy Zone Coverage | `/missing-zone-coverage` | Which inspections didn't capture all the required high-risk zones? |
+| 8 | Baseline Coverage | `/baseline-coverage` | What fraction of inspections had an approved baseline to compare against, and which instrument types don't have one? |
+| 9 | Repair / Remove From Service Queue | `/repair-remove-queue` | Which retired instruments are repairable vs. permanently removed? |
+| 10 | Executive Risk Dashboard | `/executive-risk-dashboard` | The roll-up: readiness, queues, facility rollup, and anatomy-zone failure trend in one view. |
+
+See `docs/command-center/readiness-score-model.md` for exactly how each
+readiness state and score is computed, and
+`docs/command-center/quality-gate-workflow.md` for how an instrument moves
+through the gate end to end.
+
+## Personas
+
+All six personas read the *same* dashboard payload — the page tailors
+which modules are visible by default per persona (client-side, in
+`PreSterilizationCommandCenter.tsx`'s `PERSONA_MODULES` map), because the
+underlying platform only has four RBAC roles (`admin`, `spd_manager`,
+`operator`, `viewer`). The persona selector is a lens on one dataset, not
+six separate data pipelines:
+
+| Persona | Maps to role | Default modules |
+|---|---|---|
+| SPD Technician | `operator` | Missing zone coverage, high-risk findings, instrument readiness — what to fix right now. |
+| SPD Supervisor | `spd_manager` | Supervisor review queue, high-risk findings, tray/instrument readiness. |
+| SPD Manager | `spd_manager` | All operational modules — full department view. |
+| Market Director | `admin` | Facility readiness, executive risk, baseline coverage. |
+| Infection Prevention | `admin` | High-risk findings, executive risk, missing zone coverage. |
+| Executive Leadership | `admin` | Readiness summary, executive risk, facility readiness. |
+
+## Data model change
+
+`Inspection.inspected_zones_json` was added (nullable-safe, backfilled
+automatically via `ensure_columns` — see `app/db/column_migrator.py`) to
+persist which zones a technician tagged as inspected, so Module 7 can be
+computed retroactively across history rather than only at the moment of
+capture. `json.dumps(None)` (`"null"`) means "not tagged" (coverage
+`not_assessed`); an explicit list — even empty — means coverage was
+assessed. See `app/services/inspection_coverage.py::compute_coverage` for
+the scoring logic this feeds.
+
+## What this command center is not
+
+- It is not a sterilization validation, biological indicator, or
+  sterilizer-performance system.
+- It does not fabricate CV localization (bounding boxes/heatmaps) — Stage
+  7/8 of `docs/architecture/future-ai-roadmap.md` are explicitly not
+  started.
+- It does not auto-dispose of an instrument. Every state is advisory;
+  Module 6 (Supervisor Review Queue) and Module 8's confirmation tracking
+  exist specifically because a human decision is what actually clears an
+  instrument, per Design Principle 4
+  (`docs/architecture/design-principles.md`).

--- a/docs/command-center/quality-gate-workflow.md
+++ b/docs/command-center/quality-gate-workflow.md
@@ -1,0 +1,107 @@
+# Quality Gate Workflow
+
+How an instrument actually moves through the pre-sterilization command
+center, end to end — the operational story behind the ten modules.
+
+## The gate, in sequence
+
+```
+1. Technician captures inspection image + tags inspected zones
+        ↓
+2. AI scoring engine runs (baseline comparison, zone-aware findings)
+        ↓
+3. Command center classifies readiness (classify_readiness)
+        ↓
+4a. READY_FOR_PACKAGING           → proceeds toward packaging
+4b. REQUIRES_RECLEANING           → Supervisor Review Queue / Reclean and re-inspect
+4c. REQUIRES_SUPERVISOR_REVIEW    → Supervisor Review Queue
+4d. REQUIRES_REPAIR               → Repair / Remove From Service Queue (repair path)
+4e. REMOVED_FROM_SERVICE          → Repair / Remove From Service Queue (retired)
+4f. PENDING_ANALYSIS              → held until scoring completes
+        ↓
+5. Supervisor confirms or overrides (creates ground truth — Phase 18)
+        ↓
+6. Confirmed inspections exit the queues; instrument/tray/facility
+   readiness scores update
+```
+
+## Step-by-step
+
+### 1. Capture
+A technician runs an inspection (`POST /api/inspections`), optionally
+tagging `inspected_zones` — the checklist of anatomy zones they actually
+photographed/examined. This is what Module 7 (Missing Anatomy Zone
+Coverage) checks against the instrument family's required zones later.
+
+### 2. Scoring
+If an image was captured, `analyze_inspection`
+(`app/services/baseline_comparison_scoring_service.py`) compares it
+against the instrument's approved baseline (if one exists) and produces a
+`recommended_action` sentence, a `risk_score`, and a `detected_issue`.
+If no approved baseline exists, the inspection is held at
+`REQUIRES_SUPERVISOR_REVIEW` regardless of what the image shows — no
+score is fabricated without a baseline to compare against.
+
+### 3. Readiness classification
+The command center's `classify_readiness` (see
+`docs/command-center/readiness-score-model.md`) turns that scoring output
+into one of the six readiness states, and flags whether the finding is
+critical (blood, tissue, bone, crack, insulation damage).
+
+### 4. Routing
+- **Ready** instruments simply roll up into the readiness rate — no queue
+  action needed.
+- **Requires recleaning / supervisor review** instruments appear in
+  Module 5 (if critical) and/or Module 6 until a human confirms them.
+- **Requires repair / removed from service** instruments appear in Module
+  9, split so a repair coordinator and a disposal/replacement coordinator
+  aren't working from the same undifferentiated list.
+
+### 5. Human confirmation
+A supervisor reviews the case — through the existing supervisor-review
+form (`POST /inspections/{id}/supervisor-review`,
+`app/routes/ai_clinical_review.py`) or the separate QA review flow
+(`POST /api/qa-review/{id}`). Either one marks the inspection "confirmed"
+for command-center purposes. Per Phase 18, the supervisor-review
+submission *also* creates a `PilotValidationCase` ground-truth record in
+the same transaction — the quality gate and the model's training-label
+pipeline share the same human decision, not two separate ones.
+
+### 6. Queues clear, scores update
+Once confirmed, an inspection drops out of Modules 5 and 6 even if its
+readiness state is still blocking (e.g. still `REQUIRES_RECLEANING`) — the
+queues track *unresolved, unconfirmed* work, not the disposition itself.
+Instrument (Module 3), tray (Module 2), and facility (Module 4) readiness
+always reflect the *latest* inspection per instrument, so a re-inspection
+after reprocessing immediately updates the instrument's and its tray's
+readiness.
+
+## Why the tray is weakest-link
+
+A tray cannot go to packaging with one contaminated or unrepaired
+instrument in it, no matter how clean the other nine are. Module 2
+enforces this by reporting the tray's state as the single most-blocking
+state among its instruments — there is no "average" or "mostly ready"
+tray state, because that isn't how a physical instrument tray actually
+works in SPD.
+
+## Why "confirmed" matters more than "resolved"
+
+The gate distinguishes *readiness state* (what the AI/rules concluded)
+from *confirmation* (whether a human has actually looked at it). An
+instrument can be `REQUIRES_RECLEANING` and confirmed (a supervisor
+already sent it back for reprocessing — action is underway, no longer a
+queue item) or unconfirmed (nobody has acted on it yet — it's the exact
+item that should be at the top of someone's queue right now). Reporting
+readiness state alone, without confirmation, would either flood every
+dashboard with already-actioned items or hide the fact that action was
+taken — both wrong for an operational quality gate.
+
+## Escalation path for critical findings
+
+A critical finding (blood, tissue, bone, crack, insulation damage) that is
+also unconfirmed appears in the High-Risk Findings Queue (Module 5)
+regardless of how it's routed elsewhere — this is deliberately redundant
+with Modules 6 and 9 so Infection Prevention and Executive Leadership
+personas, who may not watch the day-to-day supervisor queue, still see
+every open critical item in one place.

--- a/docs/command-center/readiness-score-model.md
+++ b/docs/command-center/readiness-score-model.md
@@ -1,0 +1,104 @@
+# Readiness Score Model
+
+How `app/services/pre_sterilization_command_center_service.py` turns raw
+`Inspection` rows into a readiness state and score. Every number here is
+computed from real rows — nothing is fabricated, and a rate is `null`
+rather than a misleading `0.0` when there's no data yet.
+
+## Readiness states
+
+Six states, all sub-classifications of the frozen five-value Clinical
+Decision Engine outcome
+(`docs/architecture/lumenai-clinical-intelligence-architecture.md` Layer
+7) — no new engine value was introduced:
+
+| State | Derived from | Blocks packaging? |
+|---|---|---|
+| `READY_FOR_PACKAGING` | `PASS` / `MONITOR` outcome | No |
+| `REQUIRES_RECLEANING` | `REPROCESS` outcome | Yes |
+| `REQUIRES_SUPERVISOR_REVIEW` | `SUPERVISOR REVIEW` outcome, or `supervisor_review_required` | Yes |
+| `REQUIRES_REPAIR` | `REMOVE FROM SERVICE` outcome **and** the detected issue is a repairable structural defect (crack, corrosion, insulation damage) | Yes |
+| `REMOVED_FROM_SERVICE` | `REMOVE FROM SERVICE` outcome and the issue is not repairable (contamination escalated, or unrepairable structural failure) | Yes |
+| `PENDING_ANALYSIS` | `score_status != "scored"` — analysis hasn't completed | Yes (nothing to read yet) |
+
+`REQUIRES_REPAIR` vs. `REMOVED_FROM_SERVICE` is exactly the
+repair/remove-from-service split flagged as a future decision in the
+Phase 19.5 architecture roadmap — implemented here as a computed
+`repair_candidate` sub-field on the existing outcome, per that document's
+own guidance, rather than as a sixth engine-level value.
+
+## Classification logic (`classify_readiness`)
+
+1. **Primary path — the persisted `recommended_action` sentence.** The
+   scoring engine (`app/services/baseline_comparison_scoring_service.py`)
+   always writes a deterministic sentence starting with one of "Pass —",
+   "Monitor —", "Supervisor review ... —", "Reprocess —", or "Remove from
+   service —". The classifier prefix-matches (case-insensitive) on this
+   text — it's the same information a human reading the record would use.
+2. **Fallback path — no `recommended_action`.** Manual/no-image entries
+   never run the scoring engine, so `recommended_action` is `None`. In
+   that case the classifier falls back to `detected_issue` +
+   `supervisor_review_required` + `risk_score`:
+   - flagged for supervisor review → `REQUIRES_SUPERVISOR_REVIEW`
+   - no issue and no stain detected → `READY_FOR_PACKAGING`
+   - a repairable issue with `risk_score >= 70` → `REQUIRES_REPAIR`,
+     otherwise `REQUIRES_SUPERVISOR_REVIEW`
+   - a contamination issue, or `stain_detected` → `REQUIRES_RECLEANING`
+   - anything else → `REQUIRES_SUPERVISOR_REVIEW` (fail safe to a human,
+     never fail safe to "ready")
+3. **Unscored.** `score_status != "scored"` always wins first — an
+   inspection that hasn't finished analysis is never reported as ready.
+
+## Readiness score
+
+```
+readiness_score = 100 - risk_score   (only when score_status == "scored")
+```
+
+The same inverse-of-risk convention already used elsewhere in the platform
+(e.g. `ai_score` in `app/routes/ai_clinical_review.py`). `None` when not
+yet scored — never a fabricated number.
+
+## Confirmed vs. unconfirmed
+
+A finding is "confirmed" (has had human eyes on it) when any of:
+- `qa_review_status` is `approved` or `overridden` (the separate QA review
+  flow, `app/routes/qa_review.py`), or
+- `status` is `reviewed` or `closed`, or
+- a `SupervisorReview` row exists for the inspection
+  (`app/models/supervisor_review.py`).
+
+The High-Risk Findings Queue (Module 5) and Supervisor Review Queue
+(Module 6) only surface **unconfirmed** items — a confirmed finding has
+already had its human decision and isn't a queue item anymore, even if its
+underlying state is still e.g. `REQUIRES_RECLEANING`.
+
+## Aggregation rules
+
+- **Tray Readiness (Module 2):** weakest link. A tray's state is the
+  most-blocking state among its instruments' current (latest-inspection)
+  states, using the severity ordering
+  `READY_FOR_PACKAGING < PENDING_ANALYSIS < REQUIRES_SUPERVISOR_REVIEW <
+  REQUIRES_RECLEANING < REQUIRES_REPAIR < REMOVED_FROM_SERVICE`. A tray is
+  never reported ready if any instrument in it isn't.
+- **Instrument Readiness (Module 3):** grouped by
+  `instrument_barcode`/`instrument_udi` when present; falls back to a
+  per-inspection key (`untracked:{type}:{id}`) when neither was captured —
+  we don't claim re-identification we didn't actually perform. The most
+  recent inspection for that identity is its current state.
+- **Facility Readiness (Module 4):** grouped by `facility_name` (falling
+  back to `site_name`). Trend compares the readiness rate of the older
+  half of that facility's inspections (by `created_at`) to the newer half
+  — `improving` / `declining` / `stable` / `insufficient_data` when either
+  half is empty.
+
+## Honesty constraints
+
+- Zero cases → rates are `null`, not `0.0`.
+- Zone coverage (Module 7) reports `not_assessed` (not a 0% score) when a
+  technician never tagged zones — a `None` in `inspected_zones_json`.
+- The anatomy-zone failure trend surfaced in the Executive Risk Dashboard
+  (Module 10) comes directly from Phase 18's supervisor-adjudicated ground
+  truth (`app/services/pilot_validation_service.py::compute_zone_performance`)
+  — not a re-derived estimate, so the same zone-miss numbers are consistent
+  across the pilot validation dashboard and this command center.

--- a/docs/customer/30-day-go-live-plan.md
+++ b/docs/customer/30-day-go-live-plan.md
@@ -1,0 +1,59 @@
+# 30-Day Go-Live Plan
+
+Builds on `docs/customer/customer-onboarding-playbook.md` with a
+week-by-week execution plan for the first 30 days after contract signature.
+
+## Week 1 — Provisioning & Access
+
+- Tenant provisioned (`docs/deployment/multi-tenant-deployment-guide.md`)
+- Executive Sponsor and SPD Champion identified (see
+  `docs/customer/executive-sponsor-guide.md`,
+  `docs/customer/spd-champion-guide.md`)
+- Initial users created with correct RBAC roles
+  (`docs/security/lumenai-rbac-matrix-v1.md`)
+- Kickoff call: review the 30/60/90-day plan, confirm success criteria
+
+## Week 2 — Baseline & Configuration
+
+- Manufacturer/vendor baselines loaded for the site's top instrument
+  families (`docs/architecture/...` baseline governance; see
+  `app/models/baseline_library.py`)
+- Facility/department/tray structure configured
+- SPD Champion and technicians trained on capture workflow (see
+  `docs/customer/training-matrix.md`)
+
+## Week 3 — Supervised Pilot Inspections
+
+- SPD technicians begin running real inspections
+- Supervisors begin reviewing AI recommendations
+  (`POST /inspections/{id}/supervisor-review`) — every review also
+  creates a Phase 18 ground-truth label and a Phase 23 Decision Ledger
+  entry automatically
+- Daily check-ins with the SPD Champion to unblock workflow friction
+
+## Week 4 — Go-Live Readiness Review
+
+- Review Phase 18 pilot validation metrics
+  (`/api/pilot-validation/dashboard`) and Phase 20 command center
+  readiness (`/api/pre-sterilization-command-center/dashboard`)
+- Confirm the go/no-go criteria in
+  `docs/validation/pilot-go-no-go-criteria.md` are met for the pilot
+  cohort collected so far
+- Executive Sponsor review meeting — go-live decision
+- Transition to `docs/customer/60-day-optimization-plan.md`
+
+## Exit criteria for Day 30
+
+- [ ] At least one full week of unsupervised, routine daily use
+- [ ] Supervisor agreement rate tracked and trending toward the
+  go/no-go threshold (`docs/validation/pilot-go-no-go-criteria.md`)
+- [ ] No unresolved critical safety queue items
+  (`/api/pre-sterilization-command-center/high-risk-findings`)
+- [ ] Customer Success Checklist (`docs/customer/customer-success-checklist.md`)
+  Week 1–4 items complete
+
+## Escalation path
+
+Any blocker that risks the Day-30 go-live date should be raised to the
+Executive Sponsor and the LumenAI implementation lead within 24 hours —
+see the escalation contacts in `docs/customer/executive-sponsor-guide.md`.

--- a/docs/customer/60-day-optimization-plan.md
+++ b/docs/customer/60-day-optimization-plan.md
@@ -1,0 +1,51 @@
+# 60-Day Optimization Plan
+
+Picks up from `docs/customer/30-day-go-live-plan.md` once the site is
+live. Days 31–60 focus on adoption depth and data-quality optimization
+rather than initial rollout.
+
+## Weeks 5–6 — Adoption Depth
+
+- Expand instrument-family coverage — review
+  `/api/pre-sterilization-command-center/baseline-coverage` for instrument
+  types still missing an approved baseline and prioritize closing gaps
+- Review zone-coverage quality
+  (`/api/pre-sterilization-command-center/missing-zone-coverage`) and
+  retrain technicians on capture technique for instrument families with
+  frequent `not_assessed`/`incomplete` coverage
+- Confirm every active SPD shift has at least one trained supervisor
+  available to clear the Supervisor Review Queue promptly
+
+## Weeks 7–8 — Data Quality & Feedback Loop
+
+- Review the Knowledge Graph's `learning_confidence` output
+  (`/api/knowledge-graph/learning-confidence`) — this is the first point
+  where enough real supervisor reviews exist to say something meaningful
+  about zone/finding confidence for this site's instrument mix
+- Review the Enterprise Knowledge Analytics
+  (`/api/knowledge-graph/analytics`) for this site's most common findings,
+  highest-risk zones, and most common supervisor overrides — feed
+  findings back into technician training
+- Address any recurring override patterns: if supervisors consistently
+  correct the same zone or finding type, that's a signal for the
+  `docs/customer/training-matrix.md` refresh, not just a one-off note
+
+## Day 60 checkpoint
+
+- [ ] Supervisor agreement rate stable or improving vs. Day 30
+- [ ] Coverage rate (Phase 23 `/api/cios/dashboard`) trending toward the
+  target in `docs/validation/pilot-go-no-go-criteria.md`
+- [ ] Zero unresolved critical missed findings older than 48 hours
+- [ ] Customer Success Checklist Week 5–8 items complete
+  (`docs/customer/customer-success-checklist.md`)
+- [ ] Executive Sponsor mid-point business review — early ROI signal
+  using `docs/commercial/roi-model.md` inputs specific to this site
+
+## Transition to Day 90
+
+Proceed to `docs/customer/90-day-value-realization-plan.md` once adoption
+depth and data quality checkpoints are met. If they are not met, extend
+the optimization phase rather than moving to value realization on a
+site that hasn't yet stabilized — a premature ROI conversation on
+unstable data undermines the customer relationship more than a short
+delay does.

--- a/docs/customer/90-day-value-realization-plan.md
+++ b/docs/customer/90-day-value-realization-plan.md
@@ -1,0 +1,55 @@
+# 90-Day Value Realization Plan
+
+Picks up from `docs/customer/60-day-optimization-plan.md`. Days 61–90
+shift the conversation from "is it working operationally" to "what value
+has it delivered," using the site's own real data rather than industry
+benchmarks.
+
+## Weeks 9–10 — Value Data Collection
+
+- Pull the site's real `/api/pilot-analytics/roi` output — labor savings,
+  reprocessing avoidance, and cancellation avoidance estimates computed
+  from this site's actual inspection volume and contamination-detection
+  rate, not generic assumptions
+- Pull `/api/cios/dashboard`'s `enterprise_risk_index`,
+  `readiness_rate`, and `average_inspection_time_minutes` as the
+  quantitative operational baseline
+- Compare against the site's own pre-LumenAI baseline where available
+  (`baseline_period_days` parameter on the ROI endpoint) rather than only
+  industry benchmarks — a customer-specific comparison is more credible
+  than an industry-average one
+
+## Weeks 11–12 — Executive Value Review
+
+- Prepare the value realization package using
+  `docs/enterprise/roi-framework.md`'s nine value categories, populated
+  with this site's real Day 90 figures
+- Executive Sponsor review meeting: present measured value, remaining
+  gaps, and the expansion recommendation
+  (`/api/pilot-analytics/quarterly-review`'s `expansion_recommendations`)
+- Identify next-phase opportunities: additional facilities, additional
+  instrument families, or upgrading to a higher edition
+  (`docs/enterprise/commercial-packaging.md`) if usage has outgrown the
+  current one
+
+## Day 90 exit criteria
+
+- [ ] Quantified ROI figures presented to the Executive Sponsor, sourced
+  from real site data (not solely industry benchmarks)
+- [ ] Go/no-go decision recorded (`/api/pilot-validation/go-no-go`) if
+  this site is also part of the formal Phase 18 pilot validation cohort
+- [ ] Customer Success Checklist fully complete
+  (`docs/customer/customer-success-checklist.md`)
+- [ ] Customer Health Score established as an ongoing tracked metric
+  (`docs/customer-success/customer-health-framework.md`,
+  `docs/enterprise/enterprise-metrics.md`)
+- [ ] Renewal-readiness baseline established
+  (`docs/customer-success/renewal-readiness-guide.md`)
+
+## Beyond Day 90
+
+Ongoing success is tracked through the ongoing Enterprise Metrics
+framework (`docs/enterprise/enterprise-metrics.md`), not a one-time
+90-day report — value realization is a continuous measurement, and the
+same dashboards used during onboarding remain the source of truth for
+every subsequent quarterly business review.

--- a/docs/customer/customer-success-checklist.md
+++ b/docs/customer/customer-success-checklist.md
@@ -1,0 +1,57 @@
+# Customer Success Checklist
+
+A single running checklist spanning the full implementation lifecycle —
+cross-referenced from `docs/customer/30-day-go-live-plan.md`,
+`60-day-optimization-plan.md`, and `90-day-value-realization-plan.md`.
+
+## Pre-Kickoff
+
+- [ ] Contract signed, edition confirmed (`docs/enterprise/commercial-packaging.md`)
+- [ ] Executive Sponsor named
+- [ ] SPD Champion named
+- [ ] Tenant provisioned
+
+## Days 1–30 (Go-Live)
+
+- [ ] Users created with correct RBAC roles
+- [ ] Baselines loaded for top instrument families
+- [ ] Facility/department/tray structure configured
+- [ ] Technicians trained on capture workflow
+- [ ] Supervisors trained on the review workflow
+  (`docs/knowledge-graph/reasoning-engine.md` for how to interpret AI
+  explanations)
+- [ ] First full week of routine daily use completed
+- [ ] Go-live readiness review held with Executive Sponsor
+
+## Days 31–60 (Optimization)
+
+- [ ] Instrument-family baseline coverage gaps reviewed and prioritized
+- [ ] Zone-coverage quality reviewed; technician retraining scheduled
+  where needed
+- [ ] Recurring supervisor override patterns identified and addressed
+- [ ] Mid-point business review held
+
+## Days 61–90 (Value Realization)
+
+- [ ] Site-specific ROI data pulled and reviewed
+- [ ] Value realization package presented to Executive Sponsor
+- [ ] Customer Health Score baseline established
+- [ ] Renewal-readiness baseline established
+- [ ] Expansion opportunity identified (additional sites, instrument
+  families, or edition upgrade) — or explicitly noted as not applicable
+
+## Ongoing (Post-90-Day)
+
+- [ ] Quarterly business review scheduled
+- [ ] Enterprise Metrics dashboard reviewed monthly
+  (`docs/enterprise/enterprise-metrics.md`)
+- [ ] Support ticket trends reviewed for recurring friction points
+- [ ] Reference-customer program eligibility assessed
+  (`docs/customer-success/reference-customer-program.md`)
+
+## Red flags requiring escalation
+
+- Supervisor agreement rate declining rather than stabilizing after Day 30
+- Coverage rate not improving after targeted retraining
+- Any unresolved critical safety-queue item older than 48 hours
+- Executive Sponsor or SPD Champion turnover without a named replacement

--- a/docs/customer/executive-sponsor-guide.md
+++ b/docs/customer/executive-sponsor-guide.md
@@ -1,0 +1,61 @@
+# Executive Sponsor Guide
+
+## Who this is for
+
+The hospital or health-system executive (VP of Perioperative Services,
+CNO, Director of Quality, or equivalent) who sponsors the LumenAI
+implementation and is accountable for its success internally.
+
+## What the Executive Sponsor needs to know
+
+You do not need to understand the AI architecture in detail. You need to
+be able to answer, for your own leadership:
+
+1. **What is LumenAI?** An AI-assisted pre-sterilization clinical
+   inspection platform — it helps SPD staff catch contamination, damage,
+   and quality issues before instruments proceed to packaging and
+   sterilization. It is not a sterilization monitoring system (see
+   `docs/architecture/pre-sterilization-boundary.md`).
+2. **What does it require of my staff?** Technicians capture images as
+   part of their normal inspection workflow; supervisors review AI
+   recommendations and either confirm or correct them. No AI
+   recommendation is final without a supervisor's sign-off.
+3. **What value should I expect, and by when?** See the 30/60/90-day
+   plans (`docs/customer/30-day-go-live-plan.md` and following) — Day 30
+   is operational go-live, Day 90 is the first quantified value review
+   using your own site's data (`docs/customer/90-day-value-realization-plan.md`).
+4. **How is patient safety protected?** Every recommendation is
+   advisory and explainable (`docs/knowledge-graph/reasoning-engine.md`);
+   a human supervisor is the final authority on every disposition
+   (`docs/architecture/design-principles.md`, Principle 4).
+5. **How is my data protected?** Tenant-isolated, RBAC-gated, fully
+   audit-logged (`docs/security/security-compliance-center.md`).
+
+## Your role during implementation
+
+- Name an SPD Champion (`docs/customer/spd-champion-guide.md`) as the
+  day-to-day operational owner — the Executive Sponsor is the escalation
+  path and business-value owner, not the daily operator.
+- Attend the Day 30, Day 60, and Day 90 checkpoint reviews.
+- Clear organizational blockers (staffing, training time, department
+  buy-in) that are outside the SPD Champion's authority to resolve.
+- Review the value realization package at Day 90 and decide on expansion
+  (additional sites, instrument families, or edition upgrade — see
+  `docs/enterprise/commercial-packaging.md`).
+
+## Reporting you'll receive
+
+- Weekly status during Days 1–30 from the LumenAI implementation team.
+- The Executive Command Center dashboard (frontend) and
+  `/api/cios/dashboard` for a live, self-service view of system health,
+  readiness, and risk indicators at any time.
+- A formal value realization package at Day 90
+  (`docs/customer/90-day-value-realization-plan.md`), and quarterly
+  thereafter.
+
+## Escalation
+
+Any blocker risking the go-live timeline, or any critical safety-queue
+item unresolved beyond 48 hours, should reach you within one business
+day — confirm this escalation path is set up correctly with your LumenAI
+implementation lead during kickoff.

--- a/docs/customer/implementation-timeline.md
+++ b/docs/customer/implementation-timeline.md
@@ -1,0 +1,68 @@
+# Implementation Timeline
+
+A single-page view of the full implementation lifecycle, consolidating
+`docs/customer/30-day-go-live-plan.md`, `60-day-optimization-plan.md`,
+and `90-day-value-realization-plan.md`.
+
+```
+Day 0            Day 7            Day 14           Day 21           Day 30
+  │                │                │                │                │
+  ▼                ▼                ▼                ▼                ▼
+Contract      Provisioning     Baseline &       Supervised        Go-Live
+Signed &      & Access         Config           Pilot             Readiness
+Kickoff       (Week 1)         (Week 2)         Inspections       Review
+                                                (Week 3)
+
+Day 30           Day 45           Day 60
+  │                │                │
+  ▼                ▼                ▼
+Go-Live       Adoption Depth    Data Quality &
+              Review            Feedback Loop
+              (Weeks 5-6)       (Weeks 7-8)
+                                        │
+                                        ▼
+                                  Day 60 Checkpoint
+
+Day 60           Day 75           Day 90
+  │                │                │
+  ▼                ▼                ▼
+Optimization  Value Data        Executive Value
+Complete      Collection        Review
+              (Weeks 9-10)      (Weeks 11-12)
+                                        │
+                                        ▼
+                                  Day 90 Exit / Ongoing Success
+```
+
+## Milestone owners
+
+| Milestone | Primary owner | Reviewer |
+|---|---|---|
+| Kickoff | LumenAI implementation lead | Executive Sponsor |
+| Provisioning & config | LumenAI implementation lead | SPD Champion |
+| Training | SPD Champion | LumenAI implementation lead |
+| Go-live readiness | SPD Champion | Executive Sponsor |
+| Optimization | SPD Champion | LumenAI implementation lead |
+| Value realization | LumenAI implementation lead | Executive Sponsor |
+| Ongoing success | Customer Success (LumenAI) | Executive Sponsor + SPD Champion |
+
+## Dependencies to plan around
+
+- Baseline availability from manufacturers/vendors can be the
+  longest-lead-time item — start requesting baselines in Week 1, not
+  Week 2, if the vendor relationship is new.
+- Staff training schedules (shift coverage) often determine how fast
+  Week 1–2 activities can actually happen — build slack into the plan
+  for a 24/7 SPD operation vs. a single-shift department.
+- A site with an existing Phase 18 pilot cohort already underway may
+  compress the 30-day timeline since baseline/training work is already
+  done — see `docs/validation/pilot-validation-protocol.md`.
+
+## Variance handling
+
+This timeline is a target, not a guarantee. If a site is tracking behind
+(e.g., baseline loading incomplete by Day 14), extend the relevant phase
+rather than compressing training or supervised-pilot time to hit an
+artificial date — an SPD team pushed live before they're ready produces
+worse adoption data and a worse Day 90 value story than a two-week delay
+would.

--- a/docs/customer/spd-champion-guide.md
+++ b/docs/customer/spd-champion-guide.md
@@ -1,0 +1,65 @@
+# SPD Champion Guide
+
+## Who this is for
+
+The SPD supervisor, lead tech, or educator who owns day-to-day adoption
+of LumenAI within the department — the primary point of contact between
+frontline staff and the implementation team.
+
+## Your responsibilities
+
+1. **Own the rollout schedule.** Work through
+   `docs/customer/30-day-go-live-plan.md` week by week with your team.
+2. **Train your team.** Use `docs/customer/training-matrix.md` to confirm
+   every technician and supervisor role has completed the right training
+   before they start using LumenAI unsupervised.
+3. **Load baselines.** Coordinate with vendors/manufacturers to get
+   approved baselines loaded for your site's top instrument families
+   before go-live (baseline governance — see
+   `docs/architecture/domain-model.md`'s Baseline entity).
+4. **Be the first line of support.** Most day-to-day questions ("why did
+   it flag this?", "how do I correct a zone?") should go through you
+   first — use `docs/knowledge-graph/reasoning-engine.md` and the
+   Knowledge Graph Explorer (`/knowledge-graph`) to understand and
+   explain AI reasoning to your team before escalating to LumenAI
+   support.
+5. **Watch the safety queue.** Check the Supervisor Review Queue and
+   High-Risk Findings Queue
+   (`/pre-sterilization-command-center`) daily — these are the
+   inspections that need a human decision *now*.
+6. **Report friction, not just problems.** If technicians are
+   consistently missing zone coverage on a specific instrument family,
+   that's a training-matrix gap, not a bug — flag it for the Day 60
+   optimization review (`docs/customer/60-day-optimization-plan.md`).
+
+## What good supervisor review looks like
+
+- **Agree** when the AI's finding, zone, and recommendation all look
+  correct — no rationale required beyond the agreement itself.
+- **Partially agree or disagree** with a written rationale when the
+  finding is right but the zone is wrong (or vice versa) — use the
+  `corrected_zone`/`corrected_instrument_family`/`corrected_severity`
+  fields; this becomes real labeled training data (Phase 18), not just a
+  note that disappears.
+- **Override** the recommended disposition only when there's a clinical
+  reason to do so, always with a rationale — overrides are tracked
+  (`most_common_supervisor_override` in the Enterprise Knowledge
+  Analytics) and repeated overrides of the same type are a signal worth
+  investigating, not just accepting.
+
+## Daily/weekly rhythm
+
+| Cadence | Activity |
+|---|---|
+| Daily | Clear the Supervisor Review Queue; check High-Risk Findings Queue |
+| Weekly | Spot-check zone-coverage quality trends; check in with technicians on friction points |
+| At Day 30/60/90 checkpoints | Represent the SPD department's operational perspective in the Executive Sponsor review |
+
+## Escalation
+
+If you can't resolve a question about an AI recommendation, or if you
+believe a finding was clinically wrong and the reasoning chain doesn't
+explain why, escalate to LumenAI support — a genuine AI reasoning gap is
+exactly the kind of signal the Continuous Learning Agent (Phase 22) and
+the Knowledge Graph (Phase 21) need real supervisor corrections to
+improve.

--- a/docs/customer/training-matrix.md
+++ b/docs/customer/training-matrix.md
@@ -1,0 +1,53 @@
+# Training Matrix
+
+Who needs to be trained on what, before they use LumenAI unsupervised.
+
+## Role-based training requirements
+
+| Role | Required training | Format | Sign-off owner |
+|---|---|---|---|
+| SPD Technician (operator) | Capture workflow (image capture, zone tagging, instrument identification); reading AI feedback; when to escalate | Hands-on, ≥1 supervised session | SPD Champion |
+| SPD Supervisor (spd_manager) | Everything above, plus: reviewing AI recommendations, agree/partial-agree/disagree workflow, override policy, reading the reasoning chain (`/knowledge-graph`) | Hands-on + reasoning-chain walkthrough | SPD Champion |
+| SPD Manager / Department Lead | Everything above, plus: Pre-Sterilization Command Center (`/pre-sterilization-command-center`), Pilot Validation Dashboard (`/pilot-validation`), safety queue triage | Dashboard walkthrough | Executive Sponsor |
+| Executive Sponsor | Executive Command Center, CIOS Dashboard (`/cios-dashboard`), value realization reporting | Executive briefing | LumenAI implementation lead |
+| IT/Security Administrator | RBAC configuration, SSO/OIDC setup, audit log review, tenant configuration | Technical walkthrough | LumenAI implementation lead |
+
+## What "trained" means, concretely
+
+A technician is considered trained when they can, unsupervised:
+
+- Correctly identify and tag the required inspection zones for their
+  site's most common instrument families
+- Correctly interpret a "requires supervisor review" flag and route it
+  appropriately
+- Explain, in their own words, why LumenAI is a pre-sterilization tool
+  and not a sterilization-validation system
+
+A supervisor is considered trained when they can, unsupervised:
+
+- Use the reasoning chain to explain an AI recommendation to a
+  technician or auditor
+- Correctly apply the agree/partially-agree/disagree/override workflow,
+  including writing a rationale when required
+- Recognize when a finding should escalate to the safety review queue vs.
+  routine reprocessing
+
+## Refresher training triggers
+
+- A recurring override or correction pattern identified during the Day
+  60 optimization review (`docs/customer/60-day-optimization-plan.md`)
+- A new instrument family or manufacturer added to the site's baseline
+  library
+- Staff turnover — new hires require the full role-based training before
+  unsupervised use, not an abbreviated version
+- A platform version upgrade that changes the reasoning chain,
+  recommendation vocabulary, or reviewed workflow
+
+## Training materials
+
+Point-in-time training content should reference the live product, not a
+static screenshot deck that goes stale — walk trainees through the actual
+`/knowledge-graph`, `/pilot-validation`, and
+`/pre-sterilization-command-center` pages using a real (or sandboxed
+demo) inspection, per `docs/deployment/GITHUB_PAGES_DEMO.md` for a safe,
+non-production environment to train in.

--- a/docs/deployment/backup-restore-guide.md
+++ b/docs/deployment/backup-restore-guide.md
@@ -1,0 +1,53 @@
+# Backup & Restore Guide
+
+## What must be backed up
+
+| Asset | Contains | Backup approach |
+|---|---|---|
+| Primary PostgreSQL database | All clinical, tenant, audit, and governance data — inspections, supervisor reviews, pilot validation ground truth, the Clinical Decision Ledger, CIOS events | Automated daily full backup + continuous WAL archiving for point-in-time recovery |
+| Retained training images | Opt-in, consented images stored via `app/models/retained_image.py` (de-identified, EXIF-stripped, no PHI per CLAUDE.md constraints) | Included in the same backup cadence as the database if stored as BLOBs; object-storage lifecycle policy if stored externally |
+| Application configuration | Environment variables, secrets (see `docs/security/security-compliance-center.md` §Secrets Management) | Stored in the secrets manager, not backed up alongside application data — recovered by re-provisioning from the secrets manager, never from a database backup |
+
+## What is intentionally never backed up as "recoverable secrets"
+
+- Secret API keys are stored as SHA-256 hashes only (see CLAUDE.md
+  security constraints) — they are one-way and issued once
+  (`secrets.token_urlsafe(40)`). A backup restore recovers the hash, not
+  the original key; a lost key must be reissued, not "restored."
+
+## Backup cadence and retention
+
+| Backup type | Frequency | Retention |
+|---|---|---|
+| Full database backup | Daily | 35 days rolling |
+| WAL/continuous archiving | Continuous | Sufficient to support the 15-minute RPO target in `docs/deployment/disaster-recovery-guide.md` |
+| Monthly archival snapshot | Monthly | 1 year (aligned with the audit log's minimum 1-year retention commitment across editions — see `docs/enterprise/commercial-packaging.md`) |
+| Cross-region copy | Daily | Matches primary retention; stored in a separate region/provider account from production |
+
+## Restore procedure
+
+1. Identify the target restore point (latest backup, or a specific
+   point-in-time via WAL replay for a more precise RPO).
+2. Restore into an isolated environment first — never restore directly
+   over a live production database without validating the restored data.
+3. Run the schema/column-migration check
+   (`app/db/column_migrator.py::ensure_columns`) against the restored
+   database to confirm compatibility with the currently deployed
+   application version.
+4. Spot-check tenant isolation: confirm a query scoped to one
+   `tenant_id` does not return another tenant's rows (this is the same
+   check enforced by
+   `docs/security/lumenai-enterprise-tenant-isolation-test-matrix-v1.md`'s
+   automated tests).
+5. Promote the restored environment to production per
+   `docs/deployment/disaster-recovery-guide.md`'s relevant scenario.
+
+## Restore testing
+
+A full restore-to-scratch-environment test should be run on a schedule
+(recommended: quarterly) independent of an actual incident, so the first
+time a restore is attempted is never during a real outage. Record results
+(restore duration, any schema drift found, data integrity spot-check
+outcome) — this evidences the RTO/RPO targets in
+`docs/deployment/disaster-recovery-guide.md` are actually achievable, not
+just assumed.

--- a/docs/deployment/cloud-architecture-guide.md
+++ b/docs/deployment/cloud-architecture-guide.md
@@ -1,0 +1,91 @@
+# Cloud Architecture Guide
+
+## Supported deployment targets
+
+LumenAI is cloud-agnostic by design (FastAPI + PostgreSQL + a static
+frontend build) and has documented deployment paths for:
+
+- **Render** — `docs/deployment/RENDER_DEPLOYMENT.md`,
+  `RENDER_DEPLOYMENT_READINESS.md`
+- **Railway** — `docs/deployment/RAILWAY_DEPLOYMENT.md`
+- **Fly.io** — `docs/deployment/FLY_DEPLOYMENT.md`
+- **Generic cloud/Kubernetes** — `docs/deployment/CLOUD_DEPLOYMENT_PLAN.md`,
+  and this guide
+
+Pick the managed-platform path (Render/Railway/Fly) for fastest
+time-to-production; pick the generic cloud path for a customer that
+requires deployment into their own cloud account/VPC for compliance
+reasons.
+
+## Reference architecture
+
+```
+                     ┌─────────────────┐
+                     │   CDN / Static   │
+                     │  Frontend Host   │  (Vite build output)
+                     └────────┬─────────┘
+                              │
+                     ┌────────▼─────────┐
+                     │  Load Balancer /  │
+                     │  Reverse Proxy    │  (TLS termination)
+                     └────────┬─────────┘
+                              │
+              ┌───────────────┼───────────────┐
+              │               │               │
+        ┌─────▼─────┐   ┌─────▼─────┐   ┌─────▼─────┐
+        │  FastAPI   │   │  FastAPI   │   │  FastAPI   │   (stateless replicas —
+        │  Backend   │   │  Backend   │   │  Backend   │    see high-availability-guide.md)
+        └─────┬─────┘   └─────┬─────┘   └─────┬─────┘
+              │               │               │
+              └───────────────┼───────────────┘
+                              │
+                    ┌─────────▼─────────┐
+                    │   PostgreSQL       │  (primary + standby —
+                    │   (primary)        │   see high-availability-guide.md)
+                    └─────────┬─────────┘
+                              │
+                    ┌─────────▼─────────┐
+                    │  Backup storage /  │  (see backup-restore-guide.md)
+                    │  cross-region copy │
+                    └───────────────────┘
+
+        ┌───────────────────────────────────┐
+        │  Background schedulers (single     │
+        │  leader): prediction, RWE,         │
+        │  integration, quality-intelligence, │
+        │  global-aggregation (app/main.py)  │
+        └───────────────────────────────────┘
+```
+
+## Network boundaries
+
+- The frontend never talks to the database directly — all data access
+  goes through the FastAPI backend's authenticated, RBAC-gated routes.
+- Outbound integrations (external system connectors,
+  `app/models/external_connector.py`) are opt-in per tenant and gated by
+  a signed BAA where PHI-adjacent data could be involved (see the
+  integrations route's BAA check, exercised by
+  `_seed_hipaa_baa` in the test suite).
+- No component other than the backend holds a database credential.
+
+## Statelessness and horizontal scaling
+
+Every backend replica is interchangeable — there is no sticky-session
+requirement and no in-memory state that would break if a request landed
+on a different replica than a prior request from the same user. This is
+what makes the horizontal-scaling story in
+`docs/deployment/scaling-guide.md` straightforward: add replicas behind
+the load balancer, no application-level coordination required beyond the
+shared database.
+
+## Environments
+
+Maintain at least three environments per deployment:
+
+1. **Production** — `APP_ENV=production`, real auth only, real data.
+2. **Staging** — mirrors production configuration, used for pre-release
+   verification (`docs/security/staging-security-smoke-test-checklist.md`).
+3. **Development** — dev-auth tokens enabled, synthetic/demo data only
+   (see `docs/deployment/GITHUB_PAGES_DEMO.md` for the public demo
+   environment specifically, which is intentionally isolated from any
+   real customer data).

--- a/docs/deployment/disaster-recovery-guide.md
+++ b/docs/deployment/disaster-recovery-guide.md
@@ -1,0 +1,74 @@
+# Disaster Recovery Guide
+
+## Scope
+
+Recovery procedures for a full or partial loss of the LumenAI production
+environment — database loss, region outage, or application-tier failure.
+This complements `docs/deployment/backup-restore-guide.md` (the mechanics
+of taking and restoring backups) and
+`docs/deployment/high-availability-guide.md` (avoiding the outage in the
+first place).
+
+## Recovery objectives
+
+| Metric | Target | Basis |
+|---|---|---|
+| RPO (Recovery Point Objective) | ≤ 15 minutes | Driven by database backup/WAL-archiving frequency — see backup-restore-guide.md |
+| RTO (Recovery Time Objective) | ≤ 4 hours for full environment rebuild | Infrastructure-as-code redeploy + database restore + verification |
+
+These are target design objectives for this document's procedures, not a
+contractual SLA — a specific customer's actual RPO/RTO commitment is set
+in their support/SLA agreement (see
+`docs/customer-success/renewal-readiness-guide.md` and the edition-level
+support commitments in `docs/enterprise/commercial-packaging.md`).
+
+## Disaster scenarios and response
+
+### 1. Database loss or corruption
+1. Stop write traffic to the affected database (take the API out of the
+   load balancer pool or flip to maintenance mode).
+2. Restore from the most recent backup per
+   `docs/deployment/backup-restore-guide.md`.
+3. Replay any available WAL/point-in-time-recovery logs to minimize data
+   loss beyond the last full backup.
+4. Run `ensure_columns()` / migrations to confirm the restored schema
+   matches the current application version before reconnecting traffic.
+5. Verify with the post-install checklist in
+   `docs/deployment/enterprise-installation-guide.md`.
+
+### 2. Application-tier failure (backend/frontend unavailable)
+1. If running with multiple replicas (see
+   `docs/deployment/high-availability-guide.md`), traffic should already
+   have failed over automatically — confirm via `/api/agents/health` and
+   `/api/cios/dashboard`'s `system_health` field.
+2. If single-instance, redeploy from the last known-good build/image.
+   Infrastructure-as-code (the deployment configs in
+   `docs/deployment/RENDER_DEPLOYMENT.md` /
+   `RAILWAY_DEPLOYMENT.md` / `FLY_DEPLOYMENT.md`) should make this a
+   scripted redeploy, not a manual rebuild.
+
+### 3. Full region/provider outage
+1. Stand up the environment in a secondary region/provider using the same
+   infrastructure-as-code configuration.
+2. Restore the database from the most recent off-region backup copy (see
+   backup-restore-guide.md's cross-region retention requirement).
+3. Repoint DNS/load balancer to the new environment.
+4. Communicate the outage and recovery status per the incident response
+   plan (`docs/security/security-compliance-center.md` §Incident Response).
+
+## What is NOT lost in a disaster (by design)
+
+- **Audit trail integrity**: `AuditLog` rows are hash-chained
+  (`previous_event_hash`/`event_hash`) — a restored database's audit trail
+  can be verified for tamper-evidence after recovery, not just restored.
+- **Governance versions**: Every `ClinicalDecisionLedgerEntry` (Phase 23)
+  snapshots the governance versions active when it was written, so a
+  restored ledger remains historically accurate regardless of what the
+  *current* code version is at recovery time.
+
+## Testing this plan
+
+A disaster recovery drill (restoring a backup to a scratch environment
+and running the post-install verification checklist) should be performed
+at least annually and after any major schema change. Record drill results
+in `docs/evidence/lessons-learned.md`.

--- a/docs/deployment/enterprise-installation-guide.md
+++ b/docs/deployment/enterprise-installation-guide.md
@@ -1,0 +1,71 @@
+# Enterprise Installation Guide
+
+Companion to `docs/deployment/production-deployment-guide.md` — this
+guide covers the enterprise-specific installation path (multi-facility
+health systems, IT-managed rollout) rather than the single-site quick
+start covered elsewhere (`docs/deployment/HOSTED_BACKEND_QUICKSTART.md`,
+`RENDER_DEPLOYMENT.md`, `RAILWAY_DEPLOYMENT.md`, `FLY_DEPLOYMENT.md`).
+
+## Prerequisites
+
+- A supported deployment target: managed cloud (Render/Railway/Fly — see
+  the respective deployment docs) or a customer-managed Kubernetes/VM
+  environment.
+- PostgreSQL 14+ (production; SQLite is dev/test-only — see
+  `backend/app/db/session.py`).
+- An environment variable set matching
+  `docs/deployment/ENVIRONMENT_VARIABLE_CHECKLIST.md` — at minimum
+  `DATABASE_URL`, `JWT_SECRET`/OIDC configuration
+  (`docs/security/production-oidc-deployment-guide.md`), and
+  `APP_ENV=production` (which disables dev-auth tokens — see
+  `backend/app/enterprise_auth.py`).
+- TLS termination in front of the API (load balancer or reverse proxy) —
+  LumenAI does not terminate TLS itself.
+
+## Installation sequence
+
+1. **Provision the database.** Run Alembic migrations
+   (`backend/alembic/`) against a fresh PostgreSQL instance. `Base.metadata.create_all`
+   plus `ensure_columns()` (`backend/app/db/column_migrator.py`) handle
+   additive schema changes on startup, but the initial schema should come
+   from migrations, not just `create_all`, in a real production install.
+2. **Configure tenancy.** Every table that carries clinical or
+   operational data is `tenant_id`-scoped (see
+   `docs/security/lumenai-enterprise-tenant-isolation-test-matrix-v1.md`).
+   Decide up front whether this install is single-tenant (one hospital)
+   or multi-tenant (a health system or MSP hosting multiple facilities) —
+   see `docs/deployment/multi-tenant-deployment-guide.md`.
+3. **Configure authentication.** Production installs must use real
+   JWT/OIDC authentication (`docs/security/production-oidc-deployment-guide.md`,
+   `docs/security/lumenai-production-dev-auth-removal-plan-v1.md`) — dev
+   tokens (`dev-token`, `manager-token`, etc.) are rejected outright when
+   `APP_ENV=production` (`backend/app/enterprise_auth.py`).
+4. **Deploy the backend** (FastAPI + Uvicorn/Gunicorn) behind your load
+   balancer, and the frontend** (static Vite build,
+   `npm --prefix frontend run build`) behind a CDN or static host.
+5. **Verify with the go-live runbook** (`docs/deployment/go-live-runbook.md`)
+   and the public demo readiness checklist as a baseline smoke test
+   (`docs/deployment/PUBLIC_DEMO_READINESS_CHECKLIST.md`), even for a
+   private enterprise install — the same health checks apply.
+6. **Enroll the site.** Use the onboarding flow in
+   `docs/customer/customer-onboarding-playbook.md` and
+   `docs/enterprise/site-onboarding-guide.md` to configure the facility,
+   users, and RBAC roles before go-live.
+
+## Post-install verification checklist
+
+- [ ] `GET /health` (or equivalent) returns healthy
+- [ ] A test inspection can be created, scored, and reviewed end-to-end
+- [ ] Audit log entries are being written (`AuditLog` table populated)
+- [ ] RBAC roles are enforced (`docs/security/lumenai-rbac-matrix-v1.md`)
+- [ ] Backups are configured and a restore has been test-run
+  (`docs/deployment/backup-restore-guide.md`)
+- [ ] The `/api/cios/dashboard` and `/api/agents/health` endpoints report
+  `ok` system health (Phase 22/23)
+
+## Related guides
+
+- `docs/deployment/production-deployment-guide.md` — deployment mechanics
+- `docs/deployment/high-availability-guide.md` — redundancy and failover
+- `docs/deployment/scaling-guide.md` — capacity planning
+- `docs/deployment/disaster-recovery-guide.md` — recovery procedures

--- a/docs/deployment/high-availability-guide.md
+++ b/docs/deployment/high-availability-guide.md
@@ -1,0 +1,73 @@
+# High Availability Guide
+
+## Design goal
+
+No single component failure should take the whole platform down for a
+customer relying on LumenAI as their pre-sterilization quality gate.
+
+## Application tier
+
+- Run the FastAPI backend as multiple stateless replicas behind a load
+  balancer. The application holds no in-process session state that would
+  break under horizontal scaling — auth is stateless JWT/OIDC
+  (`docs/security/production-oidc-deployment-guide.md`), and every
+  request re-establishes its own DB session (`app/deps.py::get_db`).
+- Health checks: `GET /api/agents/health` (Phase 22 agent registry
+  rollup) and `GET /api/cios/dashboard`'s `system_health` field
+  (Phase 23) both report a real, computed health status suitable for a
+  load balancer health-check probe — neither is a fabricated "always
+  ok" endpoint.
+- The frontend is a static build (`npm --prefix frontend run build`) —
+  serve it from a CDN with multi-region edge caching; it has no
+  single-instance availability concern.
+
+## Data tier
+
+- PostgreSQL with a hot standby / read replica for failover (managed
+  Postgres offerings on Render/Railway/Fly provide this — see the
+  respective deployment docs). A failover to a standby should be
+  automated by the managed database provider, not a manual DBA action,
+  wherever the hosting platform supports it.
+- Connection pooling (e.g. PgBouncer or the provider's built-in pooler)
+  to avoid exhausting connections across multiple application replicas.
+
+## Background jobs
+
+- Scheduled jobs (prediction scheduler, RWE scheduler, integration
+  scheduler, quality-intelligence scheduler, global-aggregation
+  scheduler — registered in `app/main.py` via APScheduler) should run on
+  a single designated worker/leader to avoid duplicate execution, with a
+  standby worker ready to take over the schedule if the leader fails.
+
+## What "available" does NOT mean here
+
+Availability of the *platform* is separate from clinical safety
+guarantees. Even at 100% platform uptime, every recommendation still
+requires human supervisor validation (Design Principle 4,
+`docs/architecture/design-principles.md`) — high availability makes the
+tool reliably accessible, it does not reduce or replace the human review
+step.
+
+## Degraded-mode behavior
+
+If a downstream dependency degrades (e.g. the knowledge graph's
+enterprise analytics query is slow under load), the platform should
+degrade gracefully rather than fail the whole request:
+
+- Dashboard aggregation functions (Phase 20/21/23) already return `None`
+  for a metric they can't compute rather than raising — the same
+  principle should extend to infrastructure-level degradation (timeouts
+  return partial dashboards, not 500s, wherever safely possible).
+- Core inspection creation and scoring (`POST /api/inspections`) is the
+  highest-priority path to keep available even if analytics/dashboard
+  endpoints are temporarily degraded.
+
+## Multi-region considerations
+
+See `docs/deployment/cloud-architecture-guide.md` for whether a given
+deployment needs multi-region active-active, or single-region with a
+cold/warm disaster-recovery region (see
+`docs/deployment/disaster-recovery-guide.md`) — most single-hospital and
+regional health-system deployments do not need active-active multi-region;
+it becomes a relevant conversation at the scale of a national health
+system or a multi-tenant hosted offering serving many customers.

--- a/docs/deployment/multi-tenant-deployment-guide.md
+++ b/docs/deployment/multi-tenant-deployment-guide.md
@@ -1,0 +1,65 @@
+# Multi-Tenant Deployment Guide
+
+## Deployment models
+
+LumenAI supports two deployment models, both running the same codebase:
+
+| Model | Description | Typical customer |
+|---|---|---|
+| **Single-tenant** | One `tenant_id` per deployed instance (or a fixed tenant per customer database). | A large health system that wants dedicated infrastructure. |
+| **Multi-tenant (shared)** | One deployment serves many facilities/customers, isolated by `tenant_id`. | A hosted/SaaS offering (the default for Community/Professional edition customers — see `docs/enterprise/commercial-packaging.md`). |
+
+## How tenant isolation is enforced
+
+Every table carrying clinical, operational, or governance data has a
+`tenant_id` column, and every read/write route filters on it — this is
+enforced at the application layer today (see
+`docs/security/lumenai-enterprise-tenant-isolation-test-matrix-v1.md` for
+the test matrix that verifies it) rather than at the database-row-security
+layer. Concretely:
+
+- `Inspection`, `SupervisorReview`, `PilotValidationCase`,
+  `ClinicalDecisionLedgerEntry`, `CIOSEvent`, `AuditLog`, and every other
+  tenant-scoped model default to `tenant_id="default-tenant"` and are
+  always filtered by the authenticated user's resolved tenant
+  (`app/enterprise_auth.py::get_request_tenant_id`).
+- Platform `admin` role can see across tenants for legitimate cross-tenant
+  operations (e.g. the network intelligence/benchmarking features,
+  Phase 15/20) — always with anonymization at the point of aggregation
+  (hospital identities never surface in cross-hospital intelligence, per
+  the CLAUDE.md security constraint), and always audit-logged.
+
+## Onboarding a new tenant
+
+1. Provision the tenant record (`docs/enterprise/site-onboarding-guide.md`
+   covers the operational onboarding checklist).
+2. Assign an initial admin user and RBAC roles
+   (`docs/security/lumenai-rbac-matrix-v1.md`).
+3. Configure tenant-specific branding if applicable
+   (`app/models/tenant_branding.py`).
+4. Set entitlements/quotas per the customer's edition
+   (`app/models/tenant_entitlement.py`, `app/models/tenant_quota.py`) —
+   see `docs/enterprise/commercial-packaging.md` for edition limits.
+5. Verify isolation: as the new tenant, confirm zero visibility into any
+   other tenant's inspections, baselines, or dashboards.
+
+## Capacity planning for shared multi-tenant deployments
+
+See `docs/deployment/scaling-guide.md` for how per-tenant inspection
+volume translates into database and application capacity requirements.
+As a shared deployment's tenant count grows, monitor:
+
+- Per-tenant inspection volume (via `/api/pilot-analytics/*` and
+  `/api/cios/dashboard`'s throughput figures) to catch a single noisy
+  tenant before it affects others.
+- Database connection pool saturation — many small tenants generate many
+  concurrent short-lived connections; pool sizing should account for
+  tenant count, not just total request volume.
+
+## Data residency and export
+
+A tenant's data can be exported independently (compliance/trust-center
+export routes, `app/routes/trust_center_exports.py` /
+`app/routes/compliance_exports.py`) — relevant for a customer's own
+data-portability requirements or for offboarding a tenant from a shared
+deployment without touching any other tenant's data.

--- a/docs/deployment/scaling-guide.md
+++ b/docs/deployment/scaling-guide.md
@@ -1,0 +1,76 @@
+# Scaling Guide
+
+## Scaling dimensions
+
+LumenAI scales along three largely independent dimensions:
+
+1. **Inspection volume** — how many inspections/month a tenant (or the
+   whole shared deployment) processes.
+2. **Tenant count** — how many distinct facilities/customers share one
+   deployment (see `docs/deployment/multi-tenant-deployment-guide.md`).
+3. **Concurrent users** — how many SPD staff are actively using the
+   system at once (capture, review queues, dashboards).
+
+## Application tier
+
+Stateless FastAPI replicas scale horizontally — add replicas behind the
+load balancer as request volume grows (see
+`docs/deployment/high-availability-guide.md` for the same architecture
+serving redundancy, not just capacity). There is no code-level ceiling on
+replica count; the practical limit is database connection capacity.
+
+## Database tier
+
+The database is the eventual bottleneck at scale. Growth levers, in
+order of typical cost/complexity:
+
+1. **Connection pooling** (PgBouncer or managed equivalent) — the first
+   and cheapest lever before vertical scaling.
+2. **Vertical scaling** (more CPU/RAM on the primary) — straightforward
+   with managed Postgres providers, no application change required.
+3. **Read replicas** — dashboard/analytics queries (Phase 15/18/20/21/23
+   aggregation endpoints) are read-heavy and safe to route to a replica;
+   write paths (inspection creation, supervisor review, ledger entries)
+   must stay on the primary.
+4. **Indexing review** — every tenant-scoped table already indexes
+   `tenant_id`; high-volume tenants should be monitored for query plans
+   on frequently-filtered columns (`created_at`, `instrument_type`,
+   `inspection_id`) as volume grows.
+
+## Background job scaling
+
+Scheduled jobs (Phase 15 prediction scheduler, RWE scheduler, quality
+intelligence, global aggregation) run on a single leader today (see
+`docs/deployment/cloud-architecture-guide.md`). At very high tenant
+counts, these may need to shard by tenant across multiple workers —
+tracked as a future scaling enhancement, not yet required at current
+deployment scale.
+
+## Aggregation query cost
+
+The heavier dashboard aggregations (Phase 20 command center's
+`facility_readiness`, Phase 21's `enterprise_knowledge_analytics`, Phase
+23's CIOS dashboard) currently query up to 5,000 recent inspections per
+call and compute in Python rather than in SQL. This is intentional at
+current scale (keeps the aggregation logic readable and testable in one
+place) but is the first place to invest in either:
+
+- Moving the aggregation into SQL (`GROUP BY`/window functions), or
+- Caching the result with a short TTL,
+
+once a single tenant's inspection volume or the shared deployment's
+combined dashboard-query rate makes the current approach measurably slow.
+This is flagged here as a known scaling ceiling, not hidden as if it
+scales infinitely.
+
+## Capacity planning checklist
+
+- [ ] Estimate the customer's expected inspections/month (see the ROI
+  model's per-segment benchmarks in `docs/commercial/roi-model.md` for
+  typical community/regional/academic hospital volumes)
+- [ ] Size the database connection pool for expected concurrent replicas
+  × expected concurrent requests per replica
+- [ ] Confirm backup storage capacity accounts for retained training
+  images if the tenant opts into image retention
+- [ ] Load-test the dashboard aggregation endpoints at the customer's
+  expected inspection volume before go-live for a large deployment

--- a/docs/enterprise/ai-governance.md
+++ b/docs/enterprise/ai-governance.md
@@ -1,0 +1,95 @@
+# AI Governance Framework
+
+Consolidates the AI governance controls already built across Phases 17,
+18, 21, and 23 into the topic checklist an enterprise buyer's AI
+governance/compliance reviewer needs.
+
+## Model Lifecycle
+
+Data → Labels → Training → Evaluation → Registry → Shadow Mode → Pilot →
+Validation → Deployment (`docs/ai/model-training-pipeline.md`). No model
+auto-promotes between stages — every promotion requires a human-approved
+checklist including a minimum sample size
+(`app/services/ml/deployment_gates.py`).
+
+## Dataset Governance
+
+- `docs/ai/model-training-dataset-plan.md`,
+  `docs/ai/lumenai-dataset-versioning-plan.md` — versioned, stratified,
+  leakage-free training/eval/test splits (`app/services/ml/dataset_split.py`)
+- Every dataset version is referenced by both `ModelRegistryEntry` and
+  Phase 18's `PilotValidationCase.dataset_version`
+
+## Supervisor Validation
+
+- Every AI recommendation is advisory; a supervisor's agreement,
+  correction, or override is what determines actual disposition
+  (`app/models/supervisor_review.py`, Design Principle 4)
+- One supervisor submission creates the review record, the Phase 18
+  ground-truth label, and the Phase 23 Clinical Decision Ledger entry —
+  see `docs/agents/multi-agent-architecture.md` and
+  `docs/cios/clinical-decision-ledger.md`
+
+## Model Approval Process
+
+- `docs/ai/model-deployment-gates.md` — capabilities per stage:
+  experimental cannot drive or advise (shadow-only); pilot is advisory
+  with a mandatory disclaimer; validated may support a decision with
+  supervisor override; deprecated is unusable
+- Registration always starts `experimental` (server-hardened —
+  `app/models/model_registry.py`)
+
+## Shadow Mode
+
+- `docs/ai/shadow-mode-validation.md` — a candidate model runs silently,
+  reconciled against the human's actual decision, before it ever drives
+  or advises anything (`app/models/shadow_prediction.py`)
+- Shadow responses never surface the predicted label as a recommendation
+
+## Versioning
+
+- Every inspection/decision references seven governed versions
+  (architecture, ontology, knowledge graph, model, dataset, clinical
+  rule, inspection pipeline) — see `docs/cios/platform-governance.md`
+- A `ClinicalDecisionLedgerEntry` snapshots the versions active when it
+  was written and is never retroactively updated
+
+## Clinical Rule Management
+
+- `docs/cios/clinical-rule-registry.md` — every enforced clinical rule is
+  registered with an ID, purpose, evidence pointer, priority, version, and
+  approval status. No rule is documented without corresponding real
+  enforcement code.
+
+## Knowledge Graph Governance
+
+- `docs/knowledge-graph/spd-clinical-knowledge-graph.md` — the node/
+  relationship taxonomy is versioned (`knowledge_graph_version` in
+  platform governance) and every reasoning-chain output is traceable to
+  a real function, never a black box
+
+## Continuous Learning
+
+- `docs/knowledge-graph/reasoning-engine.md` §Continuous Knowledge
+  Learning, and `app/services/knowledge_graph_service.py::learning_confidence` —
+  confidence signals are recomputed live from real supervisor reviews on
+  every request; nothing here mutates a persisted model state or
+  fabricates a training event
+- `docs/agents/multi-agent-architecture.md`'s Continuous Learning Agent
+  is explicitly read-only for the same reason
+
+## Architecture Governance
+
+- `docs/architecture/` (Phase 19.5) — the frozen reference architecture;
+  every new AI capability must pass the enforcement checklist
+  (`docs/architecture/architecture-enforcement-checklist.md`) before
+  shipping
+
+## What this framework guarantees
+
+No AI model in LumenAI can reach production influence over a clinical
+decision without: passing through the registry, clearing the deployment
+gate's human-approved checklist, being validated in shadow mode against
+real outcomes, and remaining subject to supervisor override at all times.
+This is enforced in code (`app/services/ml/deployment_gates.py`), not
+just asserted in this document.

--- a/docs/enterprise/clinical-safety.md
+++ b/docs/enterprise/clinical-safety.md
@@ -1,0 +1,95 @@
+# Clinical Safety Framework
+
+## Human-in-the-Loop
+
+Every AI recommendation is advisory. Structural enforcement, not just
+policy:
+
+- The model deployment gate blocks any model from driving or advising a
+  decision until it reaches `validated` status via human-approved
+  promotion (`app/services/ml/deployment_gates.py`)
+- The Supervisor Agent (Phase 22) is read-only by design — it reports
+  whether a human has reviewed a case, it never fabricates a review
+  (`docs/agents/multi-agent-architecture.md`)
+- Every readiness state carries `human_review_required: true` through to
+  the final API response
+
+## Override Requirements
+
+- A supervisor can agree, partially agree, disagree, or override any AI
+  recommendation via `POST /inspections/{id}/supervisor-review`
+- A rationale is **required** for partial agreement, disagreement, or any
+  override (`app/routes/ai_clinical_review.py`) — not optional metadata
+- Every override is captured as a `ClinicalDecisionLedgerEntry` of type
+  `supervisor_override`, permanently
+
+## Known Limitations
+
+Stated plainly, not buried:
+
+- No pixel-level CV localization yet (zone assignment is deterministic,
+  instrument-type-derived — `docs/knowledge-graph/reasoning-engine.md`)
+- Contamination/Damage agents currently read one persisted finding per
+  inspection, not multiple simultaneous findings
+  (`docs/agents/multi-agent-architecture.md`)
+- Three instrument family profiles (cannulated, orthopedic, micro
+  instruments) borrow the closest existing anatomy family pending a
+  dedicated taxonomy split (`docs/knowledge-graph/instrument-intelligence.md`)
+- No live multi-site clinical validation completed yet
+  (`docs/evidence/validation-reports.md`)
+- Full list: `VERSION_1_0.md` §Known Limitations
+
+## Appropriate Use
+
+- Pre-sterilization clinical inspection support for SPD professionals
+- Decision support that must be reviewed by a qualified supervisor before
+  any instrument disposition is finalized
+- Quality-indicator trend analysis for SPD department management
+
+## Inappropriate Use
+
+- Autonomous instrument disposition without human review
+- Sterilization cycle monitoring, biological indicator interpretation, or
+  sterilizer performance validation (`docs/architecture/pre-sterilization-boundary.md`)
+- Any use implying FDA clearance or regulatory approval (none claimed —
+  CLAUDE.md constraint)
+- Diagnosis or treatment of a patient — LumenAI inspects instruments, not
+  patients
+
+## Clinical Workflow Boundary
+
+```
+Point of Use → Transportation → Decontamination → Assembly/Inspection
+    → LumenAI Clinical Inspection → Supervisor Review → Packaging
+    → Sterilization → Sterile Storage → Operating Room
+```
+
+LumenAI's responsibility ends at Supervisor Review, before Packaging.
+Full detail: `docs/architecture/pre-sterilization-boundary.md`.
+
+## Decision Traceability
+
+Every decision is recorded in the Clinical Decision Ledger
+(`docs/cios/clinical-decision-ledger.md`) with who made it, why, what
+evidence supported it, and which governance versions were active — an
+immutable, append-only record.
+
+## Explainability
+
+Every recommendation traces through the full reasoning chain — Instrument
+→ Manufacturer → Family → Anatomy → Zone → Retention Risk → Cleaning
+Method → Clinical Meaning → Recommendation
+(`docs/knowledge-graph/reasoning-engine.md`) — never a bare probability
+with no explanation.
+
+## Patient Safety Principles
+
+1. Prevent harm before sterilization — catch problems while they're still
+   correctable, not after.
+2. Never claim causation — findings are potential associations requiring
+   quality review, always.
+3. Critical findings (blood, tissue, organic residue, crack, missing
+   component) carry the highest safety weight and the tightest false-
+   negative thresholds (`docs/validation/pilot-go-no-go-criteria.md`).
+4. Human expertise is the final authority, always
+   (`docs/architecture/design-principles.md`, Principle 4).

--- a/docs/enterprise/commercial-packaging.md
+++ b/docs/enterprise/commercial-packaging.md
@@ -1,0 +1,85 @@
+# Commercial Packaging
+
+## Relationship to the existing tier model
+
+`docs/commercial/product-packaging.md` defines the current live
+commercial tiers (Starter / Professional / and higher tiers) with
+detailed feature/limit tables and is the authoritative source for
+exact current limits and pricing linkage
+(`docs/commercial/pricing-strategy.md`). This document defines the
+**four-edition structure** Phase 24 asks for, mapping onto and extending
+that existing model — it does not replace `product-packaging.md`'s detail,
+it reframes the top-level edition names for enterprise/partner-facing
+conversations.
+
+## The four editions
+
+### Community Edition
+**Maps to:** the existing Starter tier (`docs/commercial/product-packaging.md`)
+**For:** single-facility community hospitals, pilot programs, and
+evaluation deployments.
+
+| Dimension | Limit |
+|---|---|
+| Facilities | 1 |
+| Users | Up to 10 |
+| Inspection volume | Up to 2,000/month |
+| AI findings | Blood, tissue, residue detection |
+| Multi-agent pipeline (Phase 22) | Included |
+| Knowledge graph explorer (Phase 21) | Included |
+| Enterprise dashboards | Not included |
+| Support | Email, 5-business-day SLA |
+
+### Professional Edition
+**Maps to:** the existing Professional tier
+**For:** mid-size hospitals, multi-OR facilities, regional medical centers.
+
+Adds to Community: predictive analytics, vendor intelligence, benchmarking
+against network aggregates (Phase 15), pre-sterilization command center
+(Phase 20), pilot validation dashboard (Phase 18). Support: priority email
++ business-hours chat, 2-business-day SLA.
+
+### Enterprise Edition
+**For:** health systems with multiple facilities, requiring multi-tenant
+deployment, custom RBAC, and executive-level reporting.
+
+Adds to Professional: multi-facility/multi-tenant deployment
+(`docs/deployment/multi-tenant-deployment-guide.md`), the CIOS Enterprise
+Health Dashboard (`/cios-dashboard`, Phase 23), the Clinical Decision
+Ledger and full governance version tracking, custom SLA and dedicated
+implementation support, SSO/OIDC. High-availability deployment option
+(`docs/deployment/high-availability-guide.md`).
+
+### Manufacturer Edition
+**For:** instrument manufacturers and SPD vendors who want visibility into
+their own instruments' real-world performance across LumenAI's network,
+without access to any individual hospital's clinical data.
+
+- Read access to anonymized, aggregated network benchmarks for their own
+  instrument categories/models (Phase 15 network intelligence,
+  anonymized per the CLAUDE.md cross-hospital intelligence constraint —
+  never a specific hospital's raw data)
+- Baseline submission and approval workflow
+  (`app/models/baseline_library.py`, vendor baseline audit trail)
+  for their own products
+- Failure-mode and instrument-knowledge contribution
+  (`app/models/instrument_knowledge.py`) — a manufacturer can contribute
+  known failure modes and IFU references for their own instruments
+- No access to any hospital's tenant-scoped inspection or supervisor
+  review data, ever — this edition is architecturally read-scoped to
+  anonymized cross-tenant aggregates only
+
+## What every edition shares (non-negotiable, not a paid feature)
+
+- Human-in-the-loop supervisor validation (Design Principle 4) —
+  never gated behind a tier
+- Tenant isolation and audit logging — always on
+- The clinical ontology and knowledge graph reasoning — the core
+  reasoning engine is the same across every edition; editions differ in
+  scale, dashboards, and support, not in clinical reasoning quality
+
+## Choosing an edition
+
+See `docs/enterprise/enterprise-readiness.md`'s readiness gate for how to
+confirm a given edition is appropriate for a prospective customer's scale
+before selling it.

--- a/docs/enterprise/customer-success-framework.md
+++ b/docs/enterprise/customer-success-framework.md
@@ -1,0 +1,64 @@
+# Customer Success Framework
+
+Overview of `docs/customer/` — the Customer Implementation Playbook —
+and how it connects to the broader Customer Success program in
+`docs/customer-success/`.
+
+## The playbook
+
+| Document | Phase |
+|---|---|
+| `30-day-go-live-plan.md` | Days 1–30: provisioning through go-live |
+| `60-day-optimization-plan.md` | Days 31–60: adoption depth, data quality |
+| `90-day-value-realization-plan.md` | Days 61–90: quantified ROI review |
+| `customer-success-checklist.md` | The running checklist across all three phases |
+| `executive-sponsor-guide.md` | What the Executive Sponsor needs to know and do |
+| `spd-champion-guide.md` | What the SPD Champion needs to know and do |
+| `implementation-timeline.md` | The single-page visual timeline |
+| `training-matrix.md` | Who needs what training, by role |
+
+## Relationship to `docs/customer-success/`
+
+`docs/customer/` is the **implementation playbook** (the first 90 days).
+`docs/customer-success/` is the **ongoing program**: customer health
+scoring (`customer-health-framework.md`), renewal readiness
+(`renewal-readiness-guide.md`), the reference customer program
+(`reference-customer-program.md`), and the first-customer deployment
+guide. Together they cover the full customer lifecycle: onboarding →
+go-live → value realization → ongoing health → renewal → advocacy.
+
+## The customer lifecycle, end to end
+
+```
+Contract Signed
+      ↓
+30-Day Go-Live  ──────────────► docs/customer/30-day-go-live-plan.md
+      ↓
+60-Day Optimization ──────────► docs/customer/60-day-optimization-plan.md
+      ↓
+90-Day Value Realization ─────► docs/customer/90-day-value-realization-plan.md
+      ↓
+Ongoing Health Monitoring ────► docs/customer-success/customer-health-framework.md
+                                 docs/enterprise/enterprise-metrics.md
+      ↓
+Renewal ──────────────────────► docs/customer-success/renewal-readiness-guide.md
+      ↓
+Reference / Advocacy (opt-in) ► docs/customer-success/reference-customer-program.md
+                                 docs/evidence/case-studies.md
+```
+
+## Roles and ownership
+
+| Role | Owns |
+|---|---|
+| LumenAI Implementation Lead | Days 1–90 execution, escalation point |
+| SPD Champion (customer-side) | Day-to-day operational adoption |
+| Executive Sponsor (customer-side) | Business accountability, blocker removal |
+| Customer Success Manager (LumenAI) | Ongoing health, renewal, expansion |
+
+## Success metrics tracked throughout
+
+See `docs/enterprise/enterprise-metrics.md` for the full metric set —
+adoption rate, supervisor agreement, AI confidence, clinical readiness,
+inspection coverage, customer health score, and ROI achievement are all
+tracked continuously, not just at the 30/60/90-day checkpoints.

--- a/docs/enterprise/deployment-framework.md
+++ b/docs/enterprise/deployment-framework.md
@@ -1,0 +1,59 @@
+# Deployment Framework
+
+Overview of `docs/deployment/` — the Enterprise Deployment Kit — and how
+its pieces fit together for an implementation team planning a rollout.
+
+## The kit
+
+| Guide | Answers |
+|---|---|
+| `enterprise-installation-guide.md` | How do we install this for an enterprise customer, start to finish? |
+| `production-deployment-guide.md` | What does the production deployment actually look like mechanically? |
+| `cloud-architecture-guide.md` | What's the reference architecture, and which cloud targets are supported? |
+| `multi-tenant-deployment-guide.md` | Single-tenant or shared multi-tenant — how is isolation guaranteed? |
+| `high-availability-guide.md` | How do we avoid a single point of failure? |
+| `scaling-guide.md` | How does this grow with inspection volume, tenant count, and concurrent users? |
+| `backup-restore-guide.md` | What's backed up, how often, and how do we restore it? |
+| `disaster-recovery-guide.md` | What do we do if something goes badly wrong? |
+
+Plus the platform-specific quick-start guides (`RENDER_DEPLOYMENT.md`,
+`RAILWAY_DEPLOYMENT.md`, `FLY_DEPLOYMENT.md`) for managed-cloud
+deployments, and `go-live-runbook.md` /
+`PUBLIC_DEMO_READINESS_CHECKLIST.md` for pre-launch verification.
+
+## Choosing a deployment path
+
+```
+Is this a managed-cloud (Render/Railway/Fly) deployment,
+or does the customer require their own cloud account/VPC?
+        │
+        ├── Managed cloud → follow the platform-specific quick start,
+        │                    then enterprise-installation-guide.md for
+        │                    the enterprise-specific configuration steps
+        │
+        └── Customer-managed cloud → cloud-architecture-guide.md's
+                                      reference architecture, deployed
+                                      via the customer's own IaC
+```
+
+## Sequencing for a new enterprise deployment
+
+1. Confirm the edition (`docs/enterprise/commercial-packaging.md`) — this
+   determines whether multi-tenant, HA, or a custom SLA is in scope.
+2. Provision per `enterprise-installation-guide.md`.
+3. Configure tenancy per `multi-tenant-deployment-guide.md` if this is a
+   shared or multi-facility deployment.
+4. Configure HA per `high-availability-guide.md` if the edition/SLA
+   requires it.
+5. Verify backup/restore is working (`backup-restore-guide.md`) — before
+   go-live, not after the first incident.
+6. Run the post-install verification checklist
+   (`enterprise-installation-guide.md`).
+7. Hand off to the Customer Success team for onboarding
+   (`docs/enterprise/customer-success-framework.md`).
+
+## Ownership
+
+Deployment engineering owns the guides in `docs/deployment/`; Customer
+Success owns the handoff into `docs/customer/`. This document is the
+seam between the two.

--- a/docs/enterprise/enterprise-metrics.md
+++ b/docs/enterprise/enterprise-metrics.md
@@ -1,0 +1,45 @@
+# Enterprise Metrics
+
+The ongoing metrics tracked across every customer, beyond the one-time
+30/60/90-day checkpoints.
+
+## Metric definitions and sources
+
+| Metric | Definition | Source |
+|---|---|---|
+| **Deployment Success** | Did the site reach Day 30 go-live on the planned timeline? | `docs/customer/implementation-timeline.md` tracking |
+| **Adoption Rate** | Fraction of expected inspections actually captured through LumenAI vs. expected volume for the site's size | `/api/pilot-analytics/inspection-efficiency` volume vs. segment benchmark (`docs/commercial/roi-model.md`) |
+| **User Engagement** | Active users / provisioned users; frequency of dashboard access | Auth/session activity, tenant user counts (`app/models/tenant_membership.py`) |
+| **Supervisor Agreement** | Fraction of AI recommendations a supervisor agrees with outright | `/api/knowledge-graph/learning-confidence`'s `knowledge_confidence`, or `/api/model-performance/ai-summary` |
+| **AI Confidence** | Mean confidence score across scored inspections | `/api/cios/dashboard`'s `ai_confidence` |
+| **Clinical Readiness** | Fraction of inspections in `READY_FOR_PACKAGING` state | `/api/pre-sterilization-command-center/clinical-inspection-readiness`, surfaced in `/api/cios/dashboard`'s `readiness_rate` |
+| **Inspection Coverage** | Fraction of imaged inspections with complete/acceptable zone coverage | `/api/cios/dashboard`'s `coverage_rate` |
+| **Customer Health Score** | Composite of adoption, engagement, agreement, and support-ticket signals | `docs/customer-success/customer-health-framework.md`, `app/models/customer_health_snapshot.py` |
+| **ROI Achievement** | Realized value vs. the projected ROI at time of sale | `docs/enterprise/roi-framework.md`, tracked at each 90-day and quarterly review |
+| **Support Metrics** | Ticket volume, time-to-first-response, time-to-resolution, by edition SLA | Support system integration (edition-level SLA commitments in `docs/enterprise/commercial-packaging.md`) |
+
+## Reporting cadence
+
+| Audience | Cadence | Vehicle |
+|---|---|---|
+| SPD Champion | Daily/weekly | Live dashboards (`/pre-sterilization-command-center`, `/pilot-validation`) |
+| Executive Sponsor | Monthly | `/cios-dashboard`, quarterly review package |
+| LumenAI Customer Success | Weekly (first 90 days), monthly thereafter | Internal customer health tracking |
+| LumenAI Executive Leadership | Quarterly | Portfolio-level roll-up across all customers |
+
+## Portfolio-level (cross-customer) metrics
+
+Beyond a single customer's metrics, LumenAI leadership tracks the same
+metrics aggregated across the customer portfolio to spot systemic issues
+(e.g., a consistently low adoption rate across all Community Edition
+customers might indicate an onboarding-flow problem, not a customer-
+specific one) — see `docs/customer-success/customer-health-framework.md`
+for the portfolio-level health-scoring methodology.
+
+## Honesty constraint
+
+Every metric here is computed from real tenant data via the API endpoints
+cited — none is a manually-maintained spreadsheet figure disconnected
+from the live system. If a number reported to a customer or in an
+internal review doesn't match what the live dashboard shows, that's a
+bug in the reporting process, not an acceptable discrepancy.

--- a/docs/enterprise/enterprise-readiness.md
+++ b/docs/enterprise/enterprise-readiness.md
@@ -1,0 +1,59 @@
+# Enterprise Readiness
+
+## Objective
+
+Answer, in one place, whether LumenAI is ready for enterprise adoption by
+hospitals, health systems, manufacturers, and strategic partners — and
+point to the detailed evidence for each dimension rather than restating
+it.
+
+This document does not change the clinical architecture (frozen per
+Phase 19.5, `docs/architecture/`). It assesses the platform's readiness
+to be deployed, trusted, supported, and scaled.
+
+## Readiness dimensions
+
+| Dimension | Status | Evidence |
+|---|---|---|
+| **Deployment** | Ready — documented paths for managed cloud and customer-managed infrastructure | `docs/enterprise/deployment-framework.md`, `docs/deployment/` |
+| **Security & compliance** | Ready — RBAC, JWT/OIDC, tenant isolation, audit logging, encryption, incident response all documented and enforced in code | `docs/security/security-compliance-center.md` |
+| **AI governance** | Ready — model lifecycle, dataset governance, shadow mode, and human-gated promotion all implemented (Phase 17) | `docs/enterprise/ai-governance.md` |
+| **Clinical safety** | Ready — human-in-the-loop enforced structurally, not just by policy; known limitations documented honestly | `docs/enterprise/clinical-safety.md` |
+| **Commercial packaging** | Ready — four editions defined with clear feature/limit boundaries | `docs/enterprise/commercial-packaging.md` |
+| **ROI measurement** | Ready — real, live-data ROI computation; industry-benchmark fallback clearly labeled as such | `docs/enterprise/roi-framework.md` |
+| **Customer success** | Ready — 30/60/90-day plans, training matrix, health scoring | `docs/enterprise/customer-success-framework.md` |
+| **Clinical evidence** | Framework ready; live multi-site validation pending | `docs/evidence/` |
+| **Regulatory readiness** | Gap-analysis stage — see `docs/regulatory/qms-readiness-gap-analysis.md`, `docs/regulatory/fda-submission-readiness-checklist.md` | Not yet submission-ready; explicitly tracked |
+
+## What "enterprise-ready" means here
+
+It means an enterprise buyer's evaluation team — IT security, legal,
+clinical leadership, procurement — can get a complete, honest answer to
+every question they'll ask, sourced from real documentation and real,
+tested code, without needing an engineer in the room. It does not mean
+every future capability (full anatomy segmentation, predictive
+maintenance, FDA clearance) is already built — see
+`docs/architecture/future-ai-roadmap.md` and `VERSION_1_0.md`'s Known
+Limitations section for what's explicitly out of scope for this release.
+
+## Enterprise readiness gate
+
+Before offering LumenAI to a new enterprise customer segment (a new
+edition tier, a new geography, a new partner type), confirm:
+
+- [ ] The relevant deployment guide exists and has been exercised at
+  least once in staging (`docs/deployment/enterprise-installation-guide.md`)
+- [ ] The security review for that deployment model is current
+  (`docs/security/security-compliance-center.md`)
+- [ ] The commercial packaging tier covers the customer's expected scale
+  (`docs/enterprise/commercial-packaging.md`)
+- [ ] Support commitments match what's actually staffed
+  (`docs/enterprise/customer-success-framework.md`)
+- [ ] No known limitation (`VERSION_1_0.md`) is being misrepresented to
+  the prospective customer
+
+## Ownership
+
+Enterprise readiness spans engineering, security, clinical, and
+commercial teams — no single team should sign off alone. This document is
+the shared reference all of them should be working from.

--- a/docs/enterprise/executive-presentation-kit.md
+++ b/docs/enterprise/executive-presentation-kit.md
@@ -1,0 +1,54 @@
+# Executive Presentation Kit
+
+A guide to the materials available for presenting LumenAI to hospital
+executives, health-system leadership, and internal stakeholders — pointing
+to existing source material rather than duplicating slide content here.
+
+## The eight presentation modules
+
+| Module | Source material | Audience |
+|---|---|---|
+| **Executive Overview** | `README.md`'s mission/vision section, `VERSION_1_0.md` | C-suite, board |
+| **Product Overview** | `VERSION_1_0.md` §Core Capabilities, `docs/enterprise/commercial-packaging.md` | VP Perioperative Services, SPD Director |
+| **Architecture Overview** | `ARCHITECTURE_SUMMARY.md`, `docs/architecture/lumenai-clinical-intelligence-architecture.md` | IT leadership, technical evaluators |
+| **Clinical Workflow** | `docs/architecture/pre-sterilization-boundary.md`, `docs/cios/lumenai-clinical-intelligence-operating-system.md` | Clinical leadership, Infection Prevention |
+| **AI Explainability** | `docs/knowledge-graph/reasoning-engine.md`, `docs/agents/explainable-agent-trace.md` | Clinical leadership, IT security/AI governance reviewers |
+| **Security Overview** | `docs/security/security-compliance-center.md` | IT security, compliance/legal |
+| **ROI Presentation** | `docs/enterprise/roi-framework.md`, `docs/commercial/roi-model.md` | CFO, Executive Sponsor |
+| **Implementation Roadmap** | `docs/customer/implementation-timeline.md` | Executive Sponsor, SPD Champion |
+
+## Recommended presentation sequence for a first executive meeting
+
+1. Executive Overview — what LumenAI is and why it matters (2–3 minutes)
+2. Clinical Workflow — where LumenAI fits in the SPD process, emphasizing
+   the pre-sterilization boundary (`docs/architecture/pre-sterilization-boundary.md`)
+   so there's no confusion about sterilization-validation claims
+3. AI Explainability — the reasoning chain example
+   ("I detected probable blood in the Kerrison jaw serrations...") to
+   ground the "explainable, not a black box" claim concretely
+4. Security Overview — high-level only for a first meeting; full detail
+   reserved for IT security's dedicated review
+5. ROI Presentation — segment-appropriate benchmark figures
+   (`docs/commercial/roi-model.md`) if pre-implementation, or the
+   customer's own real figures (`docs/enterprise/roi-framework.md`) if
+   post-implementation
+6. Implementation Roadmap — the 30/60/90-day plan, setting expectations
+
+## What NOT to present
+
+- Any figure not traceable to a real computation or a clearly-labeled
+  industry benchmark (`docs/enterprise/roi-framework.md`'s honesty
+  constraint)
+- Any claim of FDA clearance or regulatory approval (none exists —
+  CLAUDE.md constraint, `VERSION_1_0.md` §Known Limitations)
+- Any capability from the future roadmap (`docs/architecture/future-ai-roadmap.md`,
+  `VERSION_1_0.md`'s Version 2.0–5.0 roadmap) presented as if it exists
+  today
+
+## Building a deck from this kit
+
+Each module above should pull directly from its source document at
+presentation time rather than maintaining a separately-drifting slide
+deck — when the underlying doc updates (e.g. a new edition is added to
+`docs/enterprise/commercial-packaging.md`), the presentation content
+should update with it.

--- a/docs/enterprise/investor-partner-readiness-kit.md
+++ b/docs/enterprise/investor-partner-readiness-kit.md
@@ -1,0 +1,55 @@
+# Investor & Partner Readiness Kit
+
+Points to the existing materials that answer an investor's or strategic
+partner's standard diligence questions, rather than duplicating them.
+
+## The eight materials
+
+| Material | Source |
+|---|---|
+| **Platform One-Pager** | `PITCH_DECK.md`, `PORTFOLIO_SUMMARY.md` |
+| **Technical Overview** | `ARCHITECTURE_SUMMARY.md`, `docs/architecture/lumenai-clinical-intelligence-architecture.md` |
+| **Clinical Overview** | `docs/enterprise/clinical-safety.md`, `docs/architecture/pre-sterilization-boundary.md` |
+| **Competitive Differentiation** | `PORTFOLIO_POSITIONING.md` |
+| **Vision** | `VERSION_1_0.md` §Vision |
+| **Mission** | `VERSION_1_0.md` §Mission, `README.md` |
+| **Roadmap** | `VERSION_1_0.md` §Future Roadmap, `docs/architecture/future-ai-roadmap.md` |
+| **Architecture Summary** | `ARCHITECTURE_SUMMARY.md` |
+
+## Standard diligence questions and where the answer lives
+
+| Question | Answer location |
+|---|---|
+| What does LumenAI actually do? | `README.md`, `VERSION_1_0.md` |
+| How is it differentiated from generic CV/AI vendors? | `PORTFOLIO_POSITIONING.md` — the Clinical Intelligence Operating System framing, not just image classification |
+| Is this FDA cleared? | No — explicitly not claimed anywhere (`VERSION_1_0.md` §Known Limitations, CLAUDE.md constraint) |
+| What clinical evidence exists? | `docs/evidence/README.md` — honest current state, including what's framework-only vs. real |
+| How is patient safety protected? | `docs/enterprise/clinical-safety.md` |
+| What's the commercial model? | `docs/enterprise/commercial-packaging.md`, `docs/commercial/pricing-strategy.md` |
+| What's the total addressable market / segment strategy? | `docs/commercial/enterprise-sales-playbook.md`, `docs/commercial/roi-model.md`'s segment definitions |
+| What's the technical moat? | The clinical ontology + knowledge graph + multi-agent architecture (Phases 19.5–23) — a competitor copying computer vision alone does not replicate the explainable, governed reasoning layer |
+| What are the known gaps/risks? | `VERSION_1_0.md` §Known Limitations, `docs/regulatory/qms-readiness-gap-analysis.md` |
+| What's the roadmap to regulatory submission, if pursued? | `docs/regulatory/fda-submission-readiness-checklist.md`, `docs/regulatory/submission-strategy.md` |
+
+## Principles for investor/partner conversations
+
+1. **Never overstate clinical validation status.** `docs/evidence/`
+   states plainly what's real (framework, prior seeded-data pilot
+   exercises) versus what's pending (live multi-site validation). This
+   is the same standard applied everywhere else in the platform's
+   documentation — an investor conversation is not an exception.
+2. **Lead with the architecture, not just the AI.** LumenAI's
+   differentiation is the governed, explainable, ontology-driven system
+   (Phases 19.5–23), not a single model's accuracy number — see
+   `PORTFOLIO_POSITIONING.md`.
+3. **Be precise about regulatory status.** LumenAI is a clinical
+   inspection decision-support tool operating before sterilization, not
+   a cleared diagnostic device — this framing protects both the company
+   and the investor relationship from a future mischaracterization risk.
+
+## Refreshing this kit
+
+Update the cross-referenced source documents when they change (a new
+edition, a completed pilot validation, a regulatory milestone) — this kit
+itself should rarely need to change, since it's an index, not primary
+content.

--- a/docs/enterprise/partnership-framework.md
+++ b/docs/enterprise/partnership-framework.md
@@ -1,0 +1,86 @@
+# Partnership Framework
+
+How LumenAI engages with each partner type. Each section below is the
+starting brief for that audience — detailed per-partner agreements are
+handled through `docs/commercial/enterprise-sales-playbook.md` and legal
+review, not defined here.
+
+## Hospitals
+
+Direct customers. Onboard via `docs/customer/` (the implementation
+playbook) into Community or Professional Edition
+(`docs/enterprise/commercial-packaging.md`). Primary relationship owners:
+Executive Sponsor + SPD Champion (customer-side), Customer Success
+Manager (LumenAI-side).
+
+## Health Systems
+
+Multi-facility customers, typically Enterprise Edition. Requires
+multi-tenant deployment planning
+(`docs/deployment/multi-tenant-deployment-guide.md`) and a rollout
+sequence across facilities — see
+`docs/enterprise/multi-site-rollout-playbook.md` for the existing
+multi-site onboarding sequence this framework builds on.
+
+## Instrument Manufacturers
+
+Engage via the Manufacturer Edition
+(`docs/enterprise/commercial-packaging.md`). Manufacturers contribute
+baseline data (`app/models/baseline_library.py`, vendor baseline
+governance), IFU references, and known failure modes
+(`app/models/instrument_knowledge.py`), and receive anonymized network
+performance visibility for their own products — never access to any
+hospital's raw clinical data. This is the same boundary enforced for
+network intelligence generally (Phase 15, CLAUDE.md's cross-hospital
+anonymization constraint).
+
+## SPD Vendors
+
+Distinct from instrument manufacturers — SPD vendors (reprocessing
+service providers, third-party sterile processing operators) may
+integrate via the external system connector framework
+(`app/models/external_connector.py`) for CMMS/ERP-adjacent data exchange,
+gated by the same BAA/consent requirements as any integration touching
+PHI-adjacent data.
+
+## Consulting Partners
+
+Implementation and change-management consultants who support hospital
+customers through the 30/60/90-day playbook
+(`docs/customer/implementation-timeline.md`). LumenAI provides consulting
+partners with the same training-matrix content
+(`docs/customer/training-matrix.md`) used to train customer staff, plus
+partner-specific enablement (not yet formalized as a separate
+certification program — tracked as a future enhancement).
+
+## Academic Research
+
+Research collaborations use the Real-World Evidence (RWE) enrollment
+framework already built for this purpose
+(`app/models/validation.py::RWEEnrollment`,
+`docs/clinical/real-world-evidence-plan.md`) — facility opt-in, versioned
+consent, and contribution tracking. Research use is always subject to the
+same no-PHI and anonymization constraints as every other data use in the
+platform.
+
+## Quality Organizations
+
+Accreditation bodies, sterile processing professional associations
+(AAMI, AORN, IAHCSMM-equivalent), and quality benchmarking organizations.
+Engagement is informational/advisory at this stage — LumenAI's clinical
+rule registry (`docs/cios/clinical-rule-registry.md`) and clinical
+performance metrics (`docs/validation/clinical-performance-metrics.md`)
+are built to be legible to this audience, paraphrasing accepted SPD
+practice rather than reproducing copyrighted standards text.
+
+## Cross-cutting partnership principles
+
+- No partner type receives access beyond what its role requires — a
+  manufacturer never sees hospital clinical data; a hospital never sees
+  another hospital's data; a consulting partner sees only what their
+  assigned customer grants.
+- Every cross-tenant or cross-partner data flow is audit-logged
+  (`app/audit.py`) with `compliance_flag=True` where required.
+- No partnership claim implies FDA clearance, regulatory endorsement, or
+  a level of clinical validation beyond what `docs/evidence/` documents
+  as actually complete.

--- a/docs/enterprise/roi-framework.md
+++ b/docs/enterprise/roi-framework.md
@@ -1,0 +1,56 @@
+# ROI Framework
+
+Expands `docs/commercial/roi-model.md` (illustrative, benchmark-based
+model) and `/api/pilot-analytics/roi` (real, live-data computation from
+`app/routes/pilot_analytics.py`) into the nine value categories an
+enterprise buyer expects a mature ROI framework to cover.
+
+## The nine value categories
+
+| Category | Source today | Status |
+|---|---|---|
+| **Inspection Time Saved** | `MINUTES_SAVED_PER_INSPECTION` × real inspection volume (`/api/pilot-analytics/inspection-efficiency`) | Real, computed live |
+| **Supervisor Time Saved** | Not yet separately tracked — inspection time savings currently bundle technician and supervisor time together | Gap — see below |
+| **Reduction in Reprocessing Events** | `reprocessing_avoidance_usd` in `/api/pilot-analytics/roi`, from real contamination-detection counts | Real, computed live |
+| **Reduction in Missing Contamination** | Phase 18's critical finding false-negative rate (`/api/pilot-validation/metrics`) — a lower FN rate is the direct measure of fewer missed contamination events | Real, computed live from ground truth |
+| **Reduction in Instrument Damage** | Phase 20's repair/remove-from-service queue trend over time (`/api/pre-sterilization-command-center/repair-remove-queue`) | Real, computed live |
+| **Improved Compliance** | Audit log completeness, coverage rate (`/api/cios/dashboard`'s `coverage_rate`), and the Clinical Decision Ledger's completeness for every reviewed inspection | Real, computed live |
+| **Training Efficiency** | Not yet quantified — the Training Matrix (`docs/customer/training-matrix.md`) defines *what* training is required; time-to-competency is not yet measured | Gap — see below |
+| **Operational Visibility** | The existence and adoption of `/pre-sterilization-command-center`, `/cios-dashboard`, `/knowledge-graph`, `/pilot-validation` themselves — visibility that did not exist pre-LumenAI | Real (qualitative); adoption/usage frequency trackable via `docs/enterprise/enterprise-metrics.md` |
+| **Executive Reporting** | The Executive Command Center, CIOS Dashboard, and quarterly review package (`/api/pilot-analytics/quarterly-review`) | Real, computed live |
+
+## Honest gaps
+
+Two categories are not yet independently quantified, stated plainly
+rather than papered over with an estimate presented as real:
+
+1. **Supervisor Time Saved** — currently folded into the general
+   inspection-efficiency estimate rather than isolated. Isolating it
+   would require timing the supervisor-review step specifically (the
+   Clinical Decision Ledger's timestamps, Phase 23, make this
+   computable in a future release — see
+   `docs/cios/clinical-decision-ledger.md`).
+2. **Training Efficiency** — the Training Matrix defines training
+   requirements but the platform does not yet measure time-to-competency
+   against them. A future enhancement could track "days from go-live to
+   a technician's first unsupervised, zero-correction week" as a direct
+   proxy.
+
+## How to present ROI to a customer
+
+1. Always lead with the customer's own real data
+   (`/api/pilot-analytics/roi?baseline_period_days=N` for a
+   before/after comparison against their own pre-LumenAI period) —
+   this is more credible than an industry benchmark.
+2. Use `docs/commercial/roi-model.md`'s segment benchmarks only when
+   real customer data isn't yet available (e.g. during a sales
+   conversation before implementation).
+3. Never present an estimate as if it were measured — every ROI
+   endpoint response includes `human_review_required: true` and
+   explicit disclaimers that figures require site financial validation.
+
+## Where this feeds
+
+`docs/customer/90-day-value-realization-plan.md` is where this framework
+is first applied to a real customer; `docs/enterprise/enterprise-metrics.md`
+tracks ROI achievement as an ongoing metric thereafter.

--- a/docs/evidence/README.md
+++ b/docs/evidence/README.md
@@ -1,0 +1,61 @@
+# Clinical Evidence Repository
+
+The index for LumenAI's clinical and operational evidence: pilot studies,
+validation reports, case studies, customer success stories, lessons
+learned, and benchmark reports.
+
+## Honesty framing (read this first)
+
+This repository holds **real evidence as it is generated**, plus the
+structure/templates for evidence not yet collected. It is not a
+collection of illustrative or fabricated results. Where a category below
+has no real entry yet, that's stated plainly rather than filled with a
+placeholder that reads like a real result.
+
+As of this writing:
+
+- **Pilot studies**: framework and protocol exist and are fully built
+  (Phase 18 — `docs/validation/pilot-validation-protocol.md`); a
+  documented prior pilot (Bon Secours) exercised the platform with seeded
+  data (`docs/pilot/pilot-findings-analysis.md`); a live, multi-site
+  clinical pilot with real supervisor-adjudicated ground truth has not
+  yet completed — see `docs/evidence/pilot-studies.md`.
+- **Validation reports**: the regulatory validation dataset is explicitly
+  mock/simulated (`docs/regulatory/clinical-evidence-summary.md`); no
+  submission-grade validation report exists yet — see
+  `docs/evidence/validation-reports.md`.
+- **Case studies / customer success stories**: none published yet — see
+  `docs/evidence/case-studies.md` and `customer-success-stories.md` for
+  the template these will follow once real customers reach Day 90.
+- **Lessons learned**: real internal lessons exist from prior pilot work
+  — see `docs/evidence/lessons-learned.md`.
+- **Benchmark reports**: network benchmarking infrastructure exists
+  (Phase 15) but requires multiple contributing facilities before
+  publishable benchmarks exist — see `docs/evidence/benchmark-reports.md`.
+
+## Why this matters
+
+LumenAI's own design principles require every clinical claim to be
+traceable and non-fabricated
+(`docs/architecture/design-principles.md`). An evidence repository that
+overstates what's been proven would violate the same principle the
+product is built on. This repository is deliberately conservative about
+what it claims is "evidence" versus "framework ready to capture evidence."
+
+## How evidence gets added here
+
+1. **Pilot studies** — populated automatically as sites complete Phase 18
+   pilot validation (`/api/pilot-validation/report`).
+2. **Validation reports** — populated as real, adjudicated validation
+   runs complete (`docs/validation/` protocol), superseding the current
+   mock dataset.
+3. **Case studies / success stories** — written by Customer Success once
+   a site reaches Day 90 value realization
+   (`docs/customer/90-day-value-realization-plan.md`) and consents to
+   being referenced (see `docs/customer-success/reference-customer-program.md`).
+4. **Lessons learned** — captured after every pilot, go-live, or incident
+   review.
+5. **Benchmark reports** — published once enough contributing facilities
+   exist to anonymize meaningfully (Phase 15 network intelligence
+   requires a minimum facility count before publishing a benchmark — see
+   `app/models/instrument_registry.py::contributing_facilities`).

--- a/docs/evidence/benchmark-reports.md
+++ b/docs/evidence/benchmark-reports.md
@@ -1,0 +1,55 @@
+# Benchmark Reports
+
+## Status: infrastructure ready, publishable benchmarks pending sufficient contributing facilities
+
+LumenAI's network benchmarking infrastructure (Phase 15) is built and
+tested:
+
+- `app/models/network_benchmark.py` — benchmark computation and storage
+- `app/models/instrument_registry.py` — network-wide instrument
+  aggregates (`network_inspection_count`, `network_defect_rate`,
+  `network_pass_rate`), gated by `contributing_facilities` — the registry
+  deliberately withholds publishing an aggregate until enough facilities
+  have contributed to make anonymization meaningful (a benchmark from
+  one or two facilities is not really anonymous)
+- `app/models/global_intelligence.py` — cross-hospital signal
+  aggregation, anonymized at the point of aggregation per the CLAUDE.md
+  constraint that hospital identities are never exposed in cross-hospital
+  intelligence
+
+## What's required before a benchmark is publishable here
+
+1. A minimum number of contributing facilities per instrument
+   category/finding type (the exact threshold is set per
+   `contributing_facilities` — publish only once this crosses the
+   platform's minimum anonymization threshold).
+2. Every contributing facility's identity anonymized in the published
+   output — no hospital name, tenant ID, or facility-identifying detail
+   in a published benchmark report.
+3. An audit trail of the aggregation itself
+   (`app/audit.py::log_audit_event`, `compliance_flag=True` for any
+   intelligence-sharing action, per CLAUDE.md).
+
+## What a benchmark report entry looks like once published
+
+```markdown
+### [Instrument category] — [Finding type] Benchmark
+
+**Contributing facilities:** N (minimum threshold met)
+**Period:** [date range]
+**Network defect rate:** X% (anonymized aggregate)
+**Network pass rate:** Y%
+**Percentile context:** how an individual facility's own rate compares
+(via the facility's own dashboard — the published report itself never
+identifies which facility is where in the distribution)
+```
+
+## Current state
+
+As of this document's creation, no benchmark report meets the
+contributing-facility threshold for publication — this is expected at
+this stage of platform adoption, not a defect. As more tenants onboard
+(see `docs/customer/implementation-timeline.md`) and opt into network
+intelligence sharing (`app/models/global_intelligence.py::GSINParticipant`
+consent), this section will be populated with real, anonymized benchmark
+reports.

--- a/docs/evidence/case-studies.md
+++ b/docs/evidence/case-studies.md
@@ -1,0 +1,63 @@
+# Case Studies
+
+## Status: none published yet
+
+No customer case study exists yet. This document defines the template a
+real case study will follow once a customer reaches Day 90 value
+realization (`docs/customer/90-day-value-realization-plan.md`) and
+consents to being featured.
+
+## Case study template
+
+```markdown
+# [Facility Name / Anonymized Identifier] Case Study
+
+## Facility profile
+- Facility type (community hospital / regional medical center / academic
+  medical center — see docs/commercial/roi-model.md segment definitions)
+- SPD team size
+- Instrument volume/month
+
+## Challenge
+What specific pre-sterilization quality problem prompted evaluation?
+
+## Implementation
+- Go-live date, timeline vs. the standard 30-day plan
+- Instrument families onboarded
+- Any notable customization or integration
+
+## Results (Day 90+, using real site data only)
+- Readiness rate, coverage rate, supervisor agreement rate
+  (from /api/cios/dashboard)
+- ROI figures (from /api/pilot-analytics/roi, this site's real inputs)
+- Notable findings caught that would otherwise have proceeded to
+  packaging (described as quality indicators, never as prevented harm
+  claims — see docs/architecture/pre-sterilization-boundary.md)
+
+## Quote
+A named or anonymized quote from the Executive Sponsor or SPD Champion,
+with their consent.
+
+## Lessons for future implementations
+What would this site do differently, or what should LumenAI improve?
+Feed into docs/evidence/lessons-learned.md.
+```
+
+## Consent and review requirements before publishing
+
+- Written consent from the customer (Executive Sponsor sign-off) is
+  required before any case study naming the facility is published
+  externally.
+- All figures must be pulled from the customer's real, live dashboard
+  data at the time of writing — never backfilled or estimated after the
+  fact.
+- No causal claims — findings are described as quality indicators and
+  potential associations, consistent with platform-wide language
+  requirements (`docs/architecture/pre-sterilization-boundary.md`).
+- No FDA clearance or regulatory approval claims in any case study
+  (CLAUDE.md constraint).
+
+## Related
+
+See `docs/customer-success/reference-customer-program.md` for how a
+customer becomes eligible and opts in to being referenced publicly.

--- a/docs/evidence/customer-success-stories.md
+++ b/docs/evidence/customer-success-stories.md
@@ -1,0 +1,46 @@
+# Customer Success Stories
+
+## Status: none published yet
+
+Distinct from `docs/evidence/case-studies.md` (a detailed, structured
+write-up of one implementation), a customer success story is a shorter,
+narrative-style highlight — suitable for a sales one-pager, a website
+testimonial, or an investor update.
+
+## Template
+
+```markdown
+### [Facility name / anonymized identifier]
+
+"[A short, real quote from the Executive Sponsor or SPD Champion about
+what changed for their team.]"
+
+**Segment:** [community hospital / regional medical center / academic
+medical center]
+**Time to value:** [Day X, per the 30/60/90-day plan]
+**Highlighted outcome:** [one real, specific, non-causal metric — e.g.
+readiness rate improvement, coverage rate improvement, ROI figure —
+sourced from that customer's real dashboard data]
+```
+
+## Rules for what qualifies as a "success story" here
+
+1. The customer must have reached at least Day 90
+  (`docs/customer/90-day-value-realization-plan.md`) with a completed
+  value realization review.
+2. The customer must have given explicit consent to be referenced
+  (`docs/customer-success/reference-customer-program.md`).
+3. Every metric cited must be traceable to a real API response from that
+  customer's tenant at the time it was captured — not an industry
+  benchmark presented as if it were customer-specific.
+4. No story may imply LumenAI prevented a specific patient safety event —
+  findings are quality indicators, and causation is never claimed
+  (`docs/architecture/pre-sterilization-boundary.md`).
+
+## Why this list is currently empty
+
+As of this document's creation, no customer has yet completed a Day 90
+value realization cycle with published consent to be referenced. This
+section will be populated as real customers reach that milestone — see
+`docs/evidence/README.md` for the overall evidence-repository honesty
+framing.

--- a/docs/evidence/lessons-learned.md
+++ b/docs/evidence/lessons-learned.md
@@ -1,0 +1,58 @@
+# Lessons Learned
+
+Real lessons captured from prior pilot, implementation, and platform-
+development work — not hypothetical best practices.
+
+## From the Bon Secours pilot exercise (`docs/pilot/pilot-findings-analysis.md`)
+
+1. **Image capture friction kills adoption.** A separate, two-step image
+   upload flow was skipped in 100% of Week 1 pilot cases. This directly
+   shaped later phases' emphasis on making capture part of the natural
+   inspection workflow rather than a bolt-on step — see the
+   `inspected_zones` capture built into `POST /api/inspections` (Phase 20
+   command center's coverage engine depends on this being captured
+   inline, not as an afterthought).
+2. **Silent scoring gaps are worse than visible ones.** The original
+   scoring engine silently returned 0 for five of seven finding
+   categories rather than surfacing an "unscored" state. This directly
+   informed the platform-wide honesty convention now enforced everywhere:
+   a metric with no real data returns `null`, never a fabricated
+   `0` (see the pattern throughout Phases 18/20/21/23 — e.g.
+   `docs/command-center/readiness-score-model.md`'s "honesty
+   constraints" section).
+3. **Persist operational context, not just clinical findings.**
+   Facility/department/tray identity were not originally persisted as ORM
+   columns, which blocked tray-level and facility-level reporting. This
+   is why Phase 20's command center's Tray Readiness and Facility
+   Readiness modules explicitly depend on these fields
+   (`Inspection.facility_name`/`department`/`tray_id`) being captured at
+   inspection time.
+
+## From platform architecture work (Phases 17–23)
+
+4. **A five-value decision vocabulary, once adopted, should not be
+   silently extended.** Phase 19.5 drafted a six-value decision
+   vocabulary and then explicitly reverted to keeping the original
+   five-value `PASS`/`MONITOR`/`SUPERVISOR REVIEW`/`REPROCESS`/`REMOVE
+   FROM SERVICE` outcome after weighing the cost of renaming a value
+   asserted by ~2,300 tests against the benefit of a slightly richer
+   vocabulary — see
+   `docs/architecture/lumenai-clinical-intelligence-architecture.md`
+   §Layer 7. Lesson: a "nicer" vocabulary is not worth breaking a
+   load-bearing contract; extend via a sub-field instead
+   (`repair_candidate` in Phase 20's `classify_readiness`).
+5. **One supervisor decision should produce every downstream artifact in
+   one transaction, not require re-entry.** Early designs had a
+   supervisor review, a pilot validation ground-truth case, and a
+   decision-ledger entry as three separate manual submissions. Phases 18,
+   21, and 23 progressively wired all three into the single existing
+   `POST /inspections/{id}/supervisor-review` submission — the lesson
+   generalized from the Bon Secours image-capture friction finding above:
+   every extra manual step a real user has to take is adoption risk.
+
+## Process for adding future entries
+
+After every pilot, go-live, or incident review, add a dated entry here
+with: what happened, what it revealed, and what changed in the product or
+process as a result. A lesson without a resulting change is a complaint,
+not a lesson — this document should only contain the latter.

--- a/docs/evidence/pilot-studies.md
+++ b/docs/evidence/pilot-studies.md
@@ -1,0 +1,52 @@
+# Pilot Studies
+
+## Status: framework complete, live multi-site pilot pending
+
+LumenAI's pilot validation framework (Phase 18) is fully built and
+tested: ground-truth capture from real supervisor reviews, clinical
+performance metrics, zone performance, the safety review queue, the
+validation report generator, and the go/no-go readiness gate. See:
+
+- `docs/validation/pilot-validation-protocol.md` — the protocol
+- `docs/validation/ground-truth-review-workflow.md` — how ground truth is
+  captured
+- `docs/validation/clinical-performance-metrics.md` — what's measured
+- `docs/validation/pilot-go-no-go-criteria.md` — the readiness gate
+
+## Prior pilot activity
+
+An earlier-phase pilot exercise (Bon Secours, tenant `bon-secours-pilot`)
+exercised the platform end-to-end with seeded baseline and inspection
+data (10 instruments, 25 baselines, 50 inspections) — see
+`docs/pilot/pilot-findings-analysis.md` for the full findings. That
+review identified and closed several adoption-blocking gaps (image
+capture workflow friction, silent scoring gaps, missing
+facility/department/tray persistence) that are now resolved in the
+current architecture (Phase 20's `Inspection.facility_name`/`department`/
+`tray_id` fields, the multi-agent scoring pipeline).
+
+**This prior activity used seeded/demo data, not a completed live
+clinical pilot with real supervisor-adjudicated ground truth at the
+target cohort size (100 lumen images per
+`docs/validation/pilot-validation-protocol.md`).**
+
+## What a completed pilot study entry looks like
+
+Once a site completes its Phase 18 pilot cohort, its entry here should
+include:
+
+- Site name/tenant (anonymized in any externally-shared version per the
+  cross-hospital anonymization requirement)
+- Study period and instrument families covered
+- The full `/api/pilot-validation/report` output at study completion
+- The go/no-go decision and rationale
+- Whether the site's data contributed to a published benchmark
+  (`docs/evidence/benchmark-reports.md`)
+
+## Next milestone
+
+The next real milestone for this section is running the Phase 18
+protocol against a live site with real supervisor reviews accumulating
+toward the 100-image target cohort — see
+`docs/validation/pilot-validation-protocol.md` §2 for the exact target
+criteria that would move an entry from "in progress" to "complete" here.

--- a/docs/evidence/validation-reports.md
+++ b/docs/evidence/validation-reports.md
@@ -1,0 +1,46 @@
+# Validation Reports
+
+## Status: mock/simulated dataset only — submission-grade validation pending
+
+`docs/regulatory/clinical-evidence-summary.md` documents the current
+validation dataset explicitly: **1,200 mock cases, 100 per category**,
+with the document's own header stating *"All performance data at Version
+1.0 is derived from mock/simulated datasets. Live multi-site clinical
+study is pending. This data should not be used as the basis for
+regulatory submissions without completion of the live reader study."*
+
+This evidence repository entry does not soften that disclaimer — it is
+repeated here deliberately so anyone browsing evidence-by-category (rather
+than starting from the regulatory package) sees it too.
+
+## What exists today
+
+- The full P12 clinical validation engine (`app/services/validation_engine.py`,
+  `app/models/validation.py`) — confusion-matrix analysis, kappa
+  agreement, sealed test set registry, reader study simulator — is real,
+  tested infrastructure. It has been exercised against the mock dataset
+  described above, not yet against a sealed, adjudicated real-world
+  dataset.
+- The Phase 18 pilot validation ground-truth pipeline (real supervisor
+  reviews → `PilotValidationCase` records) is the mechanism that will
+  eventually produce a real validation dataset — see
+  `docs/evidence/pilot-studies.md`.
+
+## What a real validation report entry requires before publication here
+
+1. A sealed test set (`app/models/validation.py::SealedTestRegistry`)
+   registered and evaluated per `docs/clinical/sealed-test-set-protocol.md`.
+2. Real, adjudicated ground truth — not mock data — as the basis for
+   every reported accuracy/precision/recall/kappa figure.
+3. The critical safety metrics (blood/tissue/organic-residue/crack/
+   missing-component false-negative rates) computed from that real
+   ground truth, evaluated against the thresholds in
+   `docs/validation/pilot-go-no-go-criteria.md`.
+4. Sign-off per `docs/regulatory/submission-readiness-review.md` before
+   any validation report here is characterized as submission-ready.
+
+## Related documents
+
+- `docs/clinical/clinical-performance-report.md`
+- `docs/clinical/human-vs-ai-study-protocol.md`
+- `docs/regulatory/master-traceability-matrix.md`

--- a/docs/instruments/anatomy-library.md
+++ b/docs/instruments/anatomy-library.md
@@ -1,0 +1,51 @@
+# Anatomy Profile Service
+
+Given an instrument's type (and optionally name/manufacturer/model), resolve
+its anatomy: family, zones, required image views, high-risk zones, per-zone
+descriptions, contamination/condition risks, and manual-check guidance. This
+is the "step 2" service LumenAI Inspect v1.1 requires before AI analysis.
+
+## Source of truth
+
+`backend/app/services/instrument_anatomy.py`
+
+- `INSTRUMENT_ANATOMY` — per-family zone definitions (`_zone(name, category,
+  risk, retention, contamination, condition)`), `match` keyword list for
+  free-text classification, `required_images`, `recommended_image_angles`,
+  `min_images`, `manual_steps`.
+- `resolve_family(instrument_type)` — free-text → family key. Falls back to
+  `"default"` (a generic SPD profile) rather than guessing.
+- `get_anatomy(instrument_type)` — full anatomy for a resolved family.
+- `anatomy_profile(instrument_type, manufacturer=None, model=None,
+  instrument_name=None)` — the full contract: considers every identity hint
+  available, and when nothing matches returns `instrument_family: "unknown"`,
+  `profile_found: False`, and a `warning` recommending supervisor review.
+  Nothing is fabricated as a specific match.
+- `list_anatomy_families()` — summary of every declared family (v1.1
+  addition), for the Anatomy Library's browse view.
+
+Families: rigid scope, flexible endoscope, drill bit, Kerrison/rongeur,
+scissors, needle holder, laparoscopic, general forceps, default (generic
+fallback). Flexible endoscopes are declared before rigid scopes in the match
+table so endoscope-specific keywords resolve first (a rigid scope's generic
+"scope"/"endoscope" match would otherwise swallow them).
+
+## API
+
+- `GET /api/instrument-anatomy` — all anatomy families (v1.1 addition).
+- `GET /api/instrument-anatomy/{instrument_type}?manufacturer=&model=&instrument_name=`
+  — resolved profile for one instrument.
+
+## Frontend
+
+`/anatomy-library` (`frontend/src/pages/AnatomyLibraryPage.tsx`) — a lookup
+form (resolve any instrument type/manufacturer/model combination) plus a
+browsable list of every declared anatomy family.
+
+## Unknown instruments
+
+When no family matches, the generic `default` profile is returned along with
+`warning: "Instrument anatomy profile not found. Supervisor review
+recommended."` — the caller (New Inspection workflow, AI analysis) surfaces
+this so a human confirms the instrument identity rather than the system
+silently guessing.

--- a/docs/instruments/capture-quality-standards.md
+++ b/docs/instruments/capture-quality-standards.md
@@ -1,0 +1,51 @@
+# Image View Tagging & Capture Quality Standards (v1.2)
+
+Every image uploaded during Guided Capture is tagged with which anatomy zone
+and image view it depicts, plus a technician-assessed capture quality and
+optional notes — metadata about the *view*, not pixel-level detection (the
+same honesty convention as the rest of the anatomy/coverage engine).
+
+## Source of truth
+
+`backend/app/models/inspection_image_tag.py` — `InspectionImageTag`:
+
+| Field | Meaning |
+|---|---|
+| `instrument_family` | The instrument family this image belongs to |
+| `anatomy_zone` | Which anatomy zone the image depicts |
+| `image_view` | The specific camera view (often the zone name; can differ, e.g. "end-on" vs. "side profile" of the same zone) |
+| `capture_quality` | Technician's own assessment — see values below |
+| `notes` | Optional free-text (e.g. "residue visible, recommend re-clean") |
+
+### Capture quality values
+
+`CAPTURE_QUALITY_VALUES = ("good", "acceptable", "poor", "unusable")`
+
+- **good** — in focus, correctly lit, zone fully visible.
+- **acceptable** — usable for review; minor blur/glare/framing issues.
+- **poor** — hard to assess; recommend re-capture if the zone is high-risk.
+- **unusable** — not usable for review; does not count toward coverage.
+
+Quality is self-reported by the technician at capture time — this is not an
+automated image-quality classifier (a related but separate capability; see
+`docs/ai/instrument-zone-detection-training-plan.md` for the future CV plan).
+
+## API
+
+- `POST /api/inspections` — accepts `image_view_tags: ImageViewTagIn[]`
+  alongside the existing `inspected_zones` checklist; each tag is persisted as
+  an `InspectionImageTag` row linked to the new inspection.
+- `GET /api/inspections/{id}/image-tags` — list an inspection's image tags.
+
+## AI context
+
+`analyze_inspection()` accepts `image_view_tags` and passes them straight
+through into the analysis result under `"image_view_tags"` — the AI context
+reflects exactly what was tagged, without altering scoring logic (tags are
+metadata/labels, not a clinical decision input).
+
+## Frontend
+
+Per-image tagging UI in `NewInspectionPage.tsx`: one row per uploaded image
+(zone, image view, quality, notes), keyed by filename+size so tags survive
+re-renders without depending on array index.

--- a/docs/instruments/coverage-engine.md
+++ b/docs/instruments/coverage-engine.md
@@ -1,0 +1,69 @@
+# Inspection Coverage Engine
+
+Computes how completely an inspection's tagged image views cover an
+instrument's required anatomy zones, and what's still missing before a
+confident clinical decision.
+
+## Source of truth
+
+`backend/app/services/inspection_coverage.py`
+
+- `compute_coverage(instrument_type, inspected_zones)` — coverage against the
+  instrument's `required_images`. When `inspected_zones` is `None` (zones
+  were never tagged), returns `assessed: False` / `quality: "not_assessed"`
+  rather than an alarming 0% — an explicit (possibly empty) list is assessed
+  normally.
+- `missing_image_guidance(instrument_type, inspected_zones)` — "Close-up image
+  of {zone}" guidance list for each missing required zone.
+- `build_risk_map(instrument_type, findings_by_zone, inspected_zones)` —
+  per-zone table: required? / inspected? / findings? / zone risk /
+  recommended manual check.
+- `coverage_dashboard_summary(db, tenant_id)` (v1.1 addition) — real
+  aggregate stats across stored inspections: average coverage, status
+  breakdown, average coverage by instrument family, most commonly missing
+  zones, recent inspections. Inspections that never had zones tagged are
+  excluded from the average (not counted as 0%) — nothing fabricated.
+
+## Coverage status vocabulary
+
+| Status | Meaning |
+|---|---|
+| `complete` | 0 missing required zones and ≥95% coverage |
+| `acceptable` | 0 missing required zones, or ≥80% coverage |
+| `incomplete` | ≥50% coverage |
+| `insufficient` | <50% coverage |
+| `not_assessed` | zones were never tagged for this inspection |
+
+## Wiring
+
+- `app/services/baseline_comparison_scoring_service.py` calls
+  `compute_coverage` / `missing_image_guidance` / `build_risk_map` and attaches
+  `instrument_anatomy`, `inspection_coverage`, `missing_image_guidance`,
+  `risk_map` onto every completed AI analysis (see `ai-context.md`
+  cross-reference in `guided-capture.md`).
+- `app/agents/coverage_agent.py` (`InspectionCoverageAgent`, Phase 22 §3) wraps
+  the same service for the multi-agent/CIOS pipeline — no separate coverage
+  logic.
+
+## API
+
+- `GET /api/coverage-dashboard/summary` (v1.1 addition) — fleet-wide
+  aggregate, backing the Coverage Dashboard page.
+- Per-inspection coverage is embedded in the `POST /api/inspections` analysis
+  response (`inspection_coverage`, `missing_image_guidance`, `risk_map`), not
+  a separate endpoint.
+
+## Frontend
+
+- `/coverage-dashboard` (`frontend/src/pages/CoverageDashboardPage.tsx`) —
+  fleet-wide aggregate view.
+- Per-inspection: `frontend/src/components/InstrumentIntelligencePanel.tsx`,
+  rendered inline in the New Inspection AI-prediction panel — shows the
+  coverage percentage, captured/missing zone chips, and the missing-image
+  guidance list described in the v1.1 spec.
+
+## Missing high-risk zones do not block submission
+
+Guidance is advisory ("Inspection coverage incomplete. Upload additional
+images for: …"); the current default does not block inspection submission on
+incomplete coverage. See `guided-capture.md` for the non-blocking rationale.

--- a/docs/instruments/coverage-gate-rules.md
+++ b/docs/instruments/coverage-gate-rules.md
@@ -1,0 +1,58 @@
+# AI Analysis Gate & Coverage Override Rules (v1.2)
+
+Governs whether an inspection with incomplete anatomy-zone coverage can reach
+a final AI decision, and how a supervisor/admin can override that gate with a
+documented reason.
+
+## Default behavior: non-blocking
+
+By default (`REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION` unset/false), the
+AI Analysis Gate never blocks inspection creation or the AI's decision —
+matching the v1.1 "advisory, not a gate" default (see
+`docs/instruments/coverage-engine.md`). Incomplete coverage only produces a
+warning banner and missing-image guidance.
+
+## Org policy: requiring full coverage
+
+Setting the env var `REQUIRE_FULL_COVERAGE_BEFORE_FINAL_DECISION=true`
+(`backend/app/config.py`) makes the gate binding: an inspection with
+`coverage_status` of `incomplete` or `insufficient` is created with
+`coverage_gate_status="blocked_pending_override"` rather than `"ready"`.
+
+## Gate states (`Inspection.coverage_gate_status`)
+
+| State | Meaning |
+|---|---|
+| `ready` | Coverage is complete/acceptable, org policy doesn't require full coverage, or a supervisor override has been applied. |
+| `draft` | Not currently persisted as a distinct gate state — a technician can instead set `save_as_draft=true` at creation (persisted as `Inspection.is_draft`) to explicitly flag the record as provisional regardless of the gate. |
+| `blocked_pending_override` | Org policy requires full coverage, coverage is incomplete/insufficient, and no override has been recorded yet. |
+
+## Source of truth
+
+`backend/app/services/guided_capture.py::coverage_readiness()` computes the
+gate; `backend/app/routes/inspections.py`'s `create_inspection` calls it at
+creation time and persists `coverage_status`, `coverage_score`,
+`coverage_gate_status`, and `is_draft` onto the `Inspection` row (a snapshot,
+so history/dashboards don't need to recompute it).
+
+## Supervisor Override
+
+`POST /api/inspections/{id}/coverage-override` (`admin`/`spd_manager` only,
+`backend/app/routes/guided_capture.py`) — requires a `reason` of at least 10
+characters (matching the existing baseline-override pattern). Sets
+`coverage_override_reason`/`coverage_override_by`/`coverage_override_at`,
+moves `coverage_gate_status` to `"ready"`, clears `is_draft`, and is
+audit-logged (`compliance_flag=True`) as `coverage_override_applied`.
+
+The override does not change the coverage score or status — it only unlocks
+the gate, with a permanent, attributed reason.
+
+## Frontend
+
+- `frontend/src/components/GuidedCapturePanel.tsx` — shows the gate banner
+  when `ready_for_ai_analysis` is false.
+- `frontend/src/components/CoverageOverridePanel.tsx` — the override form,
+  rendered in `NewInspectionPage.tsx` when the created inspection's
+  `coverage_gate_status === "blocked_pending_override"`.
+- A "Save as draft" checkbox in `NewInspectionPage.tsx` sends
+  `save_as_draft: true`, independent of org policy.

--- a/docs/instruments/guided-capture-workflow.md
+++ b/docs/instruments/guided-capture-workflow.md
@@ -1,0 +1,53 @@
+# Guided Capture Workflow (v1.2)
+
+Walks a technician through the required images for an instrument before AI
+analysis: which zone to capture next, the recommended camera angle/lighting/
+focus, and a plain-language instruction — built entirely on the existing
+Anatomy Library and Coverage Engine (see `docs/instruments/anatomy-library.md`
+and `docs/instruments/coverage-engine.md`); no new zone-assignment logic.
+
+## Source of truth
+
+`backend/app/services/guided_capture.py`
+
+- `ZONE_CAPTURE_GUIDANCE` — per-zone camera angle / lighting / focus /
+  instruction sentence for the commonly-named zones (o-ring area, drill-bit
+  flute, box lock, serrations, hinge, distal tip/end, lens edge, threaded
+  region, biopsy/suction/working channel, ratchet, insulation edge, sheath
+  connection). This is instructional UI copy (camera technique), not a
+  clinical claim, so it's authored directly.
+- `_CATEGORY_FALLBACK` — generic angle/lighting/focus guidance keyed by the
+  zone's `zone_category` (from `instrument_anatomy.py`) for zones without a
+  specific entry — honest, not fabricated zone-specific detail.
+- `zone_capture_guidance(instrument_type, zone_name)` — resolves guidance for
+  one zone, falling back to category-level, then a generic default.
+- `capture_checklist(instrument_type, captured_zones)` — required / optional /
+  captured / missing / high-risk zones.
+- `guided_capture_panel(instrument_type, captured_zones)` — the full panel
+  payload: family, checklist, the next zone to capture (missing required
+  zones, high-risk first), and that zone's capture guidance.
+
+## API
+
+`GET /api/guided-capture/{instrument_type}?captured_zones=a,b,c` — Guided
+Capture Panel + Capture Checklist + Coverage Score/readiness in one response.
+`captured_zones` omitted means "not yet assessed" (coverage is honestly
+`not_assessed`, not 0%); an explicit (possibly empty) list is assessed
+normally.
+
+## Frontend
+
+`frontend/src/components/GuidedCapturePanel.tsx`, rendered inside
+`NewInspectionPage.tsx` next to the zone-tagging checklist. Shows:
+
+1. Coverage score/status
+2. The next zone to capture, with its recommended angle/lighting/focus and
+   instruction sentence (e.g. "Capture close-up of o-ring area.")
+3. The full checklist (required/optional/captured/missing/high-risk zones)
+4. The AI Analysis Gate banner when coverage is insufficient (see
+   `coverage-gate-rules.md`)
+
+## Next-zone prioritization
+
+Missing required zones are offered in order, high-risk zones first — the
+technician is guided to close the highest-risk gaps before lower-risk ones.

--- a/docs/instruments/guided-capture.md
+++ b/docs/instruments/guided-capture.md
@@ -1,0 +1,51 @@
+# Guided Capture — Image View Selection in New Inspection
+
+After a technician selects an instrument type in the New Inspection workflow,
+LumenAI Inspect resolves that instrument's required anatomy zones and asks
+the technician to tag which zones their images actually cover, before AI
+analysis runs.
+
+## Where it lives
+
+`frontend/src/pages/NewInspectionPage.tsx`
+
+1. On `instrument_type` change, the page calls
+   `GET /api/instrument-anatomy/{instrument_type}` and loads
+   `zone_names` into `anatomyZones` state.
+2. A "Zones inspected" checklist renders one checkbox per anatomy zone
+   (`inspectedZones` state) — this **is** the image-view-capture step: each
+   checked zone represents an image view the technician captured for that
+   zone.
+3. On submit, `inspected_zones` is sent to `POST /api/inspections` alongside
+   the instrument/image data.
+
+## Per-family recommended views
+
+The zone lists a technician tags against come directly from
+`instrument_anatomy.py`'s `required_images` / zone names per family, e.g.:
+
+- **Rigid scope**: distal tip, lens edge, o-ring area, light post, eyepiece,
+  working channel, sheath connection, seal.
+- **Flexible endoscope**: distal end, bending section, insertion tube,
+  suction channel, biopsy channel, air/water nozzle, light guide lens,
+  control body.
+- **Drill bit**: tip, flutes, threaded region, cutting edge, shank, hub.
+- **Kerrison/rongeur**: jaw, serrations, box lock, hinge, spring, ratchet,
+  handle.
+- **Scissors**: tip, blade, cutting edge, serration, box lock, handle.
+- **Needle holder**: jaw inserts, serrations, box lock, ratchet, tungsten
+  carbide inserts, handle.
+
+These names are the canonical zone vocabulary used across anatomy
+resolution, zone-aware scoring, and the Coverage Engine — the v1.1 spec's
+requested view names (e.g. "cutting tip", "jaw serration", "channel opening")
+map onto this existing vocabulary rather than introducing a second,
+parallel naming scheme that would fork zone data already in production
+(`inspected_zones_json` on stored inspections uses these names).
+
+## Non-blocking by design
+
+Missing high-risk zones surface as guidance ("Inspection coverage incomplete.
+Upload additional images for: …" — see `coverage-engine.md`), not a hard
+block. Org policy that requires full coverage before submission is a future
+extension point, not the current default.

--- a/docs/instruments/inspection-zones.md
+++ b/docs/instruments/inspection-zones.md
@@ -1,0 +1,45 @@
+# Inspection Zones
+
+The zone taxonomy underlying anatomy resolution and zone-aware scoring: SPD
+contamination and damage hide in specific instrument zones (serrations, box
+locks, lumens, drill-bit flutes, o-ring areas, hinges …), not uniformly across
+the whole instrument.
+
+## Source of truth
+
+`backend/app/services/instrument_zones.py`
+
+- `ZONE_TAXONOMY` — zone category → representative zone names (e.g.
+  `cutting_working_surface`, `rotary_orthopedic`, `lumen_scope`, `mechanical`,
+  `handle_external`, `unknown`).
+- `HIGH_RETENTION_ZONES` — zones where residual soil is hard to remove;
+  contamination findings here are escalated.
+- `ZONE_INFO` — per-zone `risk`, `reason` (why this zone matters), and
+  `manual_check` (the recommended manual inspection step).
+- `resolve_zones(instrument_type)` / `zone_for_finding(instrument_type,
+  finding_type)` / `zone_fields(...)` — deterministic zone assignment for a
+  finding, labeled `assignment_method: "pilot_zone_assignment"` with a capped
+  confidence (never claimed as computer-vision certainty).
+
+This is structured knowledge and deterministic pilot logic — **not**
+pixel-level localization. A future CV release can localize the actual region
+and drop into the same schema.
+
+## API
+
+`GET /api/instrument-zones` (v1.1 addition) — the full taxonomy,
+high-retention zone list, and per-zone info, for the Inspection Zones library
+page and for anyone integrating without reading the Python source.
+
+## Frontend
+
+`/inspection-zones` (`frontend/src/pages/InspectionZonesPage.tsx`) — zone
+categories, the high-retention zone list, and a per-zone reference table
+(risk / reason / recommended manual check).
+
+## Relationship to the Coverage Engine
+
+A zone only becomes part of an instrument's *required* image views if it's
+listed in that family's `required_images` (see `anatomy-library.md`). The
+Coverage Engine (`coverage-engine.md`) checks captured zones against that
+required list — the zone taxonomy here is the shared vocabulary both use.

--- a/docs/instruments/instrument-library.md
+++ b/docs/instruments/instrument-library.md
@@ -34,8 +34,8 @@ general-forceps anatomy family also has its own dedicated zone taxonomy, see
 
 ## API
 
-- `GET /api/instrument-families` — all family profiles.
-- `GET /api/instrument-families/{family_key}` — one family profile (404 with
+- `GET /api/knowledge-graph/instrument-families` — all family profiles.
+- `GET /api/knowledge-graph/instrument-families/{family_key}` — one family profile (404 with
   the list of known keys if unrecognized).
 
 ## Frontend

--- a/docs/instruments/instrument-library.md
+++ b/docs/instruments/instrument-library.md
@@ -1,0 +1,52 @@
+# Instrument Knowledge Library
+
+LumenAI Inspect v1.1 — before any contamination/damage analysis runs, the
+platform first resolves what instrument it is looking at. The Instrument
+Knowledge Library is the structured, data-driven knowledge base behind that
+step.
+
+## Source of truth
+
+`backend/app/services/instrument_family_profiles.py` — `INSTRUMENT_FAMILY_PROFILES`
+
+Ten instrument families, each with:
+
+| Field | Meaning |
+|---|---|
+| `display_name` | Human-readable family name |
+| `typical_anatomy` | Live anatomy zones for the family (resolved from `instrument_anatomy.py` — never a duplicated copy) |
+| `high_risk_zones` | Zones with elevated inherent/retention risk |
+| `typical_contamination` | Contamination types typically found on this family |
+| `typical_damage` | Damage patterns typically found on this family |
+| `typical_repair_issues` | Common repair/rework reasons |
+| `inspection_priorities` | Zones to prioritize during visual inspection |
+| `cleaning_priorities` | Manual-check guidance for reprocessing staff |
+| `supervisor_focus_areas` | What a supervisor should specifically verify |
+| `anatomy_family_note` | Present only when a family honestly borrows another family's anatomy taxonomy rather than fabricating zones that were never defined (e.g. Cannulated Instruments, Orthopedic Instruments, Micro Instruments) |
+
+Covered families: Rigid Scope, Flexible Endoscope, Kerrison, Needle Holder,
+Scissors, Drill Bit, Laparoscopic Instruments, Cannulated Instruments,
+Orthopedic Instruments, Micro Instruments — a superset of the eight families
+in the v1.1 spec (rigid scope, flexible endoscope, drill bit, Kerrison/rongeur,
+scissors, needle holder, laparoscopic instrument, general forceps — the
+general-forceps anatomy family also has its own dedicated zone taxonomy, see
+`anatomy-library.md`).
+
+## API
+
+- `GET /api/instrument-families` — all family profiles.
+- `GET /api/instrument-families/{family_key}` — one family profile (404 with
+  the list of known keys if unrecognized).
+
+## Frontend
+
+`/instrument-library` (`frontend/src/pages/InstrumentLibraryPage.tsx`) —
+browsable cards, one per family, expandable to the full profile.
+
+## Design decision: no fabricated coverage
+
+Three families (Cannulated Instruments, Orthopedic Instruments, Micro
+Instruments) do not yet have a dedicated anatomy-zone split — they borrow the
+closest existing anatomy family and say so via `anatomy_family_note`, rather
+than inventing zones that were never defined. Extend by adding a new anatomy
+family in `instrument_anatomy.py` and pointing `anatomy_family_key` at it.

--- a/docs/knowledge-graph/agent-architecture.md
+++ b/docs/knowledge-graph/agent-architecture.md
@@ -1,0 +1,68 @@
+# Future AI Agent Architecture (Phase 21 §10)
+
+## Objective
+
+Prepare the knowledge graph so a future set of specialized agents can
+consume the same ontology without each one re-implementing its own
+version of instrument/anatomy/finding knowledge. This document describes
+the intended agent boundaries — no agent orchestration code ships in
+Phase 21; the knowledge graph service functions are written so each
+agent's eventual responsibility maps to one existing function, not a
+rewrite.
+
+## Why one shared ontology matters
+
+Every agent below would otherwise be tempted to hold its own copy of
+"what zone is high-risk" or "what does blood mean clinically." That's
+exactly the disconnected-features failure mode Phase 19.5 exists to
+prevent (`docs/architecture/lumenai-clinical-intelligence-architecture.md`).
+Instead, every agent is expected to call into the same knowledge graph
+service (`app/services/knowledge_graph_service.py`) and the modules it
+composes (`instrument_anatomy.py`, `instrument_zones.py`,
+`cleaning_knowledge.py`, `clinical_mentor.py`,
+`instrument_family_profiles.py`) — never a parallel implementation.
+
+## Planned agents and their ontology touchpoints
+
+| Agent | Responsibility | Reads from |
+|---|---|---|
+| **Instrument Agent** | Resolves instrument identity (family, manufacturer, model) from capture metadata/UDI/barcode. | `instrument_anatomy.py::resolve_family`, `app/models/instrument_registry.py`, `app/models/baseline_library.py` |
+| **Anatomy Agent** | Determines anatomy zones, required views, and coverage for a resolved instrument. | `instrument_anatomy.py::anatomy_profile`, `app/services/inspection_coverage.py` |
+| **Inspection Agent** | Runs/coordinates the capture + scoring workflow for one inspection. | `app/services/baseline_comparison_scoring_service.py`, `app/routes/inspections.py` |
+| **Clinical Reasoning Agent** | Produces the traceable chain and explanation for a finding. | `knowledge_graph_service.py::reasoning_chain`, `explain_inspection` |
+| **Supervisor Agent** | Surfaces the right queue items to the right human at the right time. | `app/services/pre_sterilization_command_center_service.py` (Modules 5/6/9), `app/models/supervisor_review.py` |
+| **Executive Agent** | Rolls up readiness, risk, and analytics for leadership consumption. | `pre_sterilization_command_center_service.py::executive_risk_dashboard`, `knowledge_graph_service.py::enterprise_knowledge_analytics` |
+| **Knowledge Graph Agent** | Answers ad hoc exploratory queries across the ontology (manufacturer/instrument/model/finding/zone/failure mode/recommendation/supervisor learning). | `knowledge_graph_service.py::explore` |
+
+## Design constraints for future agents
+
+1. **No agent invents its own instrument/zone/finding vocabulary.** All
+   must resolve through the functions above so a "hinge" means the same
+   thing to the Supervisor Agent as it does to the Clinical Reasoning
+   Agent.
+2. **No agent auto-disposes an instrument.** Per Design Principle 4
+   (`docs/architecture/design-principles.md`), every agent's output is
+   advisory; only a Supervisor Review changes an instrument's actual
+   disposition.
+3. **Every agent action that touches a real record creates an audit
+   event**, consistent with the platform-wide requirement (see
+   `app/audit.py::log_audit_event`, used throughout Phases 15–21).
+4. **An agent's "learning" always routes through the real ground-truth
+   path** — `PilotValidationCase` (Phase 18) — not a private feedback
+   loop. `learning_confidence()` in `knowledge_graph_service.py` is the
+   read-only view any future agent should query to know how much to trust
+   the current knowledge base, rather than maintaining its own confidence
+   state.
+5. **Agents are additive, not a replacement for the deterministic
+   knowledge functions.** An agent framework (should one be introduced)
+   should orchestrate calls into the existing services — the services
+   themselves remain the source of truth, testable independent of any
+   agent runtime.
+
+## What ships now vs. later
+
+Phase 21 ships the knowledge graph, reasoning engine, explorer, and
+analytics that every one of these agents would need to call into. It does
+not ship an agent orchestration framework, agent-to-agent messaging, or
+autonomous multi-step agent workflows — those are explicitly future work,
+gated on this ontology being stable and validated first.

--- a/docs/knowledge-graph/clinical-rules.md
+++ b/docs/knowledge-graph/clinical-rules.md
@@ -1,0 +1,65 @@
+# Clinical Rules — Cleaning Knowledge Library & Recommendation Mapping
+
+## Cleaning Knowledge Library (Phase 21 §4)
+
+`app/services/cleaning_knowledge.py::CLEANING_KNOWLEDGE` stores, for every
+anatomy zone in `app/services/instrument_zones.py::ZONE_INFO`:
+
+| Field | Meaning |
+|---|---|
+| `cleaning_method` | The recommended manual cleaning approach for this zone. |
+| `brush_type` | What kind of brush (and why — e.g. "soft brush; abrasive tools can damage the insulation"). |
+| `flushing_requirement` | Whether/how the zone needs flushing (lumens/channels: mandatory; surface zones: not applicable). |
+| `ultrasonic_guidance` | Whether ultrasonic cleaning is recommended, and any caveats. |
+| `visual_inspection_guidance` | How to visually inspect the zone (magnification, borescope, etc.). |
+| `manual_verification_guidance` | How to confirm the zone is actually clean before moving on. |
+
+**This is explicitly not an IFU replacement.** Every response from
+`get_cleaning_knowledge(zone)` carries the note: *"Advisory clinical
+knowledge, not an IFU replacement — the device IFU governs when the two
+differ."* This is a clinical knowledge layer, paraphrased general SPD
+practice (in the same spirit as `clinical_mentor.py`'s existing
+`FINDING_EDUCATION` library) — never a specific manufacturer's written
+instructions.
+
+Coverage: all 18 zones in `ZONE_INFO` have a dedicated entry
+(`serrations`, `grooves`, `box lock`, `hinge`, `ratchet`, `drill-bit
+flute`, `threaded region`, `lumen opening`, `inner channel`, `biopsy
+channel`, `suction channel`, `air/water nozzle`, `o-ring area`, `rigid
+scope port`, `insulation edge`, `cutting edge`, `surface discoloration
+area`, `unspecified region`) plus a fallback for any zone name not in the
+list.
+
+## Recommendation mapping (generic, severity-unaware queries)
+
+For the Knowledge Graph Explorer's `reasoning_chain()`, where no real
+scored inspection exists, the finding type is mapped to one of the five
+frozen decision-engine outcomes conservatively:
+
+| Finding category | Outcome | Rationale |
+|---|---|---|
+| Contamination (`blood`, `bone`, `tissue`, `debris`, `other`, `other_organic_residue`) | `REPROCESS` | Contamination findings are, by default, addressed by recleaning — see the real scoring engine's `recommended_action()` in `baseline_comparison_scoring_service.py`. |
+| `crack`, `missing_component` | `REMOVE FROM SERVICE` | Never repairable in place — always a removal candidate pending evaluation. |
+| `corrosion` in a high-retention zone | `REMOVE FROM SERVICE` | Severe corrosion in a high-retention zone is treated as structurally significant. |
+| Other structural findings (`insulation_damage`, `pitting`, `rust`, `discoloration`, `corrosion` elsewhere) | `SUPERVISOR REVIEW` | Requires a human judgment call the generic mapping can't make without severity data. |
+| No finding | `PASS` | Routine processing. |
+
+This mapping is intentionally more conservative than the real scoring
+engine (which has access to severity indices, baseline match scores, and
+zone-aware escalation — see `_overall_result()` in
+`baseline_comparison_scoring_service.py`). It exists only to give the
+Knowledge Graph Explorer a reasonable illustrative answer when no real
+inspection is behind the query; **the real scored outcome from
+`explain_inspection()` always takes precedence** for an actual
+inspection record.
+
+## Zone assignment note
+
+Both the reasoning chain and the explainability graph use
+`app/services/instrument_zones.py::zone_fields()` — the same deterministic
+`pilot_zone_assignment` engine used throughout Phases 15–20. This means
+the "Inspection Zone" step in the reasoning chain is not a free choice of
+words; it's the exact same zone a supervisor would see on the Pre-
+Sterilization Command Center or the Pilot Validation Dashboard for the
+same instrument/finding combination — the knowledge graph doesn't
+introduce a second, inconsistent zone-naming scheme.

--- a/docs/knowledge-graph/instrument-intelligence.md
+++ b/docs/knowledge-graph/instrument-intelligence.md
@@ -1,0 +1,76 @@
+# Instrument Intelligence — Family Knowledge Profiles
+
+`app/services/instrument_family_profiles.py` defines a knowledge profile
+for each of the ten instrument families SPD sees most often, exposed at
+`GET /api/knowledge-graph/instrument-families` and
+`GET /api/knowledge-graph/instrument-families/{family_key}`.
+
+## Profile contents
+
+Each profile includes:
+
+- **typical_anatomy** — pulled live from
+  `app/services/instrument_anatomy.py` (never duplicated as static text)
+- **typical_contamination** — the finding types most often seen on this
+  family
+- **typical_damage** — the structural/condition issues most often seen
+- **typical_repair_issues** — what a repair vendor typically fixes for
+  this family
+- **inspection_priorities** — which zones an inspector should check first
+- **cleaning_priorities** — the cleaning steps that matter most for this
+  family
+- **supervisor_focus_areas** — what a supervisor should specifically
+  verify before releasing this family
+
+## The ten families
+
+| Family key | Display name | Anatomy source |
+|---|---|---|
+| `rigid_scope` | Rigid Scope | `rigid_scope` anatomy family (real, dedicated) |
+| `flexible_endoscope` | Flexible Endoscope | `flexible_endoscope` anatomy family (real, dedicated) |
+| `kerrison` | Kerrison | `kerrison_rongeur` anatomy family (real, dedicated) |
+| `needle_holder` | Needle Holder | `needle_holder` anatomy family (real, dedicated) |
+| `scissors` | Scissors | `scissors` anatomy family (real, dedicated) |
+| `drill_bit` | Drill Bit | `drill_bit` anatomy family (real, dedicated) |
+| `laparoscopic_instruments` | Laparoscopic Instruments | `laparoscopic` anatomy family (real, dedicated) |
+| `cannulated_instruments` | Cannulated Instruments | borrows `laparoscopic`'s lumen/cannulated channel zone |
+| `orthopedic_instruments` | Orthopedic Instruments | borrows `drill_bit`'s zones |
+| `micro_instruments` | Micro Instruments | borrows the generic `default` anatomy family |
+
+## Honest limitation: three borrowed profiles
+
+Cannulated Instruments, Orthopedic Instruments, and Micro Instruments do
+not yet have a dedicated anatomy-zone taxonomy split out in
+`app/services/instrument_anatomy.py`. Rather than fabricate zones that
+were never defined, their profiles borrow the closest existing anatomy
+family and carry an `anatomy_family_note` explaining exactly that — surfaced
+in the API response and in the Knowledge Graph Explorer UI. This is a
+deliberate, documented limitation, not a silent gap:
+
+- **Cannulated Instruments** → borrows `laparoscopic`'s lumen/cannulated
+  channel zone. A broader class of cannulated instruments (guide pins,
+  cannulated screws, cannulated reamers) exists beyond laparoscopic
+  devices; a dedicated split is future work.
+- **Orthopedic Instruments** → borrows `drill_bit`'s zones. Orthopedic
+  instrumentation beyond drill bits (saws, awls, broaches, impactors) is
+  real SPD inventory that doesn't yet have its own zone definition.
+- **Micro Instruments** → borrows the generic `default` profile. Fine
+  ophthalmic/micro-surgical instruments have distinct handling needs
+  (avoiding tip damage during cleaning) that the profile's
+  `cleaning_priorities` and `supervisor_focus_areas` capture as text even
+  though the anatomy zones themselves are still generic.
+
+**Next step:** when real inspection volume accumulates for these three
+families (trackable via the Knowledge Graph Explorer's `instrument`
+category and the Pre-Sterilization Command Center's instrument-family
+performance), split out dedicated anatomy families in
+`instrument_anatomy.py` the same way the other seven were defined, and
+update `anatomy_family_key` here to point at the new dedicated family.
+
+## Extending this library
+
+To add an eleventh family: add an entry to
+`INSTRUMENT_FAMILY_PROFILES` in `instrument_family_profiles.py` with a
+real or borrowed `anatomy_family_key`, then fill in the six knowledge
+fields. No manufacturer is ever hardcoded — this mirrors the extensibility
+pattern already established in `instrument_anatomy.py`.

--- a/docs/knowledge-graph/reasoning-engine.md
+++ b/docs/knowledge-graph/reasoning-engine.md
@@ -1,0 +1,103 @@
+# Clinical Reasoning Engine
+
+## What changes for the user
+
+Before Phase 21, an AI output could read like:
+
+> "I detected blood."
+
+After Phase 21, the same detection is explained through the knowledge
+graph:
+
+> "I detected probable blood in the Kerrison jaw serrations. Serrations
+> are a high-retention anatomy zone where blood and tissue commonly
+> persist after inadequate manual cleaning. Based on SPD best practices
+> and the instrument profile, recleaning, repeat inspection, and
+> supervisor verification are recommended before the instrument proceeds
+> to packaging."
+
+(The exact zone named in the sentence depends on the instrument's real,
+deterministic zone assignment — see the note on zone assignment below.)
+
+## Two reasoning entry points
+
+### 1. `reasoning_chain()` — generic, severity-unaware
+
+`app/services/knowledge_graph_service.py::reasoning_chain(instrument_type,
+finding_type, manufacturer="", model="")`, exposed at
+`GET /api/knowledge-graph/reasoning-chain`. Used by the Knowledge Graph
+Explorer to demonstrate "if this instrument shows this finding, here's how
+LumenAI would reason about it" — without a real scored inspection behind
+it. The recommended action is a generic categorization (contamination →
+reprocess-class guidance; unrepairable structural → remove-from-service;
+other structural → supervisor-review) since no real severity score exists
+yet for a hypothetical query.
+
+### 2. `explain_inspection()` — real, severity-aware
+
+`app/services/knowledge_graph_service.py::explain_inspection(db, inspection)`,
+exposed at `GET /api/knowledge-graph/explain/{inspection_id}`. Used for a
+specific, already-scored inspection. This reads the inspection's *actual*
+persisted `recommended_action` (the real scoring engine's deterministic
+sentence — see
+`docs/command-center/readiness-score-model.md`) rather than re-deriving a
+generic one, so the explanation always matches what the instrument was
+actually told to do.
+
+## The reasoning chain, step by step
+
+Both entry points walk the same ontology:
+
+1. **Instrument** — the raw `instrument_type` string.
+2. **Manufacturer** — if known.
+3. **Instrument Family** — resolved via
+   `app/services/instrument_anatomy.py::resolve_family`.
+4. **Model** — if known.
+5. **Anatomy Zone / Inspection Zone** — resolved via
+   `app/services/instrument_zones.py::zone_fields`, the same deterministic
+   zone-assignment engine used by Phase 18 pilot validation and the Phase
+   20 command center. This is honestly labeled `pilot_zone_assignment` —
+   instrument-type-derived, not pixel-level CV localization (see
+   `docs/architecture/future-ai-roadmap.md` Stages 7–8, not yet started).
+6. **Retention Risk** — the zone's risk level (`ZONE_INFO`).
+7. **Cleaning Method** — `app/services/cleaning_knowledge.py`.
+8. **Typical Contamination / Typical Damage** — the zone's
+   `contamination_risks` / `condition_risks` from the anatomy profile.
+9. **Clinical Meaning** — `FINDING_EDUCATION`'s `clinical_significance` /
+   `why_it_matters` for the finding.
+10. **Recommended Action** — mapped to one of the five frozen decision
+    engine outcomes (`_ACTION_TEXT` in
+    `baseline_comparison_scoring_service.py`; see
+    `docs/architecture/lumenai-clinical-intelligence-architecture.md`
+    Layer 7).
+11. **Supervisor Validation** — always present, always required; routes to
+    the Supervisor Review Queue (Phase 20 Module 6).
+12. **Learning** — a confirmed or corrected supervisor review becomes a
+    Phase 18 `PilotValidationCase` ground-truth label.
+
+## Explainability Graph ("Why?")
+
+The narrower "Why?" expansion (Phase 21 §6,
+`GET /api/knowledge-graph/explain/{inspection_id}`) surfaces exactly five
+nodes for a real inspection:
+
+```
+Finding -> Zone -> Clinical Significance -> SPD Rule -> Recommendation
+```
+
+This is the drill-down a supervisor clicks into from a specific inspection
+record — narrower than the full reasoning chain, focused on "why did the
+AI say this" rather than the full knowledge-graph traversal.
+
+## Honesty constraints
+
+- The narrative is built entirely from real function outputs
+  (`zone_fields`, `FINDING_EDUCATION`, `_ACTION_TEXT`) — no hardcoded
+  per-instrument sentences.
+- `reasoning_chain()` never claims a severity-driven outcome it hasn't
+  computed; it uses the same conservative outcome mapping documented
+  above, and always recommends supervisor validation regardless.
+- `explain_inspection()` never re-derives a recommendation that
+  contradicts what was actually persisted on the inspection — it reads
+  the real `recommended_action`, so the explanation and the actual
+  disposition can never drift apart.

--- a/docs/knowledge-graph/spd-clinical-knowledge-graph.md
+++ b/docs/knowledge-graph/spd-clinical-knowledge-graph.md
@@ -1,0 +1,91 @@
+# SPD Clinical Knowledge Graph
+
+## Objective
+
+Transform LumenAI from a system that only reports computer-vision output
+into one that reasons using structured SPD clinical knowledge. Every AI
+recommendation should be traceable through the same ontology chain that
+`docs/architecture/lumenai-clinical-ontology.md` already establishes
+platform-wide:
+
+```
+Instrument -> Manufacturer -> Instrument Family -> Model -> Anatomy ->
+Inspection Zone -> Retention Risk -> Cleaning Method -> Typical
+Contamination -> Typical Damage -> Clinical Meaning -> Recommended Action
+-> Supervisor Validation -> Learning
+```
+
+## Implementation approach
+
+This is **not** backed by a separate graph database (Neo4j, etc.). The
+graph is represented as queryable nodes/edges computed on demand from:
+
+- **Existing structured knowledge modules** — no duplication, only
+  composition:
+  - `app/services/instrument_anatomy.py` — Instrument → Family → Anatomy →
+    Zone
+  - `app/services/instrument_zones.py` — Zone → Retention Risk, per-zone
+    `ZONE_INFO`
+  - `app/services/cleaning_knowledge.py` (new, Phase 21) — Zone →
+    Cleaning Method / Brush Type / Flushing / Ultrasonic / Visual /
+    Manual Verification
+  - `app/services/clinical_mentor.py`'s `FINDING_EDUCATION` — Finding →
+    Clinical Meaning
+  - `app/services/instrument_family_profiles.py` (new, Phase 21) —
+    Instrument Family → typical contamination/damage/repair/priorities
+  - `app/services/baseline_comparison_scoring_service.py`'s `_ACTION_TEXT`
+    — Finding/Severity → Recommended Action
+- **Real database rows** — `Inspection`, `SupervisorReview`,
+  `PilotValidationCase`, `BaselineLibraryEntry`, `InstrumentKnowledge` —
+  for anything that needs live data rather than static knowledge
+  (Manufacturer, Model, Supervisor Decision, Training Dataset).
+
+Every graph query is deterministic and grounded in real code/data. Nothing
+in this module is a trained model or a black box.
+
+## Node types
+
+`Instrument`, `Manufacturer`, `InstrumentFamily`, `Model`, `AnatomyZone`,
+`InspectionZone`, `Finding`, `Severity`, `SPDRisk`, `CleaningMethod`,
+`BrushType`, `IFU`, `RepairRecommendation`, `ReplacementRecommendation`,
+`SupervisorDecision`, `ClinicalRecommendation`, `TrainingDataset`.
+
+`GET /api/knowledge-graph/schema` returns this list plus the relationship
+types below and the ontology chain, programmatically — the taxonomy is
+defined once in `app/services/knowledge_graph_service.py::graph_schema()`.
+
+## Relationships
+
+- `Instrument HAS Anatomy`
+- `Anatomy HAS Zone`
+- `Zone HAS Retention Risk`
+- `Zone HAS Cleaning Method`
+- `Zone HAS Common Findings`
+- `Finding HAS Clinical Meaning`
+- `Finding HAS Severity`
+- `Finding REQUIRES Action`
+- `Supervisor VALIDATES Finding`
+- `Inspection CREATES Learning Signal`
+
+Each relationship corresponds to a real function call in the codebase —
+e.g. `Zone HAS Cleaning Method` is
+`app/services/cleaning_knowledge.py::get_cleaning_knowledge(zone)`, and
+`Supervisor VALIDATES Finding` is the existing
+`POST /inspections/{id}/supervisor-review` → `PilotValidationCase` link
+from Phase 18.
+
+## Where this fits with prior phases
+
+| Phase | Contributes |
+|---|---|
+| 15 | Instrument anatomy, zone taxonomy, instrument knowledge library |
+| 14 | Per-finding clinical education (`FINDING_EDUCATION`) |
+| 18 | Ground-truth labels (`PilotValidationCase`) — the "Learning" node |
+| 19.5 | The platform-wide ontology this graph specializes |
+| 20 | Readiness classification reused for repair-reason analytics |
+| 21 | This document — the graph representation, reasoning engine, and explorer that tie the above together |
+
+See `docs/knowledge-graph/reasoning-engine.md` for how the graph is
+traversed to produce a recommendation, and
+`docs/knowledge-graph/instrument-intelligence.md` for the ten instrument
+family profiles.

--- a/docs/knowledge/ai-knowledge-assistant.md
+++ b/docs/knowledge/ai-knowledge-assistant.md
@@ -1,0 +1,52 @@
+# AI Knowledge Assistant & Knowledge Analytics
+
+## AI Knowledge Assistant (Deliverable 8)
+
+`POST /api/knowledge/assistant`
+
+Answers contextual technician questions ("Why is this finding important?",
+"Where does blood commonly hide on this instrument?", "Why is this anatomy
+considered high risk?") using the same deterministic, source-grounded
+pattern already used by `knowledge_graph_service.reasoning_chain()` —
+never a call to an external LLM. The question is parsed for the same
+finding/zone/instrument-family vocabulary as Smart Knowledge Search, and
+the answer is composed from:
+
+1. **Finding education** (`clinical_mentor.FINDING_EDUCATION`) — clinical
+   significance for any matched finding.
+2. **Approved institutional knowledge** — up to 3 approved
+   `KnowledgeArticle` entries tagged to the matched finding. Unapproved
+   (draft/pending_review) articles are never surfaced here — the
+   assistant only cites guidance the organization has actually signed off
+   on.
+3. **Instrument anatomy profile** — for a matched or supplied instrument
+   family, the zones classified `high`/`critical` risk, answering "why is
+   this anatomy considered high risk" with the same data
+   `instrument_anatomy.py` already maintains.
+
+Every response includes `sources` — exactly which of the above contributed
+— so nothing is presented as authoritative without a traceable origin. If
+nothing matches, the assistant says so explicitly rather than fabricating
+an answer, and suggests the gap be filled via the Knowledge Repository.
+
+Every question (both from Search and the Assistant) is logged to
+`KnowledgeQueryLog` for analytics.
+
+## Knowledge Analytics (Deliverable 10)
+
+`GET /api/knowledge/analytics` (admin/spd_manager only)
+
+All six rollups are computed from real, already-recorded data:
+
+| Metric | Source |
+|---|---|
+| Most viewed articles | `KnowledgeArticle.view_count`, incremented on every `GET /api/knowledge/articles/{id}` |
+| Most common questions | `KnowledgeQueryLog`, grouped by exact query text |
+| Most frequent teaching points | `KnowledgeArticle` where `category=teaching_point`, grouped by tagged finding |
+| Common supervisor comments | `DispositionOverride.reason` (v1.6), grouped by exact text |
+| Knowledge gaps | Finding types with a real `ClinicalCase` but no approved article tagged to that finding |
+| Training opportunities | Technicians with a `repeated_error` competency event (v1.4) for a finding type with no approved article |
+
+Knowledge gaps and training opportunities are the two forward-looking
+metrics — both point at real, unaddressed needs rather than a general
+"engagement" score.

--- a/docs/knowledge/clinical-case-library.md
+++ b/docs/knowledge/clinical-case-library.md
@@ -1,0 +1,58 @@
+# Clinical Case Library & Supervisor Knowledge Capture
+
+## Clinical Case Library (Deliverable 2)
+
+`GET /api/knowledge/cases`, `GET /api/knowledge/cases/{id}`
+
+Significant inspections are saved automatically as a `ClinicalCase` —
+never fabricated after the fact, always tied to a real inspection:
+
+- At inspection creation, if the inspection has any real actionable
+  finding (matching the spec's own examples — blood, bone, corrosion,
+  missing insulation, a crack are all ordinary findings, not just
+  remove-from-service-tier ones), or the risk stratification tier is
+  `Critical`, or the readiness engine's own `is_critical_finding`
+  classification is true.
+- At every supervisor disposition action (v1.6), which both is itself a
+  significance trigger and updates the case with the real
+  `supervisor_corrections`, `final_disposition`, and `outcome`.
+
+One case per inspection — later events update the same row rather than
+creating a duplicate, so a case's history stays a single coherent record
+of what happened.
+
+Each case contains: `ai_findings` (a JSON snapshot of the real
+`InspectionFinding` rows at save time), `supervisor_corrections`,
+`final_disposition`, `clinical_reasoning`, `educational_notes`, and
+`outcome`. Images are referenced via `inspection_id`, not duplicated.
+
+## Supervisor Knowledge Capture (Deliverable 3)
+
+`POST /api/inspections/{id}/teaching-point` (admin/spd_manager only)
+
+After a disposition override, a supervisor can capture what future
+technicians should know: `explanation`, `teaching_point` (headline),
+`common_mistake`, `prevention_tip`, `references`. This creates a
+`KnowledgeArticle` with `category=teaching_point`, tagged to the
+inspection's real instrument type and primary finding, and updates that
+inspection's `ClinicalCase.educational_notes`.
+
+Teaching points are **auto-approved** rather than routed through the
+general `pending_review` queue — a supervisor is already exercising real
+clinical authority at the point of a disposition decision (the same
+authority already granted to disposition overrides in v1.6), so requiring
+a second reviewer would be redundant. They still carry a `reviewer` (the
+authoring supervisor) and remain fully subject to later archival via
+Knowledge Governance if the guidance becomes outdated.
+
+## Similar Case Finder (Deliverable 5)
+
+`GET /api/inspections/{id}/similar-cases`
+
+When the AI detects a finding on a new inspection, surfaces prior real
+cases with the same finding type on the same **instrument family**
+(`instrument_anatomy.resolve_family()` — not exact instrument type, since a
+Kerrison from one manufacturer and another share the anatomy that drives
+the finding, not the brand). Each result includes the previous
+recommendation, supervisor outcome, and educational notes — nothing here
+is a fabricated "similar" case, only ones that are real matches.

--- a/docs/knowledge/institutional-knowledge.md
+++ b/docs/knowledge/institutional-knowledge.md
@@ -1,0 +1,54 @@
+# Institutional Knowledge Repository
+
+`GET/POST /api/knowledge/articles` · frontend route `/knowledge-center`
+
+## What it is
+
+A user-authored repository of institutional SPD knowledge — supervisor
+best practices, local inspection standards, organization-approved
+workflows, clinical pearls, lessons learned, FAQs, competency guidance, and
+manufacturer clarifications. Deliberately distinct from two existing
+stores it might be confused with:
+
+- `education_library.py` (v1.4) — a fixed, code-generated reference for
+  the 12 finding categories. Static, not authored or governed.
+- `InstrumentKnowledge` (Phase 15) — manufacturer/model technical data
+  (failure modes, maintenance intervals). Not staff-authored guidance.
+
+`KnowledgeArticle` is what SPD staff actually write themselves, with real
+governance (see `knowledge-governance.md`).
+
+## Search facets
+
+Every article stores the facets it's searchable by — populated only when
+actually supplied at authoring time, never inferred:
+
+| Facet | Field |
+|---|---|
+| Instrument | `applicable_instruments` (list) |
+| Manufacturer | `applicable_manufacturers` (list) |
+| Instrument family | derived by resolving each `applicable_instruments` entry via `instrument_anatomy.resolve_family()` at search time |
+| Anatomy zone | `anatomy_zone` |
+| Finding | `applicable_findings` (list) |
+| Procedure | `procedure` (free text, substring match) |
+| Specialty | `specialty` |
+
+`GET /api/knowledge/articles?instrument=&manufacturer=&anatomy_zone=&finding=&procedure=&specialty=&category=&approval_status=`
+combines any of these filters.
+
+## Categories
+
+`best_practice`, `local_standard`, `approved_workflow`, `clinical_pearl`,
+`lesson_learned`, `faq`, `competency_guidance`, `manufacturer_clarification`,
+`teaching_point` (the last one is written via the Supervisor Knowledge
+Capture flow — see `clinical-case-library.md`).
+
+## Honesty notes
+
+- New articles start `pending_review` — nothing self-publishes as
+  authoritative institutional knowledge without a reviewer, except
+  supervisor teaching points captured at the point of a real disposition
+  decision (see `knowledge-governance.md` for why that's different).
+- Editing an approved article's title/body bumps its version and reopens
+  review — staff relying on "approved" guidance never see it silently
+  change underneath them.

--- a/docs/knowledge/knowledge-governance.md
+++ b/docs/knowledge/knowledge-governance.md
@@ -1,0 +1,39 @@
+# Knowledge Governance & Organization Standards
+
+## Knowledge Governance (Deliverable 9)
+
+`POST /api/knowledge/articles/{id}/{submit-for-review,approve,reject,archive}`,
+`GET /api/knowledge/governance-summary` (admin/spd_manager only for
+approve/reject/archive/summary)
+
+Every `KnowledgeArticle` tracks:
+
+| Field | Meaning |
+|---|---|
+| `author` | who wrote it (the actor at creation time) |
+| `reviewer` | who approved/rejected/archived it |
+| `approval_status` | `draft` → `pending_review` → `approved` / `rejected` / `archived` |
+| `version` | incremented on every substantive edit |
+| `last_reviewed_at` | set on approve/reject/archive |
+| `applicable_instruments` / `applicable_findings` | the search facets governance and search both use |
+
+Archiving never deletes an article — it drops out of default
+list/search results (`include_archived=False` unless explicitly
+requested) but remains available for audit. This is the mechanism for
+retiring outdated knowledge without losing the record of what the
+organization used to believe and why it changed.
+
+## Organization Standards (Deliverable 6)
+
+`GET/POST /api/knowledge/standards`, `POST /api/knowledge/standards/{id}/deactivate`
+(admin/spd_manager only for create/deactivate)
+
+Per-tenant local policy in five categories: `inspection_standard`,
+`photography_standard`, `coverage_requirement`,
+`supervisor_approval_threshold`, `competency_requirement`. These
+**supplement, never replace**, manufacturer IFUs — nothing in this module
+overrides the AI's readiness/disposition/risk engines; a standard is
+documentation and policy, not a code path the scoring engine reads.
+Deactivated standards are excluded from the default list (`active_only=True`)
+but not deleted, mirroring the same archive-not-delete governance
+principle as knowledge articles.

--- a/docs/knowledge/similar-case-search.md
+++ b/docs/knowledge/similar-case-search.md
@@ -1,0 +1,43 @@
+# Smart Knowledge Search & Competency Knowledge Library
+
+## Smart Knowledge Search (Deliverable 4)
+
+`POST /api/knowledge/search`
+
+A deterministic, keyword-matched search — the same "explainable, not a
+black box" approach already used by the disposition/priority/risk engines,
+rather than a call to an external LLM. The query is matched against real,
+already-known vocabulary:
+
+- **Findings** — every key in `clinical_mentor.FINDING_EDUCATION` (blood,
+  bone, corrosion, crack, ...).
+- **Anatomy zones** — every key in `instrument_zones.ZONE_INFO`.
+- **Instrument families** — every family in `instrument_anatomy.py`,
+  matched either by family name or by any of that family's own match
+  keywords (so "Kerrison" resolves to the `kerrison_rongeur` family).
+
+A recognized finding keyword filters both `KnowledgeArticle` (approved
+only) and `ClinicalCase` to that finding; a recognized instrument family
+additionally filters cases to that family. With no recognized finding
+keyword, the search falls back to a free-text substring match over
+approved article title/body. Every query is logged (`KnowledgeQueryLog`)
+for the "most common questions" analytic.
+
+Example: *"show all blood findings in Kerrisons"* → `matched_findings:
+["blood"]`, `matched_instrument_families: ["kerrison_rongeur"]` → real
+articles and cases tagged to blood, further narrowed to the Kerrison
+family.
+
+## Competency Knowledge Library (Deliverable 7)
+
+`GET /api/knowledge/competency-topics[/{finding_type}]`
+
+Organizes competency knowledge by instrument family / anatomy / finding /
+risk / inspection technique / cleaning consideration / corrective action —
+merging the existing static `education_library.py` reference (definition,
+clinical importance, inspection tips, cleaning considerations, corrective
+actions) with any **approved** institutional `KnowledgeArticle` entries
+tagged to the same finding type. Supervisor-contributed guidance sits
+alongside the baseline reference rather than living in a second,
+disconnected list — a technician looking up "blood" sees both the
+standard reference and anything the department has since added.

--- a/docs/mentor/anatomy-aware-coaching.md
+++ b/docs/mentor/anatomy-aware-coaching.md
@@ -1,0 +1,37 @@
+# Anatomy-Aware Coaching (v1.4)
+
+## What it does
+`spd_mentor_engine.anatomy_coaching(result)` returns technician-facing
+coaching sentences tied to the instrument's actual anatomy profile
+(`result.instrument_anatomy`, from the Phase 15 Instrument Anatomy Library) —
+never generic filler.
+
+## Canned phrasing for well-known SPD lore
+A small set of instrument families have specific, widely-recognized SPD
+coaching phrases (`_FAMILY_COACHING_PHRASES`):
+
+- **Kerrison rongeur**: "Kerrison jaw serrations are high-retention anatomy
+  zones." / "Open the box lock and actuate the hinge during inspection — soil
+  hides in the pivot."
+- **Rigid scope**: "Rigid scope O-ring regions frequently retain organic
+  material." / "Inspect the working channel and seal closely; these are
+  high-retention zones."
+- **Drill bit**: "Drill-bit flutes require careful brushing." / "Threaded
+  regions between the flutes are a common site for retained residue."
+- **Needle holder**: "Needle-holder box locks should be opened during
+  inspection." / "Jaw inserts and serrations are high-retention anatomy
+  zones."
+
+## Generated fallback
+For every other instrument family (laparoscopic, general forceps, scissors,
+flexible endoscope, and anything unclassified), coaching sentences are
+generated from the instrument's own zone data: any zone with
+`retention_risk == "high"` (or listed in `high_risk_zones`) produces
+`"{category} {zone_name} is a high-retention anatomy zone."` — always derived
+from the actual anatomy profile, never invented per-instrument detail.
+
+## Zone descriptions (Training Mode)
+When Training Mode is on, every anatomy zone for the instrument gets an
+explanation via `_zone_description()`, which reuses
+`instrument_zones.ZONE_INFO`'s per-zone reason (falling back to a generic
+retention-risk sentence for zones without a specific entry).

--- a/docs/mentor/clinical-decision-support.md
+++ b/docs/mentor/clinical-decision-support.md
@@ -1,0 +1,51 @@
+# Clinical Decision Support — v1.4 additions
+
+## Clinical Decision Summary
+`spd_mentor.clinical_decision_summary` gives the concise, plain-language
+summary a supervisor scans first:
+
+```
+{
+  "instrument": "Rigid Scope",
+  "inspection_coverage": 95,
+  "findings": "Blood indicators detected within the O-ring region.",
+  "risk": "High",
+  "recommendation": "Reclean and repeat inspection before packaging.",
+  "supervisor_review": "Recommended"
+}
+```
+
+`supervisor_review` is `"Recommended"` whenever the overall disposition is
+`SUPERVISOR REVIEW`, `REPROCESS`, or `REMOVE FROM SERVICE`, and `"Not
+required"` for `PASS`/`MONITOR` — derived from the same disposition already
+computed by the Phase 13 Explainable AI Clinical Decision Support payload, not
+a separate judgment.
+
+## Corrective Action Recommendations
+`spd_mentor.corrective_actions` gives one structured, ordered step chain per
+actionable finding (severity index ≥ 1), e.g.:
+
+- **Blood** → Reclean → Brush serrations manually → Flush the lumen → Repeat
+  visual inspection → Supervisor verification.
+- **Rust / Corrosion** → Remove from service → Evaluate for repair → Inspect
+  surrounding anatomy → Document corrosion.
+- **Crack** → Remove from service immediately → Notify supervisor → Repair
+  evaluation.
+
+Full chains for all twelve categories live in
+`spd_mentor_engine.CORRECTIVE_ACTION_CHAINS` and are reused by the Educational
+Knowledge Library so the two never drift apart.
+
+## AI Confidence Coaching
+`spd_mentor.confidence_coaching` returns `null` when confidence and coverage
+are both adequate. Otherwise:
+
+```
+{
+  "message": "Confidence is limited because image quality and inspection coverage are incomplete.",
+  "suggestions": ["Capture additional images.", "Capture missing anatomy zones.", "Improve lighting.", "Request supervisor review."]
+}
+```
+
+Triggered when confidence < 70%, required-zone coverage < 75%, or zones were
+never tagged at all (`inspection_coverage.assessed == false`).

--- a/docs/mentor/competency-support.md
+++ b/docs/mentor/competency-support.md
@@ -1,0 +1,50 @@
+# Competency Support (v1.4)
+
+## What it tracks
+`backend/app/models/competency_event.py` is an append-only event log; each row
+is one of:
+
+- `finding_reviewed` — a supervisor reviewed one of this technician's
+  inspections.
+- `supervisor_correction` — the supervisor disagreed, partially agreed, or
+  overrode the AI on that inspection, tagged with the `finding_type` involved.
+- `repeated_error` — the same technician has now been corrected on the same
+  `finding_type` at least twice; logged automatically alongside the
+  correction that crosses the threshold.
+- `education_completed` — the technician marked a knowledge-library article
+  as read (`POST /api/mentor/education/{finding_type}/complete`).
+
+## Where it's recorded
+`app/routes/ai_clinical_review.py`'s existing `POST
+/inspections/{id}/supervisor-review` endpoint (the ML ground-truth capture
+path) also calls `competency_service.record_finding_reviewed` /
+`record_supervisor_correction` in the same transaction — competency tracking
+piggybacks on a review that was already happening, rather than requiring a
+second workflow.
+
+## Technician attribution
+`Inspection.technician` (added in v1.4, nullable) is set from the request
+actor at creation time (`POST /api/inspections`). Older inspections created
+before this field existed have `technician = null` and are simply excluded
+from competency aggregation — never backfilled with a guess.
+
+## Summary shape
+`GET /api/mentor/competency/{technician}`:
+```
+{
+  "technician": "jane@hospital.org",
+  "findings_reviewed": 12,
+  "supervisor_corrections": 3,
+  "repeated_errors": {"blood": 2},
+  "education_completed": ["blood", "crack"],
+  "training_progress_pct": 33,
+  "has_activity": true
+}
+```
+`training_progress_pct` is `null` (not `0`) when there have been no supervisor
+corrections yet — there is nothing to score, and the engine never fabricates
+a number for a technician with no recorded activity.
+
+## Access control
+A technician may only view their own summary; `admin`/`spd_manager` may view
+anyone's.

--- a/docs/mentor/education-library.md
+++ b/docs/mentor/education-library.md
@@ -1,0 +1,48 @@
+# Educational Knowledge Library (v1.4)
+
+## What it does
+`backend/app/services/education_library.py` exposes a structured knowledge
+article for each of the twelve contamination/condition categories LumenAI
+recognizes: Blood, Bone, Tissue, Organic residue, Debris, Rust, Corrosion,
+Cracks, Wear, Pitting, Missing component, Insulation damage.
+
+Nothing here is duplicated content — every article is reshaped from the same
+source of truth the AI Mentor already uses
+(`clinical_mentor.FINDING_EDUCATION`) plus the corrective-action chains from
+`spd_mentor_engine.py`, so the library and the live coaching can never drift
+apart.
+
+## Article shape
+```
+{
+  "finding": "crack",
+  "finding_type": "crack",
+  "definition": "...",
+  "clinical_importance": "...",
+  "typical_anatomy_locations": ["box lock", "hinge", "jaw", ...],
+  "inspection_tips": "...",
+  "cleaning_considerations": "...",
+  "corrective_actions": ["Remove from service immediately.", ...],
+  "reference": "AAMI ST79 (institution-specific implementation may vary)."
+}
+```
+
+## Typical anatomy locations
+`instrument_anatomy.py`'s per-zone `contamination_risks`/`condition_risks`
+lists are the same default vocabulary on every zone (no instrument family
+customizes them), so they cannot distinguish "typical" locations for one
+finding from another. Instead, `_typical_anatomy_locations()` derives them
+honestly from what the anatomy data *does* differentiate:
+
+- **Contamination findings** (blood, bone, tissue, organic residue, debris):
+  zones marked `retention_risk == "high"` across every instrument family.
+- **Structural/condition findings** (rust, corrosion, pitting, crack, wear,
+  missing component): zones with `zone_risk_level` of `high` or `critical`.
+- **Insulation damage**: the one zone actually named for it (`insulation
+  edge`), rather than the broad structural set.
+
+## API
+- `GET /api/mentor/education` — all twelve articles.
+- `GET /api/mentor/education/{finding_type}` — one article, 404 if unknown.
+- `POST /api/mentor/education/{finding_type}/complete` — mark an article
+  completed for the current user (feeds Competency Support).

--- a/docs/mentor/spd-mentor-engine.md
+++ b/docs/mentor/spd-mentor-engine.md
@@ -1,0 +1,44 @@
+# SPD Mentor Engine (v1.4)
+
+## What it does
+Turns an inspection analysis into active SPD education: interprets findings,
+explains contamination/damage/anatomy risk, suggests structured corrective
+action, and references SPD best practice — without ever replacing supervisor
+judgment.
+
+Implemented in `backend/app/services/spd_mentor_engine.py`, composed on top of
+the existing Phase 13/14/15 infrastructure (`clinical_mentor.py`,
+`instrument_anatomy.py`, `instrument_zones.py`, `inspection_coverage.py`)
+rather than duplicating it.
+
+## Where it runs
+`build_spd_mentor(result, overall, training_mode=False)` is called from
+`build_clinical_decision()` in `baseline_comparison_scoring_service.py` and
+attached to every analysis under `clinical_decision.spd_mentor`. It can also be
+re-derived for a past inspection via `GET /api/inspections/{id}/mentor`.
+
+## Payload shape
+```
+spd_mentor: {
+  disclaimer: str,
+  corrective_actions: [{finding, steps: [...]}],
+  anatomy_coaching: [str, ...],
+  confidence_coaching: {message, suggestions} | null,
+  clinical_decision_summary: {instrument, inspection_coverage, findings, risk, recommendation, supervisor_review},
+  education_cards: [{finding, clinical_significance, recommended_practice, reference}],
+  training_mode: bool,
+  expanded_explanations?: {...}   # only when training_mode is true
+}
+```
+
+## Disclaimer
+Every payload carries `MENTOR_DISCLAIMER`: this guidance is AI-generated
+educational support and does not replace supervisor judgment or the
+manufacturer's IFU. It is never omitted.
+
+## Never claims
+Consistent with project-wide governance rules, the engine never claims
+causation or regulatory clearance — corrective-action language is imperative
+("Reclean the instrument") but the overall recommendation stays advisory
+("Supervisor review: Recommended"), and every actionable output remains
+subject to `human_review_required: true` on the parent analysis.

--- a/docs/pilot/lumenai-inspect-v1-9-go-live-checklist.md
+++ b/docs/pilot/lumenai-inspect-v1-9-go-live-checklist.md
@@ -1,0 +1,72 @@
+# LumenAI Inspect v1.9 — Pilot Go-Live Checklist
+
+Use this checklist before allowing real inspection data at the first
+pilot site. Every item should be verifiable — check it against a real
+screen or a real API response, not against intent.
+
+## 1. User Setup
+
+- [ ] At least one `admin` account exists and can log in (`POST /api/auth/login` or the login UI).
+- [ ] At least one `spd_manager` account exists per shift/supervisor on staff.
+- [ ] At least one `operator` account exists per technician expected to run inspections.
+- [ ] Any `viewer` accounts (auditors, leadership observers) are confirmed **read-only** — see Acceptance Test Script, Test Case 3.
+- [ ] `ADMIN_BOOTSTRAP_TOKEN` (or equivalent bootstrap secret) has been rotated from any value used during setup/demo and is not shared outside the deployment operator.
+- [ ] `ENABLE_DEV_AUTH` is **not** set in the production environment (dev-token auth must never be reachable outside local/test).
+
+## 2. Baseline Setup
+
+- [ ] At least one approved manufacturer baseline exists for every instrument type the pilot site will actually inspect (`GET /api/baselines` or the Manufacturer Baselines page).
+- [ ] `PilotSiteConfig.baseline_required` reflects the site's real policy (default `true` — an inspection without a baseline routes to supervisor review, it is never silently scored).
+- [ ] Vendor baseline submission workflow tested end-to-end at least once if the site uses vendor-submitted baselines.
+
+## 3. Instrument Setup
+
+- [ ] `PilotSiteConfig.enabled_instrument_families` set to the families this site actually processes (`PUT /api/pilot-deployment/site-config`, admin only).
+- [ ] Anatomy zone requirements for each enabled family reviewed with SPD leadership (`GET /api/knowledge/competency-topics` and the Anatomy Library page).
+- [ ] `PilotSiteConfig.minimum_coverage_pct` set to the site's real coverage policy (default 75%).
+
+## 4. Role Setup
+
+- [ ] Verified against the Acceptance Test Script: viewer cannot create an inspection, cannot upload, cannot run AI analysis, cannot approve a disposition.
+- [ ] Verified: operator can create an inspection, upload an image, and see the AI analysis result.
+- [ ] Verified: spd_manager can review, override, approve, add a teaching point, and finalize a disposition.
+- [ ] Verified: admin can manage users, baselines, and pilot site configuration.
+
+## 5. Image Capture Workflow
+
+- [ ] A technician has completed at least one real (non-demo) inspection end-to-end: instrument selection → anatomy zone tagging → image upload → AI analysis result displayed.
+- [ ] `GET /api/inspections/{id}/data-quality` reviewed for that inspection — confirm no unexpected guardrail failures for a normal, well-captured inspection.
+- [ ] Borescope/device-key capture station workflow (`/station`) tested if the site uses shared capture hardware.
+
+## 6. Supervisor Review Workflow
+
+- [ ] A supervisor has completed at least one real disposition action (`POST /api/inspections/{id}/disposition-action`) — approve, and at least one override (reclean/repair/escalate).
+- [ ] The Smart Inspection Queue (`/inspection-work-queue`) and Findings Queue (`/findings`) both show the same real pending inspection — confirms the two pages are not showing divergent data.
+- [ ] A supervisor has captured at least one teaching point (`POST /api/inspections/{id}/teaching-point`) and confirmed it appears in the Knowledge Center.
+
+## 7. Daily Support Process
+
+- [ ] A named on-call contact (with phone/pager or equivalent) is documented for the first two weeks of pilot use.
+- [ ] `GET /api/pilot-deployment/data-collection` is checked daily by the pilot lead during the first two weeks — incomplete inspections and failed uploads reviewed same-day.
+- [ ] `GET /api/pilot-deployment/site-config` reviewed weekly to confirm thresholds still match the site's operating reality.
+
+## 8. Escalation Path
+
+- [ ] Critical/high-risk findings (`risk_tier` Critical or High Risk in the Smart Inspection Queue) have a documented same-shift escalation path to a supervisor.
+- [ ] A `report_generation_failure` or repeated `upload_failure`/`ai_analysis_failure` in the error log (`app.services.pilot_error_log_service.error_summary`) triggers a support ticket, not silent retry-and-hope.
+- [ ] A path exists to reach the engineering team directly if the daily data-collection dashboard shows a sustained spike in incomplete inspections.
+
+## 9. Go/No-Go Criteria
+
+Go live only when **all** of the following are true:
+
+- [ ] Full backend test suite passes (`PYTHONPATH=. python -m pytest tests -q`) with zero unexpected failures.
+- [ ] `ruff check backend/app backend/tests` passes clean.
+- [ ] `npm --prefix frontend run build` succeeds clean.
+- [ ] At least one technician and one supervisor have each completed a real end-to-end workflow pass (see Acceptance Test Script).
+- [ ] A viewer account has been confirmed read-only.
+- [ ] The Pilot Data Collection Dashboard is reachable and shows zero unexplained `failed_uploads`.
+- [ ] The named on-call contact and escalation path are documented and communicated to the pilot site's staff.
+
+If any Go/No-Go item is not met, treat it as a blocker — do not go live
+on a partial pass.

--- a/docs/pilot/pilot-acceptance-test-script.md
+++ b/docs/pilot/pilot-acceptance-test-script.md
@@ -1,0 +1,104 @@
+# Pilot Acceptance Test Script — v1.9
+
+Run through these test cases against a live environment (dev server or
+staging) before pilot go-live. Each case lists the concrete steps, the API
+calls involved, and the expected result. All of these are covered by
+automated tests in `backend/tests/test_pilot_deployment.py` and the
+relevant v1.6–v1.8 test files — this script is for a **manual, live**
+confirmation pass, not a replacement for the automated suite.
+
+## Test Case 1 — Technician completes an inspection
+
+1. Log in as an `operator`.
+2. Navigate to New Inspection (`/inspection/new`).
+3. Select an instrument type, tag anatomy zones, and upload an image.
+4. Submit.
+
+**Expected**: HTTP 201; the response includes a real `analysis` block (or
+`supervisor_review_required: true` if no baseline exists) and a
+`data_quality` block. The inspection appears in the Smart Inspection Queue
+(`/inspection-work-queue`) with a real `workflow_state` of `Image
+Capture`/`AI Analysis` — never a fabricated or blank status.
+
+## Test Case 2 — Supervisor review and approval
+
+1. Log in as `spd_manager`.
+2. Open `/inspection-work-queue`, find the inspection from Test Case 1 in
+   the "Supervisor Reviews" bucket (if the disposition engine flagged it).
+3. Call `POST /api/inspections/{id}/disposition-action` with
+   `{"action": "approve", "ai_recommended_disposition": "..."}`.
+
+**Expected**: HTTP 201. `GET /api/inspections/{id}/workflow-state` shows a
+new `Completed` (or the relevant) transition with a real `actor` and
+`created_at` — the audit trail is real, not fabricated.
+
+## Test Case 3 — Viewer access restriction
+
+1. Log in as `viewer`.
+2. Attempt `POST /api/inspections` (create).
+3. Attempt `POST /api/inspections/{id}/disposition-action`.
+4. Attempt `GET /api/inspection-work-queue`.
+
+**Expected**: Steps 2 and 3 return **HTTP 403** with a clear message
+(e.g. *"Viewer access is read-only. Ask an admin to assign Operator or
+SPD Manager access to run inspections."*) — never a silent failure or a
+500. Step 4 returns **HTTP 200** — viewing is allowed.
+
+## Test Case 4 — Missing baseline
+
+1. Submit an inspection (`POST /api/inspections`) for an instrument type
+   with **no** approved `BaselineLibraryEntry`.
+
+**Expected**: HTTP 201 (the inspection is still recorded), but
+`score_status: "supervisor_review_required"`, `baseline_status:
+"no_approved_baseline"`, and `data_quality.issues` includes a
+`missing_baseline` entry with a clear message — never scored as if a
+baseline existed.
+
+## Test Case 5 — Missing anatomy zone
+
+1. Submit an inspection with `has_image: true` but no `inspected_zones`.
+
+**Expected**: `coverage_pct` is `null` (not fabricated as 0 or 100), and
+`data_quality.issues` includes a `missing_anatomy_zone` entry.
+
+## Test Case 6 — AI analysis completion
+
+1. Submit an inspection with a real image hash and an approved baseline
+   on file for that instrument type.
+
+**Expected**: `analysis.analysis_status: "completed"`,
+`score_status: "scored"`, `risk_score` populated, and the Smart Inspection
+Queue shows a real `disposition` (Proceed to Packaging / Reclean / etc.)
+derived from the actual finding, not a placeholder.
+
+## Test Case 7 — Knowledge note capture
+
+1. Log in as `spd_manager`. Submit a disposition action (reclean/repair/
+   escalate) on an inspection.
+2. Call `POST /api/inspections/{id}/teaching-point` with a real
+   explanation and teaching point.
+
+**Expected**: HTTP 201, `approval_status: "approved"` (auto-approved —
+see `docs/knowledge/clinical-case-library.md`). The note appears in
+`GET /api/knowledge/articles?category=teaching_point` and the associated
+`ClinicalCase.educational_notes` is updated.
+
+## Test Case 8 — Clinical report generation
+
+1. Call `GET /api/inspections/{id}/readiness-report.pdf` for a real,
+   scored inspection.
+
+**Expected**: HTTP 200, `Content-Type: application/pdf`, a non-empty PDF
+body. If report generation throws (simulate by an instrument type with no
+baseline history, or via the automated
+`test_report_generation_failure_returns_500_not_silent` test), the
+response is a clear **HTTP 500** with `"...has been logged"` in the
+detail — never a silent 200 with an empty or corrupt file.
+
+## Reporting results
+
+For each test case, record: pass/fail, the actual HTTP status/response
+observed, and (for any failure) whether it reproduces against the
+automated suite. Do not mark the pilot go-live checklist's "Go/No-Go"
+section complete until every test case above has a recorded **pass**.

--- a/docs/pilot/pilot-site-configuration.md
+++ b/docs/pilot/pilot-site-configuration.md
@@ -1,0 +1,46 @@
+# Pilot Site Configuration — v1.9
+
+`GET/PUT /api/pilot-deployment/site-config` (GET: any authenticated role;
+PUT: admin only)
+
+## What it is
+
+One row per tenant (`PilotSiteConfig`) holding the small set of
+structured, machine-read settings the pilot's own guardrails and the
+Pilot Data Collection Dashboard read directly:
+
+| Field | Meaning | Default |
+|---|---|---|
+| `facility_name` | The pilot site's facility name | `""` |
+| `department` | The pilot site's department | `""` |
+| `enabled_instrument_families` | Which of `instrument_anatomy.py`'s families this site actually processes | `[]` (all families remain usable; this is an informational filter, not a hard gate) |
+| `required_inspection_zones` | Site-declared required zones, supplementing (never replacing) each instrument family's own required-image list in `instrument_anatomy.py` | `[]` |
+| `baseline_required` | Whether an approved baseline must exist before an inspection can be scored complete | `true` |
+| `minimum_coverage_pct` | Coverage percent below which an inspection is flagged incomplete by the Data Quality Guardrails | `75` |
+| `supervisor_review_threshold_score` | Advisory threshold surfaced to supervisors — not a hard gate on top of the existing disposition engine | `70` |
+
+A site always has a config — `get_or_create_config()` returns
+conservative defaults on first access rather than leaving "no config"
+ambiguous about which rules apply.
+
+## Why this is separate from `OrganizationStandard` (v1.8)
+
+`OrganizationStandard` is a list of free-text policy documents a
+supervisor authors and titles (inspection standards, photography
+standards, competency requirements, etc.) — narrative guidance for humans
+to read. `PilotSiteConfig` is the handful of *structured* values other
+code actually reads (the guardrails service, the data-collection
+dashboard). Both supplement, never replace, manufacturer IFUs or the AI's
+own readiness/disposition/risk engines — neither overrides a code path in
+the scoring engine.
+
+## Relationship to per-instrument-family requirements
+
+`instrument_anatomy.py` already defines each family's own `required_images`
+and `min_images` (e.g. how many views a Kerrison rongeur needs) — this is
+the authoritative, per-family requirement used by
+`guided_capture.coverage_readiness()` at inspection time.
+`PilotSiteConfig.required_inspection_zones` is an **additional**,
+site-level declaration (e.g. "this site additionally wants X documented
+for audit purposes") — it does not replace or reduce the per-family
+requirement.

--- a/docs/pilot/pilot-workflow-audit.md
+++ b/docs/pilot/pilot-workflow-audit.md
@@ -1,0 +1,90 @@
+# Pilot Workflow Audit — v1.9
+
+An end-to-end pass over the workflows a pilot site actually depends on:
+login, dashboard, new inspection (image upload, instrument selection,
+anatomy zone selection), AI analysis, supervisor review, knowledge
+capture, clinical report, and inspection history. Findings are grouped by
+severity; only real, verified gaps are listed — nothing here is
+speculative.
+
+## Critical
+
+### 1. `/findings` ("Review Queue" / "Findings" nav links) shows fabricated demo data, not real inspections
+
+`frontend/src/pages/FindingsQueuePage.tsx` renders a hardcoded
+`sampleFindings` array (fictional facilities "ORC", "St. Francis", "St.
+Mary's"; fictional finding IDs `F-1000`–`F-1007`) with **no `useEffect`,
+no API call, and no connection to the real backend at all**. Two separate
+nav entries ("Review Queue" and "Findings" in `AppShell.tsx`) point here.
+
+This is the page a pilot supervisor would land on expecting to see
+inspections awaiting review — instead they'd see permanently-stale fake
+data with no way to act on a real inspection. The *real* supervisor review
+workflow already exists and works (the v1.7 Smart Inspection Queue's
+"Supervisor Reviews" bucket at `/inspection-work-queue`, and the
+per-inspection `ReadinessDispositionPanel`/disposition-action endpoints
+from v1.6) — this page just predates that work and was never reconnected
+or removed.
+
+**Fix**: redirect `/findings` to `/inspection-work-queue` (or rewire this
+page to pull the real `supervisor_reviews` bucket from
+`GET /api/inspection-work-queue`) so both nav entries lead to real,
+actionable data.
+
+### 2. `/operations` ("Operational Analytics" nav link) is explicitly labeled sample data
+
+`frontend/src/pages/OperationsDashboard.tsx` literally reads
+*"Pilot-safe sample activity for daily review"* in its own UI copy — an
+acknowledged placeholder, never wired to a real endpoint. Same nav-mismatch
+problem as above: a manager clicking "Operational Analytics" sees
+permanent fake numbers.
+
+**Fix**: redirect `/operations` to the real v1.7
+`/api/workflow/analytics` + `/api/workflow/daily-dashboard` data (or point
+the nav entry directly at a page backed by them), since that's the
+non-fabricated equivalent already built.
+
+## Moderate
+
+### 3. Inconsistent error-handling coverage across pages
+
+- `Dashboard.tsx` (main `/` dashboard): well-hardened — `Promise.allSettled`
+  across four endpoints, explicit `loading`/`error`/empty states, partial
+  failures degrade individual KPI cards to "—" rather than crashing. No
+  action needed.
+- `LoginPage.tsx`: has explicit `error`/`loading` state and a `.catch`
+  around the failure path. No action needed.
+- `NewInspectionPage.tsx`: has `.catch` around its main submission calls
+  but not uniformly around every secondary fetch (e.g. anatomy-zone
+  lookups) — a secondary lookup failure could leave a section silently
+  stuck loading rather than showing an error. Lower severity since the
+  primary inspection-submission path is covered.
+- `IntakeHistoryPage.tsx` delegates all data-fetching to child components
+  (`EnterpriseIntakeHistoryPanel`, `InspectionResultsHistory`) rather than
+  fetching itself — those components were not individually audited in this
+  pass; flagged for the next iteration.
+
+### 4. Role enforcement (backend) — verified correct
+
+`routes/inspections.py`'s `require_inspection_runner` correctly restricts
+inspection creation (image upload + AI analysis) to
+`operator`/`spd_manager`/`admin`, rejecting `viewer` with a clear,
+actionable 403 (`"Viewer access is read-only. Ask an admin to assign
+Operator or SPD Manager access to run inspections."`) rather than a
+generic or silent failure. The v1.6/v1.7/v1.8 disposition/override/
+teaching-point endpoints all correctly gate on `admin`/`spd_manager` only.
+This part of the spec's role matrix is already solid — see
+`docs/pilot/pilot-site-configuration.md` for the full matrix as
+documented/verified.
+
+## Not yet audited (carried to the next iteration)
+
+- Full click-through of instrument selection, anatomy zone selection, and
+  clinical report generation in a live browser session (this pass was a
+  static code audit; a live pass is queued).
+- `EnterpriseIntakeHistoryPanel` / `InspectionResultsHistory` error
+  handling.
+- Hard-refresh behavior on deep routes (e.g. reloading directly on
+  `/inspection-work-queue`) — `main.tsx`'s chunk-load recovery guard
+  (`recoverFromStaleAssets`) already handles the *stale-asset-after-deploy*
+  case; a live pilot-network reload test is still queued.

--- a/docs/quality/capa-integration.md
+++ b/docs/quality/capa-integration.md
@@ -1,0 +1,28 @@
+# CAPA Integration (v1.5)
+
+## What it does
+`app/services/capa_suggestion_service.py` scans the last 90 days of
+`InspectionFinding` and `Inspection` rows for three recurring patterns and
+suggests a Corrective and Preventive Action for each:
+
+1. **Repeated contamination finding in the same anatomy zone** (≥3
+   occurrences) → recommend reviewing manual cleaning competency for that
+   zone.
+2. **Repeated condition finding (rust/corrosion/pitting/crack/insulation
+   damage/missing component) on the same instrument family** (≥3
+   occurrences) → recommend evaluating storage and maintenance practices.
+3. **Repeated low-confidence or low-coverage inspections by the same
+   technician** (≥3 occurrences) → recommend an image-capture refresher.
+
+## Suggestions, never auto-created CAPAs
+Consistent with the platform-wide rule that AI output never bypasses human
+review, `generate_capa_suggestions()` only returns suggestions — it never
+writes to the CAPA store. A supervisor reviews a suggestion and explicitly
+creates the CAPA via `POST /api/quality/capa-suggestions/create`, which
+calls the existing `app/services/capa_service.create_capa()` (the same CAPA
+store already used elsewhere in the platform — no parallel CAPA system).
+
+## API
+- `GET /api/quality/capa-suggestions` — current suggestions (leadership only).
+- `POST /api/quality/capa-suggestions/create` — materialize a chosen
+  suggestion into a real CAPA.

--- a/docs/quality/continuous-improvement.md
+++ b/docs/quality/continuous-improvement.md
@@ -1,0 +1,19 @@
+# Continuous Improvement Tracker (v1.5)
+
+## What it tracks
+Named quality initiatives from proposal through completion:
+`initiative`, `owner`, `target_date`, `status`
+(`proposed`/`in_progress`/`completed`/`abandoned`), `expected_impact`,
+`actual_impact`.
+
+## Why `actual_impact` is a free-text field a human fills in
+Observed impact requires human judgment about what changed and why — a raw
+before/after metric delta can't distinguish "this initiative worked" from
+"pass rate also improved for an unrelated reason." The tracker records the
+initiative's lifecycle; a leader records the actual outcome once observed,
+alongside whichever dashboard metrics they used to judge it.
+
+## API
+- `GET /api/quality/improvement-initiatives` — list (leadership only).
+- `POST /api/quality/improvement-initiatives` — create.
+- `PATCH /api/quality/improvement-initiatives/{id}` — update status/actual_impact.

--- a/docs/quality/executive-quality-score.md
+++ b/docs/quality/executive-quality-score.md
@@ -1,0 +1,27 @@
+# Executive Quality Score (v1.5)
+
+## What it does
+A single 0–100 score for leadership, computed from real data over the
+trailing quarter for the requesting tenant.
+
+## Weighted factors
+| Factor | Weight | Source |
+|---|---|---|
+| Pass rate | 0.25 | `Inspection.disposition == "PASS"` |
+| Coverage compliance | 0.15 | `Inspection.coverage_pct` |
+| Supervisor agreement | 0.15 | `SupervisorReview.agreement == "agree"` |
+| Low high-risk findings (inverted) | 0.15 | `100 - remove_from_service_rate` |
+| Low repeat findings (inverted) | 0.10 | `100 - (repeated_error / supervisor_correction)` (CompetencyEvent) |
+| Competency (education completion) | 0.10 | `education_completed / finding_reviewed` (CompetencyEvent) |
+| Baseline compliance | 0.10 | `Inspection.baseline_status == "approved_baseline_found"` |
+
+## Missing data is excluded, not defaulted
+If a tenant has no data for a factor (e.g. no supervisor reviews yet), that
+factor is dropped from the weighted average and the remaining weights are
+renormalized — never defaulted to 0, 50, or 100. `factors_used` in the
+response lists exactly which factors contributed, so the score is
+auditable. If *no* factor has data, `score` is `null` with an explanatory
+`note`, not a fabricated number.
+
+## API
+`GET /api/quality/executive-score` (leadership only).

--- a/docs/quality/quality-intelligence.md
+++ b/docs/quality/quality-intelligence.md
@@ -1,0 +1,36 @@
+# Quality Intelligence (v1.5)
+
+## What it does
+Turns every inspection into measurable quality-improvement intelligence:
+volume, pass/reclean/repair/remove-from-service rates, supervisor override
+rate, baseline and coverage compliance, and AI confidence trend — plus
+finding trends by type and time period, anatomy zone risk, instrument family
+performance, and per-technician/per-supervisor quality rollups.
+
+Distinct from the existing `quality_intelligence_service.py` (Phase 21),
+which tracks network-wide emerging-risk signals across hospitals via mocked
+data. v1.5 is per-tenant, real-data-only, and lives under `/api/quality/*`
+and the `/quality-dashboard` route to avoid colliding with that unrelated
+feature.
+
+## New persisted fields (Inspection)
+- `disposition` — the clinical_decision.overall_result computed at analysis
+  time (PASS/MONITOR/SUPERVISOR REVIEW/REPROCESS/REMOVE FROM SERVICE),
+  persisted so pass/reclean/remove-from-service rates don't require
+  re-deriving analysis for every dashboard load.
+- `coverage_pct` / `coverage_quality` — the Inspection Coverage Engine's
+  result at submission time, persisted for coverage-compliance reporting.
+
+## New table: InspectionFinding
+Inspection only stores the rolled-up disposition — not which individual
+finding types were detected. `InspectionFinding` logs one row per actionable
+finding (severity_index >= 1) at analysis time: finding type, anatomy zone,
+instrument type, severity. This is the real data source behind Finding Trend
+Intelligence, the Anatomy Risk Dashboard, and Instrument Family Performance —
+nothing in those dashboards is derived from a single rolled-up field or
+fabricated.
+
+## Dashboard endpoint
+`GET /api/quality/dashboard?period=day|week|month|quarter|year|all_time`
+returns the KPI set for the requested window. A metric with no underlying
+data returns `null`, never a fabricated zero.

--- a/docs/quality/root-cause-framework.md
+++ b/docs/quality/root-cause-framework.md
@@ -1,0 +1,30 @@
+# Root Cause Intelligence (v1.5)
+
+## What it does
+Lets a supervisor categorize a finding by its probable root cause and trends
+recurring causes across the tenant.
+
+## Why root cause is always human-assigned
+The engine never infers *why* a finding occurred — only a human reviewing
+the instrument and context can make that judgment. Auto-inferring a cause
+from a finding type alone would be a fabricated causal claim, which the
+platform's governance rules (`docs/architecture/*`, CLAUDE.md) explicitly
+forbid: "never claim causation."
+
+## Accepted vocabulary (`app/models/root_cause.py::ROOT_CAUSES`)
+- `incomplete_manual_cleaning`
+- `improper_brushing`
+- `improper_flushing`
+- `missed_inspection_zone`
+- `poor_lighting`
+- `image_quality`
+- `instrument_damage`
+- `manufacturer_wear`
+- `unknown` — a legitimate, honest choice when the cause isn't identifiable
+  at review time; not every finding needs a forced categorization.
+
+## API
+- `POST /api/quality/root-cause` — assign a root cause to a specific finding
+  on a specific inspection (leadership only).
+- `GET /api/quality/root-cause-trends` — recurring causes overall and by
+  finding type, for any authenticated role.

--- a/docs/readiness/clinical-service-readiness.md
+++ b/docs/readiness/clinical-service-readiness.md
@@ -1,0 +1,36 @@
+# Clinical Service Readiness Engine (v1.6)
+
+## What it does
+Answers: is this instrument suitable to proceed through the remainder of the
+reprocessing workflow after clinical inspection?
+
+Built as a thin vocabulary layer over the existing pre-sterilization
+readiness classification (`pre_sterilization_command_center_service.classify_readiness`,
+introduced by an earlier phase) rather than re-deriving disposition logic a
+third time. `app/services/readiness_engine.py::compute_readiness()` maps that
+classification onto v1.6's spec vocabulary and adds the repair-history signal
+the spec asks for.
+
+## Inputs
+- Inspection findings and severity (`predicted_findings` from the AI analysis)
+- Coverage score (`Inspection.coverage_pct`)
+- Baseline match (`baseline_status`, `baseline_source`)
+- Instrument condition / damage assessment (`detected_issue`, `risk_level`)
+- Supervisor review (`SupervisorReview` rows for this inspection)
+- Repair history (`has_repair_history()` — a prior REMOVE FROM SERVICE
+  disposition on the same physical instrument, identified by barcode/UDI)
+
+## Output
+- `readiness_score`: 0-100 (the same `100 - risk_score` the scoring engine
+  already computes — never a separate fabricated number)
+- `status`: one of **Ready**, **Ready with Supervisor Approval**, **Requires
+  Recleaning**, **Requires Repair**, **Remove From Service**, plus two honest
+  additions beyond the spec's five — **Pending Supervisor Review** and
+  **Pending Analysis** — for inspections that haven't finished the workflow
+  yet. Collapsing an unfinished inspection into one of the five outcomes
+  would misrepresent it as complete.
+
+## Instrument identity
+Grouped by `instrument_barcode`/`instrument_udi` when captured; falls back to
+an explicit `untracked:{type}:{inspection_id}` key rather than claiming a
+re-identification that was never actually performed.

--- a/docs/readiness/disposition-engine.md
+++ b/docs/readiness/disposition-engine.md
@@ -1,0 +1,32 @@
+# Instrument Disposition Engine (v1.6)
+
+## What it does
+`app/services/disposition_engine.py::recommend_disposition()` maps a
+readiness classification onto one of seven standardized, action-oriented
+outcomes — every disposition carries a required, non-generic explanation
+grounded in the actual finding, coverage, and repair-history data.
+
+## Allowed outcomes
+- **Proceed to Packaging** — no actionable findings, supervisor-confirmed.
+- **Reclean** — residual contamination detected.
+- **Repeat Inspection** — coverage was too incomplete (< 50%) to trust any
+  disposition; requested regardless of what else was found.
+- **Supervisor Review Required** — nothing scored/reviewed yet, or an
+  unrecognized readiness status (a safe fallback, never a silent pass).
+- **Repair Evaluation** — a repairable structural finding (crack, corrosion,
+  insulation damage) without a prior repair-history pattern.
+- **Manufacturer Evaluation** — a repairable condition finding recurring on
+  an instrument with prior remove-from-service history — routed to
+  manufacturer-attributable evaluation instead of a one-off repair.
+- **Remove From Service** — an escalated, non-repairable finding.
+
+## Why coverage is checked first
+An instrument with insufficient anatomy coverage can't honestly support *any*
+of the other six dispositions — the AI hasn't actually seen enough of the
+instrument to say. Repeat Inspection is checked before every other rule.
+
+## Every disposition requires an explanation
+`recommend_disposition()` always returns both `disposition` and
+`explanation` — there is no code path that returns a disposition without a
+grounded rationale, including the defensive fallback for an unrecognized
+status.

--- a/docs/readiness/readiness-score.md
+++ b/docs/readiness/readiness-score.md
@@ -1,0 +1,33 @@
+# Readiness Score, Timeline, Risk Stratification & Dashboard (v1.6)
+
+## Readiness Score
+0-100, the same score the baseline-comparison scoring engine already computes
+(`100 - risk_score`) — surfaced through `readiness_engine.compute_readiness()`
+rather than recalculated. `None` when the inspection hasn't been scored yet
+(no approved baseline, or still pending).
+
+## Readiness Timeline (Deliverable 4)
+`app/services/readiness_timeline_service.py::build_timeline()` returns eight
+steps: Image Uploaded → Instrument Identified → Coverage Completed → AI
+Findings → Clinical Reasoning → Supervisor Review → Disposition → Ready for
+Packaging. Steps that happen synchronously within one `POST /api/inspections`
+call share that submission's real timestamp rather than fabricating
+individually-spaced fake times — only Supervisor Review has its own
+independently-timed record. Exportable via `GET
+/api/inspections/{id}/readiness-timeline` (JSON) and embedded in the PDF
+readiness report.
+
+## Instrument Risk Stratification (Deliverable 8)
+`app/services/risk_stratification_service.py::stratify_risk()` is a
+point-based rubric over already-computed signals (structural finding
+severity, remove-from-service escalation, high-retention-zone involvement,
+coverage completeness, baseline confidence) — not a separate model. Returns
+`risk_tier` (Low/Moderate/High/Critical) alongside `reasons`, so the
+classification is auditable rather than a black box.
+
+## Readiness Dashboard (Deliverable 7)
+`GET /api/clinical-readiness/dashboard` (route `/clinical-readiness`) rolls
+up every inspection's readiness status and disposition: counts by status
+(including Supervisor Pending), average readiness score, and disposition
+trends — all derived live from `readiness_engine`/`disposition_engine`, no
+separate aggregation logic.

--- a/docs/readiness/supervisor-disposition.md
+++ b/docs/readiness/supervisor-disposition.md
@@ -1,0 +1,29 @@
+# Supervisor Disposition Workspace (v1.6)
+
+## What a supervisor may do
+`POST /api/inspections/{id}/disposition-action` records one of:
+`approve`, `modify`, `escalate`, `reclean`, `repair`,
+`remove_from_service`, `manufacturer_review`.
+
+## Reason required for overrides
+A `reason` is required for every action except `approve` — enforced by
+`disposition_workspace_service.submit_disposition_action()`
+(`ReasonRequiredError`, surfaced as HTTP 422), not just a frontend nicety.
+Approving the AI's recommendation as-is needs no justification; changing it
+does.
+
+## Separate from the ML-ground-truth supervisor-review endpoint
+`DispositionOverride` (this feature) is deliberately a different table from
+`SupervisorReview` (the existing `/inspections/{id}/supervisor-review`
+endpoint, which captures AI-agreement for model-performance tracking) and
+from `MentorCoachingReview` (v1.4's coaching-quality tracking). Each table
+answers a different question:
+- `SupervisorReview` — did the AI get it right? (ML ground truth)
+- `MentorCoachingReview` — was the AI's coaching helpful? (education quality)
+- `DispositionOverride` — what should happen to this instrument next, and
+  why? (operational decision)
+
+## History
+`GET /api/inspections/{id}/disposition-actions` returns every action taken
+on an inspection, newest first — a full audit trail of who changed what
+disposition and why.

--- a/docs/security/security-compliance-center.md
+++ b/docs/security/security-compliance-center.md
@@ -1,0 +1,107 @@
+# Security & Compliance Center
+
+A single index tying together LumenAI's existing, extensive security
+documentation into the topic checklist an enterprise security team,
+auditor, or compliance officer needs to review. This document does not
+replace any of the detailed docs it links to — it's the map, not the
+territory.
+
+## Authentication
+
+Production authentication is JWT/OIDC-based; hardcoded dev tokens
+(`Bearer dev-token` and equivalents) are rejected outright when
+`APP_ENV=production` (`app/enterprise_auth.py`).
+
+- `docs/security/production-oidc-deployment-guide.md` — OIDC setup
+- `docs/security/jwt-revocation-design.md` — token revocation
+- `docs/security/lumenai-production-dev-auth-removal-plan-v1.md` — how
+  dev-auth is disabled in production
+- `docs/security/production-auth-readiness-plan.md`
+
+## Authorization & RBAC
+
+- `docs/security/lumenai-rbac-matrix-v1.md` — the full role/permission
+  matrix (`admin`, `spd_manager`, `operator`, `viewer`)
+- Enforced via `app/authz.py::require_roles` on every route — see
+  `docs/architecture/architecture-enforcement-checklist.md` for the rule
+  that every new feature must preserve auditability and role-gating
+
+## Tenant Isolation
+
+- `docs/security/lumenai-tenant-isolation-plan-v1.md` — design
+- `docs/security/lumenai-enterprise-tenant-isolation-test-matrix-v1.md` —
+  the automated test matrix verifying it
+- See also `docs/deployment/multi-tenant-deployment-guide.md`
+
+## Audit Logging
+
+- `app/audit.py::log_audit_event` + `app/models/audit_log.py` — every
+  consequential action (supervisor reviews, ground-truth submissions,
+  data exports, intelligence sharing) is logged with a tamper-evident
+  hash chain (`previous_event_hash`/`event_hash`)
+- Phase 23's Clinical Decision Ledger
+  (`docs/cios/clinical-decision-ledger.md`) extends this with a
+  clinical-decision-specific permanent record
+
+## Encryption
+
+- TLS in transit (terminated at the load balancer —
+  `docs/deployment/cloud-architecture-guide.md`)
+- Secrets never stored in plaintext application code or logs
+- Secret API keys stored as SHA-256 hashes only, issued once via
+  `secrets.token_urlsafe(40)`, never retrievable again (CLAUDE.md
+  constraint, enforced across the API key issuance flow)
+
+## Secrets Management
+
+- Environment-variable-driven configuration
+  (`docs/deployment/ENVIRONMENT_VARIABLE_CHECKLIST.md`)
+- No secret is ever committed to the repository or logged — see
+  `docs/security/bandit-triage.md` for the static-analysis process that
+  catches this class of issue
+
+## Logging
+
+- Structured JSON application logging (`app/main.py`'s `JSONFormatter`)
+- `docs/security/lumenai-production-error-response-policy-v1.md` — what
+  is and isn't surfaced in error responses (no stack traces or internal
+  details leaked to clients in production)
+
+## Incident Response
+
+- `docs/security/security-risk-register.md` — tracked risks and their
+  status
+- `docs/security/lumenai-threat-model-v1.md` — the threat model informing
+  what an "incident" looks like for this platform
+- Disaster scenarios and response procedures:
+  `docs/deployment/disaster-recovery-guide.md`
+
+## Vulnerability Management
+
+- `docs/security/bandit-triage.md` — static analysis (Bandit) triage
+  process
+- `docs/regulatory/external-pentest-scope.md` — external penetration
+  testing scope
+- `docs/security/lumenai-security-hardening-checklist-v1.md` — the
+  hardening checklist run before each release
+- CI-enforced: `docs/security/lumenai-security-hardening-ci-validation-v1.md`
+
+## Business Continuity & Disaster Recovery
+
+- `docs/deployment/disaster-recovery-guide.md`
+- `docs/deployment/backup-restore-guide.md`
+- `docs/deployment/high-availability-guide.md`
+
+## Compliance Control Matrix
+
+- `docs/security/compliance-control-matrix.md` — maps controls to
+  relevant frameworks (HIPAA Security Rule, SOC 2-style control
+  categories) — see that document for exact framework coverage; this
+  center does not duplicate its content.
+
+## For auditors and security reviewers
+
+Start with `docs/security/README.md` for the full security documentation
+index, and `docs/security/compliance-control-matrix.md` for a
+control-by-control mapping. This document exists to orient a first-time
+reviewer to where each topic lives, not to be the sole source of truth.

--- a/docs/workflow/operations-board.md
+++ b/docs/workflow/operations-board.md
@@ -1,0 +1,46 @@
+# Supervisor Operations Board
+
+`GET /api/operations-board` (admin/spd_manager only) · frontend route
+`/operations-board`
+
+## What it is
+
+A leadership-facing rollup of the same queue and workload data the Smart
+Inspection Queue already computes, reorganized around what a supervisor
+needs to run the shift: who's carrying what workload, what's waiting for
+approval, and what needs escalated attention.
+
+## Sections
+
+| Section | Source |
+|---|---|
+| Technician Workload | `technician_workload_service.technician_workload()` |
+| Supervisor Queue / Pending Approvals | Queue items in the `Supervisor Review` workflow state |
+| High-Risk Findings | Queue items with `risk_tier` in `High Risk`/`Critical` |
+| Repair Queue | Queue items in the `Repair` workflow state |
+| OR Urgent Items | Queue items with an emergency/trauma/first-case procedure priority |
+| Vendor Instruments | Queue items on a vendor tray |
+
+## Technician Assignment & Workload (Deliverable 3)
+
+Supervisors assign (or reassign) a technician to an inspection via
+`POST /api/inspections/{id}/assign`. Every assignment is recorded — the
+current assignment is the latest row, so reassignment history is never
+lost. Assigning a technician only advances the workflow state from
+`Waiting` to `Assigned`; it never regresses an inspection that has already
+progressed further (e.g. one already past AI analysis or in Supervisor
+Review) — it just updates who is responsible.
+
+Per-technician workload tracks:
+
+- **Open inspections** — assigned inspections that haven't reached
+  `Completed`.
+- **Completed inspections** and the **average real inspection time**
+  (creation to the first audited `Completed` workflow-state event) — `null`
+  for a technician with no completed inspections yet, never a fabricated
+  average.
+
+This is a capacity view; `competency_service.technician_quality_dashboard()`
+(v1.4) remains the quality-of-work view (coverage, AI confidence,
+supervisor agreement) for the same technicians — the two are deliberately
+separate because they answer different questions.

--- a/docs/workflow/prioritization-engine.md
+++ b/docs/workflow/prioritization-engine.md
@@ -1,0 +1,46 @@
+# Intelligent Prioritization Engine
+
+`app/services/prioritization_engine.py` — `compute_priority()`
+
+## What it is
+
+A point-based, auditable ranking of inspection urgency — mirroring the same
+rubric style already used by `risk_stratification_service.stratify_risk()`
+(v1.6). Every point awarded comes with a plain-English reason, so the
+ranking a supervisor sees is never a black box.
+
+## Scoring rubric
+
+| Factor | Points | Real signal used |
+|---|---|---|
+| Emergency procedure | +4 | `Inspection.procedure_priority == "emergency"` |
+| Trauma procedure | +3 | `Inspection.procedure_priority == "trauma"` |
+| First case | +2 | `Inspection.procedure_priority == "first_case"` |
+| Supervisor escalation | +3 | Latest `DispositionOverride.action == "escalate"` |
+| Critical finding | +3 | `readiness["is_critical_finding"]` (v1.6) |
+| High-risk anatomy | +2 | Instrument family resolves to a high/critical-risk zone (`instrument_anatomy.py`) |
+| Prior repair/removal history | +2 | `readiness["repair_history"]` (v1.6) |
+| Repair return awaiting evaluation | +2 | Disposition is Repair/Manufacturer Evaluation |
+| Repeat findings | +1 | A prior `InspectionFinding` row exists for the same physical instrument |
+| Vendor tray | +1 | `vendor_name` is real and `tray_id` is set |
+| Loaner instrument | +1 | `Inspection.is_loaner_instrument` |
+
+## Tiers
+
+| Score | Tier |
+|---|---|
+| ≥ 8 | Critical |
+| 5–7 | High |
+| 2–4 | Medium |
+| 0–1 | Low |
+
+## Honesty notes
+
+- A factor with no real signal contributes zero points — there is no
+  fabricated "default urgency."
+- `reasons` always lists exactly which factors fired, so the score is
+  explainable to a supervisor questioning why one inspection outranked
+  another.
+- Repeat-findings detection only fires for instruments with a real tracked
+  identity (barcode/UDI) — an `untracked:` instrument can never honestly
+  claim a repeat-condition history.

--- a/docs/workflow/shift-handoff.md
+++ b/docs/workflow/shift-handoff.md
@@ -1,0 +1,65 @@
+# Shift Handoff & Daily Operations
+
+## Daily Operations Dashboard (Deliverable 8)
+
+`GET /api/workflow/daily-dashboard`
+
+A same-day rollup: inspections created/completed today, pending count,
+high-risk findings, average inspection time, supervisor/repair backlog, and
+how many inspections are ready for packaging right now. Built entirely from
+the Smart Inspection Queue and SLA Monitoring services — no separate
+computation.
+
+## Shift Handoff Report (Deliverable 9)
+
+`GET /api/workflow/shift-handoff` (admin/spd_manager only)
+
+Generates a real-time snapshot for the next shift:
+
+- **Outstanding inspections** — the full pending queue.
+- **Critical instruments** — high-risk queue items.
+- **Pending supervisor reviews** — queue items awaiting a supervisor
+  decision.
+- **Repair holds** — queue items currently in the `Repair` workflow state.
+- **Escalations** — every inspection that meets at least one escalation
+  rule, with the specific reason(s).
+- **OR priorities** — queue items tied to an emergency/trauma/first-case
+  procedure.
+
+The report is generated on demand from live data — there is no separate
+"handoff snapshot" storage to go stale between shifts.
+
+## Notification Framework (Deliverable 10)
+
+`GET /api/workflow/notifications`, `POST /api/workflow/notifications/generate`,
+`POST /api/workflow/notifications/{id}/read`
+
+An in-app, per-role notification queue (`WorkflowNotification`) — distinct
+from the existing Slack/Teams/email `AlertEvent` dispatcher
+(`app/notifications/notifier.py`), which is for external critical-finding
+alerts unrelated to per-inspection workflow tracking.
+
+Notification types generated from real queue/escalation state:
+
+| Type | Trigger | Recipient |
+|---|---|---|
+| `inspection_assigned` | A technician is assigned | That technician |
+| `supervisor_review_required` | Inspection enters Supervisor Review | spd_manager |
+| `critical_finding` | Inspection is in the high-risk queue | spd_manager |
+| `repair_recommendation` | Inspection is in the repair queue | spd_manager |
+| `inspection_overdue` | Waiting > 8 hours | spd_manager |
+| `coverage_incomplete` | Coverage < 75% | operator |
+
+Generation is idempotent per inspection + notification type — re-running
+`POST /api/workflow/notifications/generate` never duplicates an
+already-emitted notification.
+
+## Operational Analytics (Deliverable 11)
+
+`GET /api/workflow/analytics?days=30` (admin/spd_manager only)
+
+Inspection throughput, per-technician productivity (completed-inspection
+counts), queue aging (average/max minutes waiting), average turnaround,
+high-risk workload, and workload balance (min/max/spread of open
+assignments across technicians) — all derived from the queue, SLA, and
+workload services above.

--- a/docs/workflow/sla-monitoring.md
+++ b/docs/workflow/sla-monitoring.md
@@ -1,0 +1,59 @@
+# SLA Monitoring & Escalation
+
+`GET /api/workflow/sla-monitoring`, `GET /api/workflow/escalations`
+(admin/spd_manager only)
+
+## Inspection Workflow State Machine (Deliverable 4)
+
+Every inspection moves through an append-only, audited log of transitions
+(`WorkflowStateEvent`) rather than a single mutable "current state" column
+— the full history is always reconstructable via
+`GET /api/inspections/{id}/workflow-state`.
+
+States: `Waiting → Assigned → Image Capture → AI Analysis → Supervisor
+Review → Reclean / Repair → Completed`, with `Cancelled` reachable at any
+point as an explicit, terminal action
+(`POST /api/inspections/{id}/workflow/cancel`, reason required).
+
+Transitions are appended at the real moment they happen:
+
+- **Image Capture** + **AI Analysis** — recorded together when an image is
+  submitted (`POST /api/inspections`), since both happen synchronously in
+  that one request. This mirrors the same honesty principle already used
+  by `readiness_timeline_service.py`: no fabricated gap between two events
+  that really happened in the same call.
+- **Supervisor Review** — entered automatically when the disposition
+  engine recommends `Supervisor Review Required`.
+- **Reclean / Repair / Completed** — driven by a supervisor's disposition
+  action (`POST /api/inspections/{id}/disposition-action`, v1.6).
+- **Assigned** — only when assignment happens while still `Waiting`
+  (see `operations-board.md`).
+
+## SLA targets
+
+| Stage | Target |
+|---|---|
+| Supervisor Review | 8 hours |
+| Reclean turnaround | 4 hours |
+| Repair referral | 24 hours |
+| Overall turnaround (creation → Completed) | 24 hours |
+
+Averages are computed only from real, completed stage transitions — a
+stage an inspection hasn't reached yet contributes no data point.
+`sla_breaches` lists any inspection still *open* in a stage past its
+target, using the real elapsed time so far (never estimated).
+
+## Escalation rules (Deliverable 7)
+
+`escalation_engine.evaluate_escalation()` fires when any of these real
+signals are true — never a generic "flagged" verdict:
+
+- Critical contamination/risk finding (risk tier `Critical`).
+- Repeated failure history (prior repair/removal + a current critical
+  finding).
+- Low AI confidence (< 60%).
+- No approved baseline available.
+- 2+ prior non-approve supervisor overrides on this inspection.
+- High-priority OR instrument (emergency/trauma procedure priority).
+
+Each escalated inspection lists exactly which rule(s) fired.

--- a/docs/workflow/work-queue.md
+++ b/docs/workflow/work-queue.md
@@ -1,0 +1,61 @@
+# Smart Inspection Queue
+
+`GET /api/inspection-work-queue` · frontend route `/inspection-work-queue`
+
+## What it is
+
+A single, ranked view of every inspection that hasn't reached a terminal
+workflow state (`Completed` or `Cancelled`), answering the question SPD asks
+every shift: **"what should we inspect next?"**
+
+Nothing in the queue is a new analysis — each item is a rollup of signals
+that already exist elsewhere in the platform:
+
+| Signal | Source |
+|---|---|
+| Readiness score/status | `readiness_engine.compute_readiness()` (v1.6) |
+| Disposition recommendation | `disposition_engine.recommend_disposition()` (v1.6) |
+| Risk tier | `risk_stratification_service.stratify_risk()` (v1.6) |
+| Priority score/tier | `prioritization_engine.compute_priority()` (Deliverable 2) |
+| Current workflow state | `workflow_state_service.current_state()` (Deliverable 4) |
+| Assigned technician | `workflow_state_service.latest_assignment()` (Deliverable 3) |
+
+## Response shape
+
+```json
+{
+  "pending_inspections": [ ... ],
+  "high_risk_inspections": [ ... ],
+  "or_priority_instruments": [ ... ],
+  "vendor_trays": [ ... ],
+  "loaner_instruments": [ ... ],
+  "repeat_inspections": [ ... ],
+  "supervisor_reviews": [ ... ],
+  "repair_holds": [ ... ],
+  "total_pending": 12,
+  "human_review_required": true
+}
+```
+
+Each queue item includes: `instrument_type`, `procedure_priority`,
+`workflow_state`, `risk_tier`, `priority_score`/`priority_tier` (with the
+`priority_reasons` that produced the score), `disposition`, `coverage_pct`,
+`minutes_waiting`, `assigned_technician`, and the `is_vendor_tray` /
+`is_loaner_instrument` / `has_repeat_findings` flags used to place the item
+into its buckets.
+
+`pending_inspections` is the master list (sorted by `priority_score`
+descending); the other keys are the same items filtered into the specific
+buckets SPD asks for. An item can appear in more than one bucket (e.g. a
+high-risk vendor-tray instrument in a repair hold).
+
+## Honesty notes
+
+- An inspection only leaves the queue once it reaches `Completed` or
+  `Cancelled` — there is no "hide after N days" behavior that could mask a
+  stalled inspection.
+- `procedure_priority` and `is_loaner_instrument` are `null`/`false` unless
+  actually declared at intake (`POST /api/inspections`) — never inferred or
+  defaulted to "routine".
+- `assigned_technician` is `null` until a supervisor explicitly assigns one
+  (Deliverable 3) — never guessed from who submitted the inspection.

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useAuth, API_BASE } from "@/lib/auth";
 import SupervisorNotes from "@/components/SupervisorNotes";
+import ReadinessDispositionPanel from "@/components/ReadinessDispositionPanel";
 import { apiFetch } from "@/lib/api";
 
 /**
@@ -527,6 +528,9 @@ export default function ClinicalDecisionPanel({
           </ul>
         )}
       </div>
+
+      {/* v1.6 — Clinical Service Readiness & Instrument Disposition Intelligence */}
+      <ReadinessDispositionPanel inspectionId={inspectionId} />
 
       {/* Supervisor Review Notes — admin/spd_manager only */}
       {canReview && <SupervisorNotes inspectionId={inspectionId} />}

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -150,9 +150,16 @@ function Stars({ n }: { n: number }) {
 export default function ClinicalDecisionPanel({
   cd,
   inspectionId,
+  rawResult,
 }: {
   cd: ClinicalDecision;
   inspectionId?: number;
+  /** The raw analysis result already shown on screen (from a just-submitted
+   * inspection). When present, Training Mode is toggled by rebuilding the
+   * mentor payload from this exact data (POST /mentor/build) instead of
+   * re-deriving from the database — so toggling it can never change which
+   * findings or disposition are being explained. */
+  rawResult?: Record<string, unknown>;
 }) {
   const { headers, role } = useAuth();
   const [pdfBusy, setPdfBusy] = useState(false);
@@ -163,14 +170,18 @@ export default function ClinicalDecisionPanel({
   const canReview = role === "admin" || role === "spd_manager";
 
   async function toggleTrainingMode() {
-    if (!inspectionId) return;
     const next = !(mentor?.training_mode ?? false);
     setTrainingBusy(true);
     try {
-      const updated = await apiFetch<SpdMentor>(
-        `/api/inspections/${inspectionId}/mentor?training_mode=${next}`
-      );
-      setMentor(updated);
+      const updated = rawResult
+        ? await apiFetch<SpdMentor>(`/api/mentor/build?training_mode=${next}`, {
+            method: "POST",
+            body: { result: rawResult, overall: cd.overall_result },
+          })
+        : inspectionId
+          ? await apiFetch<SpdMentor>(`/api/inspections/${inspectionId}/mentor?training_mode=${next}`)
+          : undefined;
+      if (updated) setMentor(updated);
     } finally {
       setTrainingBusy(false);
     }
@@ -275,7 +286,7 @@ export default function ClinicalDecisionPanel({
         <div className="rounded-lg border border-indigo-200 bg-indigo-50/50 p-4 space-y-3">
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">SPD Mentor</p>
-            {inspectionId && (
+            {(rawResult || inspectionId) && (
               <button
                 onClick={toggleTrainingMode}
                 disabled={trainingBusy}

--- a/frontend/src/components/ClinicalDecisionPanel.tsx
+++ b/frontend/src/components/ClinicalDecisionPanel.tsx
@@ -51,6 +51,27 @@ type ClinicalDecision = {
     standard_practice: string; what_should_happen_next: string[];
     where_was_it_detected?: string; why_this_zone_is_high_risk?: string; verify_manually?: string;
   };
+  // v1.4 — SPD Mentor Engine
+  spd_mentor?: SpdMentor;
+};
+
+type SpdMentor = {
+  disclaimer: string;
+  corrective_actions: { finding: string; steps: string[] }[];
+  anatomy_coaching: string[];
+  confidence_coaching: { message: string; suggestions: string[] } | null;
+  clinical_decision_summary: {
+    instrument: string; inspection_coverage: number | null; findings: string;
+    risk: string | null; recommendation: string | null; supervisor_review: string;
+  };
+  education_cards: { finding: string; clinical_significance: string; recommended_practice: string; reference: string }[];
+  training_mode: boolean;
+  expanded_explanations?: {
+    every_finding: Record<string, unknown>[];
+    anatomy_explained: { zone: string; explanation: string }[];
+    recommendation_explained: { disposition: string; next_actions: string[]; standards_guidance: string };
+    terminology: { term: string; definition: string }[];
+  };
 };
 
 const RISK_BADGE: Record<string, string> = {
@@ -136,8 +157,24 @@ export default function ClinicalDecisionPanel({
   const { headers, role } = useAuth();
   const [pdfBusy, setPdfBusy] = useState(false);
   const [learning, setLearning] = useState(false);
+  const [mentor, setMentor] = useState<SpdMentor | undefined>(cd.spd_mentor);
+  const [trainingBusy, setTrainingBusy] = useState(false);
   const result = cd.overall_result;
   const canReview = role === "admin" || role === "spd_manager";
+
+  async function toggleTrainingMode() {
+    if (!inspectionId) return;
+    const next = !(mentor?.training_mode ?? false);
+    setTrainingBusy(true);
+    try {
+      const updated = await apiFetch<SpdMentor>(
+        `/api/inspections/${inspectionId}/mentor?training_mode=${next}`
+      );
+      setMentor(updated);
+    } finally {
+      setTrainingBusy(false);
+    }
+  }
 
   async function downloadPdf() {
     if (!inspectionId) return;
@@ -230,6 +267,102 @@ export default function ClinicalDecisionPanel({
             <p><span className="font-semibold text-slate-900">Standard practice:</span> {cd.ai_mentor.standard_practice}</p>
             <p><span className="font-semibold text-slate-900">What should happen next:</span> {cd.ai_mentor.what_should_happen_next.join("; ")}</p>
           </div>
+        </div>
+      )}
+
+      {/* v1.4 — SPD Mentor Engine */}
+      {mentor && (
+        <div className="rounded-lg border border-indigo-200 bg-indigo-50/50 p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">SPD Mentor</p>
+            {inspectionId && (
+              <button
+                onClick={toggleTrainingMode}
+                disabled={trainingBusy}
+                className="text-xs font-medium text-indigo-700 underline disabled:opacity-50"
+              >
+                {trainingBusy ? "Loading…" : mentor.training_mode ? "Training Mode: On" : "Training Mode: Off"}
+              </button>
+            )}
+          </div>
+
+          {/* Clinical Decision Summary */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-sm">
+            <div><div className="text-xs text-slate-500">Instrument</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.instrument}</div></div>
+            <div><div className="text-xs text-slate-500">Coverage</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.inspection_coverage ?? "—"}%</div></div>
+            <div><div className="text-xs text-slate-500">Supervisor Review</div><div className="font-medium text-slate-800">{mentor.clinical_decision_summary.supervisor_review}</div></div>
+          </div>
+          <p className="text-sm text-slate-700">{mentor.clinical_decision_summary.findings}</p>
+
+          {/* Corrective Action Recommendations */}
+          {mentor.corrective_actions.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-slate-600 mb-1">Corrective Action</p>
+              {mentor.corrective_actions.map((a, i) => (
+                <p key={i} className="text-sm text-slate-700">
+                  <span className="font-medium capitalize">{a.finding}:</span> {a.steps.join(" → ")}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {/* Anatomy-Aware Coaching */}
+          {mentor.anatomy_coaching.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-slate-600 mb-1">Anatomy Coaching</p>
+              <ul className="space-y-0.5 text-sm text-slate-700">
+                {mentor.anatomy_coaching.map((c, i) => <li key={i}>• {c}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {/* AI Confidence Coaching */}
+          {mentor.confidence_coaching && (
+            <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2">
+              <p className="text-sm font-medium text-amber-800">{mentor.confidence_coaching.message}</p>
+              <ul className="mt-1 text-sm text-amber-700">
+                {mentor.confidence_coaching.suggestions.map((s, i) => <li key={i}>• {s}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {/* SPD Education Cards */}
+          {mentor.education_cards.length > 0 && (
+            <div className="space-y-1.5">
+              {mentor.education_cards.map((c, i) => (
+                <div key={i} className="rounded border border-slate-200 bg-white px-3 py-2">
+                  <p className="text-sm font-semibold capitalize text-slate-800">{c.finding}</p>
+                  <p className="text-sm text-slate-600">{c.clinical_significance}</p>
+                  <p className="text-sm text-slate-600"><span className="text-slate-500">Recommended practice:</span> {c.recommended_practice}</p>
+                  <p className="text-xs text-slate-400">{c.reference}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Training Mode expanded explanations */}
+          {mentor.training_mode && mentor.expanded_explanations && (
+            <div className="rounded border border-indigo-300 bg-white px-3 py-2 space-y-2">
+              <p className="text-xs font-semibold text-indigo-700">Terminology</p>
+              <ul className="text-sm text-slate-700 space-y-0.5">
+                {mentor.expanded_explanations.terminology.map((t, i) => (
+                  <li key={i}><span className="font-medium">{t.term}:</span> {t.definition}</li>
+                ))}
+              </ul>
+              {mentor.expanded_explanations.anatomy_explained.length > 0 && (
+                <>
+                  <p className="text-xs font-semibold text-indigo-700">Anatomy Explained</p>
+                  <ul className="text-sm text-slate-700 space-y-0.5">
+                    {mentor.expanded_explanations.anatomy_explained.map((z, i) => (
+                      <li key={i}><span className="font-medium capitalize">{z.zone}:</span> {z.explanation}</li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          )}
+
+          <p className="text-xs text-slate-400 italic">{mentor.disclaimer}</p>
         </div>
       )}
 

--- a/frontend/src/components/CoverageOverridePanel.tsx
+++ b/frontend/src/components/CoverageOverridePanel.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { useAuth } from "@/lib/auth";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://lumen-ai-53u4.onrender.com";
+
+/**
+ * v1.2 §7 — Supervisor Override for insufficient coverage. Role-gated at the
+ * call site (admin/spd_manager); the backend also enforces it. A reason
+ * (min 10 chars) is required, matching the baseline-override pattern.
+ */
+export default function CoverageOverridePanel({
+  inspectionId,
+  onApplied,
+}: {
+  inspectionId: number;
+  onApplied?: () => void;
+}) {
+  const { headers } = useAuth();
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  async function submit() {
+    if (reason.trim().length < 10) {
+      setMsg({ ok: false, text: "Reason must be at least 10 characters." });
+      return;
+    }
+    setBusy(true);
+    setMsg(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/inspections/${inspectionId}/coverage-override`, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ reason: reason.trim() }),
+      });
+      if (res.status === 403) { setMsg({ ok: false, text: "Supervisor access (admin/SPD manager) required." }); return; }
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        setMsg({ ok: false, text: b?.detail || `Override failed (${res.status}).` });
+        return;
+      }
+      setMsg({ ok: true, text: "Coverage override applied — inspection can proceed to a final decision." });
+      onApplied?.();
+    } catch {
+      setMsg({ ok: false, text: "Unable to reach the server." });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-red-300 bg-red-50 p-4 space-y-2">
+      <p className="text-sm font-semibold text-red-900">Coverage Override Required</p>
+      <p className="text-xs text-red-700">
+        Org policy requires full anatomy-zone coverage before a final AI decision. A supervisor or admin can
+        proceed anyway with a documented reason.
+      </p>
+      <textarea
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        placeholder="Reason for proceeding despite incomplete coverage (min 10 characters)…"
+        rows={2}
+        className="w-full rounded-lg border border-red-300 px-3 py-2 text-sm"
+      />
+      <div className="flex items-center gap-3">
+        <button
+          onClick={submit}
+          disabled={busy}
+          className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:opacity-50"
+        >
+          {busy ? "Applying…" : "Apply Coverage Override"}
+        </button>
+        {msg && <span className={`text-sm ${msg.ok ? "text-emerald-700" : "text-red-700"}`}>{msg.text}</span>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/GuidedCapturePanel.tsx
+++ b/frontend/src/components/GuidedCapturePanel.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://lumen-ai-53u4.onrender.com";
+
+interface GuidedCaptureData {
+  instrument_family: string;
+  instrument_category: string;
+  required_zones: string[];
+  optional_zones: string[];
+  captured_zones: string[];
+  missing_zones: string[];
+  high_risk_zones: string[];
+  current_zone: string | null;
+  recommended_camera_angle: string | null;
+  lighting_tips: string | null;
+  focus_tips: string | null;
+  example_placeholder_guidance: string;
+  all_required_captured: boolean;
+  coverage_score: number | null;
+  coverage_status: string;
+  missing_high_risk_zones: string[];
+  missing_image_guidance: string[];
+  ready_for_ai_analysis: boolean;
+  gate_status: "ready" | "draft" | "blocked_pending_override";
+  require_full_coverage: boolean;
+}
+
+const STATUS_STYLE: Record<string, string> = {
+  complete: "bg-emerald-100 text-emerald-800",
+  acceptable: "bg-amber-100 text-amber-800",
+  incomplete: "bg-orange-100 text-orange-800",
+  insufficient: "bg-red-100 text-red-800",
+  not_assessed: "bg-slate-100 text-slate-500",
+};
+
+function ZoneChips({ zones, tone }: { zones: string[]; tone: "slate" | "emerald" | "red" | "amber" }) {
+  const cls = {
+    slate: "bg-slate-100 text-slate-700",
+    emerald: "bg-emerald-50 text-emerald-700",
+    red: "bg-red-50 text-red-700",
+    amber: "bg-amber-50 text-amber-800",
+  }[tone];
+  if (zones.length === 0) return <span className="text-xs text-slate-400">none</span>;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {zones.map((z) => (
+        <span key={z} className={`rounded-full px-2 py-0.5 text-xs capitalize ${cls}`}>{z}</span>
+      ))}
+    </div>
+  );
+}
+
+export default function GuidedCapturePanel({
+  instrumentType,
+  capturedZones,
+}: {
+  instrumentType: string;
+  capturedZones: string[];
+}) {
+  const { headers } = useAuth();
+  const [data, setData] = useState<GuidedCaptureData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!instrumentType.trim()) {
+      setData(null);
+      return;
+    }
+    const params = new URLSearchParams({ captured_zones: capturedZones.join(",") });
+    let cancelled = false;
+    fetch(`${API_BASE}/api/guided-capture/${encodeURIComponent(instrumentType)}?${params}`, { headers: headers() })
+      .then((r) => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}`); return r.json(); })
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch((e) => { if (!cancelled) setError(String(e)); });
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [instrumentType, capturedZones.join(",")]);
+
+  if (!instrumentType.trim()) return null;
+  if (error) return <p className="text-sm text-red-600">Guided capture unavailable: {error}</p>;
+  if (!data) return <p className="text-sm text-slate-400">Loading guided capture guidance…</p>;
+
+  return (
+    <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Guided Capture — <span className="capitalize">{data.instrument_family.replace(/_/g, " ")}</span>
+        </p>
+        <span className={`rounded-full px-2 py-0.5 text-xs font-bold capitalize ${STATUS_STYLE[data.coverage_status] ?? "bg-slate-100"}`}>
+          {data.coverage_status.replace(/_/g, " ")}
+        </span>
+      </div>
+
+      {/* Coverage score */}
+      {data.coverage_score != null && (
+        <div className="flex items-center gap-3">
+          <div className="text-2xl font-bold text-slate-900">{data.coverage_score}%</div>
+          <div className="flex-1 h-2 rounded-full bg-slate-100 overflow-hidden">
+            <div
+              className={`h-full ${data.coverage_score >= 80 ? "bg-emerald-500" : data.coverage_score >= 50 ? "bg-amber-500" : "bg-red-500"}`}
+              style={{ width: `${data.coverage_score}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Current zone to capture */}
+      {data.current_zone ? (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 space-y-1">
+          <p className="text-sm font-semibold text-blue-900">
+            Next: capture <span className="capitalize">{data.current_zone}</span>
+          </p>
+          <p className="text-sm text-blue-800">{data.example_placeholder_guidance}</p>
+          <div className="mt-1 grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs text-blue-700">
+            <div><span className="font-medium">Angle:</span> {data.recommended_camera_angle}</div>
+            <div><span className="font-medium">Lighting:</span> {data.lighting_tips}</div>
+            <div><span className="font-medium">Focus:</span> {data.focus_tips}</div>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+          All required zones captured.
+        </div>
+      )}
+
+      {/* Capture checklist */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+        <div>
+          <div className="text-xs text-slate-500 mb-0.5">Required zones</div>
+          <ZoneChips zones={data.required_zones} tone="slate" />
+        </div>
+        <div>
+          <div className="text-xs text-slate-500 mb-0.5">Optional zones</div>
+          <ZoneChips zones={data.optional_zones} tone="slate" />
+        </div>
+        <div>
+          <div className="text-xs text-slate-500 mb-0.5">Captured</div>
+          <ZoneChips zones={data.captured_zones} tone="emerald" />
+        </div>
+        <div>
+          <div className="text-xs text-slate-500 mb-0.5">Missing (required)</div>
+          <ZoneChips zones={data.missing_zones} tone="red" />
+        </div>
+        <div className="sm:col-span-2">
+          <div className="text-xs text-slate-500 mb-0.5">High-risk zones</div>
+          <ZoneChips zones={data.high_risk_zones} tone="amber" />
+        </div>
+      </div>
+
+      {/* AI Analysis Gate */}
+      {!data.ready_for_ai_analysis && (
+        <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+          <p className="font-semibold">Coverage insufficient for a final AI decision.</p>
+          <p className="text-xs mt-0.5">
+            Org policy requires full coverage before a final decision. A supervisor/admin override with a reason
+            will be required after submission, or save this inspection as a draft.
+          </p>
+        </div>
+      )}
+      {data.ready_for_ai_analysis && data.missing_high_risk_zones.length > 0 && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">
+          Missing high-risk zones: <span className="capitalize">{data.missing_high_risk_zones.join(", ")}</span>. Upload
+          additional images before finalizing when possible.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ReadinessDispositionPanel.tsx
+++ b/frontend/src/components/ReadinessDispositionPanel.tsx
@@ -1,0 +1,195 @@
+import { useState, useEffect, useCallback } from "react";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+
+interface EvidencePanel {
+  instrument_identity: string;
+  instrument_type: string;
+  inspection_coverage_pct: number | null;
+  coverage_quality: string | null;
+  detected_issue: string | null;
+  severity: string | null;
+  baseline_used: string | null;
+  supervisor_status: string;
+  supervisor_agreement: string | null;
+  readiness_score: number | null;
+  readiness_status: string;
+  recommended_disposition: string;
+  clinical_rationale: string;
+}
+
+interface RiskStratification {
+  risk_tier: string;
+  points: number;
+  reasons: string[];
+}
+
+interface TimelineStep {
+  step: string;
+  completed: boolean;
+  timestamp: string | null;
+  value?: string;
+}
+
+const ACTIONS = [
+  { value: "approve", label: "Approve" },
+  { value: "modify", label: "Modify" },
+  { value: "escalate", label: "Escalate" },
+  { value: "reclean", label: "Request Reclean" },
+  { value: "repair", label: "Request Repair" },
+  { value: "remove_from_service", label: "Remove From Service" },
+  { value: "manufacturer_review", label: "Require Manufacturer Review" },
+];
+
+const RISK_STYLE: Record<string, string> = {
+  "Low Risk": "bg-emerald-100 text-emerald-800",
+  "Moderate Risk": "bg-amber-100 text-amber-800",
+  "High Risk": "bg-orange-100 text-orange-800",
+  "Critical": "bg-red-100 text-red-800",
+};
+
+export default function ReadinessDispositionPanel({ inspectionId }: { inspectionId?: number }) {
+  const { role } = useAuth();
+  const isLeadership = role === "admin" || role === "spd_manager";
+  const [evidence, setEvidence] = useState<EvidencePanel | null>(null);
+  const [risk, setRisk] = useState<RiskStratification | null>(null);
+  const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
+  const [showTimeline, setShowTimeline] = useState(false);
+  const [action, setAction] = useState("approve");
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const load = useCallback(() => {
+    if (!inspectionId) return;
+    apiFetch<EvidencePanel>(`/api/inspections/${inspectionId}/evidence-panel`).then(setEvidence);
+    apiFetch<RiskStratification>(`/api/inspections/${inspectionId}/risk-stratification`).then(setRisk);
+  }, [inspectionId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function loadTimeline() {
+    if (!inspectionId) return;
+    const data = await apiFetch<{ steps: TimelineStep[] }>(`/api/inspections/${inspectionId}/readiness-timeline`);
+    setTimeline(data.steps);
+    setShowTimeline(true);
+  }
+
+  async function submitAction() {
+    if (!inspectionId || !evidence) return;
+    setBusy(true);
+    try {
+      await apiFetch(`/api/inspections/${inspectionId}/disposition-action`, {
+        method: "POST",
+        body: {
+          action,
+          ai_recommended_disposition: evidence.recommended_disposition,
+          reason,
+        },
+      });
+      setSubmitted(true);
+      setReason("");
+      load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function downloadReport() {
+    if (!inspectionId) return;
+    const res = await apiFetch(`/api/inspections/${inspectionId}/readiness-report.pdf`, { raw: true });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    window.open(url, "_blank", "noopener,noreferrer");
+    setTimeout(() => URL.revokeObjectURL(url), 30000);
+  }
+
+  if (!inspectionId || !evidence) return null;
+
+  const reasonRequired = action !== "approve";
+
+  return (
+    <div className="rounded-lg border border-teal-200 bg-teal-50/50 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-wide text-teal-700">Clinical Service Readiness</p>
+        <button onClick={downloadReport} className="text-xs text-teal-700 underline">
+          Export Readiness Report (PDF)
+        </button>
+      </div>
+
+      {/* Disposition Evidence Panel */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm">
+        <div><div className="text-xs text-slate-500">Coverage</div><div className="font-medium">{evidence.inspection_coverage_pct ?? "—"}%</div></div>
+        <div><div className="text-xs text-slate-500">Readiness Score</div><div className="font-medium">{evidence.readiness_score ?? "—"}</div></div>
+        <div><div className="text-xs text-slate-500">Readiness Status</div><div className="font-medium">{evidence.readiness_status}</div></div>
+        <div><div className="text-xs text-slate-500">Supervisor Status</div><div className="font-medium capitalize">{evidence.supervisor_status}</div></div>
+      </div>
+      <div className="text-sm">
+        <span className="text-slate-500">Findings:</span> {evidence.detected_issue || "None"}
+        {" · "}<span className="text-slate-500">Severity:</span> {evidence.severity || "—"}
+        {" · "}<span className="text-slate-500">Baseline:</span> {evidence.baseline_used || "—"}
+      </div>
+
+      <div className="rounded border border-teal-300 bg-white px-3 py-2">
+        <p className="text-sm font-semibold text-teal-900">Recommended Disposition: {evidence.recommended_disposition}</p>
+        <p className="text-sm text-slate-700">{evidence.clinical_rationale}</p>
+      </div>
+
+      {risk && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-slate-500">Risk Stratification:</span>
+          <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${RISK_STYLE[risk.risk_tier] ?? "bg-slate-100"}`}>
+            {risk.risk_tier}
+          </span>
+        </div>
+      )}
+
+      <button onClick={loadTimeline} className="text-xs text-teal-700 underline">
+        {showTimeline ? "Hide" : "Show"} Readiness Timeline
+      </button>
+      {showTimeline && timeline && (
+        <ol className="space-y-1 text-sm">
+          {timeline.map((s, i) => (
+            <li key={i} className="flex items-center gap-2">
+              <span className={s.completed ? "text-emerald-600" : "text-slate-300"}>{s.completed ? "✓" : "○"}</span>
+              <span className={s.completed ? "text-slate-800" : "text-slate-400"}>{s.step}</span>
+              {s.value && <span className="text-xs text-slate-500">({s.value})</span>}
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {/* Supervisor Disposition Workspace */}
+      {isLeadership && (
+        <div className="rounded border border-slate-200 bg-white p-3 space-y-2">
+          <p className="text-xs font-semibold text-slate-600">Supervisor Disposition Workspace</p>
+          <select
+            value={action}
+            onChange={(e) => setAction(e.target.value)}
+            className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+          >
+            {ACTIONS.map((a) => <option key={a.value} value={a.value}>{a.label}</option>)}
+          </select>
+          {reasonRequired && (
+            <input
+              type="text"
+              placeholder="Reason (required for this action)"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+            />
+          )}
+          <button
+            onClick={submitAction}
+            disabled={busy || (reasonRequired && !reason.trim())}
+            className="text-xs font-semibold px-3 py-1.5 rounded bg-teal-600 text-white disabled:opacity-50"
+          >
+            {busy ? "Submitting…" : "Submit"}
+          </button>
+          {submitted && <p className="text-xs text-emerald-700">Disposition action recorded.</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SupervisorNotes.tsx
+++ b/frontend/src/components/SupervisorNotes.tsx
@@ -28,6 +28,10 @@ export default function SupervisorNotes({
   const [correctedZone, setCorrectedZone] = useState("");
   const [familyCorrect, setFamilyCorrect] = useState<boolean | null>(null);
   const [correctedFamily, setCorrectedFamily] = useState("");
+  const [imageViewCorrect, setImageViewCorrect] = useState<boolean | null>(null);
+  const [correctedImageView, setCorrectedImageView] = useState("");
+  const [missingZoneCorrect, setMissingZoneCorrect] = useState<boolean | null>(null);
+  const [correctedMissingZone, setCorrectedMissingZone] = useState("");
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const [busy, setBusy] = useState(false);
   const commentRequired = agreement !== "agree" || !!override.trim();
@@ -52,6 +56,10 @@ export default function SupervisorNotes({
           corrected_zone: correctedZone.trim(),
           instrument_family_correct: familyCorrect,
           corrected_instrument_family: correctedFamily.trim(),
+          image_view_correct: imageViewCorrect,
+          corrected_image_view: correctedImageView.trim(),
+          missing_zone_correct: missingZoneCorrect,
+          corrected_missing_zone: correctedMissingZone.trim(),
         }),
       });
       if (res.status === 403) { setMsg({ ok: false, text: "Supervisor access (admin/SPD manager) required." }); return; }
@@ -124,6 +132,34 @@ export default function SupervisorNotes({
             value={correctedZone}
             onChange={(e) => setCorrectedZone(e.target.value)}
             placeholder="Corrected zone (e.g. hinge, box lock)"
+            className="flex-1 min-w-[10rem] rounded-lg border border-slate-300 px-2 py-1"
+          />
+        )}
+      </div>
+      {/* Image-view feedback → labeled training data */}
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+        <span className="text-slate-500">AI image view correct?</span>
+        <button onClick={() => setImageViewCorrect(true)} className={`rounded-full px-2 py-0.5 border ${imageViewCorrect === true ? "bg-emerald-600 text-white border-emerald-600" : "border-slate-300 text-slate-600"}`}>Yes</button>
+        <button onClick={() => setImageViewCorrect(false)} className={`rounded-full px-2 py-0.5 border ${imageViewCorrect === false ? "bg-red-600 text-white border-red-600" : "border-slate-300 text-slate-600"}`}>No</button>
+        {imageViewCorrect === false && (
+          <input
+            value={correctedImageView}
+            onChange={(e) => setCorrectedImageView(e.target.value)}
+            placeholder="Corrected image view (e.g. o-ring area, distal tip)"
+            className="flex-1 min-w-[10rem] rounded-lg border border-slate-300 px-2 py-1"
+          />
+        )}
+      </div>
+      {/* Missing-zone feedback → labeled training data (Coverage Engine) */}
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+        <span className="text-slate-500">AI missing-zone determination correct?</span>
+        <button onClick={() => setMissingZoneCorrect(true)} className={`rounded-full px-2 py-0.5 border ${missingZoneCorrect === true ? "bg-emerald-600 text-white border-emerald-600" : "border-slate-300 text-slate-600"}`}>Yes</button>
+        <button onClick={() => setMissingZoneCorrect(false)} className={`rounded-full px-2 py-0.5 border ${missingZoneCorrect === false ? "bg-red-600 text-white border-red-600" : "border-slate-300 text-slate-600"}`}>No</button>
+        {missingZoneCorrect === false && (
+          <input
+            value={correctedMissingZone}
+            onChange={(e) => setCorrectedMissingZone(e.target.value)}
+            placeholder="Zone that was actually captured/missing (e.g. hinge)"
             className="flex-1 min-w-[10rem] rounded-lg border border-slate-300 px-2 py-1"
           />
         )}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -126,6 +126,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/analytics", label: "Benchmarking", icon: BarChart3 },
       { to: "/quality-intelligence", label: "Risk Signals", icon: AlertTriangle },
       { to: "/quality-dashboard", label: "Quality Dashboard", icon: BarChart3 },
+      { to: "/clinical-readiness", label: "Clinical Service Readiness", icon: ShieldCheck },
       { to: "/operations", label: "Operational Analytics", icon: Activity },
       { to: "/pilot-validation", label: "Pilot Validation", icon: Activity, roles: ["admin", "spd_manager"] },
     ],

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -93,6 +93,10 @@ const NAV_GROUPS: NavGroup[] = [
     items: [
       { to: "/infrastructure", label: "Instrument Registry", icon: Database },
       { to: "/instrument-passport", label: "Instrument Passport", icon: CreditCard },
+      { to: "/instrument-library", label: "Instrument Library", icon: BookOpen },
+      { to: "/anatomy-library", label: "Anatomy Library", icon: Network },
+      { to: "/inspection-zones", label: "Inspection Zones", icon: FileSearch },
+      { to: "/coverage-dashboard", label: "Coverage Dashboard", icon: BarChart3 },
       { to: "/vendor-intake", label: "Barcode / QR / KeyDot", icon: ScanLine },
       { to: "/demo-image-library", label: "Image Library", icon: Images },
       { to: "/baseline-image-upload", label: "Upload Baseline Image", icon: Upload },

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -41,6 +41,8 @@ import {
   Network,
   Workflow,
   Cpu,
+  ListChecks,
+  ClipboardList,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -77,6 +79,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/intake-history", label: "Inspection History", icon: History },
       { to: "/findings", label: "Review Queue", icon: ClipboardCheck },
       { to: "/analytics", label: "Inspection Analytics", icon: LineChart },
+      { to: "/inspection-work-queue", label: "Smart Work Queue", icon: ListChecks },
     ],
   },
   {
@@ -128,6 +131,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/quality-dashboard", label: "Quality Dashboard", icon: BarChart3 },
       { to: "/clinical-readiness", label: "Clinical Service Readiness", icon: ShieldCheck },
       { to: "/operations", label: "Operational Analytics", icon: Activity },
+      { to: "/operations-board", label: "Operations Board", icon: ClipboardList, roles: ["admin", "spd_manager"] },
       { to: "/pilot-validation", label: "Pilot Validation", icon: Activity, roles: ["admin", "spd_manager"] },
     ],
   },

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -39,6 +39,7 @@ import {
   DollarSign,
   Camera,
   Network,
+  Workflow,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -106,6 +107,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/enterprise", label: "Enterprise Quality", icon: Building2, roles: ELEVATED_ROLES },
       { to: "/pre-sterilization-command-center", label: "Pre-Sterilization Command Center", icon: CheckCircle2 },
       { to: "/knowledge-graph", label: "Knowledge Graph", icon: Network },
+      { to: "/agent-trace", label: "Agent Trace", icon: Workflow },
     ],
   },
   {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -40,6 +40,7 @@ import {
   Camera,
   Network,
   Workflow,
+  Cpu,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -108,6 +109,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/pre-sterilization-command-center", label: "Pre-Sterilization Command Center", icon: CheckCircle2 },
       { to: "/knowledge-graph", label: "Knowledge Graph", icon: Network },
       { to: "/agent-trace", label: "Agent Trace", icon: Workflow },
+      { to: "/cios-dashboard", label: "Clinical Intelligence OS", icon: Cpu },
     ],
   },
   {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -43,6 +43,7 @@ import {
   Cpu,
   ListChecks,
   ClipboardList,
+  BookMarked,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -117,6 +118,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/coaching-dashboard", label: "Supervisor Coaching", icon: ClipboardCheck, roles: ELEVATED_ROLES },
       { to: "/pre-sterilization-command-center", label: "Pre-Sterilization Command Center", icon: CheckCircle2 },
       { to: "/knowledge-graph", label: "Knowledge Graph", icon: Network },
+      { to: "/knowledge-center", label: "Knowledge Center", icon: BookMarked },
       { to: "/agent-trace", label: "Agent Trace", icon: Workflow },
       { to: "/cios-dashboard", label: "Clinical Intelligence OS", icon: Cpu },
     ],

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -103,6 +103,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/capa", label: "CAPA", icon: ShieldCheck },
       { to: "/audit-evidence", label: "Audit Evidence", icon: FileText, roles: [...ELEVATED_ROLES, "auditor"] },
       { to: "/enterprise", label: "Enterprise Quality", icon: Building2, roles: ELEVATED_ROLES },
+      { to: "/pre-sterilization-command-center", label: "Pre-Sterilization Command Center", icon: CheckCircle2 },
     ],
   },
   {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -38,6 +38,7 @@ import {
   GraduationCap,
   DollarSign,
   Camera,
+  Network,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -104,6 +105,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/audit-evidence", label: "Audit Evidence", icon: FileText, roles: [...ELEVATED_ROLES, "auditor"] },
       { to: "/enterprise", label: "Enterprise Quality", icon: Building2, roles: ELEVATED_ROLES },
       { to: "/pre-sterilization-command-center", label: "Pre-Sterilization Command Center", icon: CheckCircle2 },
+      { to: "/knowledge-graph", label: "Knowledge Graph", icon: Network },
     ],
   },
   {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -114,6 +114,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/pilot-analytics", label: "Executive Dashboard", icon: TrendingUp, roles: EXECUTIVE_ROLES },
       { to: "/analytics", label: "Benchmarking", icon: BarChart3 },
       { to: "/quality-intelligence", label: "Risk Signals", icon: AlertTriangle },
+      { to: "/quality-dashboard", label: "Quality Dashboard", icon: BarChart3 },
       { to: "/operations", label: "Operational Analytics", icon: Activity },
       { to: "/pilot-validation", label: "Pilot Validation", icon: Activity, roles: ["admin", "spd_manager"] },
     ],

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -103,6 +103,8 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/capa", label: "CAPA", icon: ShieldCheck },
       { to: "/audit-evidence", label: "Audit Evidence", icon: FileText, roles: [...ELEVATED_ROLES, "auditor"] },
       { to: "/enterprise", label: "Enterprise Quality", icon: Building2, roles: ELEVATED_ROLES },
+      { to: "/education-library", label: "SPD Education Library", icon: BookOpen },
+      { to: "/coaching-dashboard", label: "Supervisor Coaching", icon: ClipboardCheck, roles: ELEVATED_ROLES },
     ],
   },
   {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -134,6 +134,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/clinical-readiness", label: "Clinical Service Readiness", icon: ShieldCheck },
       { to: "/operations", label: "Operational Analytics", icon: Activity },
       { to: "/operations-board", label: "Operations Board", icon: ClipboardList, roles: ["admin", "spd_manager"] },
+      { to: "/pilot-data-collection", label: "Pilot Data Collection", icon: Database, roles: ["admin", "spd_manager"] },
       { to: "/pilot-validation", label: "Pilot Validation", icon: Activity, roles: ["admin", "spd_manager"] },
     ],
   },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -186,6 +186,20 @@ export async function apiFetch<T = unknown>(
     } catch {
       /* fall through with the generic message */
     }
+
+    // v1.9 — fire-and-forget role-permission-failure logging. Inlined
+    // (rather than importing errorLog.ts) to avoid a circular import, and
+    // skipped for the logging endpoint itself so a permission failure can
+    // never recurse into logging its own failure.
+    if (res.status === 403 && !path.includes("/api/pilot-deployment/error-log")) {
+      fetch(buildUrl("/api/pilot-deployment/error-log"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...Object.fromEntries(finalHeaders.entries()) },
+        credentials: "include",
+        body: JSON.stringify({ error_type: "role_permission_failure", detail: message.slice(0, 500) }),
+      }).catch(() => { /* logging must never surface a second error */ });
+    }
+
     throw new ApiError(res.status, message, parsed);
   }
 

--- a/frontend/src/lib/errorLog.ts
+++ b/frontend/src/lib/errorLog.ts
@@ -1,0 +1,27 @@
+/**
+ * v1.9 — Production Error Logging (Deliverable 7).
+ *
+ * A thin, fire-and-forget client for POST /api/pilot/error-log. Never
+ * throws and never blocks the caller's own error handling — logging a
+ * failure must never itself become a second failure the user has to deal
+ * with. `detail` must be a short, developer-facing reason (an exception
+ * message or HTTP status) — never image data, patient/procedure
+ * identifiers, or any other PHI.
+ */
+import { apiFetch } from "@/lib/api";
+
+export type PilotErrorType =
+  | "upload_failure"
+  | "ai_analysis_failure"
+  | "baseline_lookup_failure"
+  | "role_permission_failure"
+  | "report_generation_failure";
+
+export function logPilotError(errorType: PilotErrorType, detail: string, inspectionId?: number): void {
+  apiFetch("/api/pilot-deployment/error-log", {
+    method: "POST",
+    body: { error_type: errorType, detail: String(detail).slice(0, 500), inspection_id: inspectionId },
+  }).catch(() => {
+    // Logging itself must never surface a second error to the user.
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -86,6 +86,7 @@ const ClinicalReadinessPage = lazy(() => import("./pages/ClinicalReadinessPage")
 const InspectionWorkQueuePage = lazy(() => import("./pages/InspectionWorkQueuePage"));
 const OperationsBoardPage = lazy(() => import("./pages/OperationsBoardPage"));
 const KnowledgeCenterPage = lazy(() => import("./pages/KnowledgeCenterPage"));
+const PilotDataCollectionPage = lazy(() => import("./pages/PilotDataCollectionPage"));
 const DemoImageLibraryPage = lazy(() => import("./pages/DemoImageLibraryPage"));
 const BaselineImageUploadPage = lazy(() => import("./pages/BaselineImageUploadPage"));
 const InspectionImageUploadPage = lazy(() => import("./pages/InspectionImageUploadPage"));
@@ -393,6 +394,7 @@ function App() {
                       <Route path="/inspection-work-queue" element={<Page name="InspectionWorkQueue"><InspectionWorkQueuePage /></Page>} />
                       <Route path="/operations-board" element={<Page name="OperationsBoard"><RequireRole allowed={ELEVATED_ROLES}><OperationsBoardPage /></RequireRole></Page>} />
                       <Route path="/knowledge-center" element={<Page name="KnowledgeCenter"><KnowledgeCenterPage /></Page>} />
+                      <Route path="/pilot-data-collection" element={<Page name="PilotDataCollection"><RequireRole allowed={["admin", "spd_manager"]}><PilotDataCollectionPage /></RequireRole></Page>} />
                       <Route path="/baseline-library" element={<Page name="BaselineLibrary"><BaselineLibraryPage /></Page>} />
                       <Route path="/instrument-passport" element={<Page name="InstrumentPassport"><InstrumentPassportPage /></Page>} />
                       <Route path="/executive-command-center" element={<Page name="CommandCenter"><ExecutiveCommandCenterPage /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -85,6 +85,7 @@ const QualityDashboardPage = lazy(() => import("./pages/QualityDashboardPage"));
 const ClinicalReadinessPage = lazy(() => import("./pages/ClinicalReadinessPage"));
 const InspectionWorkQueuePage = lazy(() => import("./pages/InspectionWorkQueuePage"));
 const OperationsBoardPage = lazy(() => import("./pages/OperationsBoardPage"));
+const KnowledgeCenterPage = lazy(() => import("./pages/KnowledgeCenterPage"));
 const DemoImageLibraryPage = lazy(() => import("./pages/DemoImageLibraryPage"));
 const BaselineImageUploadPage = lazy(() => import("./pages/BaselineImageUploadPage"));
 const InspectionImageUploadPage = lazy(() => import("./pages/InspectionImageUploadPage"));
@@ -391,6 +392,7 @@ function App() {
                       <Route path="/clinical-readiness" element={<Page name="ClinicalReadiness"><ClinicalReadinessPage /></Page>} />
                       <Route path="/inspection-work-queue" element={<Page name="InspectionWorkQueue"><InspectionWorkQueuePage /></Page>} />
                       <Route path="/operations-board" element={<Page name="OperationsBoard"><RequireRole allowed={ELEVATED_ROLES}><OperationsBoardPage /></RequireRole></Page>} />
+                      <Route path="/knowledge-center" element={<Page name="KnowledgeCenter"><KnowledgeCenterPage /></Page>} />
                       <Route path="/baseline-library" element={<Page name="BaselineLibrary"><BaselineLibraryPage /></Page>} />
                       <Route path="/instrument-passport" element={<Page name="InstrumentPassport"><InstrumentPassportPage /></Page>} />
                       <Route path="/executive-command-center" element={<Page name="CommandCenter"><ExecutiveCommandCenterPage /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -65,6 +65,7 @@ const FindingsQueuePage = lazy(() => import("./pages/FindingsQueuePage"));
 const CapaQueuePage = lazy(() => import("./pages/CapaQueuePage"));
 const AnalyticsDashboardPage = lazy(() => import("./pages/AnalyticsDashboardPage"));
 const PilotAnalyticsDashboard = lazy(() => import("./pages/PilotAnalyticsDashboard"));
+const PreSterilizationCommandCenter = lazy(() => import("./pages/PreSterilizationCommandCenter"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
 const GrowthConsole = lazy(() => import("./pages/GrowthConsole"));
@@ -357,6 +358,7 @@ function App() {
                       <Route path="/vendor-baseline-portal" element={<Page name="VendorBaselines"><VendorBaselinePortalPage /></Page>} />
                       <Route path="/intake-history" element={<Page name="IntakeHistory"><IntakeHistoryPage /></Page>} />
                       <Route path="/pilot-analytics" element={<Page name="PilotAnalytics"><PilotAnalyticsDashboard /></Page>} />
+                      <Route path="/pre-sterilization-command-center" element={<Page name="PreSterilizationCommandCenter"><PreSterilizationCommandCenter /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />
                       <Route path="/growth" element={<Page name="Growth"><GrowthConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -83,6 +83,8 @@ const DigitalTwinPage = lazy(() => import("./pages/DigitalTwinPage"));
 const QualityIntelligencePage = lazy(() => import("./pages/QualityIntelligencePage"));
 const QualityDashboardPage = lazy(() => import("./pages/QualityDashboardPage"));
 const ClinicalReadinessPage = lazy(() => import("./pages/ClinicalReadinessPage"));
+const InspectionWorkQueuePage = lazy(() => import("./pages/InspectionWorkQueuePage"));
+const OperationsBoardPage = lazy(() => import("./pages/OperationsBoardPage"));
 const DemoImageLibraryPage = lazy(() => import("./pages/DemoImageLibraryPage"));
 const BaselineImageUploadPage = lazy(() => import("./pages/BaselineImageUploadPage"));
 const InspectionImageUploadPage = lazy(() => import("./pages/InspectionImageUploadPage"));
@@ -387,6 +389,8 @@ function App() {
                       <Route path="/quality-intelligence" element={<Page name="QualityIntelligence"><QualityIntelligencePage /></Page>} />
                       <Route path="/quality-dashboard" element={<Page name="QualityDashboard"><QualityDashboardPage /></Page>} />
                       <Route path="/clinical-readiness" element={<Page name="ClinicalReadiness"><ClinicalReadinessPage /></Page>} />
+                      <Route path="/inspection-work-queue" element={<Page name="InspectionWorkQueue"><InspectionWorkQueuePage /></Page>} />
+                      <Route path="/operations-board" element={<Page name="OperationsBoard"><RequireRole allowed={ELEVATED_ROLES}><OperationsBoardPage /></RequireRole></Page>} />
                       <Route path="/baseline-library" element={<Page name="BaselineLibrary"><BaselineLibraryPage /></Page>} />
                       <Route path="/instrument-passport" element={<Page name="InstrumentPassport"><InstrumentPassportPage /></Page>} />
                       <Route path="/executive-command-center" element={<Page name="CommandCenter"><ExecutiveCommandCenterPage /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -82,6 +82,7 @@ const VendorIntelligencePage = lazy(() => import("./pages/VendorIntelligencePage
 const DigitalTwinPage = lazy(() => import("./pages/DigitalTwinPage"));
 const QualityIntelligencePage = lazy(() => import("./pages/QualityIntelligencePage"));
 const QualityDashboardPage = lazy(() => import("./pages/QualityDashboardPage"));
+const ClinicalReadinessPage = lazy(() => import("./pages/ClinicalReadinessPage"));
 const DemoImageLibraryPage = lazy(() => import("./pages/DemoImageLibraryPage"));
 const BaselineImageUploadPage = lazy(() => import("./pages/BaselineImageUploadPage"));
 const InspectionImageUploadPage = lazy(() => import("./pages/InspectionImageUploadPage"));
@@ -385,6 +386,7 @@ function App() {
                       <Route path="/digital-twin" element={<Page name="DigitalTwin"><DigitalTwinPage /></Page>} />
                       <Route path="/quality-intelligence" element={<Page name="QualityIntelligence"><QualityIntelligencePage /></Page>} />
                       <Route path="/quality-dashboard" element={<Page name="QualityDashboard"><QualityDashboardPage /></Page>} />
+                      <Route path="/clinical-readiness" element={<Page name="ClinicalReadiness"><ClinicalReadinessPage /></Page>} />
                       <Route path="/baseline-library" element={<Page name="BaselineLibrary"><BaselineLibraryPage /></Page>} />
                       <Route path="/instrument-passport" element={<Page name="InstrumentPassport"><InstrumentPassportPage /></Page>} />
                       <Route path="/executive-command-center" element={<Page name="CommandCenter"><ExecutiveCommandCenterPage /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -67,6 +67,7 @@ const AnalyticsDashboardPage = lazy(() => import("./pages/AnalyticsDashboardPage
 const PilotAnalyticsDashboard = lazy(() => import("./pages/PilotAnalyticsDashboard"));
 const PreSterilizationCommandCenter = lazy(() => import("./pages/PreSterilizationCommandCenter"));
 const KnowledgeGraphExplorer = lazy(() => import("./pages/KnowledgeGraphExplorer"));
+const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
 const GrowthConsole = lazy(() => import("./pages/GrowthConsole"));
@@ -361,6 +362,7 @@ function App() {
                       <Route path="/pilot-analytics" element={<Page name="PilotAnalytics"><PilotAnalyticsDashboard /></Page>} />
                       <Route path="/pre-sterilization-command-center" element={<Page name="PreSterilizationCommandCenter"><PreSterilizationCommandCenter /></Page>} />
                       <Route path="/knowledge-graph" element={<Page name="KnowledgeGraph"><KnowledgeGraphExplorer /></Page>} />
+                      <Route path="/agent-trace" element={<Page name="AgentTrace"><AgentTraceViewer /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />
                       <Route path="/growth" element={<Page name="Growth"><GrowthConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -66,6 +66,7 @@ const CapaQueuePage = lazy(() => import("./pages/CapaQueuePage"));
 const AnalyticsDashboardPage = lazy(() => import("./pages/AnalyticsDashboardPage"));
 const PilotAnalyticsDashboard = lazy(() => import("./pages/PilotAnalyticsDashboard"));
 const PreSterilizationCommandCenter = lazy(() => import("./pages/PreSterilizationCommandCenter"));
+const KnowledgeGraphExplorer = lazy(() => import("./pages/KnowledgeGraphExplorer"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
 const GrowthConsole = lazy(() => import("./pages/GrowthConsole"));
@@ -359,6 +360,7 @@ function App() {
                       <Route path="/intake-history" element={<Page name="IntakeHistory"><IntakeHistoryPage /></Page>} />
                       <Route path="/pilot-analytics" element={<Page name="PilotAnalytics"><PilotAnalyticsDashboard /></Page>} />
                       <Route path="/pre-sterilization-command-center" element={<Page name="PreSterilizationCommandCenter"><PreSterilizationCommandCenter /></Page>} />
+                      <Route path="/knowledge-graph" element={<Page name="KnowledgeGraph"><KnowledgeGraphExplorer /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />
                       <Route path="/growth" element={<Page name="Growth"><GrowthConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -100,6 +100,8 @@ const ImageQualityPage = lazy(() => import("./pages/ImageQualityPage"));
 const GoLiveCenterPage = lazy(() => import("./pages/GoLiveCenterPage"));
 const ImplementationTrackerPage = lazy(() => import("./pages/ImplementationTrackerPage"));
 const TrainingCompliancePage = lazy(() => import("./pages/TrainingCompliancePage"));
+const EducationLibraryPage = lazy(() => import("./pages/EducationLibraryPage"));
+const SupervisorCoachingDashboard = lazy(() => import("./pages/SupervisorCoachingDashboard"));
 const BaselineReadinessPage = lazy(() => import("./pages/BaselineReadinessPage"));
 const InspectionReadinessPage = lazy(() => import("./pages/InspectionReadinessPage"));
 const ExecutiveAdoptionPage = lazy(() => import("./pages/ExecutiveAdoptionPage"));
@@ -387,6 +389,8 @@ function App() {
                       <Route path="/go-live-center" element={<Page name="GoLiveCenter"><GoLiveCenterPage /></Page>} />
                       <Route path="/implementation-tracker" element={<Page name="ImplementationTracker"><ImplementationTrackerPage /></Page>} />
                       <Route path="/training-compliance" element={<Page name="TrainingCompliance"><TrainingCompliancePage /></Page>} />
+                      <Route path="/education-library" element={<Page name="EducationLibrary"><EducationLibraryPage /></Page>} />
+                      <Route path="/coaching-dashboard" element={<Page name="CoachingDashboard"><RequireRole allowed={ELEVATED_ROLES}><SupervisorCoachingDashboard /></RequireRole></Page>} />
                       <Route path="/baseline-readiness" element={<Page name="BaselineReadiness"><BaselineReadinessPage /></Page>} />
                       <Route path="/inspection-readiness" element={<Page name="InspectionReadiness"><InspectionReadinessPage /></Page>} />
                       <Route path="/executive-adoption" element={<Page name="ExecutiveAdoption"><ExecutiveAdoptionPage /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -68,6 +68,7 @@ const PilotAnalyticsDashboard = lazy(() => import("./pages/PilotAnalyticsDashboa
 const PreSterilizationCommandCenter = lazy(() => import("./pages/PreSterilizationCommandCenter"));
 const KnowledgeGraphExplorer = lazy(() => import("./pages/KnowledgeGraphExplorer"));
 const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
+const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
 const GrowthConsole = lazy(() => import("./pages/GrowthConsole"));
@@ -363,6 +364,7 @@ function App() {
                       <Route path="/pre-sterilization-command-center" element={<Page name="PreSterilizationCommandCenter"><PreSterilizationCommandCenter /></Page>} />
                       <Route path="/knowledge-graph" element={<Page name="KnowledgeGraph"><KnowledgeGraphExplorer /></Page>} />
                       <Route path="/agent-trace" element={<Page name="AgentTrace"><AgentTraceViewer /></Page>} />
+                      <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />
                       <Route path="/growth" element={<Page name="Growth"><GrowthConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -116,6 +116,10 @@ const ROICenterPage = lazy(() => import("./pages/ROICenterPage"));
 const SubscriptionReadinessPage = lazy(() => import("./pages/SubscriptionReadinessPage"));
 const DashboardApp = lazy(() => import("./pages/DashboardApp"));
 const LoginPage = lazy(() => import("./pages/LoginPage"));
+const InstrumentLibraryPage = lazy(() => import("./pages/InstrumentLibraryPage"));
+const AnatomyLibraryPage = lazy(() => import("./pages/AnatomyLibraryPage"));
+const InspectionZonesPage = lazy(() => import("./pages/InspectionZonesPage"));
+const CoverageDashboardPage = lazy(() => import("./pages/CoverageDashboardPage"));
 
 // ─── Loading spinner shown during lazy chunk loads ────────────────────────────
 
@@ -405,6 +409,10 @@ function App() {
                       <Route path="/training-center" element={<Page name="TrainingCenter"><TrainingCenterPage /></Page>} />
                       <Route path="/roi-center" element={<Page name="ROICenter"><ROICenterPage /></Page>} />
                       <Route path="/subscription-readiness" element={<Page name="SubscriptionReadiness"><SubscriptionReadinessPage /></Page>} />
+                      <Route path="/instrument-library" element={<Page name="InstrumentLibrary"><InstrumentLibraryPage /></Page>} />
+                      <Route path="/anatomy-library" element={<Page name="AnatomyLibrary"><AnatomyLibraryPage /></Page>} />
+                      <Route path="/inspection-zones" element={<Page name="InspectionZones"><InspectionZonesPage /></Page>} />
+                      <Route path="/coverage-dashboard" element={<Page name="CoverageDashboard"><CoverageDashboardPage /></Page>} />
                       <Route path="/legacy" element={<Page name="Legacy"><DashboardApp /></Page>} />
                       <Route path="*" element={<NotFound />} />
                     </Routes>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -77,6 +77,7 @@ const GlobalInfrastructureConsole = lazy(() => import("./pages/GlobalInfrastruct
 const VendorIntelligencePage = lazy(() => import("./pages/VendorIntelligencePage"));
 const DigitalTwinPage = lazy(() => import("./pages/DigitalTwinPage"));
 const QualityIntelligencePage = lazy(() => import("./pages/QualityIntelligencePage"));
+const QualityDashboardPage = lazy(() => import("./pages/QualityDashboardPage"));
 const DemoImageLibraryPage = lazy(() => import("./pages/DemoImageLibraryPage"));
 const BaselineImageUploadPage = lazy(() => import("./pages/BaselineImageUploadPage"));
 const InspectionImageUploadPage = lazy(() => import("./pages/InspectionImageUploadPage"));
@@ -371,6 +372,7 @@ function App() {
                       <Route path="/vendor-intelligence" element={<Page name="VendorIntelligence"><VendorIntelligencePage /></Page>} />
                       <Route path="/digital-twin" element={<Page name="DigitalTwin"><DigitalTwinPage /></Page>} />
                       <Route path="/quality-intelligence" element={<Page name="QualityIntelligence"><QualityIntelligencePage /></Page>} />
+                      <Route path="/quality-dashboard" element={<Page name="QualityDashboard"><QualityDashboardPage /></Page>} />
                       <Route path="/baseline-library" element={<Page name="BaselineLibrary"><BaselineLibraryPage /></Page>} />
                       <Route path="/instrument-passport" element={<Page name="InstrumentPassport"><InstrumentPassportPage /></Page>} />
                       <Route path="/executive-command-center" element={<Page name="CommandCenter"><ExecutiveCommandCenterPage /></Page>} />

--- a/frontend/src/pages/AgentTraceViewer.tsx
+++ b/frontend/src/pages/AgentTraceViewer.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem("token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function fetchJSON(path: string) {
+  const res = await fetch(`${API_BASE}${path}`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+interface AgentInfo {
+  name: string;
+  version: string;
+  capabilities: string[];
+  depends_on: string[];
+  pipeline_position: number;
+  status: string;
+  health: string;
+}
+
+interface TraceEntry {
+  agent: string;
+  version: string;
+  input_summary: Record<string, unknown>;
+  output_summary: Record<string, unknown>;
+}
+
+function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="mb-3">
+      <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+      {subtitle && <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>}
+    </div>
+  );
+}
+
+function summarize(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (Array.isArray(value)) return value.length ? value.join(", ") : "none";
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return "—";
+    return entries.slice(0, 3).map(([k, v]) => `${k}: ${summarize(v)}`).join(" · ");
+  }
+  return String(value);
+}
+
+function TraceCard({ entry, index, total }: { entry: TraceEntry; index: number; total: number }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="relative">
+      <div className="rounded-lg border bg-white p-4">
+        <button className="w-full text-left flex items-center justify-between" onClick={() => setExpanded((e) => !e)}>
+          <div>
+            <p className="text-xs text-gray-400">Step {index + 1} of {total}</p>
+            <p className="font-semibold text-gray-900">{entry.agent}</p>
+          </div>
+          <span className="text-xs text-gray-400">v{entry.version}</span>
+        </button>
+        {expanded && (
+          <div className="mt-3 grid md:grid-cols-2 gap-3 text-sm">
+            <div>
+              <p className="font-medium text-gray-700 mb-1">Input</p>
+              <pre className="text-xs bg-gray-50 border rounded p-2 overflow-x-auto">{JSON.stringify(entry.input_summary, null, 2)}</pre>
+            </div>
+            <div>
+              <p className="font-medium text-gray-700 mb-1">Output</p>
+              <pre className="text-xs bg-gray-50 border rounded p-2 overflow-x-auto">{JSON.stringify(entry.output_summary, null, 2)}</pre>
+            </div>
+          </div>
+        )}
+        {!expanded && (
+          <p className="text-xs text-gray-500 mt-2">{summarize(entry.output_summary)}</p>
+        )}
+      </div>
+      {index < total - 1 && <div className="h-4 w-px bg-gray-300 mx-auto" />}
+    </div>
+  );
+}
+
+export default function AgentTraceViewer() {
+  const [inspectionId, setInspectionId] = useState("");
+  const [registry, setRegistry] = useState<AgentInfo[]>([]);
+  const [trace, setTrace] = useState<TraceEntry[] | null>(null);
+  const [finalRecommendation, setFinalRecommendation] = useState<Record<string, unknown> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchJSON("/api/agents/registry").then((d) => setRegistry(d.agents)).catch(() => {});
+  }, []);
+
+  const runTrace = () => {
+    if (!inspectionId) return;
+    setLoading(true);
+    setError(null);
+    fetchJSON(`/api/agents/trace/${inspectionId}`)
+      .then((d) => {
+        setTrace(d.trace);
+        setFinalRecommendation(d.final_recommendation);
+      })
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <div className="p-6 space-y-8 max-w-5xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Explainable Agent Trace</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Which specialized agent produced which decision — instrument identity through anatomy,
+          findings, risk, and recommended action.
+        </p>
+      </div>
+
+      <section>
+        <SectionHeader title="Agent Registry" subtitle="The ten agents in the pipeline, in order." />
+        <div className="grid md:grid-cols-2 gap-3">
+          {registry.map((a) => (
+            <div key={a.name} className="rounded-lg border bg-white p-3 text-sm flex items-center justify-between">
+              <div>
+                <span className="font-medium text-gray-900">{a.pipeline_position}. {a.name}</span>
+                <p className="text-xs text-gray-500">{a.capabilities.join(", ")}</p>
+              </div>
+              <span className={`text-xs font-semibold px-2 py-0.5 rounded ${a.health === "ok" ? "bg-green-50 text-green-700 border border-green-200" : "bg-red-50 text-red-700 border border-red-200"}`}>
+                {a.health}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="Trace an Inspection" subtitle="Enter an inspection ID to see the full agent-by-agent reasoning trace." />
+        <div className="flex gap-2 mb-4">
+          <input
+            value={inspectionId}
+            onChange={(e) => setInspectionId(e.target.value)}
+            placeholder="Inspection ID"
+            className="text-sm border rounded px-2 py-1 flex-1"
+            onKeyDown={(e) => e.key === "Enter" && runTrace()}
+          />
+          <button onClick={runTrace} className="text-sm bg-blue-600 text-white rounded px-3 py-1">
+            Trace
+          </button>
+        </div>
+        {loading && <p className="text-sm text-gray-400">Running the agent pipeline…</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {trace && (
+          <div className="space-y-0">
+            {trace.map((entry, i) => (
+              <TraceCard key={entry.agent} entry={entry} index={i} total={trace.length} />
+            ))}
+          </div>
+        )}
+        {finalRecommendation && (
+          <div className="mt-4 rounded-lg border border-blue-300 bg-blue-50 p-4">
+            <p className="text-sm font-semibold text-blue-900">Final recommendation: {String(finalRecommendation.readiness_state)}</p>
+            <p className="text-sm text-blue-800 mt-1">{String(finalRecommendation.explanation)}</p>
+          </div>
+        )}
+      </section>
+
+      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+        ⚠ Every agent's output is advisory. The Supervisor Agent never fabricates a review — a real
+        supervisor decision is required before any instrument's disposition is final.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/AnatomyLibraryPage.tsx
+++ b/frontend/src/pages/AnatomyLibraryPage.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://lumen-ai-53u4.onrender.com";
+
+interface AnatomyFamilySummary {
+  family: string;
+  category: string;
+  zone_names: string[];
+  required_images: string[];
+  min_images: number;
+  high_risk_zones: string[];
+}
+
+interface AnatomyProfile {
+  family: string;
+  category: string;
+  instrument_family: string;
+  profile_found: boolean;
+  zone_names: string[];
+  required_zones: string[];
+  high_risk_zones: string[];
+  recommended_image_views: string[];
+  zone_descriptions: Record<string, string>;
+  contamination_risks: Record<string, string[]>;
+  condition_risks: Record<string, string[]>;
+  manual_check_steps: string[];
+  warning: string | null;
+}
+
+function Tag({ children, tone = "slate" }: { children: React.ReactNode; tone?: "slate" | "red" }) {
+  const cls = tone === "red" ? "bg-red-50 text-red-700" : "bg-slate-100 text-slate-700";
+  return <span className={`inline-block text-xs ${cls} rounded px-2 py-0.5 mr-1 mb-1`}>{children}</span>;
+}
+
+function LookupPanel() {
+  const { headers } = useAuth();
+  const [instrumentType, setInstrumentType] = useState("rigid scope");
+  const [manufacturer, setManufacturer] = useState("");
+  const [model, setModel] = useState("");
+  const [profile, setProfile] = useState<AnatomyProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = () => {
+    setLoading(true);
+    setError(null);
+    const params = new URLSearchParams();
+    if (manufacturer) params.set("manufacturer", manufacturer);
+    if (model) params.set("model", model);
+    fetch(`${API_BASE}/api/instrument-anatomy/${encodeURIComponent(instrumentType)}?${params}`, { headers: headers() })
+      .then((r) => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}`); return r.json(); })
+      .then(setProfile)
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { run(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input value={instrumentType} onChange={(e) => setInstrumentType(e.target.value)} placeholder="Instrument type"
+          className="text-sm border border-slate-300 rounded px-2 py-1 flex-1 min-w-[160px]" />
+        <input value={manufacturer} onChange={(e) => setManufacturer(e.target.value)} placeholder="Manufacturer (optional)"
+          className="text-sm border border-slate-300 rounded px-2 py-1 flex-1 min-w-[160px]" />
+        <input value={model} onChange={(e) => setModel(e.target.value)} placeholder="Model (optional)"
+          className="text-sm border border-slate-300 rounded px-2 py-1 flex-1 min-w-[160px]" />
+        <button onClick={run} className="text-sm bg-blue-600 text-white rounded px-3 py-1">Resolve anatomy profile</button>
+      </div>
+      {loading && <p className="text-sm text-slate-400">Resolving…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {profile && !loading && (
+        <div className="space-y-2 text-sm">
+          {profile.warning && (
+            <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1">{profile.warning}</p>
+          )}
+          <p><span className="font-medium">Instrument family:</span> {profile.instrument_family} <span className="text-slate-400">({profile.category})</span></p>
+          <div><span className="font-medium">Anatomy zones: </span>{profile.zone_names.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">Required zones: </span>{profile.required_zones.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">High-risk zones: </span>{profile.high_risk_zones.map((z) => <Tag key={z} tone="red">{z}</Tag>)}</div>
+          <div><span className="font-medium">Recommended image views: </span>{profile.recommended_image_views.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div>
+            <span className="font-medium">Zone descriptions:</span>
+            <ul className="mt-1 list-disc list-inside text-slate-700">
+              {Object.entries(profile.zone_descriptions).map(([zone, desc]) => (
+                <li key={zone}><span className="font-medium capitalize">{zone}:</span> {desc}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <span className="font-medium">Manual check steps:</span>
+            <ul className="mt-1 list-disc list-inside text-slate-700">
+              {profile.manual_check_steps.map((s, i) => <li key={i}>{s}</li>)}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FamilyCard({ f }: { f: AnatomyFamilySummary }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <button className="w-full text-left" onClick={() => setExpanded((e) => !e)}>
+        <p className="font-semibold text-slate-900 capitalize">{f.family.replace(/_/g, " ")}</p>
+        <p className="text-xs text-slate-500 mt-1">{f.category} · min {f.min_images} required image{f.min_images === 1 ? "" : "s"}</p>
+      </button>
+      {expanded && (
+        <div className="mt-3 space-y-2 text-sm border-t border-slate-100 pt-3">
+          <div><span className="font-medium">Zones: </span>{f.zone_names.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">Required images: </span>{f.required_images.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">High-risk zones: </span>{f.high_risk_zones.map((z) => <Tag key={z} tone="red">{z}</Tag>)}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function AnatomyLibraryPage() {
+  const { headers } = useAuth();
+  const [families, setFamilies] = useState<AnatomyFamilySummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/instrument-anatomy`, { headers: headers() })
+      .then((r) => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}`); return r.json(); })
+      .then((d) => setFamilies(d.families ?? []))
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="p-6 space-y-8 max-w-6xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">Anatomy Library</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          The Anatomy Profile Service: every declared instrument-family zone taxonomy, required image views,
+          and high-risk zones — the same data LumenAI resolves before contamination/damage analysis.
+        </p>
+      </div>
+
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900 mb-3">Resolve a profile</h2>
+        <LookupPanel />
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900 mb-3">Browse anatomy families</h2>
+        {loading && <p className="text-sm text-slate-400">Loading…</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {families.map((f) => <FamilyCard key={f.family} f={f} />)}
+        </div>
+      </section>
+
+      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+        ⚠ Unrecognized instruments fall back to a generic SPD profile with a supervisor-review flag — nothing
+        is fabricated as a specific match.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/CIOSDashboard.tsx
+++ b/frontend/src/pages/CIOSDashboard.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem("token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function fetchJSON(path: string) {
+  const res = await fetch(`${API_BASE}${path}`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+interface Dashboard {
+  system_health: { overall_status: string; degraded_agents: string[]; agent_count: number };
+  inspection_throughput: number;
+  average_inspection_time_minutes: number | null;
+  coverage_rate: number | null;
+  supervisor_agreement_rate: number | null;
+  ai_confidence: number | null;
+  governance_versions: Record<string, string>;
+  digital_twin_health: { available: boolean; snapshot_count: number };
+  most_common_findings: { key: string; count: number }[];
+  most_common_zones: { zone: string; missed_count: number; case_count: number }[];
+  enterprise_risk_index: number | null;
+  readiness_rate: number | null;
+}
+
+function pct(v: number | null): string {
+  return v === null || v === undefined ? "—" : `${Math.round(v * 100)}%`;
+}
+
+function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="mb-3">
+      <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+      {subtitle && <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>}
+    </div>
+  );
+}
+
+function KPI({ label, value, tone }: { label: string; value: string | number; tone?: "danger" | "warning" | "ok" }) {
+  const toneClass =
+    tone === "danger" ? "border-red-300 bg-red-50 text-red-800"
+    : tone === "warning" ? "border-amber-300 bg-amber-50 text-amber-800"
+    : tone === "ok" ? "border-green-300 bg-green-50 text-green-800"
+    : "border-gray-200 bg-white text-gray-900";
+  return (
+    <div className={`rounded-lg border p-4 ${toneClass}`}>
+      <p className="text-xs font-medium uppercase tracking-wide opacity-70">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
+    </div>
+  );
+}
+
+export default function CIOSDashboard() {
+  const [dashboard, setDashboard] = useState<Dashboard | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchJSON("/api/cios/dashboard")
+      .then(setDashboard)
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div className="p-6 text-gray-500">Loading Clinical Intelligence Operating System dashboard…</div>;
+  if (error) return <div className="p-6 text-red-600">Failed to load CIOS dashboard: {error}</div>;
+  if (!dashboard) return null;
+
+  const riskTone =
+    dashboard.enterprise_risk_index === null ? undefined
+    : dashboard.enterprise_risk_index <= 20 ? "ok"
+    : dashboard.enterprise_risk_index <= 45 ? "warning"
+    : "danger";
+
+  return (
+    <div className="p-6 space-y-8 max-w-7xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">LumenAI Clinical Intelligence Operating System</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Every inspection follows one governed, explainable, anatomy-aware, knowledge-driven workflow
+          before an instrument is approved to proceed to packaging and sterilization.
+        </p>
+      </div>
+
+      <section>
+        <SectionHeader title="System Health" />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <KPI
+            label="Overall status"
+            value={dashboard.system_health.overall_status.toUpperCase()}
+            tone={dashboard.system_health.overall_status === "ok" ? "ok" : "danger"}
+          />
+          <KPI label="Active agents" value={dashboard.system_health.agent_count} />
+          <KPI label="Inspection throughput" value={dashboard.inspection_throughput} />
+          <KPI
+            label="Avg. inspection time"
+            value={dashboard.average_inspection_time_minutes !== null ? `${dashboard.average_inspection_time_minutes} min` : "—"}
+          />
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="Clinical Quality Indicators" />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <KPI label="Readiness rate" value={pct(dashboard.readiness_rate)} />
+          <KPI label="Coverage rate" value={pct(dashboard.coverage_rate)} />
+          <KPI label="Supervisor agreement" value={pct(dashboard.supervisor_agreement_rate)} />
+          <KPI label="AI confidence" value={dashboard.ai_confidence !== null ? dashboard.ai_confidence.toFixed(1) : "—"} />
+          <KPI
+            label="Enterprise risk index"
+            value={dashboard.enterprise_risk_index !== null ? dashboard.enterprise_risk_index : "—"}
+            tone={riskTone}
+          />
+          <KPI
+            label="Digital twin"
+            value={dashboard.digital_twin_health.available ? `${dashboard.digital_twin_health.snapshot_count} snapshots` : "Unavailable"}
+            tone={dashboard.digital_twin_health.available ? "ok" : undefined}
+          />
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="Platform Governance" subtitle="Every inspection references these versions." />
+        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-3">
+          {Object.entries(dashboard.governance_versions).map(([key, value]) => (
+            <div key={key} className="rounded-lg border bg-white p-3 text-sm">
+              <p className="text-xs text-gray-500 uppercase">{key.replace(/_/g, " ")}</p>
+              <p className="font-semibold text-gray-900">{value}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="Most Common Findings" />
+        <div className="rounded-lg border bg-white divide-y">
+          {dashboard.most_common_findings.map((f) => (
+            <div key={f.key} className="p-3 text-sm flex justify-between">
+              <span>{f.key}</span>
+              <span className="text-gray-500">{f.count}</span>
+            </div>
+          ))}
+          {dashboard.most_common_findings.length === 0 && (
+            <div className="p-6 text-center text-gray-400">No findings yet.</div>
+          )}
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="Most Missed Anatomy Zones" />
+        <div className="rounded-lg border bg-white divide-y">
+          {dashboard.most_common_zones.map((z) => (
+            <div key={z.zone} className="p-3 text-sm flex justify-between">
+              <span>{z.zone}</span>
+              <span className="text-gray-500">{z.missed_count}/{z.case_count} missed</span>
+            </div>
+          ))}
+          {dashboard.most_common_zones.length === 0 && (
+            <div className="p-6 text-center text-gray-400">No pilot validation ground truth yet.</div>
+          )}
+        </div>
+      </section>
+
+      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+        ⚠ The Enterprise Risk Index is a composite indicator (readiness rate, coverage rate, supervisor
+        agreement), not a validated clinical risk score. All figures require human review before action.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/ClinicalReadinessPage.tsx
+++ b/frontend/src/pages/ClinicalReadinessPage.tsx
@@ -1,0 +1,201 @@
+import { useState, useEffect } from "react";
+import { ShieldCheck } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+
+interface Dashboard {
+  ready_for_packaging: number;
+  requires_recleaning: number;
+  requires_repair: number;
+  remove_from_service: number;
+  supervisor_pending: number;
+  average_readiness_score: number | null;
+  disposition_trends: Record<string, number>;
+  total_inspections: number;
+}
+
+interface EnterpriseAnalytics {
+  readiness_trends: { total_inspections: number; average_readiness_score: number | null };
+  disposition_distribution: Record<string, number>;
+  supervisor_overrides: Record<string, number>;
+  repair_referrals: number;
+  high_risk_instrument_families: { family: string; total: number; high_risk_count: number; high_risk_rate_pct: number | null }[];
+  most_common_disposition_reasons: Record<string, string>;
+}
+
+function Stat({ label, value }: { label: string; value: number | string | null }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="text-xs text-slate-500">{label}</div>
+      <div className="text-2xl font-bold text-slate-900">{value ?? "—"}</div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+export default function ClinicalReadinessPage() {
+  const { role } = useAuth();
+  const isLeadership = role === "admin" || role === "spd_manager";
+  const [dashboard, setDashboard] = useState<Dashboard | null>(null);
+  const [analytics, setAnalytics] = useState<EnterpriseAnalytics | null>(null);
+  const [instrumentIdentity, setInstrumentIdentity] = useState("");
+  const [conditionResult, setConditionResult] = useState<Record<string, unknown> | null>(null);
+  const [conditionError, setConditionError] = useState("");
+
+  useEffect(() => {
+    apiFetch<Dashboard>("/api/clinical-readiness/dashboard").then(setDashboard);
+    if (isLeadership) {
+      apiFetch<EnterpriseAnalytics>("/api/clinical-readiness/enterprise-analytics").then(setAnalytics);
+    }
+  }, [isLeadership]);
+
+  async function lookupInstrument() {
+    setConditionError("");
+    setConditionResult(null);
+    try {
+      const data = await apiFetch<Record<string, unknown>>(
+        `/api/clinical-readiness/instrument-condition?instrument_identity=${encodeURIComponent(instrumentIdentity)}`
+      );
+      setConditionResult(data);
+    } catch {
+      setConditionError("No inspection history found for this instrument identity.");
+    }
+  }
+
+  if (!dashboard) return <div className="p-6 text-sm text-slate-500">Loading…</div>;
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="h-6 w-6 text-teal-600" />
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Clinical Service Readiness</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            Evidence-based disposition recommendations for the remainder of the reprocessing workflow.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <Stat label="Ready for Packaging" value={dashboard.ready_for_packaging} />
+        <Stat label="Requires Recleaning" value={dashboard.requires_recleaning} />
+        <Stat label="Requires Repair" value={dashboard.requires_repair} />
+        <Stat label="Remove From Service" value={dashboard.remove_from_service} />
+        <Stat label="Supervisor Pending" value={dashboard.supervisor_pending} />
+        <Stat label="Avg Readiness Score" value={dashboard.average_readiness_score} />
+      </div>
+
+      <Section title="Disposition Trends">
+        <div className="flex flex-wrap gap-2">
+          {Object.entries(dashboard.disposition_trends).map(([disp, count]) => (
+            <span key={disp} className="text-xs font-medium px-2 py-1 rounded-full bg-slate-100 text-slate-700">
+              {disp}: {count}
+            </span>
+          ))}
+          {Object.keys(dashboard.disposition_trends).length === 0 && (
+            <p className="text-sm text-slate-400">No dispositions recorded yet.</p>
+          )}
+        </div>
+      </Section>
+
+      <Section title="Instrument Condition Lookup">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            placeholder="barcode:XXXX or udi:XXXX"
+            value={instrumentIdentity}
+            onChange={(e) => setInstrumentIdentity(e.target.value)}
+            className="flex-1 rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+          <button onClick={lookupInstrument} className="text-xs font-semibold px-3 py-1.5 rounded bg-teal-600 text-white">
+            Look Up
+          </button>
+        </div>
+        {conditionError && <p className="text-sm text-red-600 mt-2">{conditionError}</p>}
+        {conditionResult && (
+          <div className="mt-2 text-sm space-y-1">
+            <p><span className="text-slate-500">Instrument:</span> {String(conditionResult.instrument_type)}</p>
+            <p><span className="text-slate-500">Inspections:</span> {String(conditionResult.inspection_count)}</p>
+            <p><span className="text-slate-500">Repair count:</span> {String(conditionResult.repair_count)}</p>
+            <p><span className="text-slate-500">Corrosion history:</span> {String(conditionResult.corrosion_history_count)}</p>
+            <p><span className="text-slate-500">Condition trend:</span> {String(conditionResult.condition_trend)}</p>
+          </div>
+        )}
+      </Section>
+
+      {isLeadership && analytics && (
+        <>
+          <Section title="Enterprise Readiness Analytics">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              <Stat label="Total Inspections (180d)" value={analytics.readiness_trends.total_inspections} />
+              <Stat label="Avg Readiness Score" value={analytics.readiness_trends.average_readiness_score} />
+              <Stat label="Repair Referrals" value={analytics.repair_referrals} />
+            </div>
+          </Section>
+
+          <Section title="Disposition Distribution">
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(analytics.disposition_distribution).map(([disp, count]) => (
+                <span key={disp} className="text-xs font-medium px-2 py-1 rounded-full bg-slate-100 text-slate-700">
+                  {disp}: {count}
+                </span>
+              ))}
+            </div>
+          </Section>
+
+          <Section title="Supervisor Overrides">
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(analytics.supervisor_overrides).map(([action, count]) => (
+                <span key={action} className="text-xs font-medium px-2 py-1 rounded-full bg-amber-100 text-amber-800">
+                  {action.replace(/_/g, " ")}: {count}
+                </span>
+              ))}
+              {Object.keys(analytics.supervisor_overrides).length === 0 && (
+                <p className="text-sm text-slate-400">No supervisor overrides recorded yet.</p>
+              )}
+            </div>
+          </Section>
+
+          <Section title="High-Risk Instrument Families">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-400 text-xs">
+                  <th className="py-1 pr-3">Family</th>
+                  <th className="py-1 px-2">Total</th>
+                  <th className="py-1 px-2">High-Risk Count</th>
+                  <th className="py-1 px-2">High-Risk Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {analytics.high_risk_instrument_families.map((f) => (
+                  <tr key={f.family} className="border-t border-slate-100">
+                    <td className="py-1 pr-3 font-medium capitalize">{f.family.replace(/_/g, " ")}</td>
+                    <td className="py-1 px-2">{f.total}</td>
+                    <td className="py-1 px-2">{f.high_risk_count}</td>
+                    <td className="py-1 px-2">{f.high_risk_rate_pct == null ? "—" : `${f.high_risk_rate_pct}%`}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Section>
+
+          <Section title="Most Common Disposition Reasons">
+            <div className="space-y-1.5 text-sm">
+              {Object.entries(analytics.most_common_disposition_reasons).map(([disp, reason]) => (
+                <p key={disp}><span className="font-medium">{disp}:</span> {reason}</p>
+              ))}
+            </div>
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/CoverageDashboardPage.tsx
+++ b/frontend/src/pages/CoverageDashboardPage.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://lumen-ai-53u4.onrender.com";
+
+interface RecentInspection {
+  inspection_id: number;
+  instrument_type: string;
+  coverage_score: number | null;
+  coverage_status: string;
+  missing: string[];
+  created_at: string | null;
+}
+
+interface CoverageDashboard {
+  total_inspections_with_image: number;
+  assessed_count: number;
+  not_assessed_count: number;
+  average_coverage: number | null;
+  coverage_status_breakdown: Record<string, number>;
+  average_coverage_by_family: Record<string, number>;
+  most_commonly_missing_zones: { zone: string; missed_count: number }[];
+  recent_inspections: RecentInspection[];
+  note: string;
+}
+
+const STATUS_STYLE: Record<string, string> = {
+  complete: "bg-emerald-100 text-emerald-800",
+  acceptable: "bg-amber-100 text-amber-800",
+  incomplete: "bg-orange-100 text-orange-800",
+  insufficient: "bg-red-100 text-red-800",
+  not_assessed: "bg-slate-100 text-slate-500",
+};
+
+function StatTile({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="text-2xl font-bold text-slate-900 mt-1">{value}</p>
+    </div>
+  );
+}
+
+export default function CoverageDashboardPage() {
+  const { headers } = useAuth();
+  const [data, setData] = useState<CoverageDashboard | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/coverage-dashboard/summary`, { headers: headers() })
+      .then((r) => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}`); return r.json(); })
+      .then(setData)
+      .catch((e) => setError(String(e)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="p-6 space-y-8 max-w-6xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">Inspection Coverage Dashboard</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          Real aggregate coverage stats computed from stored inspections — how completely required anatomy zones
+          are being imaged before AI analysis, across the fleet.
+        </p>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {!data && !error && <p className="text-sm text-slate-400">Loading…</p>}
+
+      {data && (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <StatTile label="Average Coverage" value={data.average_coverage != null ? `${data.average_coverage}%` : "Not enough data"} />
+            <StatTile label="Assessed Inspections" value={data.assessed_count} />
+            <StatTile label="Not Assessed" value={data.not_assessed_count} />
+            <StatTile label="Total (with image)" value={data.total_inspections_with_image} />
+          </div>
+
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 mb-3">Coverage status breakdown</h2>
+            <div className="flex flex-wrap gap-3">
+              {Object.entries(data.coverage_status_breakdown).map(([status, count]) => (
+                <span key={status} className={`rounded-full px-3 py-1.5 text-sm font-medium capitalize ${STATUS_STYLE[status] ?? "bg-slate-100"}`}>
+                  {status}: {count}
+                </span>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 mb-3">Average coverage by instrument family</h2>
+            {Object.keys(data.average_coverage_by_family).length === 0 ? (
+              <p className="text-sm text-slate-400">No assessed inspections yet.</p>
+            ) : (
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {Object.entries(data.average_coverage_by_family).map(([family, avg]) => (
+                  <div key={family} className="rounded-lg border border-slate-200 bg-white p-3 flex items-center justify-between">
+                    <span className="text-sm font-medium capitalize text-slate-800">{family.replace(/_/g, " ")}</span>
+                    <span className="text-sm font-bold text-slate-900">{avg}%</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 mb-3">Most commonly missing zones</h2>
+            {data.most_commonly_missing_zones.length === 0 ? (
+              <p className="text-sm text-slate-400">No missing-zone data yet.</p>
+            ) : (
+              <ul className="space-y-1">
+                {data.most_commonly_missing_zones.map((z) => (
+                  <li key={z.zone} className="flex items-center justify-between text-sm rounded border border-slate-100 bg-white px-3 py-1.5">
+                    <span className="capitalize text-slate-700">{z.zone}</span>
+                    <span className="text-slate-500">{z.missed_count} inspection{z.missed_count === 1 ? "" : "s"}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 mb-3">Recent inspections</h2>
+            <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-slate-400 border-b border-slate-100">
+                    <th className="py-2 px-3 font-medium">ID</th>
+                    <th className="py-2 px-3 font-medium">Instrument type</th>
+                    <th className="py-2 px-3 font-medium">Coverage</th>
+                    <th className="py-2 px-3 font-medium">Status</th>
+                    <th className="py-2 px-3 font-medium">Missing</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.recent_inspections.map((r) => (
+                    <tr key={r.inspection_id} className="border-t border-slate-100 align-top">
+                      <td className="py-2 px-3 text-slate-500">#{r.inspection_id}</td>
+                      <td className="py-2 px-3 capitalize text-slate-800">{r.instrument_type}</td>
+                      <td className="py-2 px-3">{r.coverage_score != null ? `${r.coverage_score}%` : "—"}</td>
+                      <td className="py-2 px-3">
+                        <span className={`rounded-full px-2 py-0.5 text-xs font-medium capitalize ${STATUS_STYLE[r.coverage_status] ?? "bg-slate-100"}`}>{r.coverage_status}</span>
+                      </td>
+                      <td className="py-2 px-3 capitalize text-slate-600">{r.missing.length ? r.missing.join(", ") : "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <p className="text-xs text-slate-400">{data.note}</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/EducationLibraryPage.tsx
+++ b/frontend/src/pages/EducationLibraryPage.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from "react";
+import { BookOpen } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface Article {
+  finding: string;
+  finding_type: string;
+  definition: string;
+  clinical_importance: string;
+  typical_anatomy_locations: string[];
+  inspection_tips: string;
+  cleaning_considerations: string;
+  corrective_actions: string[];
+  reference: string;
+}
+
+export default function EducationLibraryPage() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await apiFetch<{ articles: Article[] }>("/api/mentor/education");
+        setArticles(data.articles);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return <div className="p-6 text-sm text-slate-500">Loading education library…</div>;
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-4">
+      <div className="flex items-center gap-2">
+        <BookOpen className="h-6 w-6 text-indigo-600" />
+        <h1 className="text-xl font-bold text-slate-900">SPD Education Library</h1>
+      </div>
+      <p className="text-sm text-slate-500">
+        Structured reference for every contamination and condition category LumenAI recognizes —
+        definition, clinical importance, typical anatomy locations, inspection tips, cleaning
+        considerations, and corrective actions.
+      </p>
+
+      <div className="space-y-2">
+        {articles.map((a) => (
+          <div key={a.finding_type} className="rounded-lg border border-slate-200 bg-white">
+            <button
+              onClick={() => setOpen(open === a.finding_type ? null : a.finding_type)}
+              className="w-full flex items-center justify-between px-4 py-3 text-left"
+            >
+              <span className="font-semibold capitalize text-slate-800">{a.finding.replace(/_/g, " ")}</span>
+              <span className="text-xs text-slate-400">{open === a.finding_type ? "Hide" : "View"}</span>
+            </button>
+            {open === a.finding_type && (
+              <div className="px-4 pb-4 space-y-2 text-sm text-slate-700">
+                <p><span className="font-medium text-slate-500">Definition:</span> {a.definition}</p>
+                <p><span className="font-medium text-slate-500">Clinical importance:</span> {a.clinical_importance}</p>
+                <p><span className="font-medium text-slate-500">Typical anatomy locations:</span> {a.typical_anatomy_locations.join(", ")}</p>
+                <p><span className="font-medium text-slate-500">Inspection tips:</span> {a.inspection_tips}</p>
+                <p><span className="font-medium text-slate-500">Cleaning considerations:</span> {a.cleaning_considerations}</p>
+                <div>
+                  <span className="font-medium text-slate-500">Corrective actions:</span>
+                  <ul className="mt-1 space-y-0.5">
+                    {a.corrective_actions.map((s, i) => <li key={i}>• {s}</li>)}
+                  </ul>
+                </div>
+                <p className="text-xs text-slate-400">{a.reference}</p>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/FindingsQueuePage.tsx
+++ b/frontend/src/pages/FindingsQueuePage.tsx
@@ -1,216 +1,145 @@
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { apiFetch } from "@/lib/api";
 
-const sampleFindings = [
-  {
-    id: "F-1007",
-    facility: "ORC",
-    department: "Prep and Pack",
-    tray: "Orthopedic major set",
-    instrument: "Bone cutter",
-    vendor: "Acme Surgical",
-    findingType: "Rust",
-    riskLevel: "High",
-    status: "New",
-    date: "Today",
-  },
-  {
-    id: "F-1006",
-    facility: "St. Francis",
-    department: "Decontamination",
-    tray: "Laparoscopic set",
-    instrument: "Laparoscopic grasper",
-    vendor: "Northline Medical",
-    findingType: "Blood",
-    riskLevel: "Critical",
-    status: "Under Review",
-    date: "Today",
-  },
-  {
-    id: "F-1005",
-    facility: "St. Mary’s",
-    department: "Prep and Pack",
-    tray: "Spine tray",
-    instrument: "Kerrison rongeur",
-    vendor: "SterilePro",
-    findingType: "Bone fragment",
-    riskLevel: "Critical",
-    status: "CAPA Needed",
-    date: "Yesterday",
-  },
-  {
-    id: "F-1004",
-    facility: "Memorial Regional",
-    department: "Sterilization",
-    tray: "Minor procedure set",
-    instrument: "Forceps",
-    vendor: "Acme Surgical",
-    findingType: "Discoloration",
-    riskLevel: "Medium",
-    status: "New",
-    date: "Yesterday",
-  },
-  {
-    id: "F-1003",
-    facility: "Southside",
-    department: "Sterile Storage",
-    tray: "General tray",
-    instrument: "Tray liner",
-    vendor: "Regional Supply",
-    findingType: "Lint",
-    riskLevel: "Low",
-    status: "Closed",
-    date: "2 days ago",
-  },
-  {
-    id: "F-1002",
-    facility: "Rappahannock General",
-    department: "Prep and Pack",
-    tray: "Vascular tray",
-    instrument: "Tray basin",
-    vendor: "Northline Medical",
-    findingType: "Plastic/metal fragment",
-    riskLevel: "High",
-    status: "CAPA Needed",
-    date: "2 days ago",
-  },
-  {
-    id: "F-1001",
-    facility: "ORC",
-    department: "Decontamination",
-    tray: "ENT set",
-    instrument: "Suction tip",
-    vendor: "SterilePro",
-    findingType: "Tissue",
-    riskLevel: "High",
-    status: "Under Review",
-    date: "3 days ago",
-  },
-  {
-    id: "F-1000",
-    facility: "Memorial Regional",
-    department: "OR",
-    tray: "General backup set",
-    instrument: "Clamp",
-    vendor: "Regional Supply",
-    findingType: "Other",
-    riskLevel: "Medium",
-    status: "New",
-    date: "3 days ago",
-  },
-];
+interface QueueItem {
+  inspection_id: number;
+  instrument_type: string;
+  facility_name: string | null;
+  workflow_state: string;
+  risk_tier: string;
+  disposition: string;
+  minutes_waiting: number | null;
+  assigned_technician: string | null;
+}
 
-type Finding = typeof sampleFindings[number];
+interface WorkQueue {
+  pending_inspections: QueueItem[];
+}
 
 function riskStyle(risk: string): React.CSSProperties {
   if (risk === "Critical") return { ...badge, background: "#450a0a", color: "#fecaca" };
-  if (risk === "High") return { ...badge, background: "#7f1d1d", color: "#fecaca" };
-  if (risk === "Medium") return { ...badge, background: "#78350f", color: "#fde68a" };
+  if (risk === "High Risk") return { ...badge, background: "#7f1d1d", color: "#fecaca" };
+  if (risk === "Moderate Risk") return { ...badge, background: "#78350f", color: "#fde68a" };
   return { ...badge, background: "#064e3b", color: "#a7f3d0" };
 }
 
 function statusStyle(status: string): React.CSSProperties {
-  if (status === "CAPA Needed") return { ...badge, background: "#1e3a8a", color: "#bfdbfe" };
-  if (status === "Under Review") return { ...badge, background: "#4c1d95", color: "#ddd6fe" };
-  if (status === "Closed") return { ...badge, background: "#065f46", color: "#bbf7d0" };
+  if (status === "Repair") return { ...badge, background: "#1e3a8a", color: "#bfdbfe" };
+  if (status === "Supervisor Review") return { ...badge, background: "#4c1d95", color: "#ddd6fe" };
+  if (status === "Completed") return { ...badge, background: "#065f46", color: "#bbf7d0" };
   return { ...badge, background: "#374151", color: "#e5e7eb" };
 }
 
+function formatWait(minutes: number | null): string {
+  if (minutes == null) return "—";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
 export default function FindingsQueuePage() {
-  const [findings, setFindings] = useState<Finding[]>(sampleFindings);
-  const [notice, setNotice] = useState("");
+  const [items, setItems] = useState<QueueItem[] | null>(null);
+  const [error, setError] = useState("");
 
-  const summary = useMemo(() => {
-    return {
-      total: findings.length,
-      highCritical: findings.filter((finding) => ["High", "Critical"].includes(finding.riskLevel)).length,
-      capaNeeded: findings.filter((finding) => finding.status === "CAPA Needed").length,
-      closed: findings.filter((finding) => finding.status === "Closed").length,
-    };
-  }, [findings]);
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch<WorkQueue>("/api/inspection-work-queue")
+      .then((d) => { if (!cancelled) setItems(d.pending_inspections); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { cancelled = true; };
+  }, []);
 
-  function updateStatus(id: string, status: string, action: string) {
-    setFindings((current) =>
-      current.map((finding) => finding.id === id ? { ...finding, status } : finding)
-    );
-    setNotice(`${action} saved in pilot mode for finding ${id}.`);
-  }
+  const summary = items
+    ? {
+        total: items.length,
+        highCritical: items.filter((i) => ["High Risk", "Critical"].includes(i.risk_tier)).length,
+        repairPending: items.filter((i) => i.workflow_state === "Repair").length,
+        supervisorReview: items.filter((i) => i.workflow_state === "Supervisor Review").length,
+      }
+    : null;
 
   return (
     <main style={pageShell}>
       <section style={hero}>
-        <nav style={topNav} aria-label="Findings navigation">
-          <a href="/operations" style={navLink}>Operations Dashboard</a>
-          <a href="/inspection/new" style={navLink}>New Inspection</a>
-          <a href="/capa" style={navLink}>CAPA Queue</a>
-          <a href="/analytics" style={navLink}>Analytics</a>
-          <a href="/" style={navLink}>Public Landing</a>
-        </nav>
-
         <p style={eyebrow}>Daily review queue</p>
         <h1 style={title}>Findings Queue</h1>
-        <p style={subtitle}>Review, prioritize, and route SPD quality findings for action.</p>
+        <p style={subtitle}>Real, live inspections awaiting review or action — backed by the Smart Inspection Queue.</p>
       </section>
 
-      <section style={summaryGrid} aria-label="Findings summary">
-        <SummaryCard label="Total Findings" value={summary.total} tone="#38bdf8" />
-        <SummaryCard label="High/Critical Findings" value={summary.highCritical} tone="#f87171" />
-        <SummaryCard label="CAPA Needed" value={summary.capaNeeded} tone="#a78bfa" />
-        <SummaryCard label="Closed Findings" value={summary.closed} tone="#34d399" />
-      </section>
+      {error && (
+        <section style={{ ...panel, marginBottom: 18, borderColor: "rgba(248, 113, 113, 0.4)" }}>
+          <p style={{ color: "#fca5a5", margin: 0 }}>Failed to load the findings queue: {error}</p>
+        </section>
+      )}
 
-      <section style={panel}>
-        <div style={panelHeader}>
-          <div>
-            <h2 style={panelTitle}>Review Worklist</h2>
-            <p style={panelHint}>Pilot sample findings for daily SPD review and routing.</p>
+      {!error && items === null && (
+        <section style={panel}>
+          <p style={{ color: "#94a3b8", margin: 0 }}>Loading…</p>
+        </section>
+      )}
+
+      {summary && (
+        <section style={summaryGrid} aria-label="Findings summary">
+          <SummaryCard label="Total Pending" value={summary.total} tone="#38bdf8" />
+          <SummaryCard label="High/Critical Risk" value={summary.highCritical} tone="#f87171" />
+          <SummaryCard label="Awaiting Supervisor Review" value={summary.supervisorReview} tone="#a78bfa" />
+          <SummaryCard label="Repair Pending" value={summary.repairPending} tone="#f59e0b" />
+        </section>
+      )}
+
+      {items && (
+        <section style={panel}>
+          <div style={panelHeader}>
+            <div>
+              <h2 style={panelTitle}>Review Worklist</h2>
+              <p style={panelHint}>
+                Live pending inspections, ranked by priority.{" "}
+                <Link to="/inspection-work-queue" style={{ color: "#67e8f9" }}>Open the full Smart Inspection Queue →</Link>
+              </p>
+            </div>
           </div>
-        </div>
 
-        {notice ? <div style={noticeBox}>{notice}</div> : null}
-
-        <div style={tableWrap}>
-          <table style={table}>
-            <thead>
-              <tr>
-                <th style={th}>ID</th>
-                <th style={th}>Facility</th>
-                <th style={th}>Department</th>
-                <th style={th}>Tray</th>
-                <th style={th}>Instrument</th>
-                <th style={th}>Vendor</th>
-                <th style={th}>Finding Type</th>
-                <th style={th}>Risk Level</th>
-                <th style={th}>Status</th>
-                <th style={th}>Date</th>
-                <th style={th}>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {findings.map((finding) => (
-                <tr key={finding.id} style={tr}>
-                  <td style={tdStrong}>{finding.id}</td>
-                  <td style={td}>{finding.facility}</td>
-                  <td style={td}>{finding.department}</td>
-                  <td style={td}>{finding.tray}</td>
-                  <td style={td}>{finding.instrument}</td>
-                  <td style={td}>{finding.vendor}</td>
-                  <td style={td}>{finding.findingType}</td>
-                  <td style={td}><span style={riskStyle(finding.riskLevel)}>{finding.riskLevel}</span></td>
-                  <td style={td}><span style={statusStyle(finding.status)}>{finding.status}</span></td>
-                  <td style={tdMuted}>{finding.date}</td>
-                  <td style={td}>
-                    <div style={actionGroup}>
-                      <button type="button" style={smallButton} onClick={() => updateStatus(finding.id, "Under Review", "Review")}>Review</button>
-                      <button type="button" style={smallButton} onClick={() => updateStatus(finding.id, "CAPA Needed", "Create CAPA")}>Create CAPA</button>
-                      <button type="button" style={smallButton} onClick={() => updateStatus(finding.id, "Closed", "Close")}>Close</button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+          {items.length === 0 ? (
+            <p style={{ color: "#94a3b8" }}>No inspections are currently pending review.</p>
+          ) : (
+            <div style={tableWrap}>
+              <table style={table}>
+                <thead>
+                  <tr>
+                    <th style={th}>Inspection</th>
+                    <th style={th}>Facility</th>
+                    <th style={th}>Instrument</th>
+                    <th style={th}>Risk</th>
+                    <th style={th}>Status</th>
+                    <th style={th}>Disposition</th>
+                    <th style={th}>Waiting</th>
+                    <th style={th}>Assigned</th>
+                    <th style={th}>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => (
+                    <tr key={item.inspection_id} style={tr}>
+                      <td style={tdStrong}>#{item.inspection_id}</td>
+                      <td style={td}>{item.facility_name ?? "—"}</td>
+                      <td style={td}>{item.instrument_type}</td>
+                      <td style={td}><span style={riskStyle(item.risk_tier)}>{item.risk_tier}</span></td>
+                      <td style={td}><span style={statusStyle(item.workflow_state)}>{item.workflow_state}</span></td>
+                      <td style={td}>{item.disposition}</td>
+                      <td style={tdMuted}>{formatWait(item.minutes_waiting)}</td>
+                      <td style={td}>{item.assigned_technician ?? "Unassigned"}</td>
+                      <td style={td}>
+                        <Link to="/inspection-work-queue" style={smallButtonLink}>Review →</Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      )}
     </main>
   );
 }
@@ -236,23 +165,6 @@ const pageShell: React.CSSProperties = {
 const hero: React.CSSProperties = {
   maxWidth: "1360px",
   margin: "0 auto 22px",
-};
-
-const topNav: React.CSSProperties = {
-  display: "flex",
-  gap: "12px",
-  flexWrap: "wrap",
-  marginBottom: "22px",
-};
-
-const navLink: React.CSSProperties = {
-  color: "#cbd5e1",
-  textDecoration: "none",
-  fontWeight: 800,
-  padding: "10px 12px",
-  borderRadius: "8px",
-  border: "1px solid rgba(148, 163, 184, 0.24)",
-  background: "rgba(15, 23, 42, 0.72)",
 };
 
 const eyebrow: React.CSSProperties = {
@@ -345,16 +257,6 @@ const panelHint: React.CSSProperties = {
   fontSize: "14px",
 };
 
-const noticeBox: React.CSSProperties = {
-  marginBottom: "14px",
-  padding: "12px 14px",
-  borderRadius: "8px",
-  border: "1px solid rgba(56, 189, 248, 0.36)",
-  background: "rgba(14, 116, 144, 0.18)",
-  color: "#cffafe",
-  fontWeight: 700,
-};
-
 const tableWrap: React.CSSProperties = {
   overflowX: "auto",
 };
@@ -404,13 +306,7 @@ const badge: React.CSSProperties = {
   whiteSpace: "nowrap",
 };
 
-const actionGroup: React.CSSProperties = {
-  display: "flex",
-  flexWrap: "wrap",
-  gap: "8px",
-};
-
-const smallButton: React.CSSProperties = {
+const smallButtonLink: React.CSSProperties = {
   border: "1px solid rgba(148, 163, 184, 0.32)",
   borderRadius: "8px",
   background: "rgba(30, 41, 59, 0.84)",
@@ -418,4 +314,6 @@ const smallButton: React.CSSProperties = {
   cursor: "pointer",
   fontWeight: 800,
   padding: "8px 10px",
+  textDecoration: "none",
+  display: "inline-block",
 };

--- a/frontend/src/pages/InspectionWorkQueuePage.tsx
+++ b/frontend/src/pages/InspectionWorkQueuePage.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+import { ListChecks } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface QueueItem {
+  inspection_id: number;
+  instrument_type: string;
+  facility_name: string | null;
+  procedure_priority: string | null;
+  workflow_state: string;
+  risk_tier: string;
+  priority_score: number;
+  priority_tier: string;
+  priority_reasons: string[];
+  disposition: string;
+  minutes_waiting: number | null;
+  assigned_technician: string | null;
+  is_vendor_tray: boolean;
+  is_loaner_instrument: boolean;
+  has_repeat_findings: boolean;
+}
+
+interface WorkQueue {
+  pending_inspections: QueueItem[];
+  high_risk_inspections: QueueItem[];
+  or_priority_instruments: QueueItem[];
+  vendor_trays: QueueItem[];
+  loaner_instruments: QueueItem[];
+  repeat_inspections: QueueItem[];
+  supervisor_reviews: QueueItem[];
+  repair_holds: QueueItem[];
+  total_pending: number;
+}
+
+function priorityBadgeClass(tier: string): string {
+  switch (tier) {
+    case "Critical":
+      return "bg-red-100 text-red-800";
+    case "High":
+      return "bg-orange-100 text-orange-800";
+    case "Medium":
+      return "bg-amber-100 text-amber-800";
+    default:
+      return "bg-slate-100 text-slate-600";
+  }
+}
+
+function formatWait(minutes: number | null): string {
+  if (minutes == null) return "—";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rem = minutes % 60;
+  return `${hours}h ${rem}m`;
+}
+
+function QueueTable({ items }: { items: QueueItem[] }) {
+  if (items.length === 0) {
+    return <p className="text-sm text-slate-400 py-2">Nothing in this queue right now.</p>;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-slate-400 text-xs">
+            <th className="py-1 pr-3">Instrument</th>
+            <th className="py-1 px-2">Procedure Priority</th>
+            <th className="py-1 px-2">Status</th>
+            <th className="py-1 px-2">Risk</th>
+            <th className="py-1 px-2">Priority</th>
+            <th className="py-1 px-2">Waiting</th>
+            <th className="py-1 px-2">Assigned</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.inspection_id} className="border-t border-slate-100">
+              <td className="py-1.5 pr-3 font-medium">
+                #{item.inspection_id} — {item.instrument_type}
+                {item.facility_name && <span className="text-slate-400"> · {item.facility_name}</span>}
+              </td>
+              <td className="py-1.5 px-2 capitalize">{item.procedure_priority?.replace(/_/g, " ") ?? "—"}</td>
+              <td className="py-1.5 px-2">{item.workflow_state}</td>
+              <td className="py-1.5 px-2">{item.risk_tier}</td>
+              <td className="py-1.5 px-2">
+                <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${priorityBadgeClass(item.priority_tier)}`}>
+                  {item.priority_tier} ({item.priority_score})
+                </span>
+              </td>
+              <td className="py-1.5 px-2">{formatWait(item.minutes_waiting)}</td>
+              <td className="py-1.5 px-2">{item.assigned_technician ?? "Unassigned"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Section({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{title}</p>
+        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-slate-100 text-slate-600">{count}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default function InspectionWorkQueuePage() {
+  const [queue, setQueue] = useState<WorkQueue | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    apiFetch<WorkQueue>("/api/inspection-work-queue")
+      .then(setQueue)
+      .catch(() => setError("Failed to load the inspection work queue."));
+  }, []);
+
+  if (error) return <div className="p-6 text-sm text-red-600">{error}</div>;
+  if (!queue) return <div className="p-6 text-sm text-slate-500">Loading…</div>;
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <ListChecks className="h-6 w-6 text-blue-600" />
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Smart Inspection Queue</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            {queue.total_pending} inspection{queue.total_pending === 1 ? "" : "s"} pending, ranked by clinical risk,
+            OR urgency, and supervisor workload.
+          </p>
+        </div>
+      </div>
+
+      <Section title="All Pending Inspections" count={queue.pending_inspections.length}>
+        <QueueTable items={queue.pending_inspections} />
+      </Section>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Section title="High-Risk Inspections" count={queue.high_risk_inspections.length}>
+          <QueueTable items={queue.high_risk_inspections} />
+        </Section>
+        <Section title="OR Priority Instruments" count={queue.or_priority_instruments.length}>
+          <QueueTable items={queue.or_priority_instruments} />
+        </Section>
+        <Section title="Vendor Trays" count={queue.vendor_trays.length}>
+          <QueueTable items={queue.vendor_trays} />
+        </Section>
+        <Section title="Loaner Instruments" count={queue.loaner_instruments.length}>
+          <QueueTable items={queue.loaner_instruments} />
+        </Section>
+        <Section title="Repeat Inspections" count={queue.repeat_inspections.length}>
+          <QueueTable items={queue.repeat_inspections} />
+        </Section>
+        <Section title="Supervisor Reviews" count={queue.supervisor_reviews.length}>
+          <QueueTable items={queue.supervisor_reviews} />
+        </Section>
+        <Section title="Repair Holds" count={queue.repair_holds.length}>
+          <QueueTable items={queue.repair_holds} />
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/InspectionZonesPage.tsx
+++ b/frontend/src/pages/InspectionZonesPage.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://lumen-ai-53u4.onrender.com";
+
+interface ZoneInfoEntry {
+  risk: string;
+  reason: string;
+  manual_check: string;
+}
+
+interface ZoneTaxonomyResponse {
+  zone_taxonomy: Record<string, string[]>;
+  high_retention_zones: string[];
+  zone_info: Record<string, ZoneInfoEntry>;
+}
+
+const RISK_STYLE: Record<string, string> = {
+  low: "bg-slate-100 text-slate-600",
+  medium: "bg-amber-100 text-amber-800",
+  high: "bg-orange-100 text-orange-800",
+  critical: "bg-red-100 text-red-800",
+};
+
+export default function InspectionZonesPage() {
+  const { headers } = useAuth();
+  const [data, setData] = useState<ZoneTaxonomyResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/instrument-zones`, { headers: headers() })
+      .then((r) => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}`); return r.json(); })
+      .then(setData)
+      .catch((e) => setError(String(e)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="p-6 space-y-8 max-w-6xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">Inspection Zones</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          The zone taxonomy LumenAI reasons over: instrument-zone categories, which zones are high-retention
+          (residual soil is hard to remove), and the recommended manual check per zone.
+        </p>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {!data && !error && <p className="text-sm text-slate-400">Loading…</p>}
+
+      {data && (
+        <>
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 mb-3">Zone categories</h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              {Object.entries(data.zone_taxonomy).map(([category, zones]) => (
+                <div key={category} className="rounded-lg border border-slate-200 bg-white p-4">
+                  <p className="font-semibold text-slate-900 capitalize">{category.replace(/_/g, " ")}</p>
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {zones.map((z) => (
+                      <span key={z} className="inline-block text-xs bg-slate-100 text-slate-700 rounded px-2 py-0.5">{z}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 mb-3">
+              High-retention zones <span className="text-sm font-normal text-slate-500">({data.high_retention_zones.length})</span>
+            </h2>
+            <p className="text-sm text-slate-500 mb-3">
+              Zones where residual soil commonly persists after manual cleaning — escalate contamination findings here.
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {data.high_retention_zones.map((z) => (
+                <span key={z} className="inline-block text-xs bg-red-50 text-red-700 rounded px-2 py-1">{z}</span>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 mb-3">Per-zone reference</h2>
+            <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-slate-400 border-b border-slate-100">
+                    <th className="py-2 px-3 font-medium">Zone</th>
+                    <th className="py-2 px-3 font-medium">Risk</th>
+                    <th className="py-2 px-3 font-medium">Reason</th>
+                    <th className="py-2 px-3 font-medium">Recommended manual check</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(data.zone_info).map(([zone, info]) => (
+                    <tr key={zone} className="border-t border-slate-100 align-top">
+                      <td className="py-2 px-3 font-medium capitalize text-slate-800">{zone}</td>
+                      <td className="py-2 px-3">
+                        <span className={`rounded-full px-2 py-0.5 text-xs font-medium capitalize ${RISK_STYLE[info.risk] ?? "bg-slate-100"}`}>{info.risk}</span>
+                      </td>
+                      <td className="py-2 px-3 text-slate-600">{info.reason}</td>
+                      <td className="py-2 px-3 text-slate-600">{info.manual_check}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </>
+      )}
+
+      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+        ⚠ Zone assignment is deterministic pilot logic from instrument type/tagged views — not pixel-level
+        computer-vision localization. See the <a href="/anatomy-library" className="underline">Anatomy Library</a> for
+        which zones apply to a given instrument family.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/InstrumentLibraryPage.tsx
+++ b/frontend/src/pages/InstrumentLibraryPage.tsx
@@ -65,7 +65,7 @@ export default function InstrumentLibraryPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/instrument-families`, { headers: headers() })
+    fetch(`${API_BASE}/api/knowledge-graph/instrument-families`, { headers: headers() })
       .then((r) => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}`); return r.json(); })
       .then((d) => setFamilies(d.families ?? []))
       .catch((e) => setError(String(e)))

--- a/frontend/src/pages/InstrumentLibraryPage.tsx
+++ b/frontend/src/pages/InstrumentLibraryPage.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "https://lumen-ai-53u4.onrender.com";
+
+interface FamilyProfile {
+  family_key: string;
+  display_name: string;
+  typical_anatomy: string[];
+  high_risk_zones: string[];
+  typical_contamination: string[];
+  typical_damage: string[];
+  typical_repair_issues: string[];
+  inspection_priorities: string[];
+  cleaning_priorities: string[];
+  supervisor_focus_areas: string[];
+  anatomy_family_note?: string;
+}
+
+function Tag({ children, tone = "slate" }: { children: React.ReactNode; tone?: "slate" | "red" }) {
+  const cls = tone === "red" ? "bg-red-50 text-red-700" : "bg-slate-100 text-slate-700";
+  return <span className={`inline-block text-xs ${cls} rounded px-2 py-0.5 mr-1 mb-1`}>{children}</span>;
+}
+
+function FamilyDetail({ profile }: { profile: FamilyProfile }) {
+  return (
+    <div className="mt-3 space-y-2 text-sm border-t border-slate-100 pt-3">
+      {profile.anatomy_family_note && (
+        <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1">{profile.anatomy_family_note}</p>
+      )}
+      <div><span className="font-medium">Anatomy zones: </span>{profile.typical_anatomy.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+      <div><span className="font-medium">High-risk zones: </span>{profile.high_risk_zones.map((z) => <Tag key={z} tone="red">{z}</Tag>)}</div>
+      <div><span className="font-medium">Typical contamination risks: </span>{profile.typical_contamination.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+      <div><span className="font-medium">Typical damage risks: </span>{profile.typical_damage.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+      <div><span className="font-medium">Typical repair issues: </span>{profile.typical_repair_issues.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+      <div><span className="font-medium">Inspection priorities: </span>{profile.inspection_priorities.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+      <div><span className="font-medium">Cleaning priorities (manual-check guidance): </span>{profile.cleaning_priorities.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+      <div><span className="font-medium">Supervisor focus areas: </span>{profile.supervisor_focus_areas.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+    </div>
+  );
+}
+
+function FamilyCard({ profile }: { profile: FamilyProfile }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <button className="w-full text-left" onClick={() => setExpanded((e) => !e)}>
+        <div className="flex items-center justify-between">
+          <p className="font-semibold text-slate-900">{profile.display_name}</p>
+          <span className="text-xs text-slate-400">{expanded ? "▲" : "▼"}</span>
+        </div>
+        <p className="text-xs text-slate-500 mt-1">
+          {profile.typical_anatomy.length} anatomy zones · {profile.high_risk_zones.length} high-risk
+        </p>
+      </button>
+      {expanded && <FamilyDetail profile={profile} />}
+    </div>
+  );
+}
+
+export default function InstrumentLibraryPage() {
+  const { headers } = useAuth();
+  const [families, setFamilies] = useState<FamilyProfile[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/instrument-families`, { headers: headers() })
+      .then((r) => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}`); return r.json(); })
+      .then((d) => setFamilies(d.families ?? []))
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6 max-w-6xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">Instrument Knowledge Library</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          Structured knowledge profiles — anatomy, high-risk zones, typical contamination/damage/repair patterns,
+          inspection and cleaning priorities — for the instrument families LumenAI reasons over before AI analysis.
+        </p>
+      </div>
+
+      {loading && <p className="text-sm text-slate-400">Loading instrument library…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {families.map((f) => <FamilyCard key={f.family_key} profile={f} />)}
+      </div>
+
+      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+        ⚠ This is structured clinical knowledge, not a substitute for the device IFU. See also the{" "}
+        <a href="/anatomy-library" className="underline">Anatomy Library</a> for per-zone detail and the{" "}
+        <a href="/inspection-zones" className="underline">Inspection Zones</a> reference for the underlying taxonomy.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/KnowledgeCenterPage.tsx
+++ b/frontend/src/pages/KnowledgeCenterPage.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useState } from "react";
+import { BookMarked } from "lucide-react";
+import { api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+
+interface Article {
+  id: number;
+  category: string;
+  title: string;
+  body: string;
+  author: string;
+  reviewer: string;
+  approval_status: string;
+  version: number;
+  applicable_instruments: string[];
+  applicable_findings: string[];
+  view_count: number;
+}
+
+interface Case {
+  id: number;
+  inspection_id: number;
+  instrument_type: string;
+  finding_type: string;
+  title: string;
+  supervisor_corrections: string;
+  final_disposition: string;
+  educational_notes: string;
+  outcome: string;
+}
+
+interface Standard {
+  id: number;
+  standard_type: string;
+  title: string;
+  description: string;
+  created_by: string;
+}
+
+interface SearchResult {
+  matched_findings: string[];
+  matched_instrument_families: string[];
+  articles: Article[];
+  cases: Case[];
+}
+
+interface AssistantResult {
+  answer: string;
+  sources: string[];
+}
+
+interface Analytics {
+  most_viewed_articles: { id: number; title: string; view_count: number }[];
+  most_common_questions: { query: string; count: number }[];
+  knowledge_gaps: { finding_type: string; clinical_case_count: number }[];
+  training_opportunities: { technician: string; finding_type: string }[];
+}
+
+const TABS = ["Search", "Articles", "Cases", "Standards", "Assistant", "Analytics"] as const;
+type Tab = (typeof TABS)[number];
+
+const CATEGORIES = [
+  "best_practice", "local_standard", "approved_workflow", "clinical_pearl",
+  "lesson_learned", "faq", "competency_guidance", "manufacturer_clarification",
+];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cls =
+    status === "approved" ? "bg-emerald-100 text-emerald-800"
+    : status === "pending_review" ? "bg-amber-100 text-amber-800"
+    : status === "rejected" ? "bg-red-100 text-red-800"
+    : status === "archived" ? "bg-slate-200 text-slate-500"
+    : "bg-slate-100 text-slate-600";
+  return <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${cls}`}>{status.replace(/_/g, " ")}</span>;
+}
+
+export default function KnowledgeCenterPage() {
+  const { role } = useAuth();
+  const isLeadership = role === "admin" || role === "spd_manager";
+  const [tab, setTab] = useState<Tab>("Search");
+
+  const [query, setQuery] = useState("");
+  const [searchResult, setSearchResult] = useState<SearchResult | null>(null);
+
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [newArticle, setNewArticle] = useState({ category: "best_practice", title: "", body: "" });
+
+  const [cases, setCases] = useState<Case[]>([]);
+  const [standards, setStandards] = useState<Standard[]>([]);
+  const [newStandard, setNewStandard] = useState({ standard_type: "coverage_requirement", title: "", description: "" });
+
+  const [question, setQuestion] = useState("");
+  const [assistantResult, setAssistantResult] = useState<AssistantResult | null>(null);
+
+  const [analytics, setAnalytics] = useState<Analytics | null>(null);
+
+  function loadArticles() {
+    api.get<{ articles: Article[] }>("/api/knowledge/articles").then((d) => setArticles(d.articles));
+  }
+  function loadCases() {
+    api.get<{ cases: Case[] }>("/api/knowledge/cases").then((d) => setCases(d.cases));
+  }
+  function loadStandards() {
+    api.get<{ standards: Standard[] }>("/api/knowledge/standards").then((d) => setStandards(d.standards));
+  }
+  function loadAnalytics() {
+    if (isLeadership) api.get<Analytics>("/api/knowledge/analytics").then(setAnalytics);
+  }
+
+  useEffect(() => {
+    if (tab === "Articles") loadArticles();
+    if (tab === "Cases") loadCases();
+    if (tab === "Standards") loadStandards();
+    if (tab === "Analytics") loadAnalytics();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab]);
+
+  async function runSearch() {
+    if (!query.trim()) return;
+    const result = await api.post<SearchResult>("/api/knowledge/search", { query });
+    setSearchResult(result);
+  }
+
+  async function submitArticle() {
+    if (!newArticle.title.trim() || !newArticle.body.trim()) return;
+    await api.post("/api/knowledge/articles", newArticle);
+    setNewArticle({ category: "best_practice", title: "", body: "" });
+    loadArticles();
+  }
+
+  async function approveArticle(id: number) {
+    await api.post(`/api/knowledge/articles/${id}/approve`);
+    loadArticles();
+  }
+  async function archiveArticle(id: number) {
+    await api.post(`/api/knowledge/articles/${id}/archive`);
+    loadArticles();
+  }
+
+  async function submitStandard() {
+    if (!newStandard.title.trim() || !newStandard.description.trim()) return;
+    await api.post("/api/knowledge/standards", newStandard);
+    setNewStandard({ standard_type: "coverage_requirement", title: "", description: "" });
+    loadStandards();
+  }
+
+  async function askAssistant() {
+    if (!question.trim()) return;
+    const result = await api.post<AssistantResult>("/api/knowledge/assistant", { question });
+    setAssistantResult(result);
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <BookMarked className="h-6 w-6 text-purple-600" />
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Institutional Knowledge Center</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            The organization's permanent clinical memory — searchable, governed, and reusable.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex gap-1 border-b border-slate-200">
+        {TABS.filter((t) => t !== "Analytics" || isLeadership).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px ${
+              tab === t ? "border-purple-600 text-purple-700" : "border-transparent text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {tab === "Search" && (
+        <Section title="Smart Knowledge Search">
+          <div className="flex gap-2 mb-3">
+            <input
+              type="text"
+              placeholder='e.g. "show all blood findings in Kerrisons"'
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && runSearch()}
+              className="flex-1 rounded border border-slate-300 px-2 py-1.5 text-sm"
+            />
+            <button onClick={runSearch} className="text-xs font-semibold px-3 py-1.5 rounded bg-purple-600 text-white">
+              Search
+            </button>
+          </div>
+          {searchResult && (
+            <div className="space-y-3 text-sm">
+              <div className="flex flex-wrap gap-2">
+                {searchResult.matched_findings.map((f) => (
+                  <span key={f} className="text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-700">finding: {f}</span>
+                ))}
+                {searchResult.matched_instrument_families.map((f) => (
+                  <span key={f} className="text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-700">family: {f}</span>
+                ))}
+              </div>
+              <div>
+                <p className="text-xs font-semibold text-slate-500 mb-1">Articles ({searchResult.articles.length})</p>
+                {searchResult.articles.map((a) => (
+                  <div key={a.id} className="border-t border-slate-100 py-1.5">
+                    <span className="font-medium">{a.title}</span> — <span className="text-slate-500">{a.body}</span>
+                  </div>
+                ))}
+              </div>
+              <div>
+                <p className="text-xs font-semibold text-slate-500 mb-1">Cases ({searchResult.cases.length})</p>
+                {searchResult.cases.map((c) => (
+                  <div key={c.id} className="border-t border-slate-100 py-1.5">
+                    <span className="font-medium">{c.title}</span>
+                    {c.final_disposition && <span className="text-slate-500"> — {c.final_disposition}</span>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </Section>
+      )}
+
+      {tab === "Articles" && (
+        <div className="space-y-4">
+          <Section title="Contribute Knowledge">
+            <div className="space-y-2">
+              <select
+                value={newArticle.category}
+                onChange={(e) => setNewArticle({ ...newArticle, category: e.target.value })}
+                className="rounded border border-slate-300 px-2 py-1.5 text-sm"
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c} value={c}>{c.replace(/_/g, " ")}</option>
+                ))}
+              </select>
+              <input
+                type="text" placeholder="Title" value={newArticle.title}
+                onChange={(e) => setNewArticle({ ...newArticle, title: e.target.value })}
+                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+              />
+              <textarea
+                placeholder="Body" value={newArticle.body}
+                onChange={(e) => setNewArticle({ ...newArticle, body: e.target.value })}
+                className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm" rows={3}
+              />
+              <button onClick={submitArticle} className="text-xs font-semibold px-3 py-1.5 rounded bg-purple-600 text-white">
+                Submit for Review
+              </button>
+            </div>
+          </Section>
+          <Section title={`Articles (${articles.length})`}>
+            <div className="space-y-2 text-sm">
+              {articles.map((a) => (
+                <div key={a.id} className="border-t border-slate-100 pt-2 flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium">{a.title} <span className="text-slate-400 text-xs">v{a.version}</span></p>
+                    <p className="text-slate-500 text-xs">{a.category.replace(/_/g, " ")} · by {a.author || "unknown"}</p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <StatusBadge status={a.approval_status} />
+                    {isLeadership && a.approval_status === "pending_review" && (
+                      <button onClick={() => approveArticle(a.id)} className="text-xs text-emerald-700 underline">Approve</button>
+                    )}
+                    {isLeadership && a.approval_status === "approved" && (
+                      <button onClick={() => archiveArticle(a.id)} className="text-xs text-slate-500 underline">Archive</button>
+                    )}
+                  </div>
+                </div>
+              ))}
+              {articles.length === 0 && <p className="text-slate-400">No articles yet.</p>}
+            </div>
+          </Section>
+        </div>
+      )}
+
+      {tab === "Cases" && (
+        <Section title={`Clinical Case Library (${cases.length})`}>
+          <div className="space-y-2 text-sm">
+            {cases.map((c) => (
+              <div key={c.id} className="border-t border-slate-100 pt-2">
+                <p className="font-medium">{c.title}</p>
+                <p className="text-slate-500 text-xs">
+                  Inspection #{c.inspection_id} · {c.final_disposition || "no disposition yet"}
+                  {c.outcome && ` · ${c.outcome}`}
+                </p>
+                {c.educational_notes && <p className="text-xs mt-1">{c.educational_notes}</p>}
+              </div>
+            ))}
+            {cases.length === 0 && <p className="text-slate-400">No significant cases recorded yet.</p>}
+          </div>
+        </Section>
+      )}
+
+      {tab === "Standards" && (
+        <div className="space-y-4">
+          {isLeadership && (
+            <Section title="Define Organization Standard">
+              <div className="space-y-2">
+                <select
+                  value={newStandard.standard_type}
+                  onChange={(e) => setNewStandard({ ...newStandard, standard_type: e.target.value })}
+                  className="rounded border border-slate-300 px-2 py-1.5 text-sm"
+                >
+                  {["inspection_standard", "photography_standard", "coverage_requirement", "supervisor_approval_threshold", "competency_requirement"].map((s) => (
+                    <option key={s} value={s}>{s.replace(/_/g, " ")}</option>
+                  ))}
+                </select>
+                <input
+                  type="text" placeholder="Title" value={newStandard.title}
+                  onChange={(e) => setNewStandard({ ...newStandard, title: e.target.value })}
+                  className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                />
+                <textarea
+                  placeholder="Description" value={newStandard.description}
+                  onChange={(e) => setNewStandard({ ...newStandard, description: e.target.value })}
+                  className="w-full rounded border border-slate-300 px-2 py-1.5 text-sm" rows={2}
+                />
+                <button onClick={submitStandard} className="text-xs font-semibold px-3 py-1.5 rounded bg-purple-600 text-white">
+                  Add Standard
+                </button>
+              </div>
+            </Section>
+          )}
+          <Section title={`Organization Standards (${standards.length})`}>
+            <div className="space-y-2 text-sm">
+              {standards.map((s) => (
+                <div key={s.id} className="border-t border-slate-100 pt-2">
+                  <p className="font-medium">{s.title} <span className="text-slate-400 text-xs">({s.standard_type.replace(/_/g, " ")})</span></p>
+                  <p className="text-slate-500 text-xs">{s.description}</p>
+                </div>
+              ))}
+              {standards.length === 0 && <p className="text-slate-400">No local standards defined yet — manufacturer IFUs apply.</p>}
+            </div>
+          </Section>
+        </div>
+      )}
+
+      {tab === "Assistant" && (
+        <Section title="AI Knowledge Assistant">
+          <div className="flex gap-2 mb-3">
+            <input
+              type="text" placeholder='e.g. "why is this finding important?"' value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && askAssistant()}
+              className="flex-1 rounded border border-slate-300 px-2 py-1.5 text-sm"
+            />
+            <button onClick={askAssistant} className="text-xs font-semibold px-3 py-1.5 rounded bg-purple-600 text-white">
+              Ask
+            </button>
+          </div>
+          {assistantResult && (
+            <div className="text-sm space-y-2">
+              <p>{assistantResult.answer}</p>
+              <div className="flex flex-wrap gap-1.5">
+                {assistantResult.sources.map((s, i) => (
+                  <span key={i} className="text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-600">{s}</span>
+                ))}
+              </div>
+            </div>
+          )}
+        </Section>
+      )}
+
+      {tab === "Analytics" && isLeadership && analytics && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <Section title="Most Viewed Articles">
+            {analytics.most_viewed_articles.map((a) => (
+              <p key={a.id} className="text-sm py-0.5">{a.title} — {a.view_count} views</p>
+            ))}
+            {analytics.most_viewed_articles.length === 0 && <p className="text-sm text-slate-400">No views yet.</p>}
+          </Section>
+          <Section title="Most Common Questions">
+            {analytics.most_common_questions.map((q, i) => (
+              <p key={i} className="text-sm py-0.5">"{q.query}" — {q.count}×</p>
+            ))}
+            {analytics.most_common_questions.length === 0 && <p className="text-sm text-slate-400">No questions logged yet.</p>}
+          </Section>
+          <Section title="Knowledge Gaps">
+            {analytics.knowledge_gaps.map((g, i) => (
+              <p key={i} className="text-sm py-0.5">{g.finding_type} — {g.clinical_case_count} case(s), no approved guidance</p>
+            ))}
+            {analytics.knowledge_gaps.length === 0 && <p className="text-sm text-slate-400">No gaps detected.</p>}
+          </Section>
+          <Section title="Training Opportunities">
+            {analytics.training_opportunities.map((t, i) => (
+              <p key={i} className="text-sm py-0.5">{t.technician} — repeated {t.finding_type} errors</p>
+            ))}
+            {analytics.training_opportunities.length === 0 && <p className="text-sm text-slate-400">None detected.</p>}
+          </Section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/KnowledgeGraphExplorer.tsx
+++ b/frontend/src/pages/KnowledgeGraphExplorer.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem("token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function fetchJSON(path: string) {
+  const res = await fetch(`${API_BASE}${path}`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+interface FamilyProfile {
+  family_key: string;
+  display_name: string;
+  typical_anatomy: string[];
+  high_risk_zones: string[];
+  typical_contamination: string[];
+  typical_damage: string[];
+  typical_repair_issues: string[];
+  inspection_priorities: string[];
+  cleaning_priorities: string[];
+  supervisor_focus_areas: string[];
+  anatomy_family_note?: string;
+}
+
+interface ChainStep {
+  node: string;
+  value: unknown;
+  outcome?: string;
+  note?: string | null;
+}
+
+interface ReasoningResult {
+  chain: ChainStep[];
+  narrative: string;
+}
+
+interface Analytics {
+  most_common_findings_by_manufacturer: { key: string; count: number }[];
+  most_common_findings_by_anatomy: { key: string; count: number }[];
+  highest_risk_anatomy_zone: string | null;
+  most_common_repair_reason: { key: string; count: number }[];
+  most_common_supervisor_override: { key: string; count: number }[];
+  most_difficult_instrument_family: string | null;
+  most_missed_anatomy_zones: { zone: string; missed_count: number; case_count: number }[];
+  most_common_contamination_type: { key: string; count: number }[];
+}
+
+const EXPLORE_CATEGORIES = [
+  "manufacturer", "instrument", "model", "finding", "zone",
+  "failure_mode", "recommendation", "supervisor_learning",
+] as const;
+
+function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="mb-3">
+      <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+      {subtitle && <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>}
+    </div>
+  );
+}
+
+function Tag({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-block text-xs bg-gray-100 text-gray-700 rounded px-2 py-0.5 mr-1 mb-1">
+      {children}
+    </span>
+  );
+}
+
+function FamilyCard({ profile }: { profile: FamilyProfile }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="rounded-lg border bg-white p-4">
+      <button className="w-full text-left" onClick={() => setExpanded((e) => !e)}>
+        <p className="font-semibold text-gray-900">{profile.display_name}</p>
+        <p className="text-xs text-gray-500 mt-1">{profile.typical_anatomy.length} anatomy zones · {profile.high_risk_zones.length} high-risk</p>
+      </button>
+      {expanded && (
+        <div className="mt-3 space-y-2 text-sm">
+          {profile.anatomy_family_note && (
+            <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1">{profile.anatomy_family_note}</p>
+          )}
+          <div><span className="font-medium">Typical anatomy: </span>{profile.typical_anatomy.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">Typical contamination: </span>{profile.typical_contamination.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">Typical damage: </span>{profile.typical_damage.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">Inspection priorities: </span>{profile.inspection_priorities.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">Cleaning priorities: </span>{profile.cleaning_priorities.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+          <div><span className="font-medium">Supervisor focus: </span>{profile.supervisor_focus_areas.map((z) => <Tag key={z}>{z}</Tag>)}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReasoningChainPanel() {
+  const [instrumentType, setInstrumentType] = useState("kerrison rongeur");
+  const [findingType, setFindingType] = useState("blood");
+  const [manufacturer, setManufacturer] = useState("");
+  const [result, setResult] = useState<ReasoningResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const run = () => {
+    setLoading(true);
+    const params = new URLSearchParams({ instrument_type: instrumentType, finding_type: findingType, manufacturer });
+    fetchJSON(`/api/knowledge-graph/reasoning-chain?${params}`)
+      .then(setResult)
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { run(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+
+  return (
+    <div className="rounded-lg border bg-white p-4">
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input value={instrumentType} onChange={(e) => setInstrumentType(e.target.value)} placeholder="Instrument type"
+          className="text-sm border rounded px-2 py-1 flex-1 min-w-[160px]" />
+        <input value={findingType} onChange={(e) => setFindingType(e.target.value)} placeholder="Finding type"
+          className="text-sm border rounded px-2 py-1 flex-1 min-w-[140px]" />
+        <input value={manufacturer} onChange={(e) => setManufacturer(e.target.value)} placeholder="Manufacturer (optional)"
+          className="text-sm border rounded px-2 py-1 flex-1 min-w-[160px]" />
+        <button onClick={run} className="text-sm bg-blue-600 text-white rounded px-3 py-1">Trace reasoning</button>
+      </div>
+      {loading && <p className="text-sm text-gray-400">Reasoning…</p>}
+      {result && !loading && (
+        <>
+          <div className="flex flex-wrap items-center gap-1 mb-4">
+            {result.chain.map((step, i) => (
+              <span key={step.node} className="flex items-center gap-1">
+                <span className="text-xs bg-blue-50 border border-blue-200 text-blue-800 rounded px-2 py-1">
+                  <span className="font-semibold">{step.node}:</span>{" "}
+                  {Array.isArray(step.value) ? step.value.join(", ") || "—" : String(step.value ?? "—")}
+                </span>
+                {i < result.chain.length - 1 && <span className="text-gray-300">→</span>}
+              </span>
+            ))}
+          </div>
+          <p className="text-sm text-gray-800 bg-gray-50 border rounded p-3">{result.narrative}</p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Explorer() {
+  const [category, setCategory] = useState<(typeof EXPLORE_CATEGORIES)[number]>("zone");
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<unknown>(null);
+
+  const run = () => {
+    const params = new URLSearchParams({ category, q: query });
+    fetchJSON(`/api/knowledge-graph/explore?${params}`).then((d) => setResults(d.results));
+  };
+
+  useEffect(() => { run(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [category]);
+
+  return (
+    <div className="rounded-lg border bg-white p-4">
+      <div className="flex flex-wrap gap-2 mb-3">
+        {EXPLORE_CATEGORIES.map((c) => (
+          <button key={c} onClick={() => setCategory(c)}
+            className={`text-xs px-2 py-1 rounded border ${category === c ? "bg-blue-600 text-white border-blue-600" : "bg-white text-gray-700 border-gray-300"}`}>
+            {c.replace("_", " ")}
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-2 mb-3">
+        <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search…"
+          className="text-sm border rounded px-2 py-1 flex-1" onKeyDown={(e) => e.key === "Enter" && run()} />
+        <button onClick={run} className="text-sm bg-gray-800 text-white rounded px-3 py-1">Search</button>
+      </div>
+      <pre className="text-xs bg-gray-50 border rounded p-3 overflow-x-auto max-h-80 overflow-y-auto">
+        {JSON.stringify(results, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+export default function KnowledgeGraphExplorer() {
+  const [families, setFamilies] = useState<FamilyProfile[]>([]);
+  const [analytics, setAnalytics] = useState<Analytics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchJSON("/api/knowledge-graph/instrument-families").then((d) => setFamilies(d.families)).catch((e) => setError(String(e)));
+    fetchJSON("/api/knowledge-graph/analytics").then(setAnalytics).catch(() => {});
+  }, []);
+
+  return (
+    <div className="p-6 space-y-8 max-w-7xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">SPD Clinical Knowledge Graph</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Traceable reasoning from instrument identity through anatomy, findings, risk, and recommended action —
+          not a black-box detector.
+        </p>
+      </div>
+
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+
+      <section>
+        <SectionHeader title="Clinical Reasoning Chain" subtitle="Trace how LumenAI reasons from instrument + finding to a recommended action." />
+        <ReasoningChainPanel />
+      </section>
+
+      <section>
+        <SectionHeader title="Instrument Family Intelligence" subtitle="Knowledge profiles for the ten instrument families SPD sees most often." />
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {families.map((f) => <FamilyCard key={f.family_key} profile={f} />)}
+        </div>
+      </section>
+
+      <section>
+        <SectionHeader title="Knowledge Graph Explorer" subtitle="Browse by manufacturer, instrument, model, finding, zone, failure mode, recommendation, or supervisor learning." />
+        <Explorer />
+      </section>
+
+      {analytics && (
+        <section>
+          <SectionHeader title="Enterprise Knowledge Analytics" />
+          <div className="grid md:grid-cols-2 gap-4 text-sm">
+            <div className="rounded-lg border bg-white p-4">
+              <p className="font-medium mb-2">Highest-risk anatomy zone</p>
+              <p className="text-gray-700">{analytics.highest_risk_anatomy_zone ?? "Not enough data yet."}</p>
+            </div>
+            <div className="rounded-lg border bg-white p-4">
+              <p className="font-medium mb-2">Most difficult instrument family</p>
+              <p className="text-gray-700">{analytics.most_difficult_instrument_family ?? "Not enough data yet."}</p>
+            </div>
+            <div className="rounded-lg border bg-white p-4">
+              <p className="font-medium mb-2">Most common contamination type</p>
+              {analytics.most_common_contamination_type.map((c) => (
+                <p key={c.key} className="text-gray-700">{c.key}: {c.count}</p>
+              ))}
+              {analytics.most_common_contamination_type.length === 0 && <p className="text-gray-400">No data yet.</p>}
+            </div>
+            <div className="rounded-lg border bg-white p-4">
+              <p className="font-medium mb-2">Most missed anatomy zones</p>
+              {analytics.most_missed_anatomy_zones.map((z) => (
+                <p key={z.zone} className="text-gray-700">{z.zone}: {z.missed_count}/{z.case_count} missed</p>
+              ))}
+              {analytics.most_missed_anatomy_zones.length === 0 && <p className="text-gray-400">No pilot validation data yet.</p>}
+            </div>
+          </div>
+        </section>
+      )}
+
+      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+        ⚠ Knowledge-graph reasoning is advisory clinical knowledge, not a substitute for the device IFU or
+        supervisor judgment. Every recommendation requires human validation before disposition.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -1077,7 +1077,11 @@ function AIPredictionPanel({
 
         {/* Phase 13 — Explainable Clinical Decision Support (primary view) */}
         {prediction.analysis?.clinical_decision && (
-          <ClinicalDecisionPanel cd={prediction.analysis.clinical_decision} inspectionId={prediction.id} />
+          <ClinicalDecisionPanel
+            cd={prediction.analysis.clinical_decision}
+            inspectionId={prediction.id}
+            rawResult={prediction.analysis}
+          />
         )}
 
         {/* Phase 15 — Instrument Intelligence: coverage, risk map, guidance */}

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -3,6 +3,8 @@ import { Link, useNavigate } from "react-router-dom";
 import { useAuth, API_BASE } from "@/lib/auth";
 import ClinicalDecisionPanel from "@/components/ClinicalDecisionPanel";
 import InstrumentIntelligencePanel, { InstrumentIntel } from "@/components/InstrumentIntelligencePanel";
+import GuidedCapturePanel from "@/components/GuidedCapturePanel";
+import CoverageOverridePanel from "@/components/CoverageOverridePanel";
 import { FormSection } from "@/components/ui/FormSection";
 import { RequiredLabel, FieldError } from "@/components/ui/RequiredField";
 import { StatusBanner } from "@/components/ui/StatusBanner";
@@ -35,6 +37,13 @@ type FormFields = {
 };
 
 type FieldErrors = Partial<Record<keyof FormFields | "images", string>>;
+
+// v1.2 — Image View Tagging (one tag per uploaded image).
+type ImageTag = { anatomy_zone: string; image_view: string; capture_quality: string; notes: string };
+const DEFAULT_IMAGE_TAG: ImageTag = { anatomy_zone: "", image_view: "", capture_quality: "acceptable", notes: "" };
+function imageFileKey(f: File): string {
+  return `${f.name}__${f.size}`;
+}
 
 type PredictedFinding = {
   type: string;
@@ -125,6 +134,9 @@ type AIPrediction = {
   confidence: number;
   instrument_type: string;
   analysis: Analysis | null;
+  // v1.2 — Guided Capture coverage gate
+  coverage_gate_status?: "ready" | "draft" | "blocked_pending_override";
+  is_draft?: boolean;
 };
 
 // ─── constants ────────────────────────────────────────────────────────────────
@@ -250,6 +262,10 @@ export default function NewInspectionPage() {
     return () => { cancelled = true; clearTimeout(t); };
   }, [form.instrument_type, headers]);
   const [borescopeImages, setBorescopeImages] = useState<File[]>([]);
+  // v1.2 — per-image view tags, keyed by "name__size" so tags survive re-renders
+  // without depending on array index (which shifts when a file is removed).
+  const [imageTags, setImageTags] = useState<Record<string, ImageTag>>({});
+  const [saveAsDraft, setSaveAsDraft] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [banner, setBanner] = useState<{ type: "success" | "error"; message: string } | null>(null);
   const [prediction, setPrediction] = useState<AIPrediction | null>(null);
@@ -345,6 +361,12 @@ export default function NewInspectionPage() {
 
   function removeImage(index: number, setter: React.Dispatch<React.SetStateAction<File[]>>) {
     setter((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  // v1.2 — Image View Tagging
+  function updateImageTag(f: File, patch: Partial<ImageTag>) {
+    const key = imageFileKey(f);
+    setImageTags((prev) => ({ ...prev, [key]: { ...DEFAULT_IMAGE_TAG, ...prev[key], ...patch } }));
   }
 
   // ── validation ─────────────────────────────────────────────────────────────
@@ -455,6 +477,18 @@ export default function NewInspectionPage() {
         file_name: allImages[0]?.name || "inspection_image",
         has_image: true,
         image_sha256: imageSha256,
+        // v1.2 — Image View Tagging + AI Analysis Gate escape hatch
+        image_view_tags: allImages.map((f) => {
+          const t = imageTags[imageFileKey(f)] ?? DEFAULT_IMAGE_TAG;
+          return {
+            instrument_family: form.instrument_type,
+            anatomy_zone: t.anatomy_zone,
+            image_view: t.image_view || t.anatomy_zone,
+            capture_quality: t.capture_quality,
+            notes: t.notes,
+          };
+        }),
+        save_as_draft: saveAsDraft,
         // Risk level is AI-determined — never required from technician
         risk_level: "pending_ai_analysis",
         // Finding categories submitted as-is (empty [] is valid — AI will determine)
@@ -916,6 +950,80 @@ export default function NewInspectionPage() {
                 <p className="mt-1 text-xs text-slate-400">Drives the Inspection Coverage score and missing-image guidance.</p>
               </div>
             )}
+
+            {/* v1.2 — Guided Capture Panel: current zone to capture + coverage/gate */}
+            {form.instrument_type.trim() && (
+              <div className="mt-3">
+                <GuidedCapturePanel instrumentType={form.instrument_type} capturedZones={inspectedZones} />
+              </div>
+            )}
+
+            {/* v1.2 — Image View Tagging: per-uploaded-image metadata */}
+            {(inspectionImages.length > 0 || borescopeImages.length > 0) && (
+              <div className="mt-3">
+                <label className="block text-sm font-medium text-gray-700">
+                  Tag captured images <span className="text-slate-400 font-normal">(zone, view, quality, notes per image)</span>
+                </label>
+                <div className="mt-2 space-y-2">
+                  {[...inspectionImages, ...borescopeImages].map((f) => {
+                    const key = imageFileKey(f);
+                    const tag = imageTags[key] ?? DEFAULT_IMAGE_TAG;
+                    return (
+                      <div key={key} className="rounded-lg border border-slate-200 p-3 grid grid-cols-1 sm:grid-cols-4 gap-2 text-sm">
+                        <div className="sm:col-span-4 text-xs font-medium text-slate-600 truncate">{f.name}</div>
+                        <select
+                          value={tag.anatomy_zone}
+                          disabled={!canRunInspection}
+                          onChange={(e) => updateImageTag(f, { anatomy_zone: e.target.value })}
+                          className="rounded border border-slate-300 px-2 py-1"
+                        >
+                          <option value="">Zone…</option>
+                          {anatomyZones.map((z) => <option key={z} value={z}>{z}</option>)}
+                        </select>
+                        <select
+                          value={tag.image_view}
+                          disabled={!canRunInspection}
+                          onChange={(e) => updateImageTag(f, { image_view: e.target.value })}
+                          className="rounded border border-slate-300 px-2 py-1"
+                        >
+                          <option value="">Image view (defaults to zone)…</option>
+                          {anatomyZones.map((z) => <option key={z} value={z}>{z}</option>)}
+                        </select>
+                        <select
+                          value={tag.capture_quality}
+                          disabled={!canRunInspection}
+                          onChange={(e) => updateImageTag(f, { capture_quality: e.target.value })}
+                          className="rounded border border-slate-300 px-2 py-1"
+                        >
+                          <option value="good">Good</option>
+                          <option value="acceptable">Acceptable</option>
+                          <option value="poor">Poor</option>
+                          <option value="unusable">Unusable</option>
+                        </select>
+                        <input
+                          value={tag.notes}
+                          disabled={!canRunInspection}
+                          onChange={(e) => updateImageTag(f, { notes: e.target.value })}
+                          placeholder="Notes (optional)"
+                          className="rounded border border-slate-300 px-2 py-1"
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* v1.2 — AI Analysis Gate escape hatch */}
+            <label className="mt-3 flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={saveAsDraft}
+                disabled={!canRunInspection}
+                onChange={(e) => setSaveAsDraft(e.target.checked)}
+              />
+              Save as draft (coverage is incomplete — proceed without a final decision for now)
+            </label>
           </FormSection>
 
           {/* Section 5 — Manual Observations (always optional) */}
@@ -1101,6 +1209,11 @@ function AIPredictionPanel({
           Human review required. All AI findings represent potential associations only — qualified clinician review is mandatory before any clinical action.
         </p>
       </div>
+
+      {/* v1.2 — Coverage Override Panel (gated final decision due to incomplete coverage) */}
+      {prediction.coverage_gate_status === "blocked_pending_override" && (
+        <CoverageOverridePanel inspectionId={Number(prediction.id)} />
+      )}
 
       {/* Supervisor Override Panel */}
       {isSupervisorRequired && (

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -9,6 +9,7 @@ import { FormSection } from "@/components/ui/FormSection";
 import { RequiredLabel, FieldError } from "@/components/ui/RequiredField";
 import { StatusBanner } from "@/components/ui/StatusBanner";
 import { apiFetch } from "@/lib/api";
+import { logPilotError } from "@/lib/errorLog";
 
 // ─── types ─────────────────────────────────────────────────────────────────── v2
 
@@ -562,10 +563,12 @@ export default function NewInspectionPage() {
       scrollToResult();
     } catch (err) {
       // Never fail silently — surface the error so the user knows what happened.
+      const detail = err instanceof Error ? err.message : "network error";
       setBanner({
         type: "error",
-        message: `Could not complete AI analysis: ${err instanceof Error ? err.message : "network error"}. Please try again.`,
+        message: `Could not complete AI analysis: ${detail}. Please try again.`,
       });
+      logPilotError(allImages.length > 0 ? "upload_failure" : "ai_analysis_failure", detail);
       scrollToResult();
     } finally {
       setSubmitting(false);

--- a/frontend/src/pages/OperationsBoardPage.tsx
+++ b/frontend/src/pages/OperationsBoardPage.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+import { ClipboardList } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface QueueItem {
+  inspection_id: number;
+  instrument_type: string;
+  workflow_state: string;
+  risk_tier: string;
+  priority_tier: string;
+  minutes_waiting: number | null;
+  assigned_technician: string | null;
+}
+
+interface TechnicianWorkload {
+  technician: string;
+  open_inspections: number;
+  completed_inspections: number;
+  workload: number;
+  avg_inspection_time_minutes: number | null;
+}
+
+interface OperationsBoard {
+  technician_workload: TechnicianWorkload[];
+  supervisor_queue: QueueItem[];
+  pending_approvals: QueueItem[];
+  high_risk_findings: QueueItem[];
+  repair_queue: QueueItem[];
+  or_urgent_items: QueueItem[];
+  vendor_instruments: QueueItem[];
+}
+
+function MiniList({ items }: { items: QueueItem[] }) {
+  if (items.length === 0) return <p className="text-sm text-slate-400 py-1">None right now.</p>;
+  return (
+    <ul className="space-y-1.5 text-sm">
+      {items.map((item) => (
+        <li key={item.inspection_id} className="flex items-center justify-between">
+          <span>
+            #{item.inspection_id} — {item.instrument_type}{" "}
+            <span className="text-slate-400">({item.workflow_state})</span>
+          </span>
+          <span className="text-xs text-slate-500">{item.assigned_technician ?? "Unassigned"}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Section({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{title}</p>
+        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-slate-100 text-slate-600">{count}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default function OperationsBoardPage() {
+  const [board, setBoard] = useState<OperationsBoard | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    apiFetch<OperationsBoard>("/api/operations-board")
+      .then(setBoard)
+      .catch(() => setError("You may not have access to the Supervisor Operations Board, or it failed to load."));
+  }, []);
+
+  if (error) return <div className="p-6 text-sm text-red-600">{error}</div>;
+  if (!board) return <div className="p-6 text-sm text-slate-500">Loading…</div>;
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <ClipboardList className="h-6 w-6 text-indigo-600" />
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Supervisor Operations Board</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            Technician workload, pending approvals, and clinical-risk queues for the shift.
+          </p>
+        </div>
+      </div>
+
+      <Section title="Technician Workload" count={board.technician_workload.length}>
+        {board.technician_workload.length === 0 ? (
+          <p className="text-sm text-slate-400 py-1">No technicians currently assigned.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-slate-400 text-xs">
+                <th className="py-1 pr-3">Technician</th>
+                <th className="py-1 px-2">Open</th>
+                <th className="py-1 px-2">Completed</th>
+                <th className="py-1 px-2">Avg. Inspection Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {board.technician_workload.map((t) => (
+                <tr key={t.technician} className="border-t border-slate-100">
+                  <td className="py-1.5 pr-3 font-medium">{t.technician}</td>
+                  <td className="py-1.5 px-2">{t.open_inspections}</td>
+                  <td className="py-1.5 px-2">{t.completed_inspections}</td>
+                  <td className="py-1.5 px-2">
+                    {t.avg_inspection_time_minutes == null ? "—" : `${Math.round(t.avg_inspection_time_minutes)}m`}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Section>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Section title="Supervisor Queue" count={board.supervisor_queue.length}>
+          <MiniList items={board.supervisor_queue} />
+        </Section>
+        <Section title="High-Risk Findings" count={board.high_risk_findings.length}>
+          <MiniList items={board.high_risk_findings} />
+        </Section>
+        <Section title="Repair Queue" count={board.repair_queue.length}>
+          <MiniList items={board.repair_queue} />
+        </Section>
+        <Section title="OR Urgent Items" count={board.or_urgent_items.length}>
+          <MiniList items={board.or_urgent_items} />
+        </Section>
+        <Section title="Vendor Instruments" count={board.vendor_instruments.length}>
+          <MiniList items={board.vendor_instruments} />
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/OperationsDashboard.tsx
+++ b/frontend/src/pages/OperationsDashboard.tsx
@@ -1,79 +1,65 @@
-const activityRows = [
-  {
-    id: "SPD-1042",
-    facility: "ORC",
-    instrument: "Laparoscopic grasper",
-    finding: "Blood residue flagged",
-    risk: "High",
-    status: "Review",
-    date: "Today",
-  },
-  {
-    id: "SPD-1041",
-    facility: "St. Francis",
-    instrument: "Orthopedic cutter",
-    finding: "Rust on hinge",
-    risk: "High",
-    status: "CAPA",
-    date: "Today",
-  },
-  {
-    id: "SPD-1039",
-    facility: "Memorial Regional",
-    instrument: "Forceps",
-    finding: "Discoloration",
-    risk: "Medium",
-    status: "Open",
-    date: "Yesterday",
-  },
-  {
-    id: "SPD-1037",
-    facility: "Southside",
-    instrument: "Tray liner",
-    finding: "Lint found during pack",
-    risk: "Low",
-    status: "Closed",
-    date: "2 days ago",
-  },
-];
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { apiFetch } from "@/lib/api";
 
-const workflowSteps = ["Capture", "Classify", "Review", "CAPA", "Close"];
+interface QueueItem {
+  inspection_id: number;
+  instrument_type: string;
+  facility_name: string | null;
+  workflow_state: string;
+  risk_tier: string;
+  minutes_waiting: number | null;
+}
+
+interface WorkQueue {
+  pending_inspections: QueueItem[];
+  high_risk_inspections: QueueItem[];
+  supervisor_reviews: QueueItem[];
+  repair_holds: QueueItem[];
+  total_pending: number;
+}
+
+const workflowSteps = ["Image Capture", "AI Analysis", "Supervisor Review", "Reclean / Repair", "Completed"];
 
 function riskStyle(risk: string): React.CSSProperties {
-  if (risk === "High") {
-    return { ...badge, background: "#7f1d1d", color: "#fecaca" };
-  }
-  if (risk === "Medium") {
-    return { ...badge, background: "#78350f", color: "#fde68a" };
-  }
+  if (risk === "Critical") return { ...badge, background: "#450a0a", color: "#fecaca" };
+  if (risk === "High Risk") return { ...badge, background: "#7f1d1d", color: "#fecaca" };
+  if (risk === "Moderate Risk") return { ...badge, background: "#78350f", color: "#fde68a" };
   return { ...badge, background: "#064e3b", color: "#a7f3d0" };
 }
 
 function statusStyle(status: string): React.CSSProperties {
-  if (status === "CAPA") {
-    return { ...badge, background: "#1e3a8a", color: "#bfdbfe" };
-  }
-  if (status === "Review") {
-    return { ...badge, background: "#4c1d95", color: "#ddd6fe" };
-  }
-  if (status === "Closed") {
-    return { ...badge, background: "#065f46", color: "#bbf7d0" };
-  }
+  if (status === "Repair") return { ...badge, background: "#1e3a8a", color: "#bfdbfe" };
+  if (status === "Supervisor Review") return { ...badge, background: "#4c1d95", color: "#ddd6fe" };
+  if (status === "Completed") return { ...badge, background: "#065f46", color: "#bbf7d0" };
   return { ...badge, background: "#374151", color: "#e5e7eb" };
 }
 
+function formatWait(minutes: number | null): string {
+  if (minutes == null) return "—";
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ago`;
+}
+
 export default function OperationsDashboard() {
+  const [queue, setQueue] = useState<WorkQueue | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch<WorkQueue>("/api/inspection-work-queue")
+      .then((d) => { if (!cancelled) setQueue(d); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const recent = queue?.pending_inspections.slice(0, 8) ?? [];
+
   return (
     <main style={pageShell}>
       <section style={hero}>
-        <nav style={topNav} aria-label="Operations navigation">
-          <a href="/" style={navLink}>Public Landing</a>
-          <a href="/dashboard" style={navLink}>Dashboard</a>
-          <a href="/operations" style={activeNavLink}>Operations</a>
-        </nav>
-
         <div style={banner}>
-          Pilot mode: focused on inspection, findings, CAPA, and quality trend workflow.
+          Live SPD operations — real inspection, workflow-state, and risk data from the Smart Inspection Queue.
         </div>
 
         <div style={heroGrid}>
@@ -81,77 +67,95 @@ export default function OperationsDashboard() {
             <p style={eyebrow}>Daily SPD workflow</p>
             <h1 style={title}>LumenAI SPD Quality Operations</h1>
             <p style={subtitle}>
-              Daily inspection, findings, CAPA, and quality review workspace for sterile processing teams.
+              Daily inspection, review, and quality workspace for sterile processing teams.
             </p>
           </div>
 
           <div style={quickActions} aria-label="Quick actions">
-            <a href="/inspection/new" style={primaryAction}>New Inspection</a>
-            <a href="/findings" style={secondaryAction}>Findings Queue</a>
-            <a href="/capa" style={secondaryAction}>CAPA Queue</a>
-            <a href="/analytics" style={secondaryAction}>Analytics</a>
+            <Link to="/inspection/new" style={primaryAction}>New Inspection</Link>
+            <Link to="/inspection-work-queue" style={secondaryAction}>Smart Work Queue</Link>
+            <Link to="/findings" style={secondaryAction}>Findings Queue</Link>
+            <Link to="/operations-board" style={secondaryAction}>Operations Board</Link>
           </div>
         </div>
       </section>
 
-      <section style={kpiGrid} aria-label="Operations KPIs">
-        <KpiCard label="Open Findings" value="18" tone="#38bdf8" />
-        <KpiCard label="Open CAPAs" value="6" tone="#a78bfa" />
-        <KpiCard label="Pending Reviews" value="9" tone="#f59e0b" />
-        <KpiCard label="High-Risk Events" value="4" tone="#f87171" />
-      </section>
+      {error && (
+        <section style={{ ...panelLarge, marginBottom: 18, borderColor: "rgba(248, 113, 113, 0.4)" }}>
+          <p style={{ color: "#fca5a5", margin: 0 }}>Failed to load live operations data: {error}</p>
+        </section>
+      )}
 
-      <section style={contentGrid}>
-        <div style={panelLarge}>
-          <div style={panelHeader}>
-            <div>
-              <h2 style={panelTitle}>Recent Activity</h2>
-              <p style={panelHint}>Pilot-safe sample activity for daily review.</p>
-            </div>
-          </div>
+      {!error && queue === null && (
+        <section style={panelLarge}>
+          <p style={{ color: "#94a3b8", margin: 0 }}>Loading…</p>
+        </section>
+      )}
 
-          <div style={tableWrap}>
-            <table style={table}>
-              <thead>
-                <tr>
-                  <th style={th}>ID</th>
-                  <th style={th}>Facility</th>
-                  <th style={th}>Instrument</th>
-                  <th style={th}>Finding</th>
-                  <th style={th}>Risk</th>
-                  <th style={th}>Status</th>
-                  <th style={th}>Date</th>
-                </tr>
-              </thead>
-              <tbody>
-                {activityRows.map((row) => (
-                  <tr key={row.id} style={tr}>
-                    <td style={tdStrong}>{row.id}</td>
-                    <td style={td}>{row.facility}</td>
-                    <td style={td}>{row.instrument}</td>
-                    <td style={td}>{row.finding}</td>
-                    <td style={td}><span style={riskStyle(row.risk)}>{row.risk}</span></td>
-                    <td style={td}><span style={statusStyle(row.status)}>{row.status}</span></td>
-                    <td style={tdMuted}>{row.date}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+      {queue && (
+        <>
+          <section style={kpiGrid} aria-label="Operations KPIs">
+            <KpiCard label="Pending Inspections" value={String(queue.total_pending)} tone="#38bdf8" />
+            <KpiCard label="Supervisor Reviews" value={String(queue.supervisor_reviews.length)} tone="#a78bfa" />
+            <KpiCard label="Repair Holds" value={String(queue.repair_holds.length)} tone="#f59e0b" />
+            <KpiCard label="High-Risk Inspections" value={String(queue.high_risk_inspections.length)} tone="#f87171" />
+          </section>
 
-        <aside style={panel}>
-          <h2 style={panelTitle}>Pilot Workflow</h2>
-          <div style={workflowList}>
-            {workflowSteps.map((step, index) => (
-              <div key={step} style={workflowStep}>
-                <span style={stepNumber}>{index + 1}</span>
-                <span>{step}</span>
+          <section style={contentGrid}>
+            <div style={panelLarge}>
+              <div style={panelHeader}>
+                <div>
+                  <h2 style={panelTitle}>Recent Activity</h2>
+                  <p style={panelHint}>Highest-priority pending inspections, live from the Smart Inspection Queue.</p>
+                </div>
               </div>
-            ))}
-          </div>
-        </aside>
-      </section>
+
+              {recent.length === 0 ? (
+                <p style={{ color: "#94a3b8" }}>No pending inspections right now.</p>
+              ) : (
+                <div style={tableWrap}>
+                  <table style={table}>
+                    <thead>
+                      <tr>
+                        <th style={th}>ID</th>
+                        <th style={th}>Facility</th>
+                        <th style={th}>Instrument</th>
+                        <th style={th}>Risk</th>
+                        <th style={th}>Status</th>
+                        <th style={th}>Waiting</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {recent.map((row) => (
+                        <tr key={row.inspection_id} style={tr}>
+                          <td style={tdStrong}>#{row.inspection_id}</td>
+                          <td style={td}>{row.facility_name ?? "—"}</td>
+                          <td style={td}>{row.instrument_type}</td>
+                          <td style={td}><span style={riskStyle(row.risk_tier)}>{row.risk_tier}</span></td>
+                          <td style={td}><span style={statusStyle(row.workflow_state)}>{row.workflow_state}</span></td>
+                          <td style={tdMuted}>{formatWait(row.minutes_waiting)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+
+            <aside style={panel}>
+              <h2 style={panelTitle}>Workflow States</h2>
+              <div style={workflowList}>
+                {workflowSteps.map((step, index) => (
+                  <div key={step} style={workflowStep}>
+                    <span style={stepNumber}>{index + 1}</span>
+                    <span>{step}</span>
+                  </div>
+                ))}
+              </div>
+            </aside>
+          </section>
+        </>
+      )}
     </main>
   );
 }
@@ -177,26 +181,6 @@ const pageShell: React.CSSProperties = {
 const hero: React.CSSProperties = {
   maxWidth: "1360px",
   margin: "0 auto 22px",
-};
-
-const topNav: React.CSSProperties = {
-  display: "flex",
-  gap: "12px",
-  flexWrap: "wrap",
-  marginBottom: "18px",
-};
-
-const navLink: React.CSSProperties = {
-  color: "#cbd5e1",
-  textDecoration: "none",
-  fontWeight: 700,
-  padding: "9px 12px",
-};
-
-const activeNavLink: React.CSSProperties = {
-  ...navLink,
-  color: "#ffffff",
-  borderBottom: "2px solid #38bdf8",
 };
 
 const banner: React.CSSProperties = {

--- a/frontend/src/pages/PilotDataCollectionPage.tsx
+++ b/frontend/src/pages/PilotDataCollectionPage.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { Database } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface IssueDetail {
+  inspection_id: number;
+  issues: { code: string; message: string }[];
+  is_dataset_ready: boolean;
+}
+
+interface Summary {
+  facility_name: string;
+  department: string;
+  inspections_collected: number;
+  baseline_images_collected: number;
+  inspection_images_collected: number;
+  supervisor_reviews_completed: number;
+  incomplete_inspections: number;
+  incomplete_inspection_details: IssueDetail[];
+  failed_uploads: number;
+  missing_anatomy_zones: number;
+  dataset_ready_images: number;
+}
+
+function Stat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="text-xs text-slate-500">{label}</div>
+      <div className="text-2xl font-bold text-slate-900">{value}</div>
+    </div>
+  );
+}
+
+export default function PilotDataCollectionPage() {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    apiFetch<Summary>("/api/pilot-deployment/data-collection")
+      .then(setSummary)
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="p-6 text-sm text-red-600">
+        Failed to load pilot data collection status: {error}
+        {error.includes("403") && (
+          <p className="mt-1 text-slate-500">This dashboard is restricted to admins and SPD managers.</p>
+        )}
+      </div>
+    );
+  }
+  if (!summary) return <div className="p-6 text-sm text-slate-500">Loading…</div>;
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <Database className="h-6 w-6 text-emerald-600" />
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Pilot Data Collection</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            {summary.facility_name || "Facility not yet configured"}
+            {summary.department && ` · ${summary.department}`} — dataset readiness for the pilot.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Stat label="Inspections Collected" value={summary.inspections_collected} />
+        <Stat label="Baseline Images Collected" value={summary.baseline_images_collected} />
+        <Stat label="Inspection Images Collected" value={summary.inspection_images_collected} />
+        <Stat label="Supervisor Reviews Completed" value={summary.supervisor_reviews_completed} />
+        <Stat label="Dataset-Ready Inspections" value={summary.dataset_ready_images} />
+        <Stat label="Incomplete Inspections" value={summary.incomplete_inspections} />
+        <Stat label="Missing Anatomy Zones" value={summary.missing_anatomy_zones} />
+        <Stat label="Failed Uploads" value={summary.failed_uploads} />
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3">
+          Incomplete Inspections ({summary.incomplete_inspection_details.length} shown)
+        </p>
+        {summary.incomplete_inspection_details.length === 0 ? (
+          <p className="text-sm text-slate-400">Every inspection currently meets the site's data quality thresholds.</p>
+        ) : (
+          <div className="space-y-2 text-sm">
+            {summary.incomplete_inspection_details.map((d) => (
+              <div key={d.inspection_id} className="border-t border-slate-100 pt-2">
+                <p className="font-medium">Inspection #{d.inspection_id}</p>
+                <ul className="list-disc list-inside text-slate-500">
+                  {d.issues.map((issue) => (
+                    <li key={issue.code}>{issue.message}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/PreSterilizationCommandCenter.tsx
+++ b/frontend/src/pages/PreSterilizationCommandCenter.tsx
@@ -1,0 +1,500 @@
+import { useEffect, useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem("token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function fetchJSON(path: string) {
+  const res = await fetch(`${API_BASE}${path}`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+type ReadinessState =
+  | "READY_FOR_PACKAGING"
+  | "REQUIRES_RECLEANING"
+  | "REQUIRES_SUPERVISOR_REVIEW"
+  | "REQUIRES_REPAIR"
+  | "REMOVED_FROM_SERVICE"
+  | "PENDING_ANALYSIS";
+
+interface ClinicalInspectionReadiness {
+  total_inspections: number;
+  ready_for_packaging: number;
+  readiness_rate: number | null;
+  mean_readiness_score: number | null;
+  by_state: Record<ReadinessState, number>;
+}
+
+interface Tray {
+  tray_id: string;
+  instrument_count: number;
+  tray_readiness_state: ReadinessState;
+  ready_for_packaging: boolean;
+  blocking_instruments: { instrument_type: string; readiness_state: ReadinessState }[];
+}
+
+interface Instrument {
+  instrument_identity: string;
+  instrument_type: string;
+  tray_id: string | null;
+  readiness_state: ReadinessState;
+  readiness_score: number | null;
+  confirmed: boolean;
+  last_inspected_at: string | null;
+}
+
+interface Facility {
+  facility: string;
+  total_inspections: number;
+  readiness_rate: number | null;
+  trend: "improving" | "declining" | "stable" | "insufficient_data";
+  by_state: Record<ReadinessState, number>;
+}
+
+interface HighRiskFinding {
+  inspection_id: number;
+  instrument_type: string;
+  detected_issue: string;
+  readiness_state: ReadinessState;
+  risk_score: number;
+  facility: string | null;
+  tray_id: string | null;
+}
+
+interface SupervisorReviewItem {
+  inspection_id: number;
+  instrument_type: string;
+  detected_issue: string;
+  recommended_action: string | null;
+  risk_score: number;
+}
+
+interface MissingZoneItem {
+  inspection_id: number;
+  instrument_type: string;
+  coverage_quality: string;
+  overall_coverage: number | null;
+  missing_required_zones: string[];
+}
+
+interface BaselineCoverage {
+  total_imaged_inspections: number;
+  with_approved_baseline: number;
+  baseline_coverage_rate: number | null;
+  instrument_types_missing_baseline: { instrument_type: string; inspection_count: number }[];
+}
+
+interface RepairRemoveQueue {
+  repair_candidates: { count: number; cases: HighRiskFinding[] };
+  removed_from_service: { count: number; cases: HighRiskFinding[] };
+}
+
+interface ExecutiveRiskDashboard {
+  readiness_summary: ClinicalInspectionReadiness;
+  high_risk_findings_count: number;
+  supervisor_review_backlog: number;
+  repair_candidates_count: number;
+  removed_from_service_count: number;
+  baseline_coverage_rate: number | null;
+  instrument_types_missing_baseline: number;
+  facility_rollup: Facility[];
+  anatomy_zone_failure_trend: { zone: string; missed_count: number; case_count: number }[];
+}
+
+interface Dashboard {
+  clinical_inspection_readiness: ClinicalInspectionReadiness;
+  tray_readiness: Tray[];
+  instrument_readiness: Instrument[];
+  facility_readiness: Facility[];
+  high_risk_findings_queue: HighRiskFinding[];
+  supervisor_review_queue: SupervisorReviewItem[];
+  missing_zone_coverage_queue: MissingZoneItem[];
+  baseline_coverage: BaselineCoverage;
+  repair_remove_queue: RepairRemoveQueue;
+  executive_risk_dashboard: ExecutiveRiskDashboard;
+}
+
+const PERSONAS = [
+  "SPD Technician",
+  "SPD Supervisor",
+  "SPD Manager",
+  "Market Director",
+  "Infection Prevention",
+  "Executive Leadership",
+] as const;
+type Persona = (typeof PERSONAS)[number];
+
+// Which of the ten modules each persona sees by default — same API payload,
+// different operational lens.
+const PERSONA_MODULES: Record<Persona, string[]> = {
+  "SPD Technician": ["missing_zone_coverage", "high_risk_findings", "instrument_readiness"],
+  "SPD Supervisor": ["supervisor_review_queue", "high_risk_findings", "tray_readiness", "instrument_readiness"],
+  "SPD Manager": [
+    "readiness_summary", "tray_readiness", "facility_readiness", "high_risk_findings",
+    "supervisor_review_queue", "missing_zone_coverage", "baseline_coverage", "repair_remove_queue",
+  ],
+  "Market Director": ["facility_readiness", "executive_risk", "baseline_coverage"],
+  "Infection Prevention": ["high_risk_findings", "executive_risk", "missing_zone_coverage"],
+  "Executive Leadership": ["readiness_summary", "executive_risk", "facility_readiness"],
+};
+
+const STATE_LABEL: Record<ReadinessState, string> = {
+  READY_FOR_PACKAGING: "Ready for packaging",
+  REQUIRES_RECLEANING: "Requires recleaning",
+  REQUIRES_SUPERVISOR_REVIEW: "Requires supervisor review",
+  REQUIRES_REPAIR: "Requires repair",
+  REMOVED_FROM_SERVICE: "Removed from service",
+  PENDING_ANALYSIS: "Pending analysis",
+};
+
+const STATE_TONE: Record<ReadinessState, string> = {
+  READY_FOR_PACKAGING: "border-green-300 bg-green-50 text-green-800",
+  REQUIRES_RECLEANING: "border-amber-300 bg-amber-50 text-amber-800",
+  REQUIRES_SUPERVISOR_REVIEW: "border-amber-300 bg-amber-50 text-amber-800",
+  REQUIRES_REPAIR: "border-red-300 bg-red-50 text-red-800",
+  REMOVED_FROM_SERVICE: "border-red-300 bg-red-50 text-red-800",
+  PENDING_ANALYSIS: "border-gray-200 bg-gray-50 text-gray-600",
+};
+
+function pct(v: number | null): string {
+  return v === null || v === undefined ? "—" : `${Math.round(v * 100)}%`;
+}
+
+function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="mb-3">
+      <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+      {subtitle && <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>}
+    </div>
+  );
+}
+
+function KPI({ label, value, tone }: { label: string; value: string | number; tone?: "danger" | "warning" | "ok" }) {
+  const toneClass =
+    tone === "danger" ? "border-red-300 bg-red-50 text-red-800"
+    : tone === "warning" ? "border-amber-300 bg-amber-50 text-amber-800"
+    : tone === "ok" ? "border-green-300 bg-green-50 text-green-800"
+    : "border-gray-200 bg-white text-gray-900";
+  return (
+    <div className={`rounded-lg border p-4 ${toneClass}`}>
+      <p className="text-xs font-medium uppercase tracking-wide opacity-70">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
+    </div>
+  );
+}
+
+function StatePill({ state }: { state: ReadinessState }) {
+  return (
+    <span className={`inline-block text-xs font-semibold px-2 py-0.5 rounded border ${STATE_TONE[state]}`}>
+      {STATE_LABEL[state]}
+    </span>
+  );
+}
+
+export default function PreSterilizationCommandCenter() {
+  const [dashboard, setDashboard] = useState<Dashboard | null>(null);
+  const [persona, setPersona] = useState<Persona>("SPD Manager");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchJSON("/api/pre-sterilization-command-center/dashboard")
+      .then(setDashboard)
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div className="p-6 text-gray-500">Loading pre-sterilization command center…</div>;
+  if (error) return <div className="p-6 text-red-600">Failed to load command center data: {error}</div>;
+  if (!dashboard) return null;
+
+  const visible = new Set(PERSONA_MODULES[persona]);
+  const readiness = dashboard.clinical_inspection_readiness;
+
+  return (
+    <div className="p-6 space-y-8 max-w-7xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Pre-Sterilization Command Center</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Are these instruments clinically ready to move forward to packaging and sterilization —
+          and if not, why not, where, and what should SPD do next?
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {PERSONAS.map((p) => (
+          <button
+            key={p}
+            onClick={() => setPersona(p)}
+            className={`text-sm px-3 py-1.5 rounded-full border transition-colors ${
+              persona === p
+                ? "bg-blue-600 text-white border-blue-600"
+                : "bg-white text-gray-700 border-gray-300 hover:border-blue-400"
+            }`}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+
+      {visible.has("readiness_summary") && (
+        <section>
+          <SectionHeader title="Clinical Inspection Readiness" subtitle="Module 1 — packaging readiness across all reviewed inspections." />
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <KPI label="Total inspections" value={readiness.total_inspections} />
+            <KPI
+              label="Ready for packaging"
+              value={pct(readiness.readiness_rate)}
+              tone={readiness.readiness_rate !== null && readiness.readiness_rate >= 0.85 ? "ok" : "warning"}
+            />
+            <KPI label="Mean readiness score" value={readiness.mean_readiness_score ?? "—"} />
+            <KPI
+              label="Requiring repair / removed"
+              value={(readiness.by_state.REQUIRES_REPAIR || 0) + (readiness.by_state.REMOVED_FROM_SERVICE || 0)}
+              tone="danger"
+            />
+          </div>
+        </section>
+      )}
+
+      {visible.has("tray_readiness") && (
+        <section>
+          <SectionHeader title="Tray Readiness" subtitle="Module 2 — a tray is only ready when every instrument in it is ready (weakest link)." />
+          <div className="overflow-x-auto bg-white border rounded-lg">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600 uppercase text-xs">
+                <tr>
+                  <th className="text-left px-3 py-2">Tray</th>
+                  <th className="text-right px-3 py-2">Instruments</th>
+                  <th className="text-left px-3 py-2">Status</th>
+                  <th className="text-left px-3 py-2">Blocking</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dashboard.tray_readiness.map((t) => (
+                  <tr key={t.tray_id} className="border-t">
+                    <td className="px-3 py-2 font-medium text-gray-900">{t.tray_id}</td>
+                    <td className="px-3 py-2 text-right">{t.instrument_count}</td>
+                    <td className="px-3 py-2"><StatePill state={t.tray_readiness_state} /></td>
+                    <td className="px-3 py-2 text-gray-600">
+                      {t.blocking_instruments.map((b) => b.instrument_type).join(", ") || "—"}
+                    </td>
+                  </tr>
+                ))}
+                {dashboard.tray_readiness.length === 0 && (
+                  <tr><td colSpan={4} className="px-3 py-6 text-center text-gray-400">No tray-tagged inspections yet.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {visible.has("instrument_readiness") && (
+        <section>
+          <SectionHeader title="Instrument Readiness" subtitle="Module 3 — current state of each identified instrument's most recent inspection." />
+          <div className="overflow-x-auto bg-white border rounded-lg">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600 uppercase text-xs">
+                <tr>
+                  <th className="text-left px-3 py-2">Instrument</th>
+                  <th className="text-left px-3 py-2">Type</th>
+                  <th className="text-left px-3 py-2">Status</th>
+                  <th className="text-right px-3 py-2">Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dashboard.instrument_readiness.slice(0, 25).map((i) => (
+                  <tr key={i.instrument_identity} className="border-t">
+                    <td className="px-3 py-2 font-mono text-xs text-gray-600">{i.instrument_identity}</td>
+                    <td className="px-3 py-2">{i.instrument_type}</td>
+                    <td className="px-3 py-2"><StatePill state={i.readiness_state} /></td>
+                    <td className="px-3 py-2 text-right">{i.readiness_score ?? "—"}</td>
+                  </tr>
+                ))}
+                {dashboard.instrument_readiness.length === 0 && (
+                  <tr><td colSpan={4} className="px-3 py-6 text-center text-gray-400">No inspections yet.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {visible.has("facility_readiness") && (
+        <section>
+          <SectionHeader title="Facility Readiness" subtitle="Module 4 — packaging readiness rate and trend by facility." />
+          <div className="overflow-x-auto bg-white border rounded-lg">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600 uppercase text-xs">
+                <tr>
+                  <th className="text-left px-3 py-2">Facility</th>
+                  <th className="text-right px-3 py-2">Inspections</th>
+                  <th className="text-right px-3 py-2">Readiness rate</th>
+                  <th className="text-left px-3 py-2">Trend</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dashboard.facility_readiness.map((f) => (
+                  <tr key={f.facility} className="border-t">
+                    <td className="px-3 py-2 font-medium text-gray-900">{f.facility}</td>
+                    <td className="px-3 py-2 text-right">{f.total_inspections}</td>
+                    <td className="px-3 py-2 text-right">{pct(f.readiness_rate)}</td>
+                    <td className="px-3 py-2 capitalize text-gray-600">{f.trend.replace("_", " ")}</td>
+                  </tr>
+                ))}
+                {dashboard.facility_readiness.length === 0 && (
+                  <tr><td colSpan={4} className="px-3 py-6 text-center text-gray-400">No facility-tagged inspections yet.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {visible.has("high_risk_findings") && (
+        <section>
+          <SectionHeader title="High-Risk Findings Queue" subtitle="Module 5 — unresolved critical findings (blood, tissue, bone, crack, insulation damage)." />
+          <div className="rounded-lg border bg-white divide-y">
+            {dashboard.high_risk_findings_queue.slice(0, 15).map((h) => (
+              <div key={h.inspection_id} className="p-3 flex items-center justify-between text-sm">
+                <div>
+                  <span className="font-medium text-gray-900">#{h.inspection_id}</span>{" "}
+                  <span className="text-gray-600">{h.instrument_type} — {h.detected_issue}</span>
+                  {h.facility && <span className="text-gray-400"> · {h.facility}</span>}
+                </div>
+                <StatePill state={h.readiness_state} />
+              </div>
+            ))}
+            {dashboard.high_risk_findings_queue.length === 0 && (
+              <div className="p-6 text-center text-gray-400">No unresolved high-risk findings.</div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {visible.has("supervisor_review_queue") && (
+        <section>
+          <SectionHeader title="Supervisor Review Queue" subtitle="Module 6 — inspections pending supervisor confirmation." />
+          <div className="rounded-lg border bg-white divide-y">
+            {dashboard.supervisor_review_queue.slice(0, 15).map((s) => (
+              <div key={s.inspection_id} className="p-3 text-sm">
+                <span className="font-medium text-gray-900">#{s.inspection_id}</span>{" "}
+                <span className="text-gray-600">{s.instrument_type} — {s.recommended_action || s.detected_issue}</span>
+              </div>
+            ))}
+            {dashboard.supervisor_review_queue.length === 0 && (
+              <div className="p-6 text-center text-gray-400">Supervisor review queue is empty.</div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {visible.has("missing_zone_coverage") && (
+        <section>
+          <SectionHeader title="Missing Anatomy Zone Coverage" subtitle="Module 7 — inspections missing required high-risk zone images." />
+          <div className="rounded-lg border bg-white divide-y">
+            {dashboard.missing_zone_coverage_queue.slice(0, 15).map((m) => (
+              <div key={m.inspection_id} className="p-3 text-sm">
+                <span className="font-medium text-gray-900">#{m.inspection_id}</span>{" "}
+                <span className="text-gray-600">{m.instrument_type} — {m.coverage_quality}</span>
+                {m.missing_required_zones.length > 0 && (
+                  <span className="text-gray-400"> · missing: {m.missing_required_zones.join(", ")}</span>
+                )}
+              </div>
+            ))}
+            {dashboard.missing_zone_coverage_queue.length === 0 && (
+              <div className="p-6 text-center text-gray-400">No coverage gaps detected.</div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {visible.has("baseline_coverage") && (
+        <section>
+          <SectionHeader title="Baseline Coverage" subtitle="Module 8 — how many inspections had an approved baseline to compare against." />
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
+            <KPI label="Imaged inspections" value={dashboard.baseline_coverage.total_imaged_inspections} />
+            <KPI label="With approved baseline" value={dashboard.baseline_coverage.with_approved_baseline} />
+            <KPI label="Coverage rate" value={pct(dashboard.baseline_coverage.baseline_coverage_rate)} />
+          </div>
+          <div className="rounded-lg border bg-white divide-y">
+            {dashboard.baseline_coverage.instrument_types_missing_baseline.slice(0, 10).map((g) => (
+              <div key={g.instrument_type} className="p-3 text-sm flex justify-between">
+                <span className="text-gray-900">{g.instrument_type}</span>
+                <span className="text-gray-500">{g.inspection_count} inspection(s)</span>
+              </div>
+            ))}
+            {dashboard.baseline_coverage.instrument_types_missing_baseline.length === 0 && (
+              <div className="p-6 text-center text-gray-400">No baseline gaps detected.</div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {visible.has("repair_remove_queue") && (
+        <section>
+          <SectionHeader title="Repair / Remove From Service Queue" subtitle="Module 9 — structural defects split into repairable vs. retired." />
+          <div className="grid md:grid-cols-2 gap-4">
+            <div>
+              <p className="text-sm font-semibold text-amber-800 mb-2">Repair candidates ({dashboard.repair_remove_queue.repair_candidates.count})</p>
+              <div className="rounded-lg border bg-white divide-y">
+                {dashboard.repair_remove_queue.repair_candidates.cases.slice(0, 10).map((c) => (
+                  <div key={c.inspection_id} className="p-2 text-sm">#{c.inspection_id} — {c.instrument_type} ({c.detected_issue})</div>
+                ))}
+                {dashboard.repair_remove_queue.repair_candidates.count === 0 && (
+                  <div className="p-4 text-center text-gray-400 text-sm">None.</div>
+                )}
+              </div>
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-red-800 mb-2">Removed from service ({dashboard.repair_remove_queue.removed_from_service.count})</p>
+              <div className="rounded-lg border bg-white divide-y">
+                {dashboard.repair_remove_queue.removed_from_service.cases.slice(0, 10).map((c) => (
+                  <div key={c.inspection_id} className="p-2 text-sm">#{c.inspection_id} — {c.instrument_type} ({c.detected_issue})</div>
+                ))}
+                {dashboard.repair_remove_queue.removed_from_service.count === 0 && (
+                  <div className="p-4 text-center text-gray-400 text-sm">None.</div>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {visible.has("executive_risk") && (
+        <section>
+          <SectionHeader title="Executive Risk Dashboard" subtitle="Module 10 — the roll-up view across readiness, safety queues, and zone trends." />
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+            <KPI label="High-risk findings" value={dashboard.executive_risk_dashboard.high_risk_findings_count} tone="danger" />
+            <KPI label="Supervisor backlog" value={dashboard.executive_risk_dashboard.supervisor_review_backlog} tone="warning" />
+            <KPI label="Repair candidates" value={dashboard.executive_risk_dashboard.repair_candidates_count} />
+            <KPI label="Removed from service" value={dashboard.executive_risk_dashboard.removed_from_service_count} tone="danger" />
+          </div>
+          <p className="text-sm font-medium text-gray-700 mb-2">Highest anatomy-zone failure trend (from pilot validation ground truth)</p>
+          <div className="rounded-lg border bg-white divide-y">
+            {dashboard.executive_risk_dashboard.anatomy_zone_failure_trend.map((z) => (
+              <div key={z.zone} className="p-2 text-sm flex justify-between">
+                <span>{z.zone}</span>
+                <span className="text-gray-500">{z.missed_count} missed / {z.case_count} cases</span>
+              </div>
+            ))}
+            {dashboard.executive_risk_dashboard.anatomy_zone_failure_trend.length === 0 && (
+              <div className="p-4 text-center text-gray-400 text-sm">No pilot validation zone data yet.</div>
+            )}
+          </div>
+        </section>
+      )}
+
+      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+        ⚠ This is a pre-sterilization clinical inspection readiness gate. It reports packaging/inspection
+        readiness only — it does not monitor, measure, or validate the sterilization cycle itself, and every
+        escalation requires SPD supervisor review before disposition.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/QualityDashboardPage.tsx
+++ b/frontend/src/pages/QualityDashboardPage.tsx
@@ -1,0 +1,480 @@
+import { useState, useEffect, useCallback } from "react";
+import { BarChart3 } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+
+type Tab =
+  | "overview" | "trends" | "anatomy" | "instruments"
+  | "technicians" | "supervisors" | "root-cause" | "improvement";
+
+function Stat({ label, value, suffix = "%" }: { label: string; value: number | null; suffix?: string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="text-xs text-slate-500">{label}</div>
+      <div className="text-2xl font-bold text-slate-900">{value == null ? "—" : `${value}${suffix}`}</div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+const CHANGE_STYLE: Record<string, string> = {
+  improvement: "text-emerald-700 bg-emerald-50 border-emerald-200",
+  regression: "text-red-700 bg-red-50 border-red-200",
+  stable: "text-slate-600 bg-slate-50 border-slate-200",
+  insufficient_data: "text-slate-400 bg-slate-50 border-slate-200",
+};
+
+export default function QualityDashboardPage() {
+  const { role } = useAuth();
+  const isLeadership = role === "admin" || role === "spd_manager";
+  const [tab, setTab] = useState<Tab>("overview");
+
+  const TABS: { id: Tab; label: string; leadershipOnly?: boolean }[] = [
+    { id: "overview", label: "Overview" },
+    { id: "trends", label: "Finding Trends" },
+    { id: "anatomy", label: "Anatomy Risk" },
+    { id: "instruments", label: "Instrument Performance" },
+    { id: "technicians", label: "Technician Quality", leadershipOnly: true },
+    { id: "supervisors", label: "Supervisor Quality", leadershipOnly: true },
+    { id: "root-cause", label: "Root Cause & CAPA" },
+    { id: "improvement", label: "Improvement Tracker", leadershipOnly: true },
+  ];
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6">
+      <div className="mb-6 flex items-center gap-2">
+        <BarChart3 className="h-6 w-6 text-indigo-600" />
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Quality Dashboard</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            Operational quality intelligence and continuous improvement — every inspection, aggregated.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex gap-1 border-b border-slate-200 mb-6 overflow-x-auto">
+        {TABS.filter((t) => !t.leadershipOnly || isLeadership).map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${
+              tab === t.id ? "border-b-2 border-blue-600 text-blue-600" : "text-slate-600 hover:text-slate-900"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "overview" && <OverviewTab />}
+      {tab === "trends" && <TrendsTab />}
+      {tab === "anatomy" && <AnatomyTab />}
+      {tab === "instruments" && <InstrumentsTab />}
+      {tab === "technicians" && isLeadership && <TechniciansTab />}
+      {tab === "supervisors" && isLeadership && <SupervisorsTab />}
+      {tab === "root-cause" && <RootCauseTab isLeadership={isLeadership} />}
+      {tab === "improvement" && isLeadership && <ImprovementTab />}
+    </div>
+  );
+}
+
+// ── Overview: KPIs + benchmark + executive score ─────────────────────────────
+function OverviewTab() {
+  const { role } = useAuth();
+  const isLeadership = role === "admin" || role === "spd_manager";
+  const [summary, setSummary] = useState<Record<string, number | null> | null>(null);
+  const [benchmark, setBenchmark] = useState<{
+    comparison_current_vs_previous_month: Record<string, string>;
+  } | null>(null);
+  const [score, setScore] = useState<{ score: number | null; note: string } | null>(null);
+
+  useEffect(() => {
+    apiFetch<Record<string, number | null>>("/api/quality/dashboard").then(setSummary);
+    apiFetch<typeof benchmark>("/api/quality/benchmark").then(setBenchmark);
+    if (isLeadership) {
+      apiFetch<typeof score>("/api/quality/executive-score").then(setScore);
+    }
+  }, [isLeadership]);
+
+  if (!summary) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <Stat label="Inspection Volume" value={summary.inspection_volume} suffix="" />
+        <Stat label="Pass Rate" value={summary.pass_rate_pct} />
+        <Stat label="Reclean Rate" value={summary.reclean_rate_pct} />
+        <Stat label="Repair Rate" value={summary.repair_rate_pct} />
+        <Stat label="Remove From Service" value={summary.remove_from_service_rate_pct} />
+        <Stat label="Supervisor Override" value={summary.supervisor_override_rate_pct} />
+        <Stat label="Baseline Compliance" value={summary.baseline_compliance_pct} />
+        <Stat label="Coverage Compliance" value={summary.coverage_compliance_pct} />
+        <Stat label="AI Confidence" value={summary.ai_confidence_trend_pct} />
+      </div>
+
+      {isLeadership && score && (
+        <Section title="Executive Quality Score">
+          <div className="text-4xl font-extrabold text-indigo-700">{score.score ?? "—"}<span className="text-lg text-slate-400">/100</span></div>
+          <p className="text-xs text-slate-500 mt-1">{score.note}</p>
+        </Section>
+      )}
+
+      {benchmark && (
+        <Section title="Benchmark: Current Month vs Previous Month">
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(benchmark.comparison_current_vs_previous_month).map(([metric, change]) => (
+              <span
+                key={metric}
+                className={`text-xs font-medium px-2 py-1 rounded border ${CHANGE_STYLE[change] ?? CHANGE_STYLE.stable}`}
+              >
+                {metric.replace(/_pct$/, "").replace(/_/g, " ")}: {change.replace(/_/g, " ")}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+// ── Finding Trends ────────────────────────────────────────────────────────────
+function TrendsTab() {
+  const [granularity, setGranularity] = useState("monthly");
+  const [data, setData] = useState<{ totals: Record<string, number> } | null>(null);
+
+  const load = useCallback(() => {
+    apiFetch<typeof data>(`/api/quality/finding-trends?granularity=${granularity}`).then(setData);
+  }, [granularity]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        {["daily", "weekly", "monthly", "quarterly", "yearly"].map((g) => (
+          <button
+            key={g}
+            onClick={() => setGranularity(g)}
+            className={`text-xs px-3 py-1.5 rounded-full border ${granularity === g ? "bg-blue-600 text-white border-blue-600" : "border-slate-300 text-slate-600"}`}
+          >
+            {g}
+          </button>
+        ))}
+      </div>
+      {data && (
+        <Section title={`Finding Totals (${granularity})`}>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            {Object.entries(data.totals).map(([type, count]) => (
+              <div key={type} className="rounded border border-slate-200 px-3 py-2">
+                <div className="text-xs text-slate-500 capitalize">{type.replace(/_/g, " ")}</div>
+                <div className="text-lg font-bold text-slate-900">{count}</div>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+// ── Anatomy Risk ──────────────────────────────────────────────────────────────
+function AnatomyTab() {
+  const [data, setData] = useState<{
+    highest_risk_anatomy_zones: { zone: string; count: number }[];
+    most_frequent_contamination_zones: { zone: string; count: number }[];
+    most_frequent_damage_zones: { zone: string; count: number }[];
+    coverage_incomplete_pct: number | null;
+  } | null>(null);
+
+  useEffect(() => { apiFetch<typeof data>("/api/quality/anatomy-risk").then(setData); }, []);
+  if (!data) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  const ZoneList = ({ items }: { items: { zone: string; count: number }[] }) => (
+    <ul className="space-y-1 text-sm">
+      {items.length === 0 && <li className="text-slate-400">No data yet.</li>}
+      {items.map((z) => (
+        <li key={z.zone} className="flex justify-between">
+          <span className="capitalize text-slate-700">{z.zone}</span>
+          <span className="font-medium text-slate-900">{z.count}</span>
+        </li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <Section title="Highest-Risk Anatomy Zones"><ZoneList items={data.highest_risk_anatomy_zones} /></Section>
+      <Section title="Most Frequent Contamination"><ZoneList items={data.most_frequent_contamination_zones} /></Section>
+      <Section title="Most Frequent Damage"><ZoneList items={data.most_frequent_damage_zones} /></Section>
+      <Section title="Coverage Incomplete Rate">
+        <div className="text-2xl font-bold text-slate-900">{data.coverage_incomplete_pct ?? "—"}%</div>
+        <p className="text-xs text-slate-400 mt-1">Share of inspections with incomplete/insufficient zone coverage.</p>
+      </Section>
+    </div>
+  );
+}
+
+// ── Instrument Family Performance ─────────────────────────────────────────────
+function InstrumentsTab() {
+  const [data, setData] = useState<{ families: Record<string, unknown>[] } | null>(null);
+  useEffect(() => { apiFetch<typeof data>("/api/quality/instrument-performance").then(setData); }, []);
+  if (!data) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  return (
+    <Section title="Instrument Family Performance">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-slate-400 text-xs">
+              <th className="py-1 pr-3">Family</th>
+              <th className="py-1 px-2">Inspections</th>
+              <th className="py-1 px-2">Pass Rate</th>
+              <th className="py-1 px-2">Failure Rate</th>
+              <th className="py-1 px-2">Repair Rate</th>
+              <th className="py-1 px-2">Supervisor Intervention</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.families.map((f) => (
+              <tr key={String(f.family)} className="border-t border-slate-100">
+                <td className="py-1 pr-3 font-medium capitalize">{String(f.family).replace(/_/g, " ")}</td>
+                <td className="py-1 px-2">{String(f.inspection_count)}</td>
+                <td className="py-1 px-2">{f.pass_rate_pct == null ? "—" : `${f.pass_rate_pct}%`}</td>
+                <td className="py-1 px-2">{f.failure_rate_pct == null ? "—" : `${f.failure_rate_pct}%`}</td>
+                <td className="py-1 px-2">{f.repair_rate_pct == null ? "—" : `${f.repair_rate_pct}%`}</td>
+                <td className="py-1 px-2">{f.supervisor_intervention_rate_pct == null ? "—" : `${f.supervisor_intervention_rate_pct}%`}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Section>
+  );
+}
+
+// ── Technician Quality (leadership only) ──────────────────────────────────────
+function TechniciansTab() {
+  const [data, setData] = useState<{ technicians: Record<string, unknown>[] } | null>(null);
+  useEffect(() => { apiFetch<typeof data>("/api/quality/technician-quality").then(setData); }, []);
+  if (!data) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  return (
+    <Section title="Technician Quality (Leadership Only)">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-slate-400 text-xs">
+              <th className="py-1 pr-3">Technician</th>
+              <th className="py-1 px-2">Inspections</th>
+              <th className="py-1 px-2">Avg Coverage</th>
+              <th className="py-1 px-2">Avg AI Confidence</th>
+              <th className="py-1 px-2">Supervisor Agreement</th>
+              <th className="py-1 px-2">Corrections</th>
+              <th className="py-1 px-2">Training Progress</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.technicians.map((t) => (
+              <tr key={String(t.technician)} className="border-t border-slate-100">
+                <td className="py-1 pr-3 font-medium">{String(t.technician)}</td>
+                <td className="py-1 px-2">{String(t.inspection_count)}</td>
+                <td className="py-1 px-2">{t.avg_coverage_pct == null ? "—" : `${t.avg_coverage_pct}%`}</td>
+                <td className="py-1 px-2">{t.avg_ai_confidence_pct == null ? "—" : `${t.avg_ai_confidence_pct}%`}</td>
+                <td className="py-1 px-2">{t.supervisor_agreement_pct == null ? "—" : `${t.supervisor_agreement_pct}%`}</td>
+                <td className="py-1 px-2">{String(t.supervisor_corrections)}</td>
+                <td className="py-1 px-2">{t.training_progress_pct == null ? "—" : `${t.training_progress_pct}%`}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Section>
+  );
+}
+
+// ── Supervisor Quality ────────────────────────────────────────────────────────
+function SupervisorsTab() {
+  const [data, setData] = useState<{
+    supervisors: Record<string, unknown>[];
+    department_trends: Record<string, unknown>[];
+  } | null>(null);
+  useEffect(() => { apiFetch<typeof data>("/api/quality/supervisor-quality").then(setData); }, []);
+  if (!data) return <p className="text-sm text-slate-400">Loading…</p>;
+
+  return (
+    <div className="space-y-4">
+      <Section title="Supervisor Quality">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-slate-400 text-xs">
+                <th className="py-1 pr-3">Supervisor</th>
+                <th className="py-1 px-2">Workload</th>
+                <th className="py-1 px-2">Override Frequency</th>
+                <th className="py-1 px-2">Education Provided</th>
+                <th className="py-1 px-2">Agreement with AI</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.supervisors.map((s) => (
+                <tr key={String(s.reviewer)} className="border-t border-slate-100">
+                  <td className="py-1 pr-3 font-medium">{String(s.reviewer)}</td>
+                  <td className="py-1 px-2">{String(s.review_workload)}</td>
+                  <td className="py-1 px-2">{s.override_frequency_pct == null ? "—" : `${s.override_frequency_pct}%`}</td>
+                  <td className="py-1 px-2">{String(s.education_provided_count)}</td>
+                  <td className="py-1 px-2">{s.agreement_with_ai_pct == null ? "—" : `${s.agreement_with_ai_pct}%`}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+      <Section title="Department Trends">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          {data.department_trends.map((d) => (
+            <div key={String(d.department)} className="rounded border border-slate-200 px-3 py-2">
+              <div className="text-xs text-slate-500">{String(d.department)}</div>
+              <div className="text-sm text-slate-900">{String(d.inspection_count)} inspections</div>
+              <div className="text-xs text-slate-500">Pass {d.pass_rate_pct == null ? "—" : `${d.pass_rate_pct}%`}</div>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+// ── Root Cause & CAPA ─────────────────────────────────────────────────────────
+function RootCauseTab({ isLeadership }: { isLeadership: boolean }) {
+  const [trends, setTrends] = useState<{ overall: Record<string, number> } | null>(null);
+  const [suggestions, setSuggestions] = useState<Record<string, unknown>[]>([]);
+
+  useEffect(() => {
+    apiFetch<typeof trends>("/api/quality/root-cause-trends").then(setTrends);
+    if (isLeadership) {
+      apiFetch<{ suggestions: Record<string, unknown>[] }>("/api/quality/capa-suggestions")
+        .then((d) => setSuggestions(d.suggestions));
+    }
+  }, [isLeadership]);
+
+  async function createCapa(suggestion: Record<string, unknown>) {
+    await apiFetch("/api/quality/capa-suggestions/create", { method: "POST", body: suggestion });
+    alert("CAPA created.");
+  }
+
+  return (
+    <div className="space-y-4">
+      {trends && (
+        <Section title="Recurring Root Causes">
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(trends.overall).length === 0 && <p className="text-sm text-slate-400">No root causes assigned yet.</p>}
+            {Object.entries(trends.overall).map(([cause, count]) => (
+              <span key={cause} className="text-xs font-medium px-2 py-1 rounded-full bg-slate-100 text-slate-700">
+                {cause.replace(/_/g, " ")}: {count}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+      {isLeadership && (
+        <Section title="CAPA Suggestions">
+          {suggestions.length === 0 && <p className="text-sm text-slate-400">No recurring patterns yet.</p>}
+          <div className="space-y-2">
+            {suggestions.map((s, i) => (
+              <div key={i} className="rounded border border-amber-200 bg-amber-50 px-3 py-2">
+                <p className="text-sm font-semibold text-amber-900">{String(s.trigger)} ({String(s.occurrences)}x)</p>
+                <p className="text-sm text-amber-800">{String(s.recommendation)}</p>
+                <button
+                  onClick={() => createCapa(s)}
+                  className="mt-2 text-xs font-semibold px-3 py-1 rounded bg-amber-600 text-white hover:bg-amber-700"
+                >
+                  Create CAPA
+                </button>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+// ── Continuous Improvement Tracker ───────────────────────────────────────────
+function ImprovementTab() {
+  const [initiatives, setInitiatives] = useState<Record<string, unknown>[]>([]);
+  const [form, setForm] = useState({ initiative: "", owner: "", target_date: "", expected_impact: "" });
+
+  const load = useCallback(() => {
+    apiFetch<{ initiatives: Record<string, unknown>[] }>("/api/quality/improvement-initiatives")
+      .then((d) => setInitiatives(d.initiatives));
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  async function submit() {
+    if (!form.initiative.trim()) return;
+    await apiFetch("/api/quality/improvement-initiatives", {
+      method: "POST",
+      body: { ...form, target_date: form.target_date || null },
+    });
+    setForm({ initiative: "", owner: "", target_date: "", expected_impact: "" });
+    load();
+  }
+
+  async function markCompleted(id: number) {
+    const actual = prompt("Actual impact observed?") ?? "";
+    await apiFetch(`/api/quality/improvement-initiatives/${id}`, {
+      method: "PATCH",
+      body: { status: "completed", actual_impact: actual },
+    });
+    load();
+  }
+
+  return (
+    <div className="space-y-4">
+      <Section title="New Initiative">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <input className="rounded border border-slate-300 px-2 py-1.5 text-sm" placeholder="Initiative"
+            value={form.initiative} onChange={(e) => setForm((f) => ({ ...f, initiative: e.target.value }))} />
+          <input className="rounded border border-slate-300 px-2 py-1.5 text-sm" placeholder="Owner"
+            value={form.owner} onChange={(e) => setForm((f) => ({ ...f, owner: e.target.value }))} />
+          <input type="date" className="rounded border border-slate-300 px-2 py-1.5 text-sm"
+            value={form.target_date} onChange={(e) => setForm((f) => ({ ...f, target_date: e.target.value }))} />
+          <input className="rounded border border-slate-300 px-2 py-1.5 text-sm" placeholder="Expected impact"
+            value={form.expected_impact} onChange={(e) => setForm((f) => ({ ...f, expected_impact: e.target.value }))} />
+        </div>
+        <button onClick={submit} className="mt-2 text-xs font-semibold px-3 py-1.5 rounded bg-blue-600 text-white hover:bg-blue-700">
+          Add Initiative
+        </button>
+      </Section>
+      <Section title="Initiatives">
+        <div className="space-y-2">
+          {initiatives.length === 0 && <p className="text-sm text-slate-400">No initiatives yet.</p>}
+          {initiatives.map((i) => (
+            <div key={String(i.id)} className="rounded border border-slate-200 px-3 py-2 flex items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold text-slate-800">{String(i.initiative)}</p>
+                <p className="text-xs text-slate-500">
+                  {String(i.owner)} · {String(i.target_date ?? "no target date")} · <span className="capitalize">{String(i.status)}</span>
+                </p>
+                {!!i.actual_impact && <p className="text-xs text-emerald-700 mt-1">Actual: {String(i.actual_impact)}</p>}
+              </div>
+              {i.status !== "completed" && (
+                <button onClick={() => markCompleted(Number(i.id))} className="text-xs font-semibold px-2 py-1 rounded bg-emerald-600 text-white">
+                  Mark Completed
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/pages/SupervisorCoachingDashboard.tsx
+++ b/frontend/src/pages/SupervisorCoachingDashboard.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect, useCallback } from "react";
+import { ClipboardCheck } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+interface QueueItem {
+  inspection_id: number;
+  instrument_type: string;
+  technician: string | null;
+  risk_level: string | null;
+  recommended_action: string | null;
+  coaching_reviewed: boolean;
+}
+
+interface Effectiveness {
+  total_reviews: number;
+  approved_unchanged: number;
+  edited: number;
+  with_educational_comment: number;
+  approved_unchanged_pct: number | null;
+}
+
+export default function SupervisorCoachingDashboard() {
+  const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [effectiveness, setEffectiveness] = useState<Effectiveness | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [comment, setComment] = useState<Record<number, string>>({});
+  const [busy, setBusy] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [q, e] = await Promise.all([
+        apiFetch<{ queue: QueueItem[] }>("/api/mentor/coaching-queue"),
+        apiFetch<Effectiveness>("/api/mentor/coaching-effectiveness"),
+      ]);
+      setQueue(q.queue);
+      setEffectiveness(e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function review(inspectionId: number, approved: boolean) {
+    setBusy(inspectionId);
+    try {
+      await apiFetch(`/api/inspections/${inspectionId}/coaching-review`, {
+        method: "POST",
+        body: { approved, educational_comment: comment[inspectionId] ?? "" },
+      });
+      await load();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (loading) {
+    return <div className="p-6 text-sm text-slate-500">Loading coaching dashboard…</div>;
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-4">
+      <div className="flex items-center gap-2">
+        <ClipboardCheck className="h-6 w-6 text-indigo-600" />
+        <h1 className="text-xl font-bold text-slate-900">Supervisor Coaching Dashboard</h1>
+      </div>
+      <p className="text-sm text-slate-500">
+        Review the AI Mentor's coaching on recent inspections — approve it, or add an educational
+        comment for the technician.
+      </p>
+
+      {effectiveness && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 rounded-lg border border-slate-200 bg-white p-4">
+          <div><div className="text-xs text-slate-500">Total reviews</div><div className="text-xl font-bold text-slate-900">{effectiveness.total_reviews}</div></div>
+          <div><div className="text-xs text-slate-500">Approved unchanged</div><div className="text-xl font-bold text-emerald-700">{effectiveness.approved_unchanged}</div></div>
+          <div><div className="text-xs text-slate-500">Edited</div><div className="text-xl font-bold text-amber-700">{effectiveness.edited}</div></div>
+          <div><div className="text-xs text-slate-500">With comment</div><div className="text-xl font-bold text-slate-900">{effectiveness.with_educational_comment}</div></div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {queue.map((item) => (
+          <div key={item.inspection_id} className="rounded-lg border border-slate-200 bg-white p-4 space-y-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="text-sm">
+                <span className="font-semibold capitalize text-slate-800">{item.instrument_type}</span>
+                <span className="text-slate-400"> · #{item.inspection_id}</span>
+                {item.technician && <span className="text-slate-500"> · {item.technician}</span>}
+              </div>
+              <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${item.coaching_reviewed ? "bg-emerald-100 text-emerald-800" : "bg-amber-100 text-amber-800"}`}>
+                {item.coaching_reviewed ? "Reviewed" : "Awaiting review"}
+              </span>
+            </div>
+            <p className="text-sm text-slate-600">{item.recommended_action ?? "—"}</p>
+            <input
+              type="text"
+              placeholder="Add an educational comment for the technician…"
+              value={comment[item.inspection_id] ?? ""}
+              onChange={(e) => setComment((c) => ({ ...c, [item.inspection_id]: e.target.value }))}
+              className="w-full rounded border border-slate-300 px-2 py-1 text-sm"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={() => review(item.inspection_id, true)}
+                disabled={busy === item.inspection_id}
+                className="rounded bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => review(item.inspection_id, false)}
+                disabled={busy === item.inspection_id}
+                className="rounded bg-slate-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+              >
+                Flag for edit
+              </button>
+            </div>
+          </div>
+        ))}
+        {queue.length === 0 && <p className="text-sm text-slate-400">No inspections in the coaching queue.</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Moves LumenAI from feature completion to operational reliability for the first real-world pilot site — an audit-and-hardening pass, not a new-feature pass, per the sprint's own scope constraint.

## Why This Change
Before real inspection data hits the platform, workflows need to be audited end-to-end, role boundaries verified, stale/fake pages fixed, and the platform needs a way to see whether its own collected data is actually usable.

## Scope

**1. Pilot Workflow Audit** (`docs/pilot/pilot-workflow-audit.md`)
Static audit of login, dashboard, new inspection, AI analysis, supervisor review, knowledge capture, and history. Found two critical gaps (see below); verified backend role enforcement was already correct.

**2 & 3. Role-Based Hardening + Frontend Reliability — real bugs fixed, not just verified**
- `/findings` ("Review Queue"/"Findings" nav) and `/operations` ("Operational Analytics" nav) previously rendered **permanently hardcoded fake data** with zero backend connection — one literally labeled its own table *"Pilot-safe sample activity"* in the UI. Their "Review"/"Create CAPA"/"Close" buttons mutated only local state and showed a fake *"saved in pilot mode"* success message without persisting anything — exactly the placeholder-that-pretends-to-work this sprint's principles forbid. Both pages now fetch real data from `GET /api/inspection-work-queue` (v1.7), with explicit loading/error/empty states, and the fake action buttons are replaced with real navigation to where the actual disposition workflow lives. Existing visual design/layout preserved unchanged.
- Verified (both statically and via 5 new live-role tests): viewer is blocked with a clear 403 from inspection creation and disposition actions but can view the queue; operator can create but not approve; spd_manager can approve and add teaching points. Frontend `RequireRole` guard confirmed to render a clear "Not authorized" card, never a blank page (screenshot-verified).

**4. Pilot Site Configuration** (`PilotSiteConfig`, `docs/pilot/pilot-site-configuration.md`)
One row per tenant: facility/department, enabled instrument families, required zones, baseline-required flag, minimum coverage threshold, supervisor review threshold. Distinct from v1.8's `OrganizationStandard` (free-text policy) — this is the small set of structured values the guardrails and dashboard actually read. Admin-only to edit, all-roles to view.

**5. Inspection Data Quality Guardrails**
Missing instrument/image/anatomy zone, poor image quality, missing baseline, incomplete coverage, missing technician identity — evaluated against the site's own configured thresholds with clear messages, surfaced on every inspection-creation response and via `GET /api/inspections/{id}/data-quality`.

**6. Pilot Data Collection Dashboard** (`/pilot-data-collection`, admin/spd_manager only)
Inspections/baseline images/inspection images collected, supervisor reviews completed, incomplete inspections, failed uploads, missing anatomy zones, dataset-ready inspections — real counts only.

**7. Production Error Logging** (`PilotErrorLog`)
Upload/AI-analysis/baseline-lookup/role-permission/report-generation failure tracking, PHI-safe (truncated, developer-facing detail only). Wired into the readiness-report PDF endpoint's real failure path, the frontend's central `apiFetch` 403 handler, and `NewInspectionPage`'s existing submission catch block — deliberately narrow, already-safe call sites rather than touching the shared `require_roles` authorization dependency used by every protected route in the app (too broad a blast radius for this sprint).

**8. Go-Live Checklist** (`docs/pilot/lumenai-inspect-v1-9-go-live-checklist.md`) and **9. Acceptance Test Script** (`docs/pilot/pilot-acceptance-test-script.md`).

## New API surface
- `GET/PUT /api/pilot-deployment/site-config`
- `POST /api/pilot-deployment/error-log`
- `GET /api/pilot-deployment/data-collection`
- `GET /api/inspections/{id}/data-quality`

Uses a distinct `/api/pilot-deployment/*` prefix — `/api/pilot/*` is already used by the existing, unrelated P14 commercial pilot-conversion (trial subscription) routes.

## Testing
- [x] 19 new tests in `test_pilot_deployment.py`, including live end-to-end role-boundary verification
- [x] Full backend suite: `2584 passed, 2 skipped` (was 2565/2 before this branch)
- [x] `ruff check app tests` — all checks passed
- [x] `npm run build` — clean
- [x] Manual verification — ran both dev servers, seeded a real inspection, confirmed `/findings` and `/operations` render live data (screenshots), confirmed data-quality guardrails correctly flag a real missing-baseline/missing-zone case, confirmed the Pilot Data Collection dashboard reflects real counts, and confirmed a viewer role sees a clear "Not authorized" card (never blank) on the restricted dashboard
- [ ] Docker build
- [ ] API/worker runtime validation

## Risks
Additive throughout: two new tables (`pilot_site_configs`, `pilot_error_logs`), one new router, one new frontend page. `/findings` and `/operations` had their data source and action buttons changed but their route paths, nav entries, and visual design are unchanged. `create_inspection` and the readiness-report PDF endpoint gain additional guardrail-evaluation/error-logging calls; existing response shapes are unchanged (only new keys added).

## Rollback Plan
Revert this commit. The new tables are additive; the `/findings` and `/operations` data-source fix is standalone and safe to keep even if other parts of this PR are rolled back.

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_011Fk9dzNXLSbHDHTsT5TCKL)_