### PR TITLE
v2.3 — Persisted finding confidence + live capture warnings

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -645,6 +645,9 @@ app.include_router(vision_session_router, prefix=settings.API_PREFIX)
 app.include_router(alerts_router, prefix=settings.API_PREFIX)
 
 app.include_router(capa_predictive_risk_router)
+
+from app.routes.clinical_memory import router as clinical_memory_router
+app.include_router(clinical_memory_router)
 app.include_router(capa_router, prefix=settings.API_PREFIX)
 app.include_router(vendor_governance_router, prefix=settings.API_PREFIX)
 

--- a/backend/app/models/inspection_finding.py
+++ b/backend/app/models/inspection_finding.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, Integer, String
+from sqlalchemy import DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -37,3 +37,9 @@ class InspectionFinding(Base):
     finding_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
     zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
     severity_index: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    # v2.3 — the scoring engine's own confidence (0-1) for this finding at
+    # analysis time, so Evidence Fusion (app/services/vision_session_engine.py)
+    # can average real per-finding confidence instead of omitting it.
+    # Nullable for rows logged before this column existed — never backfilled
+    # with a fabricated value.
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/backend/app/routes/clinical_memory.py
+++ b/backend/app/routes/clinical_memory.py
@@ -1,0 +1,50 @@
+"""v2.4 — Clinical Memory & Predictive Intelligence API (Project Insight).
+
+- GET /api/clinical-memory                 — Sections 1-5, 7, 9 for one
+  instrument (?instrument_identity=barcode:.../udi:...)
+- GET /api/clinical-memory/learning-dashboard — Section 8, tenant-wide.
+
+Read-only, informational — mirrors the existing `/api/clinical-readiness/
+instrument-condition` convention (`instrument_identity` as a query param,
+since it's a colon-delimited compound key, not a clean path segment).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app.authz import require_roles
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.services.clinical_memory_service import get_clinical_memory
+from app.services.learning_dashboard_service import learning_dashboard
+
+router = APIRouter(tags=["clinical-memory"])
+
+_ALL_ROLES = ("admin", "spd_manager", "supervisor", "operator", "viewer")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+@router.get("/api/clinical-memory")
+def get_clinical_memory_endpoint(
+    request: Request,
+    instrument_identity: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    memory = get_clinical_memory(db, _tenant(current_user, request), instrument_identity)
+    if memory is None:
+        raise HTTPException(status_code=404, detail="No inspection history found for this instrument identity.")
+    return memory
+
+
+@router.get("/api/clinical-memory/learning-dashboard")
+def get_learning_dashboard(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    return learning_dashboard(db, _tenant(current_user, request))

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -550,6 +550,7 @@ async def create_inspection(
                     finding_type=f["type"],
                     zone=f.get("instrument_zone", ""),
                     severity_index=f["severity_index"],
+                    confidence=f.get("confidence"),
                 ))
         db.commit()
 

--- a/backend/app/routes/inspections.py
+++ b/backend/app/routes/inspections.py
@@ -445,6 +445,24 @@ async def create_inspection(
             training_mode=body.training_mode,
             image_view_tags=image_view_tags_dicts,
         )
+        # v2.4 — AI Context Expansion: attach this instrument's own Clinical
+        # Memory (prior history, recurring issues, predictive risk, forecast)
+        # when it's a real re-identified instrument (barcode/UDI). Computed
+        # BEFORE this inspection is persisted below, so it only ever reflects
+        # prior history — purely additive context, never altering the score.
+        from app.services.clinical_memory_service import get_clinical_memory
+
+        if body.instrument_barcode:
+            memory_identity = f"barcode:{body.instrument_barcode}"
+        elif body.instrument_udi:
+            memory_identity = f"udi:{body.instrument_udi}"
+        else:
+            memory_identity = None
+        if memory_identity:
+            clinical_memory = get_clinical_memory(db, tenant_id, memory_identity)
+            if clinical_memory:
+                analysis["clinical_memory"] = clinical_memory
+
         # Persist the SPD verdict regardless of completion state so history and
         # the dashboard show what the analysis concluded.
         risk_level_val = analysis.get("risk_level")

--- a/backend/app/routes/vision_session.py
+++ b/backend/app/routes/vision_session.py
@@ -9,10 +9,14 @@ Vision 360").
   zone, for the Inspection Gallery.
 - POST /api/inspections/{id}/images/{tag_id}/flag — flag/unflag one
   captured image with a reason.
+- POST /api/inspections/preview-warnings (v2.3) — the same missing-anatomy
+  and duplicate-detection checks, run live during capture on tags that
+  haven't been submitted yet (nothing persisted, no inspection_id needed).
 """
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -48,8 +52,9 @@ def _get_inspection(db: Session, inspection_id: int, tenant_id: str | None, is_a
 def _reconstruct_predicted_findings(db: Session, inspection_id: int) -> list[dict]:
     """Real per-finding rows already persisted at analysis time
     (app/models/inspection_finding.py) — not a re-run of the scoring
-    engine. Confidence isn't persisted per-finding, so it's omitted rather
-    than fabricated."""
+    engine. Confidence is read from the persisted column when available
+    (v2.3); rows logged before that column existed carry null rather than
+    a fabricated value."""
     rows = db.query(InspectionFinding).filter(InspectionFinding.inspection_id == inspection_id).all()
     return [
         {
@@ -57,7 +62,7 @@ def _reconstruct_predicted_findings(db: Session, inspection_id: int) -> list[dic
             "instrument_zone": r.zone,
             "severity_index": r.severity_index,
             "status": _SEVERITY_STATUS.get(r.severity_index, "clear"),
-            "confidence": None,
+            "confidence": r.confidence,
         }
         for r in rows
     ]
@@ -141,6 +146,42 @@ def get_inspection_gallery(
             for zone, images in sorted(groups.items())
         ],
         "total_images": len(tags),
+    }
+
+
+class PreviewTagIn(BaseModel):
+    anatomy_zone: str = Field("")
+    instrument_family: str = Field("")
+    image_sha256: Optional[str] = Field(None)
+
+
+class PreviewWarningsIn(BaseModel):
+    instrument_type: str
+    tags: list[PreviewTagIn] = Field(default_factory=list)
+
+
+@router.post("/inspections/preview-warnings")
+def preview_capture_warnings(
+    body: PreviewWarningsIn,
+    current_user=Depends(require_roles(*_READ_ROLES)),
+):
+    """v2.3 — Live capture warnings: missing-anatomy prompts and duplicate/
+    wrong-anatomy/wrong-instrument detection on tags the technician has
+    added so far, before the inspection is submitted. Reuses the same
+    stateless services the after-the-fact Vision Session view uses — no
+    inspection_id, nothing persisted, no second scoring engine."""
+    tag_dicts = [
+        {
+            "id": idx,
+            "anatomy_zone": t.anatomy_zone,
+            "instrument_family": t.instrument_family or body.instrument_type,
+            "image_sha256": t.image_sha256,
+        }
+        for idx, t in enumerate(body.tags)
+    ]
+    return {
+        "missing_anatomy": missing_anatomy_prompts(body.instrument_type, tag_dicts),
+        "duplicate_detection": detect_all(tag_dicts),
     }
 
 

--- a/backend/app/services/clinical_memory_service.py
+++ b/backend/app/services/clinical_memory_service.py
@@ -1,0 +1,176 @@
+"""v2.4 — Clinical Memory Engine (Project Insight, Section 1).
+
+The central "does this instrument have a history" service. Composes:
+
+- `instrument_condition_service.instrument_condition_history` — inspection/
+  finding/repair/supervisor-comment history + condition trend (reused, not
+  re-derived).
+- `recurrence_detection_service.detect_recurring_issues` — repeated finding
+  types, repairs, overrides (Section 3).
+- `predictive_risk_engine.estimate_predictive_risk` — Low/Moderate/High/
+  Critical likelihood per outcome (Section 4).
+- `instrument_health_forecast_service.forecast_instrument_health` — condition/
+  failure/repair trend + remaining-useful-life + confidence interval
+  (Section 5).
+- `similar_instrument_search_service.find_similar_instruments` — fleet-wide
+  similarity search (Section 2).
+- `knowledge_repository_service.list_articles` — applicable knowledge
+  articles for this instrument type.
+- `build_memory_timeline` — the interactive Inspection -> Finding -> Repair ->
+  Supervisor Note -> ... -> Current sequence (Section 7).
+- `build_memory_recommendation` — one narrative recommendation enriched by
+  this instrument's own recurring history (Section 9).
+
+Nothing here re-runs AI scoring or invents a new instrument-identity scheme —
+`instrument_identity` is always `barcode:<value>` or `udi:<value>`, the same
+key `instrument_condition_service`/`prioritization_engine` already use.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.inspection_finding import InspectionFinding
+from app.services.instrument_condition_service import instrument_condition_history
+from app.services.instrument_health_forecast_service import forecast_instrument_health
+from app.services.knowledge_repository_service import list_articles
+from app.services.predictive_risk_engine import estimate_predictive_risk
+from app.services.recurrence_detection_service import detect_recurring_issues
+from app.services.similar_instrument_search_service import find_similar_instruments
+
+_KNOWLEDGE_ARTICLE_LIMIT = 5
+_RECOMMENDATION_ELEVATE_THRESHOLD = 3
+
+
+def build_memory_timeline(condition: dict) -> list[dict]:
+    """Section 7 — interactive timeline: Inspection -> Finding -> Repair ->
+    Supervisor Note, in the same chronological order the history already is,
+    followed by a terminal "current" marker."""
+    events: list[dict] = []
+    for entry in condition["history"]:
+        events.append({
+            "type": "inspection",
+            "inspection_id": entry["inspection_id"],
+            "date": entry["date"],
+            "disposition": entry["disposition"],
+        })
+        findings = entry["cleaning_findings"] + entry["damage_findings"]
+        if findings:
+            events.append({
+                "type": "finding",
+                "inspection_id": entry["inspection_id"],
+                "date": entry["date"],
+                "findings": findings,
+            })
+        if entry["repair_flag"]:
+            events.append({
+                "type": "repair",
+                "inspection_id": entry["inspection_id"],
+                "date": entry["date"],
+            })
+        for note in entry["supervisor_comments"]:
+            events.append({
+                "type": "supervisor_note",
+                "inspection_id": entry["inspection_id"],
+                "date": entry["date"],
+                "note": note,
+            })
+    events.append({"type": "current", "date": None})
+    return events
+
+
+def build_memory_recommendation(db: Session, tenant_id: str, condition: dict, recurrence: dict) -> dict | None:
+    """Section 9 — one memory-driven recommendation naming the specific
+    recurring finding/zone pair, when one exists. Returns None rather than a
+    generic filler when there's nothing recurring to call out."""
+    repeated = {
+        finding_type: count
+        for finding_type, count in recurrence["finding_counts"].items()
+        if count >= 2
+    }
+    if not repeated:
+        return None
+
+    inspection_ids = [entry["inspection_id"] for entry in condition["history"]]
+    if not inspection_ids:
+        return None
+
+    rows = (
+        db.query(InspectionFinding)
+        .filter(
+            InspectionFinding.tenant_id == tenant_id,
+            InspectionFinding.inspection_id.in_(inspection_ids),
+            InspectionFinding.finding_type.in_(repeated),
+        )
+        .all()
+    )
+    if not rows:
+        return None
+
+    # Prefer whichever recurring finding type shows up in the most recent
+    # inspection (most clinically relevant right now); fall back to the
+    # overall most-recurring type if none of them recur in the latest visit.
+    latest_inspection_id = inspection_ids[-1]
+    latest_types = {r.finding_type for r in rows if r.inspection_id == latest_inspection_id}
+    candidate_type = max(latest_types or repeated, key=lambda ft: repeated[ft])
+
+    type_rows = [r for r in rows if r.finding_type == candidate_type]
+    zone_counts: dict[str, int] = {}
+    for r in type_rows:
+        zone_counts[r.zone] = zone_counts.get(r.zone, 0) + 1
+    zone = max(zone_counts, key=lambda z: zone_counts[z]) if zone_counts else ""
+
+    occurrences = repeated[candidate_type]
+    zone_label = zone or "the inspected area"
+    finding_label = candidate_type.replace("_", " ")
+    inspection_count = condition["inspection_count"]
+
+    message = (
+        f"{finding_label.capitalize()} was identified in the {zone_label}. "
+        f"This instrument has had {occurrences} similar findings in the {zone_label} "
+        f"over the last {inspection_count} inspection{'s' if inspection_count != 1 else ''}. "
+        f"Recommend focused manual cleaning of the {zone_label}"
+        + (
+            " and supervisor review."
+            if occurrences >= _RECOMMENDATION_ELEVATE_THRESHOLD
+            else "."
+        )
+    )
+    return {
+        "finding_type": candidate_type,
+        "zone": zone,
+        "occurrences": occurrences,
+        "message": message,
+        "human_review_required": True,
+    }
+
+
+def get_clinical_memory(db: Session, tenant_id: str, instrument_identity: str) -> dict | None:
+    """The full Clinical Memory context for one instrument, or None when
+    there's no recorded history for it (untracked, or genuinely first-seen)."""
+    condition = instrument_condition_history(db, tenant_id, instrument_identity)
+    if condition is None:
+        return None
+
+    recurrence = detect_recurring_issues(db, tenant_id, condition)
+    predictive_risk = estimate_predictive_risk(condition, recurrence)
+    health_forecast = forecast_instrument_health(db, tenant_id, instrument_identity, condition)
+    similar_instruments = find_similar_instruments(db, tenant_id, instrument_identity=instrument_identity)
+    knowledge_articles = list_articles(
+        db, tenant_id, instrument=condition["instrument_type"]
+    )[:_KNOWLEDGE_ARTICLE_LIMIT]
+    timeline = build_memory_timeline(condition)
+    recommendation = build_memory_recommendation(db, tenant_id, condition, recurrence)
+
+    return {
+        "instrument_identity": instrument_identity,
+        "instrument_type": condition["instrument_type"],
+        "condition_history": condition,
+        "recurring_issues": recurrence,
+        "predictive_risk": predictive_risk,
+        "health_forecast": health_forecast,
+        "similar_instruments": similar_instruments,
+        "knowledge_articles": knowledge_articles,
+        "timeline": timeline,
+        "memory_recommendation": recommendation,
+        "human_review_required": True,
+    }

--- a/backend/app/services/instrument_health_forecast_service.py
+++ b/backend/app/services/instrument_health_forecast_service.py
@@ -1,0 +1,56 @@
+"""v2.4 — Instrument Health Forecast (Clinical Memory, Section 5).
+
+Extends the existing Predictive Instrument Intelligence
+(`app/services/instrument_intelligence.instrument_timeline` — risk trend,
+remaining-useful-life estimate) with the condition/repair trend already
+computed by `instrument_condition_service` and an honest confidence interval
+that widens as the sample size shrinks, rather than a fabricated fixed band.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services.instrument_intelligence import instrument_timeline
+
+# Wider band with fewer inspections — small samples get less claimed precision,
+# never a fixed-width interval regardless of how little history exists.
+_MARGIN_BY_SAMPLE_SIZE = ((8, 5), (4, 12), (2, 20))
+
+
+def _confidence_margin(sample_size: int) -> int | None:
+    for min_count, margin in _MARGIN_BY_SAMPLE_SIZE:
+        if sample_size >= min_count:
+            return margin
+    return None
+
+
+def forecast_instrument_health(db: Session, tenant_id: str, instrument_identity: str, condition: dict) -> dict:
+    identifier = instrument_identity.split(":", 1)[1] if ":" in instrument_identity else instrument_identity
+    base = instrument_timeline(db, identifier, tenant_id)
+    prediction = base["prediction"]
+
+    sample_size = condition["inspection_count"]
+    margin = _confidence_margin(sample_size)
+    latest_score = prediction["latest_risk_score"]
+    confidence_interval = (
+        {"low": max(0, latest_score - margin), "high": min(100, latest_score + margin)}
+        if latest_score is not None and margin is not None else None
+    )
+
+    if condition["repair_count"] >= 2:
+        repair_trend = "recurring"
+    elif condition["repair_count"] == 1:
+        repair_trend = "occurred_once"
+    else:
+        repair_trend = "none"
+
+    return {
+        "condition_trend": condition["condition_trend"],
+        "failure_risk_trend": prediction["risk_trend"],
+        "repair_trend": repair_trend,
+        "estimated_remaining_useful_life": prediction["estimated_remaining_life"],
+        "confidence_interval": confidence_interval,
+        "sample_size": sample_size,
+        "basis": prediction["note"],
+        "human_review_required": True,
+    }

--- a/backend/app/services/learning_dashboard_service.py
+++ b/backend/app/services/learning_dashboard_service.py
@@ -1,0 +1,113 @@
+"""v2.4 — Learning Dashboard (Clinical Memory, Section 8).
+
+Tenant-wide rollup of what the fleet's own history teaches: which finding
+types recur most, which anatomy zones see repeated contamination, which
+physical instruments are trending better or worse, and which are repeat
+repair candidates. Built entirely from data already persisted
+(`Inspection`, `InspectionFinding`) via
+`instrument_condition_service.instrument_condition_history` — no new
+detection model, no fabricated trend.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.inspection_finding import InspectionFinding
+from app.services.instrument_condition_service import instrument_condition_history
+from app.services.pre_sterilization_command_center_service import _instrument_identity
+from app.services.recurrence_detection_service import CONTAMINATION_TYPES
+
+_TOP_N = 5
+_RECURRENCE_THRESHOLD = 2
+
+
+def _tracked_conditions(db: Session, tenant_id: str) -> dict[str, dict]:
+    """Real re-identified instruments (barcode/UDI) with 2+ inspections —
+    untracked singletons can't be trended, so they're excluded rather than
+    faked into a one-point 'trend'."""
+    rows = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).all()
+    by_identity: dict[str, list] = defaultdict(list)
+    for row in rows:
+        by_identity[_instrument_identity(row)].append(row)
+
+    conditions: dict[str, dict] = {}
+    for identity, insp_rows in by_identity.items():
+        if identity.startswith("untracked:") or len(insp_rows) < 2:
+            continue
+        condition = instrument_condition_history(db, tenant_id, identity)
+        if condition:
+            conditions[identity] = condition
+    return conditions
+
+
+def _instrument_summary(identity: str, condition: dict) -> dict:
+    return {
+        "instrument_identity": identity,
+        "instrument_type": condition["instrument_type"],
+        "condition_trend": condition["condition_trend"],
+        "inspection_count": condition["inspection_count"],
+        "repair_count": condition["repair_count"],
+        "corrosion_history_count": condition["corrosion_history_count"],
+    }
+
+
+def learning_dashboard(db: Session, tenant_id: str) -> dict:
+    conditions = _tracked_conditions(db, tenant_id)
+
+    most_improved = sorted(
+        ((identity, c) for identity, c in conditions.items() if c["condition_trend"] == "improving"),
+        key=lambda item: item[1]["inspection_count"],
+        reverse=True,
+    )[:_TOP_N]
+    most_problematic = sorted(
+        ((identity, c) for identity, c in conditions.items() if c["condition_trend"] == "declining"),
+        key=lambda item: (item[1]["repair_count"], item[1]["corrosion_history_count"]),
+        reverse=True,
+    )[:_TOP_N]
+    repeat_repair_candidates = sorted(
+        ((identity, c) for identity, c in conditions.items() if c["repair_count"] >= _RECURRENCE_THRESHOLD),
+        key=lambda item: item[1]["repair_count"],
+        reverse=True,
+    )[:_TOP_N]
+
+    finding_rows = (
+        db.query(InspectionFinding.finding_type, InspectionFinding.zone)
+        .filter(InspectionFinding.tenant_id == tenant_id)
+        .all()
+    )
+    finding_counts: dict[str, int] = defaultdict(int)
+    contamination_zone_counts: dict[str, int] = defaultdict(int)
+    for finding_type, zone in finding_rows:
+        finding_counts[finding_type] += 1
+        if finding_type in CONTAMINATION_TYPES:
+            contamination_zone_counts[zone or "unspecified"] += 1
+
+    recurring_findings = sorted(
+        (
+            {"finding_type": finding_type, "count": count}
+            for finding_type, count in finding_counts.items()
+            if count >= _RECURRENCE_THRESHOLD
+        ),
+        key=lambda x: x["count"], reverse=True,
+    )[:10]
+    repeated_contamination_zones = sorted(
+        (
+            {"zone": zone, "count": count}
+            for zone, count in contamination_zone_counts.items()
+            if count >= _RECURRENCE_THRESHOLD
+        ),
+        key=lambda x: x["count"], reverse=True,
+    )[:10]
+
+    return {
+        "tracked_instrument_count": len(conditions),
+        "recurring_findings": recurring_findings,
+        "repeated_contamination_zones": repeated_contamination_zones,
+        "most_improved_instruments": [_instrument_summary(i, c) for i, c in most_improved],
+        "most_problematic_instruments": [_instrument_summary(i, c) for i, c in most_problematic],
+        "repeat_repair_candidates": [_instrument_summary(i, c) for i, c in repeat_repair_candidates],
+        "human_review_required": True,
+    }

--- a/backend/app/services/predictive_risk_engine.py
+++ b/backend/app/services/predictive_risk_engine.py
@@ -1,0 +1,60 @@
+"""v2.4 — Predictive Risk Engine (Clinical Memory, Section 4).
+
+Deterministic heuristic — not a validated predictive model — that turns one
+instrument's own recorded history (condition trend, recurring issues, repair
+count) into a Low/Moderate/High/Critical likelihood per outcome. Always
+carries `human_review_required: true`; never phrased as a certainty.
+"""
+from __future__ import annotations
+
+from app.services.recurrence_detection_service import CONTAMINATION_TYPES
+
+_LEVELS = ("Low", "Moderate", "High", "Critical")
+_LEVEL_RANK = {level: i for i, level in enumerate(_LEVELS)}
+
+
+def _level_from_count(count: int, thresholds: tuple[int, int, int]) -> str:
+    moderate, high, critical = thresholds
+    if count >= critical:
+        return "Critical"
+    if count >= high:
+        return "High"
+    if count >= moderate:
+        return "Moderate"
+    return "Low"
+
+
+def estimate_predictive_risk(condition: dict, recurrence: dict) -> dict:
+    """Per-outcome likelihood estimates for one instrument, derived only from
+    its own history — never a claim of causation."""
+    contamination_repeats = sum(
+        count for finding_type, count in recurrence["finding_counts"].items()
+        if finding_type in CONTAMINATION_TYPES
+    )
+    repeat_contamination_likelihood = _level_from_count(contamination_repeats, (2, 4, 6))
+    repair_likelihood = _level_from_count(condition["repair_count"], (1, 2, 3))
+    supervisor_escalation_likelihood = _level_from_count(recurrence["override_count"], (2, 3, 5))
+    declining_bump = 1 if condition["condition_trend"] == "declining" else 0
+    removal_from_service_likelihood = _level_from_count(
+        condition["repair_count"] + declining_bump, (1, 2, 3)
+    )
+
+    overall = max(
+        (repeat_contamination_likelihood, repair_likelihood,
+         supervisor_escalation_likelihood, removal_from_service_likelihood),
+        key=lambda level: _LEVEL_RANK[level],
+    )
+
+    return {
+        "repeat_contamination_likelihood": repeat_contamination_likelihood,
+        "repair_likelihood": repair_likelihood,
+        "supervisor_escalation_likelihood": supervisor_escalation_likelihood,
+        "removal_from_service_likelihood": removal_from_service_likelihood,
+        "overall_risk_level": overall,
+        "basis": (
+            "Deterministic heuristic derived from this instrument's own recorded "
+            "inspection, repair, and override history — a potential association, "
+            "not a validated predictive model or a claim of causation."
+        ),
+        "human_review_required": True,
+    }

--- a/backend/app/services/recurrence_detection_service.py
+++ b/backend/app/services/recurrence_detection_service.py
@@ -1,0 +1,80 @@
+"""v2.4 — Recurrence Detection (Clinical Memory, Section 3).
+
+Given one physical instrument's condition history (already assembled by
+`instrument_condition_service.instrument_condition_history`), flags finding
+types, repairs, and supervisor overrides that repeat across that instrument's
+own inspections — real counts from real rows, never an inferred pattern.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.supervisor_review import SupervisorReview
+
+CONTAMINATION_TYPES = {"blood", "bone", "tissue", "debris", "other_organic_residue"}
+DAMAGE_TYPES = {"corrosion", "crack", "insulation_damage", "rust", "pitting"}
+
+_RECURRENCE_THRESHOLD = 2
+
+
+def detect_recurring_issues(db: Session, tenant_id: str, condition: dict) -> dict:
+    """Recurring Issue Alerts for one instrument's history: repeated finding
+    types, repeated repairs, repeated supervisor overrides."""
+    history = condition["history"]
+
+    finding_counts: dict[str, int] = {}
+    for h in history:
+        for finding_type in h["cleaning_findings"] + h["damage_findings"]:
+            finding_counts[finding_type] = finding_counts.get(finding_type, 0) + 1
+
+    alerts: list[dict] = []
+    for finding_type, count in sorted(finding_counts.items(), key=lambda kv: -kv[1]):
+        if count >= _RECURRENCE_THRESHOLD:
+            alerts.append({
+                "type": "recurring_finding",
+                "finding_type": finding_type,
+                "occurrences": count,
+                "message": (
+                    f"Repeated {finding_type.replace('_', ' ')} identified in "
+                    f"{count} of {condition['inspection_count']} inspections."
+                ),
+            })
+
+    if condition["repair_count"] >= _RECURRENCE_THRESHOLD:
+        alerts.append({
+            "type": "recurring_repair",
+            "occurrences": condition["repair_count"],
+            "message": (
+                f"This instrument has been removed from service/repaired "
+                f"{condition['repair_count']} times."
+            ),
+        })
+
+    inspection_ids = [h["inspection_id"] for h in history]
+    override_count = (
+        db.query(SupervisorReview)
+        .filter(
+            SupervisorReview.tenant_id == tenant_id,
+            SupervisorReview.inspection_id.in_(inspection_ids),
+            SupervisorReview.override_action.isnot(None),
+            SupervisorReview.override_action != "",
+        )
+        .count()
+        if inspection_ids else 0
+    )
+    if override_count >= _RECURRENCE_THRESHOLD:
+        alerts.append({
+            "type": "recurring_override",
+            "occurrences": override_count,
+            "message": (
+                f"A supervisor has overridden the AI recommendation "
+                f"{override_count} times for this instrument."
+            ),
+        })
+
+    return {
+        "alerts": alerts,
+        "has_recurring_issues": bool(alerts),
+        "finding_counts": finding_counts,
+        "override_count": override_count,
+    }

--- a/backend/app/services/similar_instrument_search_service.py
+++ b/backend/app/services/similar_instrument_search_service.py
@@ -1,0 +1,112 @@
+"""v2.4 — Similar Instrument Search (Clinical Memory, Section 2).
+
+Fleet-wide: given one physical instrument, finds OTHER physical instruments
+in this tenant that resemble it and returns a 0-1 similarity score. Distinct
+from `similar_case_finder_service.find_similar_cases`, which matches a single
+finding to prior `ClinicalCase` snapshots — this compares whole instruments
+across type, declared vendor (the closest thing to "manufacturer" the
+`Inspection` record carries — there is no separate model field), resolved
+anatomy family, and overlapping finding types (including contamination/damage
+patterns).
+
+"Untracked" instruments (no barcode/UDI — see `_instrument_identity`) are
+per-inspection singletons, not re-identified physical instruments, so they're
+excluded from this comparison rather than compared as if they were real.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.inspection_finding import InspectionFinding
+from app.services.instrument_anatomy import resolve_family
+from app.services.pre_sterilization_command_center_service import _instrument_identity
+from app.services.recurrence_detection_service import CONTAMINATION_TYPES, DAMAGE_TYPES
+
+
+def _rows_for_identity(db: Session, tenant_id: str, instrument_identity: str) -> list:
+    if instrument_identity.startswith("barcode:"):
+        value = instrument_identity.removeprefix("barcode:")
+        column = models.Inspection.instrument_barcode
+    elif instrument_identity.startswith("udi:"):
+        value = instrument_identity.removeprefix("udi:")
+        column = models.Inspection.instrument_udi
+    else:
+        return []
+    return (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, column == value)
+        .order_by(models.Inspection.created_at.asc())
+        .all()
+    )
+
+
+def _finding_types(db: Session, inspection_ids: list[int]) -> set[str]:
+    if not inspection_ids:
+        return set()
+    rows = (
+        db.query(InspectionFinding.finding_type)
+        .filter(InspectionFinding.inspection_id.in_(inspection_ids))
+        .distinct()
+        .all()
+    )
+    return {r[0] for r in rows}
+
+
+def find_similar_instruments(db: Session, tenant_id: str, *, instrument_identity: str, limit: int = 5) -> list[dict]:
+    target_rows = _rows_for_identity(db, tenant_id, instrument_identity)
+    if not target_rows:
+        return []
+
+    target_type = target_rows[-1].instrument_type
+    target_vendor = target_rows[-1].vendor_name
+    target_family = resolve_family(target_type)
+    target_findings = _finding_types(db, [r.id for r in target_rows])
+
+    all_rows = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).all()
+    by_identity: dict[str, list] = defaultdict(list)
+    for row in all_rows:
+        by_identity[_instrument_identity(row)].append(row)
+    by_identity.pop(instrument_identity, None)
+    by_identity = {k: v for k, v in by_identity.items() if not k.startswith("untracked:")}
+
+    candidates = []
+    for identity, rows in by_identity.items():
+        rows_sorted = sorted(rows, key=lambda r: (r.created_at or r.id))
+        cand_type = rows_sorted[-1].instrument_type
+        cand_vendor = rows_sorted[-1].vendor_name
+        cand_family = resolve_family(cand_type)
+        cand_findings = _finding_types(db, [r.id for r in rows_sorted])
+
+        score = 0.0
+        if cand_type == target_type:
+            score += 0.3
+        if cand_family == target_family:
+            score += 0.2
+        if cand_vendor == target_vendor and target_vendor != "unknown":
+            score += 0.15
+
+        shared_findings = target_findings & cand_findings
+        union_findings = target_findings | cand_findings
+        if union_findings:
+            score += 0.2 * (len(shared_findings) / len(union_findings))
+        if shared_findings & CONTAMINATION_TYPES:
+            score += 0.075
+        if shared_findings & DAMAGE_TYPES:
+            score += 0.075
+
+        if score <= 0:
+            continue
+        candidates.append({
+            "instrument_identity": identity,
+            "instrument_type": cand_type,
+            "vendor_name": cand_vendor,
+            "similarity_score": round(min(1.0, score), 2),
+            "shared_finding_types": sorted(shared_findings),
+            "inspection_count": len(rows_sorted),
+        })
+
+    candidates.sort(key=lambda c: c["similarity_score"], reverse=True)
+    return candidates[:limit]

--- a/backend/tests/test_v2_3_live_capture_confidence.py
+++ b/backend/tests/test_v2_3_live_capture_confidence.py
@@ -1,0 +1,175 @@
+"""LumenAI Inspect v2.3 — Live Capture Confidence & Warnings.
+
+Follow-up to v2.2 (Vision Intelligence): (1) persists each analysis-time
+finding's own confidence on `InspectionFinding` so Evidence Fusion's
+`average_confidence` reflects real data instead of always being null, and
+(2) surfaces missing-anatomy / duplicate-image warnings during capture
+(before submission) instead of only after the fact on the Vision Session
+review page.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.inspection_finding import InspectionFinding
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+SHA_A = "a1" * 32
+SHA_B = "b2" * 32
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == itype).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"v23-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _create_session(instrument_type: str, tags: list[dict] | None = None, finding_categories=None) -> dict:
+    _baseline(instrument_type)
+    r = client.post("/api/inspections", headers=AUTH_ADMIN, json={
+        "instrument_type": instrument_type, "site_name": "Main OR", "has_image": True,
+        "image_sha256": SHA_A, "file_name": "x.jpg",
+        "finding_categories": finding_categories or [],
+        "image_view_tags": tags or [],
+    })
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestPersistedFindingConfidence:
+    def test_declared_finding_persists_a_real_confidence(self):
+        insp = _create_session("scissors", finding_categories=["blood"])
+        db = SessionLocal()
+        try:
+            rows = db.query(InspectionFinding).filter(
+                InspectionFinding.inspection_id == insp["id"]
+            ).all()
+            assert rows, "expected at least one persisted finding"
+            assert all(r.confidence is not None for r in rows)
+            assert all(0.0 <= r.confidence <= 1.0 for r in rows)
+        finally:
+            db.close()
+
+    def test_persisted_confidence_matches_the_analysis_response(self):
+        insp = _create_session("scissors", finding_categories=["blood"])
+        analysis_findings = {
+            f["type"]: f["confidence"] for f in insp["analysis"]["predicted_findings"]
+        }
+        db = SessionLocal()
+        try:
+            rows = db.query(InspectionFinding).filter(
+                InspectionFinding.inspection_id == insp["id"]
+            ).all()
+            for row in rows:
+                assert row.confidence == analysis_findings[row.finding_type]
+        finally:
+            db.close()
+
+    def test_vision_session_reconstruction_reflects_persisted_confidence(self):
+        insp = _create_session("scissors", finding_categories=["blood"], tags=[
+            {"instrument_family": "scissors", "anatomy_zone": "blade", "image_view": "blade", "image_sha256": SHA_A},
+        ])
+        r = client.get(f"/api/inspections/{insp['id']}/vision-session", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        fusion = r.json()["evidence_fusion"]
+        assert fusion["contributing_factors"]["average_confidence"] is not None
+
+    def test_no_baseline_means_no_persisted_findings_and_null_confidence(self):
+        # No BaselineLibraryEntry registered for this instrument type, so
+        # analyze_inspection() returns analysis_status="supervisor_review_required"
+        # with predicted_findings=[] — nothing is persisted, and the average
+        # is omitted rather than fabricated.
+        r = client.post("/api/inspections", headers=AUTH_ADMIN, json={
+            "instrument_type": "unbaselined_instrument_v23", "site_name": "Main OR",
+            "has_image": True, "image_sha256": SHA_B, "file_name": "x.jpg",
+        })
+        assert r.status_code == 201, r.text
+        insp = r.json()
+        db = SessionLocal()
+        try:
+            rows = db.query(InspectionFinding).filter(
+                InspectionFinding.inspection_id == insp["id"]
+            ).all()
+            assert rows == []
+        finally:
+            db.close()
+
+        vr = client.get(f"/api/inspections/{insp['id']}/vision-session", headers=AUTH_ADMIN)
+        assert vr.status_code == 200
+        fusion = vr.json()["evidence_fusion"]
+        assert fusion["contributing_factors"]["average_confidence"] is None
+
+
+class TestLiveCaptureWarnings:
+    """Objective — v2.3: the same missing-anatomy / duplicate-detection
+    checks the Vision Session review page shows after the fact, available
+    live during capture on tags that have not been submitted yet."""
+
+    def test_requires_authentication(self):
+        r = client.post("/api/inspections/preview-warnings", json={"instrument_type": "scissors", "tags": []})
+        assert r.status_code in (401, 403)
+
+    def test_no_tags_yet_reports_all_zones_missing_and_no_duplicates(self):
+        r = client.post(
+            "/api/inspections/preview-warnings", headers=AUTH_ADMIN,
+            json={"instrument_type": "scissors", "tags": []},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["missing_anatomy"]["prompts"]
+        assert body["duplicate_detection"]["has_warnings"] is False
+
+    def test_duplicate_image_hash_flagged_before_submission(self):
+        r = client.post(
+            "/api/inspections/preview-warnings", headers=AUTH_ADMIN,
+            json={
+                "instrument_type": "scissors",
+                "tags": [
+                    {"anatomy_zone": "blade", "instrument_family": "scissors", "image_sha256": SHA_A},
+                    {"anatomy_zone": "box lock", "instrument_family": "scissors", "image_sha256": SHA_A},
+                ],
+            },
+        )
+        assert r.status_code == 200
+        findings = r.json()["duplicate_detection"]["findings"]
+        assert any(f["type"] == "duplicate_image" for f in findings)
+
+    def test_wrong_anatomy_zone_flagged_before_submission(self):
+        r = client.post(
+            "/api/inspections/preview-warnings", headers=AUTH_ADMIN,
+            json={
+                "instrument_type": "scissors",
+                "tags": [
+                    {"anatomy_zone": "not_a_real_zone", "instrument_family": "scissors", "image_sha256": SHA_A},
+                ],
+            },
+        )
+        assert r.status_code == 200
+        findings = r.json()["duplicate_detection"]["findings"]
+        assert any(f["type"] == "wrong_anatomy" for f in findings)
+
+    def test_full_coverage_clears_the_missing_anatomy_prompts(self):
+        from app.services.instrument_anatomy import get_anatomy
+
+        anatomy = get_anatomy("scissors")
+        tags = [
+            {"anatomy_zone": z, "instrument_family": "scissors", "image_sha256": f"{i}" * 64}
+            for i, z in enumerate(anatomy["required_images"])
+        ]
+        r = client.post(
+            "/api/inspections/preview-warnings", headers=AUTH_ADMIN,
+            json={"instrument_type": "scissors", "tags": tags},
+        )
+        assert r.status_code == 200
+        assert r.json()["missing_anatomy"]["prompts"] == []

--- a/backend/tests/test_v2_4_clinical_memory.py
+++ b/backend/tests/test_v2_4_clinical_memory.py
@@ -1,0 +1,298 @@
+"""LumenAI Inspect v2.4 — Clinical Memory & Predictive Intelligence
+("Project Insight").
+
+Covers: memory lookup, similarity search, recurrence detection, health
+forecast, timeline generation, and recommendation enrichment.
+"""
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.knowledge import APPROVED, KnowledgeArticle
+from app.services.clinical_memory_service import (
+    build_memory_recommendation, build_memory_timeline, get_clinical_memory,
+)
+from app.services.instrument_health_forecast_service import forecast_instrument_health
+from app.services.instrument_condition_service import instrument_condition_history
+from app.services.predictive_risk_engine import estimate_predictive_risk
+from app.services.recurrence_detection_service import detect_recurring_issues
+from app.services.similar_instrument_search_service import find_similar_instruments
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+
+
+def _baseline(itype: str) -> None:
+    db = SessionLocal()
+    try:
+        db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.instrument_category == itype).delete()
+        db.add(BaselineLibraryEntry(
+            udi=f"v24-{itype}", instrument_category=itype, manufacturer_name="M",
+            model_name="X", baseline_type="manufacturer", approval_status="approved",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _create_inspection(instrument_type: str, barcode: str, sha_suffix: str, finding_categories=None) -> dict:
+    _baseline(instrument_type)
+    r = client.post("/api/inspections", headers=AUTH_ADMIN, json={
+        "instrument_type": instrument_type, "site_name": "Main OR", "has_image": True,
+        "image_sha256": sha_suffix * 64, "file_name": "x.jpg",
+        "instrument_barcode": barcode,
+        "finding_categories": finding_categories or [],
+        "image_view_tags": [{
+            "instrument_family": instrument_type, "anatomy_zone": "box lock",
+            "image_view": "box lock", "image_sha256": sha_suffix * 64,
+        }],
+    })
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestClinicalMemoryLookup:
+    def test_no_history_returns_404(self):
+        r = client.get("/api/clinical-memory?instrument_identity=barcode:no-such-instrument", headers=AUTH_ADMIN)
+        assert r.status_code == 404
+
+    def test_requires_authentication(self):
+        r = client.get("/api/clinical-memory?instrument_identity=barcode:x")
+        assert r.status_code in (401, 403)
+
+    def test_real_instrument_returns_full_memory_context(self):
+        for i in range(3):
+            _create_inspection("scissors", "V24-BC-A", str(i), finding_categories=["blood"])
+
+        r = client.get("/api/clinical-memory?instrument_identity=barcode:V24-BC-A", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "condition_history", "recurring_issues", "predictive_risk", "health_forecast",
+            "similar_instruments", "knowledge_articles", "timeline", "memory_recommendation",
+        ):
+            assert key in body
+        assert body["human_review_required"] is True
+        assert body["condition_history"]["inspection_count"] == 3
+
+    def test_untracked_instrument_has_no_memory(self):
+        insp = _create_inspection("forceps", "", "9")
+        db = SessionLocal()
+        try:
+            from app.db import models
+            row = db.query(models.Inspection).filter(models.Inspection.id == insp["id"]).first()
+            identity = f"untracked:forceps:{row.id}"
+        finally:
+            db.close()
+        r = client.get(f"/api/clinical-memory?instrument_identity={identity}", headers=AUTH_ADMIN)
+        assert r.status_code == 404
+
+    def test_ai_context_expansion_attaches_memory_on_second_inspection(self):
+        _create_inspection("scissors", "V24-BC-CTX", "1", finding_categories=["blood"])
+        second = _create_inspection("scissors", "V24-BC-CTX", "2", finding_categories=["blood"])
+        assert second["analysis"].get("clinical_memory") is not None
+        assert second["analysis"]["clinical_memory"]["condition_history"]["inspection_count"] == 1
+
+    def test_learning_dashboard_reachable(self):
+        r = client.get("/api/clinical-memory/learning-dashboard", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        body = r.json()
+        for key in (
+            "tracked_instrument_count", "recurring_findings", "repeated_contamination_zones",
+            "most_improved_instruments", "most_problematic_instruments", "repeat_repair_candidates",
+        ):
+            assert key in body
+
+
+class TestRecurrenceDetection:
+    def test_repeated_finding_type_generates_alert(self):
+        for i in range(3):
+            _create_inspection("scissors", "V24-BC-REC", str(i), finding_categories=["blood"])
+        db = SessionLocal()
+        try:
+            condition = instrument_condition_history(db, "default-tenant", "barcode:V24-BC-REC")
+            recurrence = detect_recurring_issues(db, "default-tenant", condition)
+        finally:
+            db.close()
+        assert recurrence["has_recurring_issues"] is True
+        blood_alerts = [a for a in recurrence["alerts"] if a.get("finding_type") == "blood"]
+        assert blood_alerts and blood_alerts[0]["occurrences"] >= 2
+
+    def test_single_finding_does_not_recur(self):
+        _create_inspection("scissors", "V24-BC-SINGLE", "1", finding_categories=["blood"])
+        db = SessionLocal()
+        try:
+            condition = instrument_condition_history(db, "default-tenant", "barcode:V24-BC-SINGLE")
+            recurrence = detect_recurring_issues(db, "default-tenant", condition)
+        finally:
+            db.close()
+        # A single inspection can log a finding, but with only one inspection
+        # on record it can't have recurred yet.
+        assert condition["inspection_count"] == 1
+        assert recurrence["has_recurring_issues"] is False
+        assert all(count < 2 for count in recurrence["finding_counts"].values())
+
+
+class TestPredictiveRiskEngine:
+    def test_no_repeats_is_low_risk(self):
+        condition = {"condition_trend": "stable", "repair_count": 0}
+        recurrence = {"finding_counts": {}, "override_count": 0}
+        risk = estimate_predictive_risk(condition, recurrence)
+        assert risk["overall_risk_level"] == "Low"
+        assert risk["human_review_required"] is True
+
+    def test_repeated_contamination_raises_likelihood(self):
+        condition = {"condition_trend": "stable", "repair_count": 0}
+        recurrence = {"finding_counts": {"blood": 6}, "override_count": 0}
+        risk = estimate_predictive_risk(condition, recurrence)
+        assert risk["repeat_contamination_likelihood"] in ("High", "Critical")
+
+    def test_repeated_repairs_raise_removal_likelihood(self):
+        condition = {"condition_trend": "declining", "repair_count": 3}
+        recurrence = {"finding_counts": {}, "override_count": 0}
+        risk = estimate_predictive_risk(condition, recurrence)
+        assert risk["removal_from_service_likelihood"] == "Critical"
+        assert risk["overall_risk_level"] == "Critical"
+
+
+class TestInstrumentHealthForecast:
+    def test_forecast_reflects_repair_trend_and_sample_size(self):
+        for i in range(2):
+            _create_inspection("scissors", "V24-BC-FORECAST", str(i), finding_categories=["blood"])
+        db = SessionLocal()
+        try:
+            condition = instrument_condition_history(db, "default-tenant", "barcode:V24-BC-FORECAST")
+            forecast = forecast_instrument_health(db, "default-tenant", "barcode:V24-BC-FORECAST", condition)
+        finally:
+            db.close()
+        assert forecast["repair_trend"] == "none"
+        assert forecast["sample_size"] == 2
+        assert forecast["human_review_required"] is True
+
+    def test_small_sample_confidence_interval_is_wide_or_null(self):
+        _create_inspection("scissors", "V24-BC-SMALL", "1", finding_categories=["blood"])
+        db = SessionLocal()
+        try:
+            condition = instrument_condition_history(db, "default-tenant", "barcode:V24-BC-SMALL")
+            forecast = forecast_instrument_health(db, "default-tenant", "barcode:V24-BC-SMALL", condition)
+        finally:
+            db.close()
+        ci = forecast["confidence_interval"]
+        if ci is not None:
+            assert (ci["high"] - ci["low"]) >= 20
+
+
+class TestSimilarInstrumentSearch:
+    def test_finds_other_instrument_sharing_type_and_finding(self):
+        for i in range(2):
+            _create_inspection("scissors", "V24-BC-SIM-1", str(i), finding_categories=["blood"])
+        _create_inspection("scissors", "V24-BC-SIM-2", "5", finding_categories=["blood"])
+
+        # A generous limit — other tests in this module create their own
+        # scissors/blood instruments in the same shared tenant, and this
+        # assertion only cares that SIM-2 is *found*, not that it's top-ranked.
+        db = SessionLocal()
+        try:
+            results = find_similar_instruments(db, "default-tenant", instrument_identity="barcode:V24-BC-SIM-1", limit=50)
+        finally:
+            db.close()
+        assert any(r["instrument_identity"] == "barcode:V24-BC-SIM-2" for r in results)
+        match = next(r for r in results if r["instrument_identity"] == "barcode:V24-BC-SIM-2")
+        assert match["similarity_score"] > 0
+        assert "blood" in match["shared_finding_types"]
+
+    def test_untracked_instruments_excluded(self):
+        db = SessionLocal()
+        try:
+            results = find_similar_instruments(db, "default-tenant", instrument_identity="barcode:V24-BC-SIM-1", limit=50)
+        finally:
+            db.close()
+        assert all(not r["instrument_identity"].startswith("untracked:") for r in results)
+
+    def test_no_history_returns_empty_list(self):
+        db = SessionLocal()
+        try:
+            results = find_similar_instruments(db, "default-tenant", instrument_identity="barcode:no-such-thing")
+        finally:
+            db.close()
+        assert results == []
+
+
+class TestMemoryTimeline:
+    def test_timeline_alternates_inspection_finding_repair_note(self):
+        condition = {
+            "history": [
+                {
+                    "inspection_id": 1, "date": "2026-01-01T00:00:00", "disposition": "REPROCESS",
+                    "cleaning_findings": ["blood"], "damage_findings": [], "repair_flag": False,
+                    "supervisor_comments": ["looked fine overall"],
+                },
+                {
+                    "inspection_id": 2, "date": "2026-02-01T00:00:00", "disposition": "REMOVE FROM SERVICE",
+                    "cleaning_findings": [], "damage_findings": ["crack"], "repair_flag": True,
+                    "supervisor_comments": [],
+                },
+            ],
+        }
+        timeline = build_memory_timeline(condition)
+        types = [e["type"] for e in timeline]
+        assert types == ["inspection", "finding", "supervisor_note", "inspection", "finding", "repair", "current"]
+
+    def test_empty_history_still_has_current_marker(self):
+        timeline = build_memory_timeline({"history": []})
+        assert timeline == [{"type": "current", "date": None}]
+
+
+class TestMemoryDrivenRecommendation:
+    def test_recommendation_names_recurring_finding_and_zone(self):
+        for i in range(3):
+            _create_inspection("scissors", "V24-BC-RECO", str(i), finding_categories=["blood"])
+        db = SessionLocal()
+        try:
+            memory = get_clinical_memory(db, "default-tenant", "barcode:V24-BC-RECO")
+        finally:
+            db.close()
+        rec = memory["memory_recommendation"]
+        assert rec is not None
+        assert rec["finding_type"] == "blood"
+        assert rec["occurrences"] >= 3
+        assert "blood" in rec["message"].lower()
+        assert "recommend" in rec["message"].lower()
+        assert rec["human_review_required"] is True
+
+    def test_no_recurrence_means_no_recommendation(self):
+        db = SessionLocal()
+        try:
+            condition = {"history": [{"inspection_id": 1}], "inspection_count": 1}
+            recurrence = {"has_recurring_issues": False, "finding_counts": {}}
+            rec = build_memory_recommendation(db, "default-tenant", condition, recurrence)
+        finally:
+            db.close()
+        assert rec is None
+
+
+class TestKnowledgeArticleEnrichment:
+    def test_applicable_article_surfaced_in_memory(self):
+        db = SessionLocal()
+        try:
+            db.add(KnowledgeArticle(
+                tenant_id="default-tenant", category="teaching_point", title="Box lock blood residue",
+                body="Check the box lock carefully.", approval_status=APPROVED,
+                applicable_instruments=json.dumps(["scissors"]),
+            ))
+            db.commit()
+        finally:
+            db.close()
+
+        for i in range(2):
+            _create_inspection("scissors", "V24-BC-KA", str(i), finding_categories=["blood"])
+
+        r = client.get("/api/clinical-memory?instrument_identity=barcode:V24-BC-KA", headers=AUTH_ADMIN)
+        assert r.status_code == 200
+        titles = [a["title"] for a in r.json()["knowledge_articles"]]
+        assert "Box lock blood residue" in titles

--- a/docs/memory/clinical-memory-engine.md
+++ b/docs/memory/clinical-memory-engine.md
@@ -1,0 +1,63 @@
+# Clinical Memory Engine (Project Insight, v2.4)
+
+`app/services/clinical_memory_service.py`, `app/routes/clinical_memory.py`.
+
+## Mission
+
+Every inspection should be able to answer: have I inspected this instrument
+before? Has this anatomy failed previously? Is this finding recurring? The
+Clinical Memory Engine is the composition layer that assembles a single
+instrument's complete recorded history into one context object — it does not
+re-run AI scoring or invent a new re-identification scheme.
+
+## `GET /api/clinical-memory?instrument_identity=<barcode:...|udi:...>`
+
+Roles: admin, spd_manager, supervisor, operator, viewer. 404 when there's no
+recorded history for that identity (untracked instruments — no barcode/UDI —
+never have one; see below).
+
+Composes, without duplicating any of their logic:
+
+| Field | Source |
+|---|---|
+| `condition_history` | `instrument_condition_service.instrument_condition_history` (v1.6) — inspection/finding/repair/supervisor-comment history + condition trend |
+| `recurring_issues` | `recurrence_detection_service.detect_recurring_issues` (Section 3) |
+| `predictive_risk` | `predictive_risk_engine.estimate_predictive_risk` (Section 4) |
+| `health_forecast` | `instrument_health_forecast_service.forecast_instrument_health` (Section 5) |
+| `similar_instruments` | `similar_instrument_search_service.find_similar_instruments` (Section 2) |
+| `knowledge_articles` | `knowledge_repository_service.list_articles(instrument=...)` (v1.8), top 5 |
+| `timeline` | `build_memory_timeline` (Section 7) |
+| `memory_recommendation` | `build_memory_recommendation` (Section 9) |
+
+Every field carries `human_review_required: true` (also set at the top
+level) — Clinical Memory never issues a self-executing recommendation.
+
+## Instrument identity
+
+Reuses the exact `barcode:<value>` / `udi:<value>` key already established by
+`app/services/pre_sterilization_command_center_service._instrument_identity`
+and consumed by `instrument_condition_service`/`prioritization_engine`. An
+instrument with neither a barcode nor a UDI captured gets an
+`untracked:<type>:<inspection_id>` key — a per-inspection singleton, not a
+re-identified physical instrument — and is correctly excluded from Clinical
+Memory (there's no real history to recall) rather than faked.
+
+## AI Context Expansion (Section 6)
+
+`app/routes/inspections.py`'s `create_inspection()` computes
+`get_clinical_memory(db, tenant_id, memory_identity)` from the submitted
+`instrument_barcode`/`instrument_udi` **before** the new inspection is
+persisted, and attaches it to the analysis response as
+`analysis["clinical_memory"]` when history exists. Because it's computed
+before the current row is inserted, it always reflects prior history only —
+purely additive context for the technician/reviewer, never a second scoring
+pass and never altering the risk score, findings, or recommendation the
+scoring engine already produced.
+
+## What this deliberately does not do
+
+No new instrument-identity scheme, no re-derivation of condition trend or
+inspection history (both already exist and are already tested), and no
+fabricated confidence — see `docs/memory/predictive-intelligence.md` and
+`docs/memory/instrument-health-forecast.md` for how those specifically avoid
+overclaiming precision.

--- a/docs/memory/instrument-health-forecast.md
+++ b/docs/memory/instrument-health-forecast.md
@@ -1,0 +1,32 @@
+# Instrument Health Forecast (Project Insight, Section 5)
+
+`app/services/instrument_health_forecast_service.py`.
+
+Extends the existing Predictive Instrument Intelligence
+(`app/services/instrument_intelligence.instrument_timeline` — risk trend,
+remaining-useful-life estimate, already used by Instrument Passport) rather
+than re-deriving risk trend from scratch:
+
+| Field | Source |
+|---|---|
+| `condition_trend` | `instrument_condition_service` (cleaning/damage-finding rate, first half vs second half) |
+| `failure_risk_trend` | `instrument_intelligence.instrument_timeline`'s risk-score trend |
+| `repair_trend` | `none` / `occurred_once` / `recurring`, from this instrument's own `repair_count` |
+| `estimated_remaining_useful_life` | `instrument_intelligence.instrument_timeline`'s existing projection (only offered on a clear worsening trend) |
+| `confidence_interval` | New — see below |
+| `sample_size` | How many inspections this forecast is built on |
+
+## Confidence interval — honest about small samples
+
+`confidence_interval` widens as `sample_size` shrinks (±5 at 8+ inspections,
+±12 at 4-7, ±20 at 2-3, `null` below 2 or when there's no scored risk value
+yet) — a deliberately wider, less precise band with less history, rather than
+a fixed-width interval that would claim the same precision regardless of how
+little is actually known about this instrument.
+
+## What this deliberately does not do
+
+Does not re-run or duplicate `instrument_intelligence.instrument_timeline`'s
+trend/RUL math — it's called directly and its `prediction` block is reused
+verbatim, with the condition/repair trend and confidence interval added on
+top.

--- a/docs/memory/predictive-intelligence.md
+++ b/docs/memory/predictive-intelligence.md
@@ -1,0 +1,31 @@
+# Predictive Risk Engine (Project Insight, Section 4)
+
+`app/services/predictive_risk_engine.py`.
+
+⚠️ **Deterministic heuristic — not a validated predictive model.** Every
+likelihood is derived only from this instrument's own recorded history
+(condition trend, recurring finding counts, repair count, override count) —
+never a claim of causation, and every response carries
+`human_review_required: true`.
+
+## Outputs
+
+| Field | Derived from |
+|---|---|
+| `repeat_contamination_likelihood` | Recurring-finding count restricted to `CONTAMINATION_TYPES` |
+| `repair_likelihood` | This instrument's own `repair_count` |
+| `supervisor_escalation_likelihood` | Recurring-override count |
+| `removal_from_service_likelihood` | `repair_count`, bumped by 1 when the condition trend is declining |
+| `overall_risk_level` | The highest of the four above |
+
+Each is one of `Low` / `Moderate` / `High` / `Critical`, from fixed count
+thresholds (`_level_from_count`) — not a black-box score, so the reasoning
+behind any level is always inspectable from the same numbers the technician
+can see in Clinical Memory's `condition_history`/`recurring_issues`.
+
+## Governance
+
+`basis` always states plainly that this is "a potential association, not a
+validated predictive model or a claim of causation" — matching the
+platform-wide rule that no automated output here is self-executing or
+diagnostic.

--- a/docs/memory/recurrence-detection.md
+++ b/docs/memory/recurrence-detection.md
@@ -1,0 +1,39 @@
+# Recurrence Detection (Project Insight, Section 3)
+
+`app/services/recurrence_detection_service.py`.
+
+## What it detects
+
+Given one instrument's already-assembled condition history
+(`instrument_condition_service.instrument_condition_history`), flags:
+
+- **Recurring findings** — any finding type (contamination or damage) logged
+  in 2 or more of this instrument's own inspections.
+- **Recurring repairs** — `repair_count >= 2` (a `disposition ==
+  "REMOVE FROM SERVICE"` inspection, the same repair signal
+  `instrument_condition_service` already uses).
+- **Recurring overrides** — 2 or more `SupervisorReview` rows for this
+  instrument's inspections with a non-empty `override_action`.
+
+Each becomes a `Recurring Issue Alert`:
+
+```json
+{"type": "recurring_finding", "finding_type": "blood", "occurrences": 3,
+ "message": "Repeated blood identified in 3 of 6 inspections."}
+```
+
+## Constants reused elsewhere
+
+`CONTAMINATION_TYPES` (`blood`, `bone`, `tissue`, `debris`,
+`other_organic_residue`) and `DAMAGE_TYPES` (`corrosion`, `crack`,
+`insulation_damage`, `rust`, `pitting`) are defined once here and imported by
+`predictive_risk_engine.py`, `similar_instrument_search_service.py`, and
+`learning_dashboard_service.py` — the same taxonomy every recurrence/risk/
+similarity computation in v2.4 uses, so a finding type is never classified
+differently by two different services.
+
+## Threshold
+
+Two-or-more occurrences (`_RECURRENCE_THRESHOLD = 2`) — a single finding
+isn't a pattern; real repetition is what earns an alert. This is a real count
+over real rows, not an inferred pattern or a statistical model.

--- a/docs/vision/inspection-session.md
+++ b/docs/vision/inspection-session.md
@@ -18,9 +18,9 @@ Returns the full multi-image session view for one inspection:
 `predicted_findings` used by cross-image reasoning and evidence fusion are
 reconstructed from `InspectionFinding` — the real per-finding rows already
 persisted at analysis time (`app/routes/inspections.py`) — not a re-run of
-the scoring engine. Per-finding confidence isn't persisted individually, so
-it's omitted from the reconstruction rather than fabricated; only the
-scored analysis response (returned once, at creation time) carries it.
+the scoring engine. Per-finding `confidence` (v2.3) is persisted on the same
+row and read back verbatim; rows logged before the column existed carry
+`null` rather than a fabricated value.
 
 ## `GET /api/inspections/{id}/gallery`
 

--- a/docs/vision/live-capture-warnings.md
+++ b/docs/vision/live-capture-warnings.md
@@ -1,0 +1,48 @@
+# Live Capture Warnings (v2.3)
+
+`POST /api/inspections/preview-warnings` — `app/routes/vision_session.py`.
+
+## Why
+
+v2.2's missing-anatomy and duplicate-detection warnings only appeared on the
+Vision Session review page, after the inspection was already submitted. This
+endpoint reuses the same two stateless services —
+`app/services/vision_session_engine.py`'s `missing_anatomy_prompts()` and
+`app/services/duplicate_detection_service.py`'s `detect_all()` — against the
+technician's in-progress capture, before submission.
+
+## Request
+
+```json
+{
+  "instrument_type": "scissors",
+  "tags": [
+    {"anatomy_zone": "blade", "instrument_family": "scissors", "image_sha256": "…"}
+  ]
+}
+```
+
+Nothing is persisted and no `inspection_id` is required — `tags` describes
+images the technician has captured and tagged so far but not yet submitted.
+
+## Response
+
+```json
+{
+  "missing_anatomy": {"prompts": [...], "suggested_next": "box lock"},
+  "duplicate_detection": {"findings": [...], "has_warnings": true, "count": 1}
+}
+```
+
+Same shape as the corresponding fields on `GET /api/inspections/{id}/vision-session`.
+
+## Frontend
+
+`frontend/src/pages/NewInspectionPage.tsx` hashes each captured image
+client-side (`crypto.subtle.digest("SHA-256", ...)`, cached per file so a
+re-render never rehashes an unchanged file) and calls this endpoint
+debounced (500ms) whenever the instrument type, captured images, or image
+tags change. Warnings render inline in the capture form, alongside the
+existing Guided Capture panel and per-image tagging UI — the technician sees
+"you have not captured the box lock" or "these two images are identical"
+while they can still act on it, not after the record is already saved.

--- a/docs/vision/vision-fusion.md
+++ b/docs/vision/vision-fusion.md
@@ -38,8 +38,10 @@ governance rule that no recommendation here is self-executing.
 ## What this deliberately does not do
 
 Evidence Fusion does not re-run `analyze_inspection()` or invent new
-per-image confidence values — confidence isn't persisted per finding today
-(see `docs/vision/inspection-session.md`), so the average is computed only
-over values that are actually available, and is `null` rather than
-fabricated when none are. This is the same "no fabrication" convention the
-rest of the platform's scoring/anatomy/knowledge services follow.
+per-image confidence values. Per-finding confidence (v2.3) is persisted on
+`InspectionFinding` at analysis time and read back verbatim; the average is
+computed only over values that are actually available (rows logged before
+the column existed, or findings below the logged severity threshold, carry
+none), and is `null` rather than fabricated when none are. This is the same
+"no fabrication" convention the rest of the platform's scoring/anatomy/
+knowledge services follow.

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -44,6 +44,7 @@ import {
   ListChecks,
   ClipboardList,
   BookMarked,
+  Brain,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -131,6 +132,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: "/analytics", label: "Benchmarking", icon: BarChart3 },
       { to: "/quality-intelligence", label: "Risk Signals", icon: AlertTriangle },
       { to: "/quality-dashboard", label: "Quality Dashboard", icon: BarChart3 },
+      { to: "/learning-dashboard", label: "Learning Dashboard", icon: Brain },
       { to: "/clinical-readiness", label: "Clinical Service Readiness", icon: ShieldCheck },
       { to: "/operations", label: "Operational Analytics", icon: Activity },
       { to: "/operations-board", label: "Operations Board", icon: ClipboardList, roles: ["admin", "spd_manager"] },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -82,6 +82,7 @@ const VendorIntelligencePage = lazy(() => import("./pages/VendorIntelligencePage
 const DigitalTwinPage = lazy(() => import("./pages/DigitalTwinPage"));
 const QualityIntelligencePage = lazy(() => import("./pages/QualityIntelligencePage"));
 const QualityDashboardPage = lazy(() => import("./pages/QualityDashboardPage"));
+const LearningDashboardPage = lazy(() => import("./pages/LearningDashboardPage"));
 const ClinicalReadinessPage = lazy(() => import("./pages/ClinicalReadinessPage"));
 const InspectionWorkQueuePage = lazy(() => import("./pages/InspectionWorkQueuePage"));
 const OperationsBoardPage = lazy(() => import("./pages/OperationsBoardPage"));
@@ -391,6 +392,7 @@ function App() {
                       <Route path="/digital-twin" element={<Page name="DigitalTwin"><DigitalTwinPage /></Page>} />
                       <Route path="/quality-intelligence" element={<Page name="QualityIntelligence"><QualityIntelligencePage /></Page>} />
                       <Route path="/quality-dashboard" element={<Page name="QualityDashboard"><QualityDashboardPage /></Page>} />
+                      <Route path="/learning-dashboard" element={<Page name="LearningDashboard"><LearningDashboardPage /></Page>} />
                       <Route path="/clinical-readiness" element={<Page name="ClinicalReadiness"><ClinicalReadinessPage /></Page>} />
                       <Route path="/inspection-work-queue" element={<Page name="InspectionWorkQueue"><InspectionWorkQueuePage /></Page>} />
                       <Route path="/operations-board" element={<Page name="OperationsBoard"><RequireRole allowed={ELEVATED_ROLES}><OperationsBoardPage /></RequireRole></Page>} />

--- a/frontend/src/pages/InstrumentPassportPage.tsx
+++ b/frontend/src/pages/InstrumentPassportPage.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   ArrowRight,
   BarChart3,
+  Brain,
   CheckCircle2,
   ClipboardList,
   CreditCard,
@@ -77,6 +78,64 @@ type TimelineResponse = {
   identifier: string;
   inspection_count: number;
   prediction: Prediction;
+};
+
+// v2.4 — Clinical Memory & Predictive Intelligence ("Project Insight"), from
+// the backend /api/clinical-memory endpoint.
+type RecurringAlert = { type: string; occurrences: number; message: string; finding_type?: string };
+type RiskLevel = "Low" | "Moderate" | "High" | "Critical";
+type PredictiveRisk = {
+  repeat_contamination_likelihood: RiskLevel;
+  repair_likelihood: RiskLevel;
+  supervisor_escalation_likelihood: RiskLevel;
+  removal_from_service_likelihood: RiskLevel;
+  overall_risk_level: RiskLevel;
+  basis: string;
+};
+type HealthForecast = {
+  condition_trend: string;
+  failure_risk_trend: string;
+  repair_trend: string;
+  estimated_remaining_useful_life: string | null;
+  confidence_interval: { low: number; high: number } | null;
+  sample_size: number;
+};
+type SimilarInstrument = {
+  instrument_identity: string;
+  instrument_type: string;
+  vendor_name: string;
+  similarity_score: number;
+  shared_finding_types: string[];
+  inspection_count: number;
+};
+type KnowledgeArticleRef = { id: number; title: string; category: string };
+type MemoryTimelineEvent = {
+  type: "inspection" | "finding" | "repair" | "supervisor_note" | "current";
+  inspection_id?: number;
+  date: string | null;
+  disposition?: string;
+  findings?: string[];
+  note?: string;
+};
+type MemoryRecommendation = { finding_type: string; zone: string; occurrences: number; message: string };
+type ClinicalMemory = {
+  instrument_identity: string;
+  instrument_type: string;
+  condition_history: { inspection_count: number; repair_count: number; corrosion_history_count: number; condition_trend: string };
+  recurring_issues: { alerts: RecurringAlert[]; has_recurring_issues: boolean };
+  predictive_risk: PredictiveRisk;
+  health_forecast: HealthForecast;
+  similar_instruments: SimilarInstrument[];
+  knowledge_articles: KnowledgeArticleRef[];
+  timeline: MemoryTimelineEvent[];
+  memory_recommendation: MemoryRecommendation | null;
+};
+
+const RISK_LEVEL_COLOR: Record<RiskLevel, string> = {
+  Low: "text-emerald-600 bg-emerald-50 border-emerald-200",
+  Moderate: "text-amber-600 bg-amber-50 border-amber-200",
+  High: "text-orange-600 bg-orange-50 border-orange-200",
+  Critical: "text-red-600 bg-red-50 border-red-200",
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -185,6 +244,7 @@ export default function InstrumentPassportPage() {
   const [inspections, setInspections] = useState<Inspection[]>([]);
   const [baselines, setBaselines] = useState<Baseline[]>([]);
   const [prediction, setPrediction] = useState<Prediction | null>(null);
+  const [clinicalMemory, setClinicalMemory] = useState<ClinicalMemory | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -252,6 +312,32 @@ export default function InstrumentPassportPage() {
         }
       } catch {
         /* non-fatal — prediction card simply hides */
+      }
+
+      // v2.4 — Clinical Memory: only meaningful for a real re-identified
+      // instrument (barcode/UDI). When the Instrument Registry lookup didn't
+      // resolve `found`, fall back to trying the raw URL param as both a
+      // barcode and a UDI — the same ambiguity the prediction fetch above
+      // already accepts via its OR-matched `trendKey`.
+      setClinicalMemory(null);
+      const candidateIdentities = found?.barcode
+        ? [`barcode:${found.barcode}`]
+        : found?.udi
+        ? [`udi:${found.udi}`]
+        : [`barcode:${identifier}`, `udi:${identifier}`];
+      for (const candidate of candidateIdentities) {
+        try {
+          const memRes = await apiFetch(
+            `/api/clinical-memory?instrument_identity=${encodeURIComponent(candidate)}`,
+            { raw: true, headers: hdrs }
+          );
+          if (memRes.ok) {
+            setClinicalMemory(await memRes.json());
+            break;
+          }
+        } catch {
+          /* try the next candidate identity */
+        }
       }
     } catch {
       setError("Failed to load passport data.");
@@ -562,6 +648,140 @@ export default function InstrumentPassportPage() {
             </Card>
           </div>
         </div>
+      )}
+
+      {/* v2.4 — Clinical Memory & Predictive Intelligence ("Project Insight") */}
+      {clinicalMemory && (
+        <Card>
+          <CardHeader className="pb-2">
+            <SectionTitle icon={Brain} title="Clinical Memory" />
+          </CardHeader>
+          <CardContent className="pt-0 space-y-5">
+            {clinicalMemory.memory_recommendation && (
+              <div className="rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2.5">
+                <p className="text-xs font-medium text-indigo-900 mb-0.5">Memory-driven recommendation</p>
+                <p className="text-sm text-indigo-800">{clinicalMemory.memory_recommendation.message}</p>
+              </div>
+            )}
+
+            {clinicalMemory.recurring_issues.alerts.length > 0 && (
+              <div>
+                <p className="text-xs font-medium text-slate-600 mb-2">Recurring issue alerts</p>
+                <div className="space-y-1.5">
+                  {clinicalMemory.recurring_issues.alerts.map((alert, idx) => (
+                    <div key={idx} className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+                      <AlertTriangle className="h-3.5 w-3.5 text-amber-500 shrink-0 mt-0.5" />
+                      <span className="text-xs text-amber-800">{alert.message}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <p className="text-xs font-medium text-slate-600 mb-2">Predictive risk</p>
+                <div className="space-y-1.5">
+                  {([
+                    ["Repeat contamination", clinicalMemory.predictive_risk.repeat_contamination_likelihood],
+                    ["Repair", clinicalMemory.predictive_risk.repair_likelihood],
+                    ["Supervisor escalation", clinicalMemory.predictive_risk.supervisor_escalation_likelihood],
+                    ["Removal from service", clinicalMemory.predictive_risk.removal_from_service_likelihood],
+                  ] as [string, RiskLevel][]).map(([label, level]) => (
+                    <div key={label} className="flex items-center justify-between text-xs">
+                      <span className="text-slate-500">{label}</span>
+                      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 font-medium ${RISK_LEVEL_COLOR[level]}`}>
+                        {level}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <p className="text-xs text-slate-400 mt-2 italic">{clinicalMemory.predictive_risk.basis}</p>
+              </div>
+
+              <div>
+                <p className="text-xs font-medium text-slate-600 mb-2">Health forecast</p>
+                <div className="space-y-1.5 text-xs">
+                  <Row label="Condition trend" value={clinicalMemory.health_forecast.condition_trend.replace(/_/g, " ")} capitalize />
+                  <Row label="Failure risk trend" value={clinicalMemory.health_forecast.failure_risk_trend.replace(/_/g, " ")} capitalize />
+                  <Row label="Repair trend" value={clinicalMemory.health_forecast.repair_trend.replace(/_/g, " ")} capitalize />
+                  <Row
+                    label="Confidence interval"
+                    value={
+                      clinicalMemory.health_forecast.confidence_interval
+                        ? `${clinicalMemory.health_forecast.confidence_interval.low}–${clinicalMemory.health_forecast.confidence_interval.high}`
+                        : "Not enough history"
+                    }
+                  />
+                  <Row label="Sample size" value={`${clinicalMemory.health_forecast.sample_size} inspections`} />
+                </div>
+              </div>
+            </div>
+
+            {clinicalMemory.timeline.length > 0 && (
+              <div>
+                <p className="text-xs font-medium text-slate-600 mb-2">Memory timeline</p>
+                <div className="space-y-1.5 max-h-64 overflow-y-auto pr-1">
+                  {clinicalMemory.timeline.map((event, idx) => (
+                    <div key={idx} className="flex items-start gap-2 text-xs">
+                      <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-slate-300" />
+                      <span className="text-slate-400 shrink-0 w-24">{formatDate(event.date ?? undefined)}</span>
+                      {event.type === "inspection" && (
+                        <span className="text-slate-600">Inspection #{event.inspection_id} — {event.disposition}</span>
+                      )}
+                      {event.type === "finding" && (
+                        <span className="text-slate-600">Finding: {event.findings?.join(", ")}</span>
+                      )}
+                      {event.type === "repair" && (
+                        <span className="text-red-600 font-medium">Repair / removed from service</span>
+                      )}
+                      {event.type === "supervisor_note" && (
+                        <span className="text-slate-500 italic">Supervisor note: {event.note}</span>
+                      )}
+                      {event.type === "current" && <span className="text-slate-400">Current</span>}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {clinicalMemory.similar_instruments.length > 0 && (
+              <div>
+                <p className="text-xs font-medium text-slate-600 mb-2">Similar instruments</p>
+                <div className="space-y-1.5">
+                  {clinicalMemory.similar_instruments.map((sim) => (
+                    <div key={sim.instrument_identity} className="flex items-center justify-between text-xs rounded-lg border border-slate-100 bg-slate-50 px-3 py-1.5">
+                      <span className="text-slate-600 capitalize">{sim.instrument_type.replace(/_/g, " ")} · {sim.vendor_name}</span>
+                      <span className="font-mono text-slate-400">{Math.round(sim.similarity_score * 100)}% similar</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {clinicalMemory.knowledge_articles.length > 0 && (
+              <div>
+                <p className="text-xs font-medium text-slate-600 mb-2">Applicable knowledge articles</p>
+                <div className="flex flex-wrap gap-2">
+                  {clinicalMemory.knowledge_articles.map((article) => (
+                    <Link
+                      key={article.id}
+                      to="/knowledge-center"
+                      className="text-xs text-blue-600 hover:underline rounded-full border border-blue-100 bg-blue-50 px-2.5 py-1"
+                    >
+                      {article.title}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <p className="text-xs text-slate-400 border-t border-slate-100 pt-2">
+              Clinical Memory reflects this instrument's own recorded history — a potential
+              association, never a claim of causation. Human review required before clinical action.
+            </p>
+          </CardContent>
+        </Card>
       )}
 
       <p className="text-center text-xs text-slate-400 pb-4">

--- a/frontend/src/pages/LearningDashboardPage.tsx
+++ b/frontend/src/pages/LearningDashboardPage.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Brain, TrendingDown, TrendingUp, Wrench } from "lucide-react";
+import { apiFetch } from "@/lib/api";
+
+// v2.4 — Clinical Memory & Predictive Intelligence ("Project Insight"),
+// Section 8: Learning Dashboard. Tenant-wide rollup from
+// /api/clinical-memory/learning-dashboard.
+
+type InstrumentSummary = {
+  instrument_identity: string;
+  instrument_type: string;
+  condition_trend: string;
+  inspection_count: number;
+  repair_count: number;
+  corrosion_history_count: number;
+};
+
+type LearningDashboard = {
+  tracked_instrument_count: number;
+  recurring_findings: { finding_type: string; count: number }[];
+  repeated_contamination_zones: { zone: string; count: number }[];
+  most_improved_instruments: InstrumentSummary[];
+  most_problematic_instruments: InstrumentSummary[];
+  repeat_repair_candidates: InstrumentSummary[];
+};
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+function InstrumentRow({ item }: { item: InstrumentSummary }) {
+  const barcodeOrUdi = item.instrument_identity.split(":", 2)[1];
+  return (
+    <Link
+      to={`/instrument-passport?instrument=${encodeURIComponent(barcodeOrUdi)}`}
+      className="flex items-center justify-between gap-2 rounded-lg border border-slate-100 bg-slate-50 px-3 py-2 hover:bg-slate-100 transition-colors"
+    >
+      <div className="min-w-0">
+        <p className="text-sm text-slate-700 capitalize truncate">{item.instrument_type.replace(/_/g, " ")}</p>
+        <p className="text-xs text-slate-400 font-mono truncate">{item.instrument_identity}</p>
+      </div>
+      <div className="text-right shrink-0 text-xs text-slate-500">
+        <p>{item.inspection_count} inspections</p>
+        {item.repair_count > 0 && <p className="text-red-600">{item.repair_count} repairs</p>}
+      </div>
+    </Link>
+  );
+}
+
+export default function LearningDashboardPage() {
+  const [data, setData] = useState<LearningDashboard | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiFetch<LearningDashboard>("/api/clinical-memory/learning-dashboard")
+      .then(setData)
+      .catch(() => setError("Failed to load the learning dashboard."));
+  }, []);
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-6 space-y-5">
+      <div className="flex items-center gap-2">
+        <Brain className="h-6 w-6 text-indigo-600" />
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Learning Dashboard</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            What the fleet's own history teaches — recurring findings, trending instruments, and repeat repair candidates.
+          </p>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {!data && !error && <p className="text-sm text-slate-400">Loading…</p>}
+
+      {data && (
+        <>
+          <p className="text-xs text-slate-400">
+            {data.tracked_instrument_count} instrument{data.tracked_instrument_count !== 1 ? "s" : ""} with
+            enough recorded history (2+ inspections) to trend.
+          </p>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <Section title="Recurring Findings">
+              {data.recurring_findings.length === 0 ? (
+                <p className="text-sm text-slate-400">No finding type has recurred yet.</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {data.recurring_findings.map((f) => (
+                    <span
+                      key={f.finding_type}
+                      className="text-xs font-medium px-2.5 py-1 rounded-full border border-amber-200 bg-amber-50 text-amber-800 capitalize"
+                    >
+                      {f.finding_type.replace(/_/g, " ")} × {f.count}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </Section>
+
+            <Section title="Repeated Contamination Zones">
+              {data.repeated_contamination_zones.length === 0 ? (
+                <p className="text-sm text-slate-400">No anatomy zone has repeated contamination yet.</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {data.repeated_contamination_zones.map((z) => (
+                    <span
+                      key={z.zone}
+                      className="text-xs font-medium px-2.5 py-1 rounded-full border border-red-200 bg-red-50 text-red-800 capitalize"
+                    >
+                      {z.zone.replace(/_/g, " ")} × {z.count}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </Section>
+          </div>
+
+          <Section title="Most Improved Instruments">
+            <div className="flex items-center gap-1.5 mb-2 text-xs text-emerald-600">
+              <TrendingDown className="h-3.5 w-3.5" />
+              <span>Declining finding rate over their own inspection history</span>
+            </div>
+            {data.most_improved_instruments.length === 0 ? (
+              <p className="text-sm text-slate-400">No instrument shows a clear improving trend yet.</p>
+            ) : (
+              <div className="space-y-1.5">
+                {data.most_improved_instruments.map((item) => (
+                  <InstrumentRow key={item.instrument_identity} item={item} />
+                ))}
+              </div>
+            )}
+          </Section>
+
+          <Section title="Most Problematic Instruments">
+            <div className="flex items-center gap-1.5 mb-2 text-xs text-red-600">
+              <TrendingUp className="h-3.5 w-3.5" />
+              <span>Rising finding rate over their own inspection history</span>
+            </div>
+            {data.most_problematic_instruments.length === 0 ? (
+              <p className="text-sm text-slate-400">No instrument shows a clear declining trend yet.</p>
+            ) : (
+              <div className="space-y-1.5">
+                {data.most_problematic_instruments.map((item) => (
+                  <InstrumentRow key={item.instrument_identity} item={item} />
+                ))}
+              </div>
+            )}
+          </Section>
+
+          <Section title="Repeat Repair Candidates">
+            <div className="flex items-center gap-1.5 mb-2 text-xs text-slate-500">
+              <Wrench className="h-3.5 w-3.5" />
+              <span>Removed from service / repaired 2 or more times</span>
+            </div>
+            {data.repeat_repair_candidates.length === 0 ? (
+              <p className="text-sm text-slate-400">No instrument has been repaired more than once.</p>
+            ) : (
+              <div className="space-y-1.5">
+                {data.repeat_repair_candidates.map((item) => (
+                  <InstrumentRow key={item.instrument_identity} item={item} />
+                ))}
+              </div>
+            )}
+          </Section>
+
+          <p className="text-xs text-slate-400 text-center pt-2">
+            Clinical Memory reflects the fleet's own recorded history — a potential association,
+            never a claim of causation. Human review required before clinical action.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/NewInspectionPage.tsx
+++ b/frontend/src/pages/NewInspectionPage.tsx
@@ -46,6 +46,20 @@ function imageFileKey(f: File): string {
   return `${f.name}__${f.size}`;
 }
 
+// v2.3 — Live Capture Warnings: same missing-anatomy / duplicate-detection
+// shape the Vision Session review page uses, computed here before submission.
+type CaptureWarningFinding = { type: string; message: string; [key: string]: unknown };
+type CaptureWarnings = {
+  missing_anatomy: { prompts: { zone: string; message: string }[]; suggested_next: string | null };
+  duplicate_detection: { findings: CaptureWarningFinding[]; has_warnings: boolean; count: number };
+};
+
+async function sha256Hex(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
 type PredictedFinding = {
   type: string;
   label?: string;
@@ -276,6 +290,42 @@ export default function NewInspectionPage() {
   const [overrideBanner, setOverrideBanner] = useState<{ type: "success" | "error"; message: string } | null>(null);
   const [barcodeScanned, setBarcodeScanned] = useState(false);
   const [noBaselineWarning, setNoBaselineWarning] = useState(false);
+  // v2.3 — Live Capture Warnings (missing anatomy / duplicate images), computed
+  // during capture instead of only after submission on the Vision Session page.
+  const [captureWarnings, setCaptureWarnings] = useState<CaptureWarnings | null>(null);
+  const fileHashCache = useRef<Record<string, string>>({});
+
+  // v2.3 — Live Capture Warnings: reruns the same missing-anatomy / duplicate
+  // checks the Vision Session review page uses, on the images/tags captured
+  // so far, before the inspection is ever submitted. Debounced so it doesn't
+  // fire on every keystroke while tagging.
+  useEffect(() => {
+    const type = form.instrument_type.trim();
+    const allImages = [...inspectionImages, ...borescopeImages];
+    if (!type) { setCaptureWarnings(null); return; }
+    let cancelled = false;
+    const t = setTimeout(async () => {
+      try {
+        const tags = await Promise.all(allImages.map(async (f) => {
+          const key = imageFileKey(f);
+          const tag = imageTags[key] ?? DEFAULT_IMAGE_TAG;
+          let sha256 = fileHashCache.current[key];
+          if (!sha256) {
+            sha256 = await sha256Hex(f);
+            fileHashCache.current[key] = sha256;
+          }
+          return { anatomy_zone: tag.anatomy_zone, instrument_family: type, image_sha256: sha256 };
+        }));
+        if (cancelled) return;
+        const result = await apiFetch<CaptureWarnings>("/api/inspections/preview-warnings", {
+          method: "POST",
+          body: { instrument_type: type, tags },
+        });
+        if (!cancelled) setCaptureWarnings(result);
+      } catch { if (!cancelled) setCaptureWarnings(null); }
+    }, 500);
+    return () => { cancelled = true; clearTimeout(t); };
+  }, [form.instrument_type, inspectionImages, borescopeImages, imageTags]);
 
   const inspectionInputRef = useRef<HTMLInputElement>(null);
   const borescopeInputRef = useRef<HTMLInputElement>(null);
@@ -1014,6 +1064,23 @@ export default function NewInspectionPage() {
                     );
                   })}
                 </div>
+              </div>
+            )}
+
+            {/* v2.3 — Live Capture Warnings: missing anatomy + duplicate/wrong-zone
+                images, surfaced during capture instead of only after submission. */}
+            {captureWarnings && (
+              captureWarnings.missing_anatomy.prompts.length > 0 ||
+              captureWarnings.duplicate_detection.findings.length > 0
+            ) && (
+              <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 space-y-2">
+                <p className="text-sm font-medium text-amber-900">Capture warnings</p>
+                {captureWarnings.missing_anatomy.prompts.map((p) => (
+                  <p key={p.zone} className="text-xs text-amber-800">⚠ {p.message}</p>
+                ))}
+                {captureWarnings.duplicate_detection.findings.map((f, idx) => (
+                  <p key={`${f.type}-${idx}`} className="text-xs text-amber-800">⚠ {f.message}</p>
+                ))}
               </div>
             )}
 


### PR DESCRIPTION
## Summary

Two follow-ups to v2.2 (Vision Intelligence & Multi-Image Clinical Reasoning, #84):

- **Persisted per-finding confidence.** `InspectionFinding` now stores each finding's own `confidence` (0-1) from the scoring engine at analysis time. Evidence Fusion's `average_confidence` (`app/services/vision_session_engine.py`) previously always reported `null` because nothing persisted it per-finding; it now reflects real data, and rows logged before this column existed still correctly report `null` rather than a fabricated value.
- **Live capture warnings.** The missing-anatomy and duplicate/wrong-anatomy/wrong-instrument checks previously only appeared after submission on the Vision Session review page. A new stateless `POST /api/inspections/preview-warnings` endpoint reuses the same `missing_anatomy_prompts()` and `duplicate_detection_service.detect_all()` against in-progress (unsubmitted) captured images — nothing persisted, no `inspection_id` required. `NewInspectionPage.tsx` hashes each captured image client-side (`crypto.subtle.digest`, cached per file) and calls this endpoint (debounced) whenever the instrument type, images, or tags change, surfacing warnings inline during capture.

## Changes

- `backend/app/models/inspection_finding.py` — add nullable `confidence: float` column.
- `backend/app/routes/inspections.py` — persist `confidence=f.get("confidence")` when logging findings.
- `backend/app/routes/vision_session.py` — `_reconstruct_predicted_findings()` reads `r.confidence`; new `POST /inspections/preview-warnings` route.
- `frontend/src/pages/NewInspectionPage.tsx` — client-side image hashing + debounced live warnings panel.
- `docs/vision/inspection-session.md`, `vision-fusion.md` — updated to describe persisted confidence.
- `docs/vision/live-capture-warnings.md` (new) — new endpoint reference.
- `backend/tests/test_v2_3_live_capture_confidence.py` (new) — 9 tests covering persisted confidence, evidence-fusion averaging, and the preview-warnings endpoint (auth, missing zones, duplicate images, wrong anatomy, full coverage).

## Test plan

- [x] `ruff check app tests` — clean
- [x] Full backend suite — 2687 passed, 2 skipped
- [x] `npm run build` — clean
- [x] Browser-tested: selected an instrument, uploaded two byte-identical images, confirmed the live warnings panel shows both missing-anatomy zone prompts and the duplicate-image finding before submission


---
_Generated by [Claude Code](https://claude.ai/code/session_011Fk9dzNXLSbHDHTsT5TCKL)_