### PR TITLE
Project Apollo (v4.7) + Project Athena (v4.8)

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -100,6 +100,9 @@ from app.models.p25_infrastructure import (  # noqa: F401
     InstrumentDigitalIdentity, SurgicalReadinessScore, InstrumentPassportEvent,
     GlobalQualityRegistryEntry, IndustryAPICredential,
 )
+from app.models.apollo_quality import (  # noqa: F401
+    CustomerComplaint, QualityPolicy, QualityTwinSnapshot,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -103,6 +103,9 @@ from app.models.p25_infrastructure import (  # noqa: F401
 from app.models.apollo_quality import (  # noqa: F401
     CustomerComplaint, QualityPolicy, QualityTwinSnapshot,
 )
+from app.models.athena_knowledge import (  # noqa: F401
+    ExperienceGraphEdge, ExperienceGraphNode, KnowledgeMediaAttachment, KnowledgePreservationSession,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1057,6 +1057,10 @@ from app.models import vanguard_intelligence as _vanguard_intelligence_models  #
 from app.routes.vanguard_intelligence import router as vanguard_intelligence_router
 app.include_router(vanguard_intelligence_router)
 
+from app.models import apollo_quality as _apollo_quality_models  # noqa: F401
+from app.routes.apollo_quality import router as apollo_quality_router
+app.include_router(apollo_quality_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1061,6 +1061,10 @@ from app.models import apollo_quality as _apollo_quality_models  # noqa: F401
 from app.routes.apollo_quality import router as apollo_quality_router
 app.include_router(apollo_quality_router)
 
+from app.models import athena_knowledge as _athena_knowledge_models  # noqa: F401
+from app.routes.athena_knowledge import router as athena_knowledge_router
+app.include_router(athena_knowledge_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/models/apollo_quality.py
+++ b/backend/app/models/apollo_quality.py
@@ -1,0 +1,206 @@
+"""v4.7 — LumenAI OS: Project Apollo — Autonomous Clinical Quality
+Management System (CQMS).
+
+## Naming disambiguation (read this first)
+
+Before writing any Apollo code, every existing quality-adjacent surface
+was read in full — this codebase already has an extensive quality
+management ecosystem across five prior sprints:
+
+  * **`/api/quality`** (`app/routes/quality_dashboard.py`, v1.5) already
+    owns this exact prefix (`/dashboard`, `/finding-trends`,
+    `/root-cause`, `/capa-suggestions`, `/improvement-initiatives`, etc.)
+    — Apollo's backend is mounted at **`/api/apollo`** instead.
+  * Frontend routes `/quality-command-center`, `/quality-intelligence`,
+    and `/quality-dashboard` are all already taken by earlier sprints.
+    **`/quality`** (bare, exact) was confirmed free and is Apollo's new
+    Quality Management Center root — deliberately positioned as the
+    unifying front door across all of them, not a fourth competing page.
+  * **CAPA**: `capa_service.py` (the canonical sqlite-backed store) +
+    `capa_lifecycle_service.py` (the open→assigned→in_progress→
+    verified→closed state machine, added in v2.9) together already cover
+    Owner/Root-Cause-link/Actions/Verification/Closure. Apollo does not
+    add a sixth CAPA store (a legacy `EnterpriseCapa` table and a
+    `CAPARecommendation` suggestion queue already exist too) — it
+    extends `capa_suggestion_service.py`'s existing auto-trigger
+    detectors with the specific new trigger types this sprint's brief
+    names that don't already exist (repeat repairs, supervisor
+    overrides, AI confidence decline, inspection failures, customer
+    complaints — repeated blood findings and repeated corrosion are
+    already detected by that service's existing zone/condition
+    counters).
+  * **Root cause**: `RootCauseAssignment` (human-assigned, never
+    inferred) + `RCADraft`/`rca_engine_service` (AI-assisted evidence/
+    historical-recurrence/similar-events drafting, supervisor-approved)
+    already exist. Apollo adds a *structuring layer* (5 Whys/Fishbone/
+    Pareto/Trend Analysis views) over these, never a new root-cause data
+    model, and never a path that finalizes a root cause without the
+    existing `rca_engine_service.approve_draft` supervisor step.
+  * **Audits**: `accreditation_engine.py` + `regulatory_standards_
+    catalogue.py` already cover Joint Commission, AAMI ST79, FDA, CMS,
+    ISO. Apollo extends the standards catalogue and `generate_audit_
+    package`'s `package_type` enum with AAMI ST91, AORN, DNV, Internal,
+    and Vendor — it does not add a second audit-package generator.
+  * **Standards**: `beacon_standards_service.py` (governed publications)
+    and `p24_standards_service.py` (internal quality-classification
+    standards) already exist; Apollo composes both plus the regulatory
+    catalogue into one Standards Knowledge Library view.
+  * **Competencies**: `competency_service.py`'s single `CompetencyEvent`
+    log already tracks findings-reviewed/supervisor-corrections/
+    repeated-errors/education-completed. Apollo adds four new event
+    types (annual competency, procedure validation, simulation result,
+    knowledge contribution) to the *same* log rather than a parallel
+    competency model.
+  * **Continuous Improvement**: `ContinuousImprovementInitiative`
+    (v1.5) already tracks named initiatives; Apollo adds methodology/
+    cost-savings/executive-visibility as additive columns, not a new
+    table.
+  * **Executive Quality Dashboard**: `quality_command_center_service.
+    quality_command_center_summary` (v2.9) and Vanguard's
+    `vanguard_governance_service.governance_dashboard` (v4.6) already
+    compute the large majority of the named tiles. Apollo composes both
+    rather than re-deriving CAPA/root-cause/competency/audit-readiness
+    numbers a third time.
+
+## Genuinely new tables in this file
+
+  * `CustomerComplaint` — no complaint-intake model existed anywhere;
+    this is the real gap needed as a sixth CAPA auto-trigger source.
+  * `QualityPolicy` — no clinical/quality policy versioning system
+    existed anywhere (`RetentionPolicy`/`GovernanceSlaPolicy` are
+    unrelated infrastructure policies). Follows the same
+    `supersedes_id` + `status` self-FK chain Beacon/Forge established.
+  * `QualityTwinSnapshot` — no department-level quality composite
+    existed; `digital_twin_engine.py` is facility/instrument-scoped
+    workflow telemetry, a different thing entirely. This is a pure
+    composition snapshot (trend history), not a new telemetry source.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Customer complaints (CAPA Engine trigger source, Section 2) ─────────────
+COMPLAINT_SEVERITY_LOW = "low"
+COMPLAINT_SEVERITY_MEDIUM = "medium"
+COMPLAINT_SEVERITY_HIGH = "high"
+COMPLAINT_SEVERITIES = [COMPLAINT_SEVERITY_LOW, COMPLAINT_SEVERITY_MEDIUM, COMPLAINT_SEVERITY_HIGH]
+
+COMPLAINT_OPEN = "open"
+COMPLAINT_LINKED_TO_CAPA = "linked_to_capa"
+COMPLAINT_CLOSED = "closed"
+COMPLAINT_STATUSES = [COMPLAINT_OPEN, COMPLAINT_LINKED_TO_CAPA, COMPLAINT_CLOSED]
+
+# ── Quality Policy lifecycle (Section 6) ─────────────────────────────────────
+POLICY_DRAFT = "draft"
+POLICY_PUBLISHED = "published"
+POLICY_SUPERSEDED = "superseded"
+POLICY_STATUSES = [POLICY_DRAFT, POLICY_PUBLISHED, POLICY_SUPERSEDED]
+
+# ── Root Cause Intelligence methodologies (Section 3) ────────────────────────
+RCA_FIVE_WHYS = "five_whys"
+RCA_FISHBONE = "fishbone"
+RCA_PARETO = "pareto"
+RCA_TREND_ANALYSIS = "trend_analysis"
+RCA_METHODOLOGIES = [RCA_FIVE_WHYS, RCA_FISHBONE, RCA_PARETO, RCA_TREND_ANALYSIS]
+
+FISHBONE_CATEGORIES = ["man", "machine", "method", "material", "measurement", "environment"]
+
+DISCLAIMER = (
+    "LumenAI Apollo composes real, already-computed quality/compliance/competency intelligence "
+    "from across the platform into one Clinical Quality Management System — it does not finalize "
+    "a root cause, a CAPA closure, an audit finding, or a policy change without explicit human "
+    "review and approval. Nothing here is a substitute for supervisor, quality, or regulatory "
+    "judgment; every output is decision support only."
+)
+
+
+class CustomerComplaint(Base):
+    """A logged customer/clinical complaint (Section 2 CAPA trigger
+    source) — no existing intake model covered this before Apollo."""
+
+    __tablename__ = "apollo_customer_complaints"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    source: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    severity: Mapped[str] = mapped_column(String(20), default=COMPLAINT_SEVERITY_MEDIUM, nullable=False, index=True)
+    instrument_type: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    status: Mapped[str] = mapped_column(String(20), default=COMPLAINT_OPEN, nullable=False, index=True)
+    linked_capa_id: Mapped[str] = mapped_column(String(64), default="", nullable=False)
+    reported_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+
+class QualityPolicy(Base):
+    """A versioned clinical/quality policy (Section 6) — genuinely new;
+    follows the same `supersedes_id`/`status` self-FK chain Beacon's
+    `StandardsPublication` and Forge's `WorkflowDefinition` already
+    established."""
+
+    __tablename__ = "apollo_quality_policies"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), default=POLICY_DRAFT, nullable=False, index=True)
+    supersedes_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+
+    owner: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    review_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    content: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    references_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    linked_standards_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    affected_workflows_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    affected_competencies_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    affected_ai_rules_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    published_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class QualityTwinSnapshot(Base):
+    """A department-level Quality Digital Twin snapshot (Section 9) —
+    a pure composition over Compliance/Competency/Audit Readiness/Policy
+    Maturity/CAPA Health/Education/Knowledge/Continuous Improvement.
+    Distinct from `digital_twin_engine.py`'s facility/instrument-scoped
+    workflow telemetry twin — this tracks governance health, not
+    instrument flow."""
+
+    __tablename__ = "apollo_quality_twin_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+    department: Mapped[str] = mapped_column(String(255), default="unspecified", nullable=False, index=True)
+
+    compliance_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    competency_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    audit_readiness_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    policy_maturity_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    capa_health_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    education_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    knowledge_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    continuous_improvement_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+
+    overall_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    factors_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)

--- a/backend/app/models/athena_knowledge.py
+++ b/backend/app/models/athena_knowledge.py
@@ -1,0 +1,287 @@
+"""v4.8 — LumenAI OS: Project Athena — Healthcare Knowledge Intelligence &
+Institutional Memory.
+
+## Naming disambiguation (read this first)
+
+Before writing any Athena code, every existing knowledge-adjacent surface
+was read in full — this codebase already has an extensive institutional-
+knowledge ecosystem from v1.8 (Institutional Knowledge & Clinical Memory)
+plus the Knowledge Graph (P-era) and Project Forge's workflow engine:
+
+  * **`/api/knowledge`** (`app/routes/knowledge.py`, v1.8) already owns
+    this prefix (articles, cases, standards, governance, search,
+    assistant, analytics). **`/api/knowledge-graph`** is also taken
+    (`app/routes/knowledge_graph.py`). Athena's backend is mounted at
+    **`/api/athena`** instead.
+  * Frontend routes `/knowledge-center` and `/knowledge-graph` are
+    already taken. **`/knowledge-memory`** was confirmed free and is
+    Athena's frontend route, per the sprint brief's explicit instruction.
+  * **Institutional Memory (Section 1)**: `KnowledgeArticle` (v1.8) +
+    `ClinicalCase` (v1.8) + `RootCauseAssignment` (v1.5) +
+    `capa_lifecycle_service` (v2.9) + `ContinuousImprovementInitiative`
+    (v1.5) + `QualityPolicy` (v4.7, Apollo) already store almost every
+    knowledge type the brief names. Athena does not add a parallel
+    "memory entry" table — `athena_memory_service.py` composes/normalizes
+    across all of them into one searchable view. Only "vendor
+    observations" and "repair observations" had no home: added as two new
+    `KnowledgeArticle` categories (below) rather than a new store.
+  * **Expert Knowledge Capture (Section 2)**: `KnowledgeArticle`'s
+    `approval_status` (draft/pending_review/approved/rejected/archived)
+    and `knowledge_governance_service.py` already implement the full
+    approval workflow. Athena adds no second governance engine — only the
+    genuinely new capability, photo/video/voice attachments, via
+    `KnowledgeMediaAttachment` (below), since no media-reference field
+    existed anywhere on `KnowledgeArticle`.
+  * **Experience Graph (Section 3)**: `knowledge_graph_service.py`'s
+    `explore()`/`reasoning_chain()` are real but are recomputed-on-read
+    aggregations over `Inspection`/`SupervisorReview`/static anatomy
+    profiles — there is no persisted node/edge structure. Athena's
+    `ExperienceGraphNode`/`ExperienceGraphEdge` are genuinely new, but the
+    Finding/Instrument/Anatomy/Recommendation segments of every chain are
+    populated by calling `knowledge_graph_service.reasoning_chain()`
+    directly rather than re-deriving that logic — only the new Person/
+    Experience/Outcome/Evidence/Organization node types are Athena's own.
+  * **Institutional Memory Timeline (Section 4)**: `orbit_timeline_
+    service.py` exists but is a different domain entirely (OR case
+    logistics — Case Scheduled → ... → Procedure Complete). Athena's
+    Event → Investigation → CAPA → Education → Policy Change → Outcome →
+    Verification → Future Similar Cases timeline is a new composition
+    (`athena_memory_timeline_service.py`) over `RootCauseAssignment`,
+    `capa_lifecycle_service`, `CompetencyEvent`, `QualityPolicy` version
+    history, and `similar_case_finder_service.find_similar_cases` — no
+    new table.
+  * **Clinical Playbooks (Section 5)**: `workflow_forge.py`'s
+    `WorkflowDefinition`/`WorkflowRule` (v4.1) already model a versioned,
+    approved, nested-decision-tree workflow with `is_template` and
+    `TEMPLATE_CATEGORIES` including `loaner_instrument`, `vendor_tray`,
+    and `robotic_instrument`. Athena adds the three missing scenario keys
+    (`blood_detection_investigation`, `corrosion_investigation`,
+    `joint_commission_preparation`) to that same list and one additive
+    column (`linked_standards_json`) rather than a parallel playbook
+    model. `CustomerSuccessPlaybook` (a different, unrelated SaaS-renewal
+    domain) was checked and confirmed not a real collision.
+  * **AI Knowledge Curator (Section 6)**: `knowledge_analytics_service.py`
+    already computes `knowledge_gaps()`/`training_opportunities()`/
+    `most_common_questions()`. Athena extends this file's pattern with
+    new deterministic checks (duplicates, outdated guidance, retirement
+    candidates, emerging best practices) in a new `athena_curator_service.
+    py` rather than a new analytics engine, and composes the existing
+    functions rather than re-deriving them.
+  * **Organizational Search (Section 7)**: `knowledge_search_service.
+    smart_search()` only covers Articles+Cases. No embeddings/vector
+    search/TF-IDF exists anywhere in this codebase (confirmed by grep) —
+    consistent with the platform-wide "deterministic, source-grounded,
+    zero real LLM integration" convention. Athena's `athena_search_
+    service.py` federates the existing smart_search with keyword search
+    over Policies/CAPAs/Playbooks/Competency events, each result tagged
+    with its source system — still keyword/facet-based, never a
+    fabricated semantic layer.
+  * **Knowledge Trust Score (Section 8)**: no trust/reputation/evidence-
+    quality construct exists anywhere (`beacon_standards_service.py`/
+    `p24_standards_service.py` only carry `version`/`status`). Genuinely
+    new — computed live from real fields (never persisted as a
+    fabricated number), reusing Apollo's `competency_service.
+    record_knowledge_contribution`/`CompetencyEvent` log for Contributor
+    Reputation rather than re-deriving contribution counts.
+  * **Athena Assistant (Section 9)**: `ai_knowledge_assistant_service.
+    answer_question()` (v1.8) already implements a deterministic,
+    source-cited Q&A assistant. Athena extends it with three new query
+    shapes (recurring-investigation lookup, cross-time policy comparison,
+    workflow version comparison) rather than a second assistant.
+  * **Knowledge Preservation (Section 10)**: no exit-interview, media-
+    capture, or workflow-recording system exists anywhere — genuinely
+    new. `KnowledgePreservationSession` never claims to perform real
+    speech-to-text transcription; `transcript_text` is a human-entered
+    or human-reviewed field, matching this codebase's "never fabricate a
+    capability" convention.
+
+## Genuinely new tables in this file
+
+  * `KnowledgeMediaAttachment` — a polymorphic (source_type, source_id)
+    photo/video/voice reference, attachable to a `KnowledgeArticle`, a
+    `WorkflowDefinition` (playbook), or a `KnowledgePreservationSession`.
+    Stores a reference/URL and caption/transcript — never a binary blob,
+    consistent with `inspection_image_tag.py`'s reference-only pattern.
+  * `ExperienceGraphNode` / `ExperienceGraphEdge` — the new Person →
+    Experience → Finding → Instrument → Anatomy → Recommendation →
+    Outcome → Evidence → Organization relationship graph.
+  * `KnowledgePreservationSession` — an exit interview / video capture /
+    voice transcription / workflow recording / procedure demonstration
+    session, optionally promoted into a structured `KnowledgeArticle`.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Media attachments (Section 2 / Section 5 / Section 10) ──────────────────
+MEDIA_PHOTO = "photo"
+MEDIA_VIDEO = "video"
+MEDIA_VOICE = "voice"
+MEDIA_TYPES = [MEDIA_PHOTO, MEDIA_VIDEO, MEDIA_VOICE]
+
+# Polymorphic attachment targets.
+ATTACH_TO_ARTICLE = "knowledge_article"
+ATTACH_TO_PLAYBOOK = "workflow_definition"
+ATTACH_TO_PRESERVATION_SESSION = "preservation_session"
+ATTACHMENT_SOURCE_TYPES = [ATTACH_TO_ARTICLE, ATTACH_TO_PLAYBOOK, ATTACH_TO_PRESERVATION_SESSION]
+
+# ── Experience Graph node/edge vocabulary (Section 3) ────────────────────────
+NODE_PERSON = "person"
+NODE_EXPERIENCE = "experience"
+NODE_FINDING = "finding"
+NODE_INSTRUMENT = "instrument"
+NODE_ANATOMY = "anatomy"
+NODE_RECOMMENDATION = "recommendation"
+NODE_OUTCOME = "outcome"
+NODE_EVIDENCE = "evidence"
+NODE_ORGANIZATION = "organization"
+NODE_TYPES = [
+    NODE_PERSON, NODE_EXPERIENCE, NODE_FINDING, NODE_INSTRUMENT, NODE_ANATOMY,
+    NODE_RECOMMENDATION, NODE_OUTCOME, NODE_EVIDENCE, NODE_ORGANIZATION,
+]
+
+# The canonical chain order the brief specifies — used to validate edges.
+NODE_CHAIN_ORDER = [
+    NODE_PERSON, NODE_EXPERIENCE, NODE_FINDING, NODE_INSTRUMENT, NODE_ANATOMY,
+    NODE_RECOMMENDATION, NODE_OUTCOME, NODE_EVIDENCE, NODE_ORGANIZATION,
+]
+
+EDGE_HAS_EXPERIENCE = "has_experience"
+EDGE_YIELDED_FINDING = "yielded_finding"
+EDGE_FOUND_ON_INSTRUMENT = "found_on_instrument"
+EDGE_INSTRUMENT_HAS_ANATOMY = "instrument_has_anatomy"
+EDGE_LED_TO_RECOMMENDATION = "led_to_recommendation"
+EDGE_PRODUCED_OUTCOME = "produced_outcome"
+EDGE_SUPPORTED_BY_EVIDENCE = "supported_by_evidence"
+EDGE_EVIDENCE_OWNED_BY_ORG = "evidence_owned_by_organization"
+EDGE_RELATIONSHIPS = [
+    EDGE_HAS_EXPERIENCE, EDGE_YIELDED_FINDING, EDGE_FOUND_ON_INSTRUMENT, EDGE_INSTRUMENT_HAS_ANATOMY,
+    EDGE_LED_TO_RECOMMENDATION, EDGE_PRODUCED_OUTCOME, EDGE_SUPPORTED_BY_EVIDENCE, EDGE_EVIDENCE_OWNED_BY_ORG,
+]
+
+# ── Knowledge Preservation session types (Section 10) ────────────────────────
+SESSION_EXIT_INTERVIEW = "exit_interview"
+SESSION_VIDEO_CAPTURE = "video_capture"
+SESSION_VOICE_TRANSCRIPTION = "voice_transcription"
+SESSION_WORKFLOW_RECORDING = "workflow_recording"
+SESSION_PROCEDURE_DEMONSTRATION = "procedure_demonstration"
+PRESERVATION_SESSION_TYPES = [
+    SESSION_EXIT_INTERVIEW, SESSION_VIDEO_CAPTURE, SESSION_VOICE_TRANSCRIPTION,
+    SESSION_WORKFLOW_RECORDING, SESSION_PROCEDURE_DEMONSTRATION,
+]
+
+SESSION_CAPTURED = "captured"
+SESSION_TRANSCRIBED = "transcribed"
+SESSION_STRUCTURED = "structured"
+SESSION_ARCHIVED = "archived"
+PRESERVATION_SESSION_STATUSES = [SESSION_CAPTURED, SESSION_TRANSCRIBED, SESSION_STRUCTURED, SESSION_ARCHIVED]
+
+DISCLAIMER = (
+    "LumenAI Athena preserves and organizes institutional knowledge already captured elsewhere in the "
+    "platform — it does not diagnose, finalize a root cause, or replace clinical judgment. Every "
+    "knowledge object, graph relationship, playbook, and trust score is decision support only and "
+    "requires human review before it is treated as current or authoritative guidance."
+)
+
+
+class KnowledgeMediaAttachment(Base):
+    """A photo/video/voice reference attached to an article, playbook, or
+    preservation session (Sections 2, 5, 10) — a reference only, never a
+    binary blob, matching `inspection_image_tag.py`'s existing pattern."""
+
+    __tablename__ = "athena_knowledge_media_attachments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    source_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    source_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    media_type: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+
+    url_or_ref: Mapped[str] = mapped_column(String(1000), default="", nullable=False)
+    caption: Mapped[str] = mapped_column(String(500), default="", nullable=False)
+    transcript: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    uploaded_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+
+class ExperienceGraphNode(Base):
+    """One node in the living Experience Graph (Section 3): Person,
+    Experience, Finding, Instrument, Anatomy, Recommendation, Outcome,
+    Evidence, or Organization."""
+
+    __tablename__ = "athena_experience_graph_nodes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    node_type: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    label: Mapped[str] = mapped_column(String(500), nullable=False)
+
+    # What real system this node was derived from, if any — e.g.
+    # "competency_event"/"inspection_finding"/"root_cause_assignment"/
+    # "capa"/"quality_policy"/"knowledge_article"/"reasoning_chain".
+    # Never fabricated — blank when the node is a bare label (e.g. a
+    # Person node with no linked record yet).
+    source_type: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    source_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    details_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+
+class ExperienceGraphEdge(Base):
+    """One directed relationship between two Experience Graph nodes
+    (Section 3)."""
+
+    __tablename__ = "athena_experience_graph_edges"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    from_node_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    to_node_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    relationship: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    notes: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+
+class KnowledgePreservationSession(Base):
+    """An exit interview / video capture / voice transcription / workflow
+    recording / procedure demonstration session (Section 10), optionally
+    promoted into a structured `KnowledgeArticle` via
+    `converted_article_id`. Converts tacit knowledge into organizational
+    knowledge — never fabricates a transcript the human didn't provide."""
+
+    __tablename__ = "athena_knowledge_preservation_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    subject_name: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    subject_role: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    session_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(20), default=SESSION_CAPTURED, nullable=False, index=True)
+
+    summary: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    transcript_text: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    topics_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    converted_article_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    captured_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)

--- a/backend/app/models/continuous_improvement.py
+++ b/backend/app/models/continuous_improvement.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import Date, DateTime, Integer, String, Text
+from sqlalchemy import Boolean, Date, DateTime, Float, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
 
 INITIATIVE_STATUSES: list[str] = ["proposed", "in_progress", "completed", "abandoned"]
+
+# v4.7 Project Apollo — Continuous Improvement Portfolio methodologies
+# (Section 8 of the brief); additive, not a new table.
+METHODOLOGIES: list[str] = ["pi", "lean", "six_sigma", "kaizen", "other"]
 
 
 class ContinuousImprovementInitiative(Base):
@@ -43,3 +47,13 @@ class ContinuousImprovementInitiative(Base):
     status: Mapped[str] = mapped_column(String(20), default="proposed", nullable=False, index=True)
     expected_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)
     actual_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    # v4.7 Project Apollo — Continuous Improvement Portfolio additions
+    # (Section 8): methodology classification, cost savings, quality/risk
+    # metrics, and executive visibility flag. All nullable/blank for older
+    # rows and never fabricated — human-entered only, same as actual_impact.
+    methodology: Mapped[str] = mapped_column(String(20), default="", nullable=False, index=True)
+    cost_savings_usd: Mapped[float | None] = mapped_column(Float, nullable=True)
+    quality_improvement_metric: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    risk_reduction_metric: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    executive_visible: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -35,10 +35,16 @@ FAQ = "faq"
 COMPETENCY_GUIDANCE = "competency_guidance"
 MANUFACTURER_CLARIFICATION = "manufacturer_clarification"
 TEACHING_POINT = "teaching_point"
+# v4.8 — Project Athena additions (Institutional Memory Engine, Section 1):
+# the only two memory types the brief names that had no existing home.
+SUPERVISOR_EXPERIENCE = "supervisor_experience"
+VENDOR_OBSERVATION = "vendor_observation"
+REPAIR_OBSERVATION = "repair_observation"
 
 ARTICLE_CATEGORIES = [
     BEST_PRACTICE, LOCAL_STANDARD, APPROVED_WORKFLOW, CLINICAL_PEARL,
     LESSON_LEARNED, FAQ, COMPETENCY_GUIDANCE, MANUFACTURER_CLARIFICATION, TEACHING_POINT,
+    SUPERVISOR_EXPERIENCE, VENDOR_OBSERVATION, REPAIR_OBSERVATION,
 ]
 
 # ── Governance approval states ───────────────────────────────────────────────
@@ -105,6 +111,11 @@ class KnowledgeArticle(Base):
     source_inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     view_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    # v4.8 — Project Athena. Standard codes this article cites (e.g. AAMI
+    # ST79 clauses), JSON-encoded like the other facet lists above — the
+    # basis for the Knowledge Trust Score's "Reference Strength" component.
+    linked_standards_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
 
 
 class ClinicalCase(Base):

--- a/backend/app/models/workflow_forge.py
+++ b/backend/app/models/workflow_forge.py
@@ -159,6 +159,10 @@ MARKETPLACE_STATUSES = [MARKETPLACE_PRIVATE, MARKETPLACE_PENDING_REVIEW, MARKETP
 TEMPLATE_CATEGORIES = [
     "general_instrument_inspection", "rigid_scope", "flexible_endoscope", "loaner_instrument",
     "vendor_tray", "robotic_instrument", "orthopedic", "neurosurgery", "custom_organization",
+    # v4.8 — Project Athena Clinical Playbooks (Section 5): three of the six
+    # named scenarios (loaner_instrument, vendor_tray, robotic_instrument)
+    # already existed above; these three did not.
+    "blood_detection_investigation", "corrosion_investigation", "joint_commission_preparation",
 ]
 
 # ── Section 7: Default approval chain steps ─────────────────────────────────
@@ -219,6 +223,12 @@ class WorkflowDefinition(Base):
     is_template: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, index=True)
     marketplace_status: Mapped[str] = mapped_column(String(20), default=MARKETPLACE_PRIVATE, nullable=False, index=True)
     approval_chain_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # v4.8 — Project Athena Clinical Playbooks (Section 5). Standards a
+    # playbook references (e.g. AAMI ST79, Joint Commission clauses),
+    # JSON-encoded — photos/videos attach via `KnowledgeMediaAttachment`
+    # (source_type="workflow_definition"), not a column here.
+    linked_standards_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
 
 
 class WorkflowRule(Base):

--- a/backend/app/routes/apollo_quality.py
+++ b/backend/app/routes/apollo_quality.py
@@ -1,0 +1,469 @@
+"""v4.7 — LumenAI OS: Project Apollo — Autonomous Clinical Quality
+Management System (CQMS) routes.
+
+Frontend route: /quality (Quality Management Center — 9 tabs).
+API prefix: /api/apollo — deliberately NOT `/api/quality` (already owned by
+`app/routes/quality_dashboard.py`; see `app/models/apollo_quality.py` for
+the full naming-disambiguation note).
+
+  * GET  /capa/summary, POST /capa/suggestions/create,
+    POST  /capa/complaints, GET /capa/complaints,
+    POST  /capa/complaints/{id}/link, POST /capa/complaints/{id}/close  — Section 2
+  * GET  /rca/five-whys/{draft_id}, GET /rca/fishbone/{draft_id},
+    GET  /rca/pareto, GET /rca/trend, GET /rca/summary                  — Section 3
+  * GET  /audit/summary, POST /audit/generate                            — Section 4
+  * GET  /competency/summary, POST /competency/annual,
+    POST  /competency/procedure-validation, POST /competency/simulation,
+    POST  /competency/knowledge-contribution                             — Section 5
+  * POST /policies, GET /policies, GET /policies/{id},
+    POST  /policies/{id}/publish, GET /policies/{id}/history,
+    GET   /policies/due-for-review                                        — Section 6
+  * GET  /standards/library                                                — Section 7
+  * POST /improvement-projects, GET /improvement-projects,
+    PATCH /improvement-projects/{id}, GET /improvement-projects/summary    — Section 8
+  * GET  /quality-twin/{department}, GET /quality-twin/{department}/history — Section 9
+  * GET  /executive-dashboard                                               — Section 10
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.authz import require_roles
+from app.deps import get_db
+from app.enterprise_auth import get_request_tenant_id
+from app.models.apollo_quality import COMPLAINT_STATUSES, POLICY_STATUSES
+from app.services import (
+    apollo_audit_center_service,
+    apollo_capa_engine_service,
+    apollo_competency_center_service,
+    apollo_executive_quality_service,
+    apollo_improvement_portfolio_service,
+    apollo_policy_service,
+    apollo_quality_twin_service,
+    apollo_rca_intelligence_service,
+    apollo_standards_library_service,
+)
+from app.services.rca_engine_service import RCADraftNotFoundError
+
+router = APIRouter(prefix="/api/apollo", tags=["apollo"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user, request: Request) -> str:
+    return getattr(current_user, "tenant_id", None) or get_request_tenant_id(request)
+
+
+def _actor(current_user) -> str:
+    return getattr(current_user, "email", None) or getattr(current_user, "username", "unknown")
+
+
+def _audit(db: Session, tenant_id: str, actor: str, action_type: str, resource_type: str, resource_id: str, details: dict) -> None:
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id, actor_email=actor, actor_role="",
+        action_type=action_type, resource_type=resource_type, resource_id=resource_id, details=details, compliance_flag=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — CAPA Engine
+# ---------------------------------------------------------------------------
+
+
+@router.get("/capa/summary")
+def get_capa_summary(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_capa_engine_service.capa_engine_summary(db, tenant_id)
+
+
+@router.post("/capa/suggestions/create")
+def post_create_capa_from_suggestion(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    suggestion = payload.get("suggestion")
+    if not suggestion:
+        raise HTTPException(status_code=422, detail="payload must include 'suggestion'.")
+    result = apollo_capa_engine_service.create_capa_from_suggestion_reviewed(suggestion, owner=payload.get("owner", actor))
+    _audit(db, tenant_id, actor, "apollo.capa_created_from_suggestion", "capas", str(result.get("id")), {"trigger": suggestion.get("trigger")})
+    return result
+
+
+@router.post("/capa/complaints", status_code=201)
+def post_create_complaint(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    complaint = apollo_capa_engine_service.create_complaint(
+        db, tenant_id, source=payload.get("source", ""), description=payload.get("description", ""),
+        severity=payload.get("severity", "medium"), instrument_type=payload.get("instrument_type", ""),
+        reported_by=payload.get("reported_by", actor),
+    )
+    _audit(db, tenant_id, actor, "apollo.complaint_created", "apollo_customer_complaints", str(complaint.id), {"severity": complaint.severity})
+    return {"id": complaint.id, "status": complaint.status, "severity": complaint.severity}
+
+
+@router.get("/capa/complaints")
+def get_complaints(
+    request: Request, status: str = Query(""), db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    if status and status not in COMPLAINT_STATUSES:
+        raise HTTPException(status_code=422, detail=f"status must be one of {COMPLAINT_STATUSES}")
+    tenant_id = _tenant(current_user, request)
+    complaints = apollo_capa_engine_service.list_complaints(db, tenant_id, status=status)
+    return {
+        "complaints": [
+            {
+                "id": c.id, "created_at": c.created_at.isoformat(), "source": c.source, "description": c.description,
+                "severity": c.severity, "instrument_type": c.instrument_type, "status": c.status,
+                "linked_capa_id": c.linked_capa_id, "reported_by": c.reported_by,
+            }
+            for c in complaints
+        ],
+    }
+
+
+@router.post("/capa/complaints/{complaint_id}/link")
+def post_link_complaint(
+    complaint_id: int, payload: dict, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    capa_id = payload.get("capa_id", "")
+    if not capa_id:
+        raise HTTPException(status_code=422, detail="payload must include 'capa_id'.")
+    try:
+        complaint = apollo_capa_engine_service.link_complaint_to_capa(db, tenant_id, complaint_id, capa_id=capa_id)
+    except apollo_capa_engine_service.ComplaintNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "apollo.complaint_linked_to_capa", "apollo_customer_complaints", str(complaint_id), {"capa_id": capa_id})
+    return {"id": complaint.id, "status": complaint.status, "linked_capa_id": complaint.linked_capa_id}
+
+
+@router.post("/capa/complaints/{complaint_id}/close")
+def post_close_complaint(
+    complaint_id: int, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    try:
+        complaint = apollo_capa_engine_service.close_complaint(db, tenant_id, complaint_id)
+    except apollo_capa_engine_service.ComplaintNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "apollo.complaint_closed", "apollo_customer_complaints", str(complaint_id), {})
+    return {"id": complaint.id, "status": complaint.status}
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Root Cause Intelligence
+# ---------------------------------------------------------------------------
+
+
+@router.get("/rca/five-whys/{draft_id}")
+def get_five_whys(draft_id: int, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    try:
+        return apollo_rca_intelligence_service.five_whys_view(db, tenant_id, draft_id)
+    except RCADraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/rca/fishbone/{draft_id}")
+def get_fishbone(draft_id: int, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    try:
+        return apollo_rca_intelligence_service.fishbone_view(db, tenant_id, draft_id)
+    except RCADraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/rca/pareto")
+def get_pareto(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_rca_intelligence_service.pareto_view(db, tenant_id)
+
+
+@router.get("/rca/trend")
+def get_trend(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_rca_intelligence_service.trend_view(db, tenant_id)
+
+
+@router.get("/rca/summary")
+def get_rca_summary(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_rca_intelligence_service.rca_intelligence_summary(db, tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Audit Center
+# ---------------------------------------------------------------------------
+
+
+@router.get("/audit/summary")
+def get_audit_summary(
+    request: Request, facility_id: str = Query(""), db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    return apollo_audit_center_service.audit_center_summary(db, tenant_id, facility_id=facility_id)
+
+
+@router.post("/audit/generate")
+def post_generate_audit(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    try:
+        result = apollo_audit_center_service.generate_audit(
+            tenant_id, package_type=payload.get("package_type", ""), facility_id=payload.get("facility_id", ""),
+            period_label=payload.get("period_label", ""), generated_by=actor, db=db,
+        )
+    except apollo_audit_center_service.UnsupportedAuditPackageTypeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "apollo.audit_package_generated", "regulatory_audit_packages", str(result.get("id")), {"package_type": result["package_type"]})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Competency Center
+# ---------------------------------------------------------------------------
+
+
+@router.get("/competency/summary")
+def get_competency_summary(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_competency_center_service.competency_center_summary(db, tenant_id)
+
+
+@router.post("/competency/annual")
+def post_annual_competency(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    technician = payload.get("technician", "")
+    if not technician:
+        raise HTTPException(status_code=422, detail="payload must include 'technician'.")
+    result = apollo_competency_center_service.record_annual_competency(
+        db, tenant_id=tenant_id, technician=technician, competency_area=payload.get("competency_area", ""),
+    )
+    _audit(db, tenant_id, actor, "apollo.annual_competency_recorded", "competency_events", technician, {"competency_area": payload.get("competency_area", "")})
+    return result
+
+
+@router.post("/competency/procedure-validation")
+def post_procedure_validation(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    technician = payload.get("technician", "")
+    if not technician:
+        raise HTTPException(status_code=422, detail="payload must include 'technician'.")
+    result = apollo_competency_center_service.record_procedure_validation(
+        db, tenant_id=tenant_id, technician=technician, procedure_name=payload.get("procedure_name", ""),
+    )
+    _audit(db, tenant_id, actor, "apollo.procedure_validation_recorded", "competency_events", technician, {"procedure_name": payload.get("procedure_name", "")})
+    return result
+
+
+@router.post("/competency/simulation")
+def post_simulation_result(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    technician = payload.get("technician", "")
+    if not technician:
+        raise HTTPException(status_code=422, detail="payload must include 'technician'.")
+    result = apollo_competency_center_service.record_simulation_result(
+        db, tenant_id=tenant_id, technician=technician, scenario=payload.get("scenario", ""),
+        passed=bool(payload.get("passed", False)),
+    )
+    _audit(db, tenant_id, actor, "apollo.simulation_result_recorded", "competency_events", technician, {"scenario": payload.get("scenario", ""), "passed": bool(payload.get("passed", False))})
+    return result
+
+
+@router.post("/competency/knowledge-contribution")
+def post_knowledge_contribution(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    technician = payload.get("technician", "")
+    if not technician:
+        raise HTTPException(status_code=422, detail="payload must include 'technician'.")
+    result = apollo_competency_center_service.record_knowledge_contribution(
+        db, tenant_id=tenant_id, technician=technician, topic=payload.get("topic", ""),
+    )
+    _audit(db, tenant_id, actor, "apollo.knowledge_contribution_recorded", "competency_events", technician, {"topic": payload.get("topic", "")})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Policy Intelligence
+# ---------------------------------------------------------------------------
+
+
+@router.post("/policies", status_code=201)
+def post_create_policy(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    try:
+        result = apollo_policy_service.create_policy(
+            db, tenant_id, title=payload.get("title", ""), owner=payload.get("owner", actor),
+            review_date=payload.get("review_date"), content=payload.get("content", ""),
+            references=payload.get("references"), linked_standards=payload.get("linked_standards"),
+            affected_workflows=payload.get("affected_workflows"), affected_competencies=payload.get("affected_competencies"),
+            affected_ai_rules=payload.get("affected_ai_rules"), supersedes_id=payload.get("supersedes_id"),
+        )
+    except apollo_policy_service.PolicyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "apollo.policy_created", "apollo_quality_policies", str(result["id"]), {"title": result["title"]})
+    return result
+
+
+@router.get("/policies")
+def get_policies(
+    request: Request, status: str = Query(""), db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES)),
+):
+    if status and status not in POLICY_STATUSES:
+        raise HTTPException(status_code=422, detail=f"status must be one of {POLICY_STATUSES}")
+    tenant_id = _tenant(current_user, request)
+    return {"policies": apollo_policy_service.list_policies(db, tenant_id, status=status)}
+
+
+@router.get("/policies/due-for-review")
+def get_policies_due_for_review(
+    request: Request, within_days: int = Query(30), db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    return {"policies": apollo_policy_service.policies_due_for_review(db, tenant_id, within_days=within_days)}
+
+
+@router.get("/policies/{policy_id}")
+def get_policy(policy_id: int, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    try:
+        return apollo_policy_service.get_policy(db, tenant_id, policy_id)
+    except apollo_policy_service.PolicyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/policies/{policy_id}/publish")
+def post_publish_policy(
+    policy_id: int, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    try:
+        result = apollo_policy_service.publish_policy(db, tenant_id, policy_id, published_by=actor)
+    except apollo_policy_service.PolicyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "apollo.policy_published", "apollo_quality_policies", str(policy_id), {})
+    return result
+
+
+@router.get("/policies/{policy_id}/history")
+def get_policy_history(policy_id: int, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return {"history": apollo_policy_service.version_history(db, tenant_id, policy_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Standards Knowledge Library
+# ---------------------------------------------------------------------------
+
+
+@router.get("/standards/library")
+def get_standards_library(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_standards_library_service.standards_library_summary(db, tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Continuous Improvement Portfolio
+# ---------------------------------------------------------------------------
+
+
+@router.post("/improvement-projects", status_code=201)
+def post_create_improvement_project(
+    payload: dict, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    result = apollo_improvement_portfolio_service.create_project(
+        db, tenant_id=tenant_id, initiative=payload.get("initiative", ""), owner=payload.get("owner", actor),
+        target_date=payload.get("target_date"), expected_impact=payload.get("expected_impact", ""),
+        methodology=payload.get("methodology", ""), cost_savings_usd=payload.get("cost_savings_usd"),
+        quality_improvement_metric=payload.get("quality_improvement_metric", ""),
+        risk_reduction_metric=payload.get("risk_reduction_metric", ""),
+        executive_visible=bool(payload.get("executive_visible", False)),
+    )
+    _audit(db, tenant_id, actor, "apollo.improvement_project_created", "continuous_improvement_initiatives", str(result["id"]), {"methodology": result["methodology"]})
+    return result
+
+
+@router.get("/improvement-projects")
+def get_improvement_projects(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_ALL_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return {"projects": apollo_improvement_portfolio_service.list_projects(db, tenant_id)}
+
+
+@router.get("/improvement-projects/summary")
+def get_improvement_projects_summary(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_improvement_portfolio_service.portfolio_summary(db, tenant_id)
+
+
+@router.patch("/improvement-projects/{project_id}")
+def patch_improvement_project(
+    project_id: int, payload: dict, request: Request, db: Session = Depends(get_db),
+    current_user=Depends(require_roles(*_LEADERSHIP_ROLES)),
+):
+    tenant_id = _tenant(current_user, request)
+    actor = _actor(current_user)
+    result = apollo_improvement_portfolio_service.update_project(db, tenant_id=tenant_id, initiative_id=project_id, **payload)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Improvement project {project_id} not found for tenant {tenant_id}.")
+    _audit(db, tenant_id, actor, "apollo.improvement_project_updated", "continuous_improvement_initiatives", str(project_id), payload)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Quality Digital Twin
+# ---------------------------------------------------------------------------
+
+
+@router.get("/quality-twin/{department}")
+def get_quality_twin(department: str, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_quality_twin_service.compute_quality_twin(db, tenant_id, department)
+
+
+@router.get("/quality-twin/{department}/history")
+def get_quality_twin_history(department: str, request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return {"history": apollo_quality_twin_service.twin_history(db, tenant_id, department)}
+
+
+# ---------------------------------------------------------------------------
+# Section 10 — Executive Quality Dashboard
+# ---------------------------------------------------------------------------
+
+
+@router.get("/executive-dashboard")
+def get_executive_dashboard(request: Request, db: Session = Depends(get_db), current_user=Depends(require_roles(*_LEADERSHIP_ROLES))):
+    tenant_id = _tenant(current_user, request)
+    return apollo_executive_quality_service.executive_quality_dashboard(db, tenant_id)

--- a/backend/app/routes/athena_knowledge.py
+++ b/backend/app/routes/athena_knowledge.py
@@ -1,0 +1,391 @@
+"""v4.8 — LumenAI OS: Project Athena — Healthcare Knowledge Intelligence &
+Institutional Memory routes.
+
+Frontend route: /knowledge-memory.
+API prefix: /api/athena — deliberately NOT `/api/knowledge` (v1.8) or
+`/api/knowledge-graph` (both taken); see `app/models/athena_knowledge.py`
+for the full naming-disambiguation note.
+
+## Tenant authorization — a deliberate departure from prior sprints
+
+Every route in this file uses `tenant_authz.require_tenant_roles`, which
+verifies a real `TenantMembership` row for the authenticated user's
+token-derived email before granting access — not the `_tenant()`/
+`require_roles()` pattern used by every prior sprint's routes (Catalyst
+through Apollo), which resolves the acting tenant from a client-supplied
+header with no membership check. That pattern is a real cross-tenant
+authorization gap; this file does not propagate it into an 18th module.
+The other 16 modules still need the same retrofit — tracked separately,
+not fixed here.
+
+  * GET   /memory/entries, GET /memory/search, GET /memory/summary     — Section 1
+  * POST  /expert-contributions,
+    POST/GET /expert-contributions/{id}/media                          — Section 2
+  * POST  /experience-graph/chains, GET /experience-graph/person/{p},
+    GET   /experience-graph/nodes/{id}/chain, GET /experience-graph/schema — Section 3
+  * GET   /timeline                                                     — Section 4
+  * POST  /playbooks, GET /playbooks, GET /playbooks/{id},
+    POST  /playbooks/{id}/standards, GET /playbooks/{id}/history         — Section 5
+  * GET   /curator/summary                                              — Section 6
+  * GET   /search                                                       — Section 7
+  * GET   /trust/articles, GET /trust/articles/{id}                     — Section 8
+  * POST  /assistant/ask                                                 — Section 9
+  * POST  /preservation/sessions, POST .../media, POST .../transcript,
+    POST  .../convert, GET /preservation/sessions, GET .../{id}          — Section 10
+  * GET   /governance/summary                                           — Governance
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.deps import get_db
+from app.services import (
+    athena_assistant_service,
+    athena_curator_service,
+    athena_expert_capture_service,
+    athena_experience_graph_service,
+    athena_memory_service,
+    athena_memory_timeline_service,
+    athena_playbook_service,
+    athena_preservation_service,
+    athena_search_service,
+    athena_trust_service,
+    knowledge_governance_service,
+)
+from app.services.knowledge_repository_service import get_article
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/athena", tags=["athena"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+def _audit(db: Session, tenant_id: str, actor: str, action_type: str, resource_type: str, resource_id: str, details: dict) -> None:
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id, actor_email=actor, actor_role="",
+        action_type=action_type, resource_type=resource_type, resource_id=resource_id, details=details, compliance_flag=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Institutional Memory Engine
+# ---------------------------------------------------------------------------
+
+
+@router.get("/memory/entries")
+def get_memory_entries(source_types: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    wanted = [s.strip() for s in source_types.split(",") if s.strip()] or None
+    return {"entries": athena_memory_service.list_memory_entries(db, tenant_id, source_types=wanted)}
+
+
+@router.get("/memory/search")
+def get_memory_search(q: str = Query(...), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return athena_memory_service.search_memory(db, tenant_id, q)
+
+
+@router.get("/memory/summary")
+def get_memory_summary(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return athena_memory_service.memory_summary(db, tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Expert Knowledge Capture
+# ---------------------------------------------------------------------------
+
+
+@router.post("/expert-contributions", status_code=201)
+def post_expert_contribution(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = athena_expert_capture_service.submit_expert_contribution(
+        db, tenant_id, category=payload.get("category", ""), title=payload.get("title", ""),
+        body=payload.get("body", ""), author=payload.get("author", actor),
+        applicable_instruments=payload.get("applicable_instruments"), applicable_findings=payload.get("applicable_findings"),
+        anatomy_zone=payload.get("anatomy_zone", ""), specialty=payload.get("specialty", ""),
+    )
+    _audit(db, tenant_id, actor, "athena.expert_contribution_submitted", "knowledge_articles", str(result["id"]), {"category": result["category"]})
+    return result
+
+
+@router.post("/expert-contributions/{article_id}/media", status_code=201)
+def post_expert_contribution_media(
+    article_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = athena_expert_capture_service.attach_media(
+            db, tenant_id, article_id, media_type=payload.get("media_type", ""), url_or_ref=payload.get("url_or_ref", ""),
+            caption=payload.get("caption", ""), transcript=payload.get("transcript", ""), uploaded_by=payload.get("uploaded_by", actor),
+        )
+    except athena_expert_capture_service.InvalidMediaTypeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "athena.media_attached", "knowledge_articles", str(article_id), {"media_type": result["media_type"]})
+    return result
+
+
+@router.get("/expert-contributions/{article_id}/media")
+def get_expert_contribution_media(article_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    from app.models.athena_knowledge import ATTACH_TO_ARTICLE
+
+    return {"media": athena_expert_capture_service.list_media(db, tenant_id, source_type=ATTACH_TO_ARTICLE, source_id=article_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Experience Graph
+# ---------------------------------------------------------------------------
+
+
+@router.post("/experience-graph/chains", status_code=201)
+def post_experience_chain(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = athena_experience_graph_service.build_experience_chain(
+        db, tenant_id, person=payload.get("person", ""), experience_label=payload.get("experience_label", ""),
+        instrument_type=payload.get("instrument_type", ""), finding_type=payload.get("finding_type", ""),
+        manufacturer=payload.get("manufacturer", ""), model=payload.get("model", ""),
+        outcome_label=payload.get("outcome_label", ""), evidence_label=payload.get("evidence_label", ""),
+        organization_label=payload.get("organization_label", ""),
+    )
+    _audit(db, tenant_id, actor, "athena.experience_chain_recorded", "athena_experience_graph_nodes", str(result["experience_node"]["id"]), {"person": payload.get("person", "")})
+    return result
+
+
+@router.get("/experience-graph/person/{person}")
+def get_graph_for_person(person: str, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return athena_experience_graph_service.graph_for_person(db, tenant_id, person)
+
+
+@router.get("/experience-graph/nodes/{node_id}/chain")
+def get_full_chain(node_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return athena_experience_graph_service.full_chain(db, tenant_id, node_id)
+
+
+@router.get("/experience-graph/schema")
+def get_graph_schema(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES))):
+    return athena_experience_graph_service.graph_schema()
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Institutional Memory Timeline
+# ---------------------------------------------------------------------------
+
+
+@router.get("/timeline")
+def get_memory_timeline(
+    finding_type: str = Query(...), instrument_type: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    tenant_id = _tenant(current_user)
+    return athena_memory_timeline_service.build_memory_timeline(db, tenant_id, finding_type=finding_type, instrument_type=instrument_type)
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Clinical Playbooks
+# ---------------------------------------------------------------------------
+
+
+@router.post("/playbooks", status_code=201)
+def post_playbook(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = athena_playbook_service.create_playbook(
+            db, tenant_id, name=payload.get("name", ""), category=payload.get("category", ""),
+            description=payload.get("description", ""), nodes=payload.get("nodes", []), edges=payload.get("edges", []),
+            author=payload.get("author", actor), linked_standards=payload.get("linked_standards"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "athena.playbook_created", "forge_workflow_definitions", str(result["id"]), {"category": result["category"]})
+    return result
+
+
+@router.get("/playbooks")
+def get_playbooks(category: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {"playbooks": athena_playbook_service.list_playbooks(db, tenant_id, category=category)}
+
+
+@router.get("/playbooks/{workflow_id}")
+def get_playbook(workflow_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return athena_playbook_service.get_playbook(db, workflow_id)
+    except athena_playbook_service.PlaybookNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/playbooks/{workflow_id}/standards")
+def post_playbook_standard(workflow_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = athena_playbook_service.attach_standard(db, workflow_id, payload.get("standard_code", ""))
+    _audit(db, tenant_id, actor, "athena.playbook_standard_attached", "forge_workflow_definitions", str(workflow_id), {"standard_code": payload.get("standard_code", "")})
+    return result
+
+
+@router.get("/playbooks/{workflow_id}/history")
+def get_playbook_history(workflow_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"history": athena_playbook_service.playbook_version_history(db, workflow_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — AI Knowledge Curator
+# ---------------------------------------------------------------------------
+
+
+@router.get("/curator/summary")
+def get_curator_summary(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return athena_curator_service.curator_summary(db, tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Organizational Search
+# ---------------------------------------------------------------------------
+
+
+@router.get("/search")
+def get_organizational_search(q: str = Query(...), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    return athena_search_service.organizational_search(db, tenant_id, q, actor=actor)
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Knowledge Trust Score
+# ---------------------------------------------------------------------------
+
+
+@router.get("/trust/articles")
+def get_trust_articles(min_trust: float = Query(None), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {"articles": athena_trust_service.list_articles_with_trust(db, tenant_id, min_trust=min_trust)}
+
+
+@router.get("/trust/articles/{article_id}")
+def get_trust_article(article_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    article = get_article(db, tenant_id, article_id)
+    if article is None:
+        raise HTTPException(status_code=404, detail=f"Article {article_id} not found.")
+    return athena_trust_service.compute_trust_score(db, article)
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Athena Assistant
+# ---------------------------------------------------------------------------
+
+
+@router.post("/assistant/ask")
+def post_ask_athena(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    return athena_assistant_service.ask_athena(
+        db, tenant_id, payload.get("question", ""), instrument_type=payload.get("instrument_type", ""),
+        workflow_id=payload.get("workflow_id"), actor=actor,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 10 — Knowledge Preservation
+# ---------------------------------------------------------------------------
+
+
+@router.post("/preservation/sessions", status_code=201)
+def post_preservation_session(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = athena_preservation_service.create_preservation_session(
+        db, tenant_id, subject_name=payload.get("subject_name", ""), session_type=payload.get("session_type", ""),
+        subject_role=payload.get("subject_role", ""), summary=payload.get("summary", ""),
+        captured_by=payload.get("captured_by", actor),
+    )
+    _audit(db, tenant_id, actor, "athena.preservation_session_created", "athena_knowledge_preservation_sessions", str(result["id"]), {"session_type": result["session_type"]})
+    return result
+
+
+@router.post("/preservation/sessions/{session_id}/media", status_code=201)
+def post_preservation_media(session_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = athena_preservation_service.attach_media(
+            db, tenant_id, session_id, media_type=payload.get("media_type", ""), url_or_ref=payload.get("url_or_ref", ""),
+            caption=payload.get("caption", ""), uploaded_by=payload.get("uploaded_by", actor),
+        )
+    except athena_preservation_service.PreservationSessionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except athena_preservation_service.InvalidMediaTypeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return result
+
+
+@router.post("/preservation/sessions/{session_id}/transcript")
+def post_preservation_transcript(session_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    try:
+        return athena_preservation_service.add_transcript(
+            db, tenant_id, session_id, transcript_text=payload.get("transcript_text", ""), topics=payload.get("topics"),
+        )
+    except athena_preservation_service.PreservationSessionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/preservation/sessions/{session_id}/convert")
+def post_preservation_convert(session_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = athena_preservation_service.convert_to_knowledge_article(
+            db, tenant_id, session_id, category=payload.get("category", ""), title=payload.get("title", ""),
+            author=payload.get("author", actor),
+        )
+    except athena_preservation_service.PreservationSessionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "athena.preservation_session_converted", "knowledge_articles", str(result["article"]["id"]), {"session_id": session_id})
+    return result
+
+
+@router.get("/preservation/sessions")
+def get_preservation_sessions(status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {"sessions": athena_preservation_service.list_sessions(db, tenant_id, status=status)}
+
+
+@router.get("/preservation/sessions/{session_id}")
+def get_preservation_session(session_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return athena_preservation_service.get_session(db, _tenant(current_user), session_id)
+    except athena_preservation_service.PreservationSessionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Governance
+# ---------------------------------------------------------------------------
+
+
+@router.get("/governance/summary")
+def get_governance_summary(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return knowledge_governance_service.governance_summary(db, tenant_id)

--- a/backend/app/services/accreditation_engine.py
+++ b/backend/app/services/accreditation_engine.py
@@ -214,6 +214,16 @@ def generate_audit_package(
         "aami": "aami",
         "fda": "fda",
         "cms": "cms",
+        # v4.7 Project Apollo additions — AAMI ST91 (endoscope reprocessing),
+        # AORN (perioperative practice), DNV (accreditation body), and
+        # facility-defined internal/vendor audit package types. Internal and
+        # vendor audits are not tied to a single regulatory body's standards,
+        # so they include the full standards catalogue like "full" does.
+        "aami_st91": "aami_st91",
+        "aorn": "aorn",
+        "dnv": "dnv",
+        "internal": None,
+        "vendor": None,
         "full": None,  # all bodies
     }
     target_body = body_map.get(package_type)

--- a/backend/app/services/apollo_audit_center_service.py
+++ b/backend/app/services/apollo_audit_center_service.py
@@ -1,0 +1,67 @@
+"""v4.7 — Project Apollo, Section 4: Audit Center.
+
+Composes `accreditation_engine.py` + `regulatory_standards_catalogue.py`
+(already extended with AAMI ST91/AORN/DNV standards and the
+internal/vendor package types) — this module does not add a second
+audit-package generator. Every finding an audit package carries already
+cites its evidence: a `standard_code`, `citation_text`, and
+`remediation_guidance` from the standards catalogue mapping.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services import accreditation_engine
+
+# All audit package types Apollo supports — mirrors
+# `accreditation_engine.generate_audit_package`'s `body_map` keys.
+AUDIT_PACKAGE_TYPES = [
+    "joint_commission", "aami", "aami_st91", "fda", "cms", "aorn", "dnv", "internal", "vendor", "full",
+]
+
+
+class UnsupportedAuditPackageTypeError(Exception):
+    pass
+
+
+def audit_center_summary(db: Session, tenant_id: str, *, facility_id: str = "") -> dict:
+    """Regulatory dashboard (readiness scores, standards summary, top
+    findings) — the Audit Center's home tile."""
+    dashboard = accreditation_engine.compute_regulatory_dashboard(tenant_id, facility_id, db)
+    return {
+        "overall_readiness_score": dashboard.overall_readiness_score,
+        "readiness_tier": dashboard.readiness_tier,
+        "joint_commission_score": dashboard.joint_commission_score,
+        "aami_score": dashboard.aami_score,
+        "fda_score": dashboard.fda_score,
+        "cms_score": dashboard.cms_score,
+        "iso_score": dashboard.iso_score,
+        "total_deficiencies": dashboard.total_deficiencies,
+        "critical_deficiencies": dashboard.critical_deficiencies,
+        "open_capas": dashboard.open_capas,
+        "standards_summary": dashboard.standards_summary,
+        "top_findings": [f.model_dump() for f in dashboard.top_findings],
+        "recommended_actions": dashboard.recommended_actions,
+        "supported_package_types": AUDIT_PACKAGE_TYPES,
+        "data_source": dashboard.data_source,
+        "human_review_required": True,
+    }
+
+
+def generate_audit(
+    tenant_id: str, *, package_type: str, facility_id: str = "", period_label: str = "",
+    generated_by: str = "system", db=None,
+) -> dict:
+    """Generates an audit-ready evidence package for any of the 9 supported
+    bodies (Joint Commission/AAMI ST79/AAMI ST91/AORN/CMS/DNV/Internal/
+    Vendor/full). Every finding in the package already carries its
+    standard citation and remediation guidance — no unlinked findings."""
+    if package_type not in AUDIT_PACKAGE_TYPES:
+        raise UnsupportedAuditPackageTypeError(
+            f"Unsupported audit package type '{package_type}'. Supported: {AUDIT_PACKAGE_TYPES}",
+        )
+    result = accreditation_engine.generate_audit_package(
+        tenant_id, facility_id=facility_id, package_type=package_type,
+        period_label=period_label, generated_by=generated_by, db=db,
+    )
+    return result.model_dump()

--- a/backend/app/services/apollo_capa_engine_service.py
+++ b/backend/app/services/apollo_capa_engine_service.py
@@ -1,0 +1,107 @@
+"""v4.7 — Project Apollo, Section 2: CAPA Engine.
+
+Composes the pre-existing CAPA stack — `capa_suggestion_service` (now
+extended with Apollo's 5 new detectors), `capa_lifecycle_service` (the real
+open->assigned->in_progress->verified->closed state machine), and Apollo's
+new `CustomerComplaint` intake — into one CAPA Engine view. This module adds
+no new CAPA store; every CAPA still lives in `capa_service`'s single `capas`
+table.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.apollo_quality import (
+    COMPLAINT_CLOSED,
+    COMPLAINT_LINKED_TO_CAPA,
+    COMPLAINT_OPEN,
+    CustomerComplaint,
+)
+from app.services import capa_lifecycle_service
+from app.services.capa_suggestion_service import create_capa_from_suggestion, generate_capa_suggestions
+
+
+def capa_engine_summary(db: Session, tenant_id: str) -> dict:
+    """Owner/root-cause/actions/verification/closure rollup for the CAPA
+    Engine tab — the lifecycle state machine plus current auto-trigger
+    suggestions, nothing re-derived."""
+    lifecycle_counts = capa_lifecycle_service.lifecycle_summary(tenant_id)
+    suggestions = generate_capa_suggestions(db, tenant_id)
+    open_complaints = (
+        db.query(CustomerComplaint)
+        .filter(CustomerComplaint.tenant_id == tenant_id, CustomerComplaint.status == COMPLAINT_OPEN)
+        .count()
+    )
+    return {
+        "lifecycle_counts": lifecycle_counts,
+        "total_open_or_active": sum(
+            v for k, v in lifecycle_counts.items() if k != capa_lifecycle_service.LIFECYCLE_CLOSED
+        ),
+        "pending_suggestions": suggestions,
+        "pending_suggestion_count": len(suggestions),
+        "open_complaint_count": open_complaints,
+        "human_review_required": True,
+    }
+
+
+def create_capa_from_suggestion_reviewed(suggestion: dict, *, owner: str) -> dict:
+    """Human-review materialization step — unchanged from the pre-existing
+    `capa_suggestion_service.create_capa_from_suggestion`, exposed here so
+    Apollo's routes have one CAPA Engine entry point."""
+    return create_capa_from_suggestion(suggestion, owner=owner)
+
+
+# ── Customer complaint intake (Section 2 CAPA trigger source) ───────────────
+
+def create_complaint(
+    db: Session, tenant_id: str, *, source: str, description: str, severity: str = "medium",
+    instrument_type: str = "", reported_by: str = "",
+) -> CustomerComplaint:
+    complaint = CustomerComplaint(
+        tenant_id=tenant_id, source=source, description=description, severity=severity,
+        instrument_type=instrument_type, reported_by=reported_by,
+    )
+    db.add(complaint)
+    db.commit()
+    db.refresh(complaint)
+    return complaint
+
+
+def list_complaints(db: Session, tenant_id: str, *, status: str = "") -> list[CustomerComplaint]:
+    q = db.query(CustomerComplaint).filter(CustomerComplaint.tenant_id == tenant_id)
+    if status:
+        q = q.filter(CustomerComplaint.status == status)
+    return q.order_by(CustomerComplaint.created_at.desc()).all()
+
+
+class ComplaintNotFoundError(Exception):
+    pass
+
+
+def link_complaint_to_capa(db: Session, tenant_id: str, complaint_id: int, *, capa_id: str) -> CustomerComplaint:
+    complaint = (
+        db.query(CustomerComplaint)
+        .filter(CustomerComplaint.id == complaint_id, CustomerComplaint.tenant_id == tenant_id)
+        .first()
+    )
+    if complaint is None:
+        raise ComplaintNotFoundError(f"Complaint {complaint_id} not found for tenant {tenant_id}.")
+    complaint.linked_capa_id = capa_id
+    complaint.status = COMPLAINT_LINKED_TO_CAPA
+    db.commit()
+    db.refresh(complaint)
+    return complaint
+
+
+def close_complaint(db: Session, tenant_id: str, complaint_id: int) -> CustomerComplaint:
+    complaint = (
+        db.query(CustomerComplaint)
+        .filter(CustomerComplaint.id == complaint_id, CustomerComplaint.tenant_id == tenant_id)
+        .first()
+    )
+    if complaint is None:
+        raise ComplaintNotFoundError(f"Complaint {complaint_id} not found for tenant {tenant_id}.")
+    complaint.status = COMPLAINT_CLOSED
+    db.commit()
+    db.refresh(complaint)
+    return complaint

--- a/backend/app/services/apollo_competency_center_service.py
+++ b/backend/app/services/apollo_competency_center_service.py
@@ -1,0 +1,63 @@
+"""v4.7 — Project Apollo, Section 5: Competency Center.
+
+Composes `competency_service.py`'s single `CompetencyEvent` log — including
+the four new event types Apollo added there (annual competency, procedure
+validation, simulation result, knowledge contribution) — into one
+Competency Center view. No parallel competency model.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services import competency_service
+
+
+def record_annual_competency(db: Session, *, tenant_id: str, technician: str, competency_area: str) -> dict:
+    competency_service.record_annual_competency(
+        db, tenant_id=tenant_id, technician=technician, competency_area=competency_area,
+    )
+    db.commit()
+    return competency_service.competency_summary(db, technician)
+
+
+def record_procedure_validation(db: Session, *, tenant_id: str, technician: str, procedure_name: str) -> dict:
+    competency_service.record_procedure_validation(
+        db, tenant_id=tenant_id, technician=technician, procedure_name=procedure_name,
+    )
+    db.commit()
+    return competency_service.competency_summary(db, technician)
+
+
+def record_simulation_result(db: Session, *, tenant_id: str, technician: str, scenario: str, passed: bool) -> dict:
+    competency_service.record_simulation_result(
+        db, tenant_id=tenant_id, technician=technician, scenario=scenario, passed=passed,
+    )
+    db.commit()
+    return competency_service.competency_summary(db, technician)
+
+
+def record_knowledge_contribution(db: Session, *, tenant_id: str, technician: str, topic: str) -> dict:
+    competency_service.record_knowledge_contribution(
+        db, tenant_id=tenant_id, technician=technician, topic=topic,
+    )
+    db.commit()
+    return competency_service.competency_summary(db, technician)
+
+
+def competency_center_summary(db: Session, tenant_id: str) -> dict:
+    """Technician/Supervisor/Manager rollup for the Competency Center tab —
+    reuses the existing per-technician quality dashboard, adding no second
+    aggregation of the same events."""
+    dashboard = competency_service.technician_quality_dashboard(db, tenant_id)
+    technicians = dashboard["technicians"]
+    return {
+        "technicians": technicians,
+        "technician_count": len(technicians),
+        "annual_competencies_total": sum(
+            competency_service.competency_summary(db, t["technician"])["annual_competencies"] for t in technicians
+        ),
+        "knowledge_contributions_total": sum(
+            competency_service.competency_summary(db, t["technician"])["knowledge_contributions"] for t in technicians
+        ),
+        "human_review_required": True,
+    }

--- a/backend/app/services/apollo_executive_quality_service.py
+++ b/backend/app/services/apollo_executive_quality_service.py
@@ -1,0 +1,93 @@
+"""v4.7 — Project Apollo, Section 10: Executive Quality Dashboard.
+
+Composes `quality_command_center_service.quality_command_center_summary`
+(v2.9) and `vanguard_governance_service.governance_dashboard` (v4.6) — the
+two pre-existing systems that already compute the large majority of the
+named tiles — rather than re-deriving CAPA/root-cause/competency/audit-
+readiness numbers a third time. The only genuinely new computation here is
+the Quality Maturity Index: an original weighted composite documented below.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services import capa_lifecycle_service, quality_command_center_service, vanguard_governance_service
+from app.services.apollo_improvement_portfolio_service import portfolio_summary
+from app.services.apollo_policy_service import policies_due_for_review
+
+# Quality Maturity Index weights — documented since this is the one
+# genuinely new metric in this file. Compliance/audit-readiness weighted
+# highest since they gate accreditation; CAPA health and continuous
+# improvement weighted lower as leading (not lagging) indicators.
+_QMI_WEIGHTS = {
+    "compliance": 0.30,
+    "capa_health": 0.20,
+    "competency": 0.20,
+    "continuous_improvement": 0.15,
+    "policy_currency": 0.15,
+}
+
+
+def _quality_maturity_index(
+    *, compliance_score: float, capa_closure_rate: float, competency_avg: float,
+    ci_completion_rate: float, policy_currency_pct: float,
+) -> float:
+    return round(
+        _QMI_WEIGHTS["compliance"] * compliance_score
+        + _QMI_WEIGHTS["capa_health"] * capa_closure_rate
+        + _QMI_WEIGHTS["competency"] * competency_avg
+        + _QMI_WEIGHTS["continuous_improvement"] * ci_completion_rate
+        + _QMI_WEIGHTS["policy_currency"] * policy_currency_pct,
+        1,
+    )
+
+
+def executive_quality_dashboard(db: Session, tenant_id: str, *, tenant_name: str = "") -> dict:
+    command_center = quality_command_center_service.quality_command_center_summary(db, tenant_id)
+    governance = vanguard_governance_service.governance_dashboard(db, tenant_id, tenant_name=tenant_name)
+    lifecycle_counts = capa_lifecycle_service.lifecycle_summary(tenant_id)
+    total_capas = sum(lifecycle_counts.values())
+    capa_closure_rate = (
+        round(100 * lifecycle_counts.get(capa_lifecycle_service.LIFECYCLE_CLOSED, 0) / total_capas, 1)
+        if total_capas else 100.0
+    )
+    portfolio = portfolio_summary(db, tenant_id)
+    upcoming_reviews = policies_due_for_review(db, tenant_id, within_days=30)
+    high_risk_policies = policies_due_for_review(db, tenant_id, within_days=0)  # already overdue
+
+    compliance_score = governance["audit_readiness"].get("overall_readiness_score") or 0.0
+    competency_avg = command_center.get("education_impact_avg_pct") or 0.0
+    ci_completion_rate = portfolio["completion_rate_pct"] or 0.0
+    # Each overdue-review policy deducts 10 points from a 100-point baseline
+    # — a simple, honest proxy since there's no independent "policy currency"
+    # metric to read; never fabricated as a measured rate.
+    policy_currency_pct = max(0.0, 100.0 - 10.0 * len(high_risk_policies))
+
+    qmi = _quality_maturity_index(
+        compliance_score=compliance_score, capa_closure_rate=capa_closure_rate, competency_avg=competency_avg,
+        ci_completion_rate=ci_completion_rate, policy_currency_pct=policy_currency_pct,
+    )
+
+    return {
+        "compliance_score": compliance_score,
+        "audit_readiness": governance["audit_readiness"],
+        "open_capas": total_capas - lifecycle_counts.get(capa_lifecycle_service.LIFECYCLE_CLOSED, 0),
+        "capa_closure_rate_pct": capa_closure_rate,
+        "competency_status": {
+            "technician_trends": command_center.get("technician_trends"),
+            "education_impact_avg_pct": command_center.get("education_impact_avg_pct"),
+        },
+        "high_risk_policies": high_risk_policies,
+        "upcoming_reviews": upcoming_reviews,
+        "continuous_improvement": {
+            "total_projects": portfolio["total_projects"],
+            "completion_rate_pct": portfolio["completion_rate_pct"],
+            "total_cost_savings_usd": portfolio["total_cost_savings_usd"],
+            "executive_visible_projects": portfolio["executive_visible_projects"],
+        },
+        "quality_maturity_index": qmi,
+        "quality_maturity_index_weights": _QMI_WEIGHTS,
+        "root_causes": command_center.get("root_causes"),
+        "recurring_findings": command_center.get("recurring_findings"),
+        "human_review_required": True,
+    }

--- a/backend/app/services/apollo_improvement_portfolio_service.py
+++ b/backend/app/services/apollo_improvement_portfolio_service.py
@@ -1,0 +1,94 @@
+"""v4.7 — Project Apollo, Section 8: Continuous Improvement Portfolio.
+
+Composes the pre-existing `ContinuousImprovementInitiative` table (now
+extended with methodology/cost-savings/quality-improvement/risk-reduction/
+executive-visibility columns) — no new table, no re-derivation of
+`actual_impact` (still human-filled only).
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.models.continuous_improvement import METHODOLOGIES, ContinuousImprovementInitiative
+from app.services import continuous_improvement_service
+
+
+def _to_dict(row: ContinuousImprovementInitiative) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+        "tenant_id": row.tenant_id,
+        "initiative": row.initiative,
+        "owner": row.owner,
+        "target_date": row.target_date.isoformat() if row.target_date else None,
+        "status": row.status,
+        "expected_impact": row.expected_impact,
+        "actual_impact": row.actual_impact,
+        "methodology": row.methodology,
+        "cost_savings_usd": row.cost_savings_usd,
+        "quality_improvement_metric": row.quality_improvement_metric,
+        "risk_reduction_metric": row.risk_reduction_metric,
+        "executive_visible": row.executive_visible,
+    }
+
+
+def create_project(
+    db: Session, *, tenant_id: str, initiative: str, owner: str = "", target_date: date | None = None,
+    expected_impact: str = "", methodology: str = "", cost_savings_usd: float | None = None,
+    quality_improvement_metric: str = "", risk_reduction_metric: str = "", executive_visible: bool = False,
+) -> dict:
+    row = continuous_improvement_service.create_initiative(
+        db, tenant_id=tenant_id, initiative=initiative, owner=owner, target_date=target_date,
+        expected_impact=expected_impact, methodology=methodology, cost_savings_usd=cost_savings_usd,
+        quality_improvement_metric=quality_improvement_metric, risk_reduction_metric=risk_reduction_metric,
+        executive_visible=executive_visible,
+    )
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def list_projects(db: Session, tenant_id: str) -> list[dict]:
+    return [_to_dict(r) for r in continuous_improvement_service.list_initiatives(db, tenant_id)]
+
+
+def update_project(db: Session, *, tenant_id: str, initiative_id: int, **fields) -> dict | None:
+    row = continuous_improvement_service.update_initiative(db, initiative_id=initiative_id, tenant_id=tenant_id, **fields)
+    if row is None:
+        return None
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def portfolio_summary(db: Session, tenant_id: str) -> dict:
+    """PI/Lean/Six Sigma/Kaizen rollup: counts by methodology/status, total
+    (human-entered) cost savings, and the executive-visible subset."""
+    rows = continuous_improvement_service.list_initiatives(db, tenant_id)
+    by_methodology: dict[str, int] = {m: 0 for m in METHODOLOGIES}
+    by_status: dict[str, int] = {}
+    total_cost_savings = 0.0
+    executive_visible_projects = []
+    for r in rows:
+        if r.methodology:
+            by_methodology[r.methodology] = by_methodology.get(r.methodology, 0) + 1
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+        if r.cost_savings_usd:
+            total_cost_savings += r.cost_savings_usd
+        if r.executive_visible:
+            executive_visible_projects.append(_to_dict(r))
+
+    return {
+        "total_projects": len(rows),
+        "by_methodology": by_methodology,
+        "by_status": by_status,
+        "total_cost_savings_usd": round(total_cost_savings, 2) if total_cost_savings else 0.0,
+        "executive_visible_projects": executive_visible_projects,
+        "completion_rate_pct": (
+            round(100 * by_status.get("completed", 0) / len(rows), 1) if rows else None
+        ),
+        "human_review_required": True,
+    }

--- a/backend/app/services/apollo_policy_service.py
+++ b/backend/app/services/apollo_policy_service.py
@@ -1,0 +1,163 @@
+"""v4.7 — Project Apollo, Section 6: Policy Intelligence.
+
+Versioned quality policies — `QualityPolicy` (genuinely new; no clinical
+policy versioning system existed before Apollo). Follows the same
+`supersedes_id`/`status` self-FK chain Beacon's `StandardsPublication` and
+Forge's `WorkflowDefinition` already established, including the same
+version-chain walk pattern as `beacon_standards_service.version_history`.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.apollo_quality import (
+    DISCLAIMER,
+    POLICY_DRAFT,
+    POLICY_PUBLISHED,
+    POLICY_SUPERSEDED,
+    QualityPolicy,
+)
+
+
+class PolicyNotFoundError(Exception):
+    pass
+
+
+def _to_dict(policy: QualityPolicy) -> dict:
+    return {
+        "id": policy.id,
+        "created_at": policy.created_at.isoformat() if policy.created_at else None,
+        "tenant_id": policy.tenant_id,
+        "title": policy.title,
+        "version": policy.version,
+        "status": policy.status,
+        "supersedes_id": policy.supersedes_id,
+        "owner": policy.owner,
+        "review_date": policy.review_date.isoformat() if policy.review_date else None,
+        "content": policy.content,
+        "references": json.loads(policy.references_json or "[]"),
+        "linked_standards": json.loads(policy.linked_standards_json or "[]"),
+        "affected_workflows": json.loads(policy.affected_workflows_json or "[]"),
+        "affected_competencies": json.loads(policy.affected_competencies_json or "[]"),
+        "affected_ai_rules": json.loads(policy.affected_ai_rules_json or "[]"),
+        "published_by": policy.published_by,
+        "published_at": policy.published_at.isoformat() if policy.published_at else None,
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def create_policy(
+    db: Session, tenant_id: str, *, title: str, owner: str = "", review_date=None, content: str = "",
+    references: list | None = None, linked_standards: list | None = None, affected_workflows: list | None = None,
+    affected_competencies: list | None = None, affected_ai_rules: list | None = None,
+    supersedes_id: int | None = None,
+) -> dict:
+    version = 1
+    if supersedes_id is not None:
+        prior = db.query(QualityPolicy).filter(
+            QualityPolicy.id == supersedes_id, QualityPolicy.tenant_id == tenant_id,
+        ).first()
+        if prior is None:
+            raise PolicyNotFoundError(f"Policy {supersedes_id} not found for tenant {tenant_id} to supersede.")
+        version = prior.version + 1
+
+    policy = QualityPolicy(
+        tenant_id=tenant_id, title=title, version=version, status=POLICY_DRAFT, supersedes_id=supersedes_id,
+        owner=owner, review_date=review_date, content=content,
+        references_json=json.dumps(references or []), linked_standards_json=json.dumps(linked_standards or []),
+        affected_workflows_json=json.dumps(affected_workflows or []),
+        affected_competencies_json=json.dumps(affected_competencies or []),
+        affected_ai_rules_json=json.dumps(affected_ai_rules or []),
+    )
+    db.add(policy)
+    db.commit()
+    db.refresh(policy)
+    return _to_dict(policy)
+
+
+def get_policy(db: Session, tenant_id: str, policy_id: int) -> dict:
+    policy = db.query(QualityPolicy).filter(
+        QualityPolicy.id == policy_id, QualityPolicy.tenant_id == tenant_id,
+    ).first()
+    if policy is None:
+        raise PolicyNotFoundError(f"Policy {policy_id} not found for tenant {tenant_id}.")
+    return _to_dict(policy)
+
+
+def list_policies(db: Session, tenant_id: str, *, status: str = "") -> list[dict]:
+    q = db.query(QualityPolicy).filter(QualityPolicy.tenant_id == tenant_id)
+    if status:
+        q = q.filter(QualityPolicy.status == status)
+    rows = q.order_by(QualityPolicy.created_at.desc()).all()
+    return [_to_dict(r) for r in rows]
+
+
+def publish_policy(db: Session, tenant_id: str, policy_id: int, *, published_by: str) -> dict:
+    policy = db.query(QualityPolicy).filter(
+        QualityPolicy.id == policy_id, QualityPolicy.tenant_id == tenant_id,
+    ).first()
+    if policy is None:
+        raise PolicyNotFoundError(f"Policy {policy_id} not found for tenant {tenant_id}.")
+    if policy.supersedes_id is not None:
+        prior = db.query(QualityPolicy).filter(QualityPolicy.id == policy.supersedes_id).first()
+        if prior is not None and prior.status == POLICY_PUBLISHED:
+            prior.status = POLICY_SUPERSEDED
+    policy.status = POLICY_PUBLISHED
+    policy.published_by = published_by
+    policy.published_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(policy)
+    return _to_dict(policy)
+
+
+def version_history(db: Session, tenant_id: str, policy_id: int) -> list[dict]:
+    """Walks the `supersedes_id` chain to the root, then returns every
+    version in order — mirrors Beacon's `version_history` walk."""
+    row = db.query(QualityPolicy).filter(
+        QualityPolicy.id == policy_id, QualityPolicy.tenant_id == tenant_id,
+    ).first()
+    if row is None:
+        return []
+
+    root_id = row.id
+    seen = set()
+    while True:
+        current = db.query(QualityPolicy).filter(QualityPolicy.id == root_id).first()
+        if current is None or not current.supersedes_id or current.supersedes_id in seen:
+            break
+        seen.add(current.supersedes_id)
+        root_id = current.supersedes_id
+
+    chain = []
+    current_id = root_id
+    visited = set()
+    while current_id and current_id not in visited:
+        visited.add(current_id)
+        current = db.query(QualityPolicy).filter(QualityPolicy.id == current_id).first()
+        if current is None:
+            break
+        chain.append(_to_dict(current))
+        successor = db.query(QualityPolicy).filter(QualityPolicy.supersedes_id == current_id).first()
+        current_id = successor.id if successor else None
+    return chain
+
+
+def policies_due_for_review(db: Session, tenant_id: str, *, within_days: int = 30) -> list[dict]:
+    """Published policies whose `review_date` is within the window (or
+    already past) — the basis for the Executive Quality Dashboard's
+    "high-risk policies"/"upcoming reviews" tiles."""
+    cutoff = datetime.now(timezone.utc) + timedelta(days=within_days)
+    rows = (
+        db.query(QualityPolicy)
+        .filter(
+            QualityPolicy.tenant_id == tenant_id, QualityPolicy.status == POLICY_PUBLISHED,
+            QualityPolicy.review_date.isnot(None), QualityPolicy.review_date <= cutoff,
+        )
+        .order_by(QualityPolicy.review_date.asc())
+        .all()
+    )
+    return [_to_dict(r) for r in rows]

--- a/backend/app/services/apollo_quality_twin_service.py
+++ b/backend/app/services/apollo_quality_twin_service.py
@@ -1,0 +1,155 @@
+"""v4.7 — Project Apollo, Section 9: Quality Digital Twin.
+
+A genuinely new pure-composition snapshot per department — no department-
+level quality composite existed before Apollo. Distinct from
+`digital_twin_engine.py`'s facility/instrument-scoped workflow telemetry
+twin: this tracks governance health (compliance/competency/audit-
+readiness/policy-maturity/CAPA-health/education/knowledge/continuous-
+improvement), not instrument flow.
+
+Several factors below are not natively department-scoped in this codebase
+(accreditation readiness, CAPA lifecycle, and the standards library are all
+tenant-wide) — where that's the case, the tenant-wide value is used as an
+honest proxy and the `factors_json` explicitly records which sub-scores are
+department-scoped vs. tenant-wide, rather than fabricating a department
+split with no underlying data.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.apollo_quality import DISCLAIMER, POLICY_PUBLISHED, QualityTwinSnapshot
+from app.services import accreditation_engine, capa_lifecycle_service, competency_service
+from app.services.apollo_improvement_portfolio_service import portfolio_summary
+from app.services.apollo_policy_service import list_policies
+
+# Overall score is an equal-weighted average across the eight named
+# dimensions — the one genuinely new scoring decision in this file.
+
+
+def _department_technicians(db: Session, tenant_id: str, department: str) -> list[str]:
+    rows = (
+        db.query(models.Inspection.technician)
+        .filter(
+            models.Inspection.tenant_id == tenant_id, models.Inspection.technician.isnot(None),
+            models.Inspection.department == (None if department == "unspecified" else department),
+        )
+        .distinct()
+        .all()
+    )
+    return [r[0] for r in rows if r[0]]
+
+
+def compute_quality_twin(db: Session, tenant_id: str, department: str = "unspecified") -> dict:
+    factors: dict[str, str] = {}
+
+    # Audit readiness / compliance — tenant-wide (accreditation_engine has no
+    # department dimension).
+    readiness = accreditation_engine.compute_accreditation_readiness(tenant_id, "", db)
+    audit_readiness_score = readiness.overall_score
+    compliance_score = readiness.overall_score
+    factors["audit_readiness_score"] = "tenant-wide (accreditation_engine has no department dimension)"
+    factors["compliance_score"] = "tenant-wide, same source as audit_readiness_score"
+
+    # Competency — department-scoped via technicians who logged inspections
+    # in this department.
+    technicians = _department_technicians(db, tenant_id, department)
+    training_scores = []
+    education_counts = 0
+    knowledge_counts = 0
+    for tech in technicians:
+        summary = competency_service.competency_summary(db, tech)
+        if summary["training_progress_pct"] is not None:
+            training_scores.append(summary["training_progress_pct"])
+        education_counts += len(summary["education_completed"])
+        knowledge_counts += summary["knowledge_contributions"]
+    competency_score = round(sum(training_scores) / len(training_scores), 1) if training_scores else 0.0
+    factors["competency_score"] = f"department-scoped across {len(technicians)} technician(s)"
+
+    # Education — pct of department technicians with at least one completed
+    # education article.
+    education_score = (
+        round(100 * sum(1 for t in technicians if competency_service.competency_summary(db, t)["education_completed"]) / len(technicians), 1)
+        if technicians else 0.0
+    )
+    factors["education_score"] = f"department-scoped across {len(technicians)} technician(s)"
+
+    # Knowledge — contributions per technician, capped at 100.
+    knowledge_score = min(100.0, round(100 * knowledge_counts / len(technicians), 1)) if technicians else 0.0
+    factors["knowledge_score"] = f"department-scoped across {len(technicians)} technician(s)"
+
+    # Policy maturity — tenant-wide published-vs-total ratio (policies are
+    # not department-tagged today; `affected_workflows` is free-text).
+    all_policies = list_policies(db, tenant_id)
+    published_policies = [p for p in all_policies if p["status"] == POLICY_PUBLISHED]
+    policy_maturity_score = (
+        round(100 * len(published_policies) / len(all_policies), 1) if all_policies else 0.0
+    )
+    factors["policy_maturity_score"] = "tenant-wide (policies are not department-tagged)"
+
+    # CAPA health — tenant-wide lifecycle closure rate.
+    lifecycle_counts = capa_lifecycle_service.lifecycle_summary(tenant_id)
+    total_capas = sum(lifecycle_counts.values())
+    capa_health_score = (
+        round(100 * lifecycle_counts.get(capa_lifecycle_service.LIFECYCLE_CLOSED, 0) / total_capas, 1)
+        if total_capas else 100.0
+    )
+    factors["capa_health_score"] = "tenant-wide (CAPAs are not department-tagged)"
+
+    # Continuous improvement — tenant-wide portfolio completion rate.
+    portfolio = portfolio_summary(db, tenant_id)
+    continuous_improvement_score = portfolio["completion_rate_pct"] or 0.0
+    factors["continuous_improvement_score"] = "tenant-wide (initiatives are not department-tagged)"
+
+    scores = {
+        "compliance_score": compliance_score, "competency_score": competency_score,
+        "audit_readiness_score": audit_readiness_score, "policy_maturity_score": policy_maturity_score,
+        "capa_health_score": capa_health_score, "education_score": education_score,
+        "knowledge_score": knowledge_score, "continuous_improvement_score": continuous_improvement_score,
+    }
+    overall_score = round(sum(scores.values()) / len(scores), 1)
+
+    snapshot = QualityTwinSnapshot(
+        tenant_id=tenant_id, department=department, overall_score=overall_score,
+        factors_json=json.dumps(factors), **scores,
+    )
+    db.add(snapshot)
+    db.commit()
+    db.refresh(snapshot)
+
+    return {
+        "id": snapshot.id,
+        "department": department,
+        "created_at": snapshot.created_at.isoformat(),
+        "scores": scores,
+        "overall_score": overall_score,
+        "factors": factors,
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def twin_history(db: Session, tenant_id: str, department: str = "unspecified", *, limit: int = 20) -> list[dict]:
+    rows = (
+        db.query(QualityTwinSnapshot)
+        .filter(QualityTwinSnapshot.tenant_id == tenant_id, QualityTwinSnapshot.department == department)
+        .order_by(QualityTwinSnapshot.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            "id": r.id, "created_at": r.created_at.isoformat(), "department": r.department,
+            "overall_score": r.overall_score,
+            "scores": {
+                "compliance_score": r.compliance_score, "competency_score": r.competency_score,
+                "audit_readiness_score": r.audit_readiness_score, "policy_maturity_score": r.policy_maturity_score,
+                "capa_health_score": r.capa_health_score, "education_score": r.education_score,
+                "knowledge_score": r.knowledge_score, "continuous_improvement_score": r.continuous_improvement_score,
+            },
+        }
+        for r in rows
+    ]

--- a/backend/app/services/apollo_rca_intelligence_service.py
+++ b/backend/app/services/apollo_rca_intelligence_service.py
@@ -1,0 +1,158 @@
+"""v4.7 — Project Apollo, Section 3: Root Cause Intelligence.
+
+A pure *structuring/presentation* layer over data that already exists —
+`RCADraft`/`rca_engine_service` (evidence, contributing factors, historical
+recurrence, similar events — supervisor-approved) and `root_cause_service.
+root_cause_trends` (confirmed `RootCauseAssignment` rows). This module never
+writes a new root-cause data model and never finalizes a root cause itself;
+`approve_draft`'s supervisor gate remains the only path that ever creates a
+real `RootCauseAssignment`.
+
+Four methodology views, all derived from real evidence already on the draft
+or from real assignment counts — never a fabricated score:
+  * Five Whys — the draft's own evidence/contributing-factors chain,
+    presented as a "why" ladder for the supervisor to keep extending.
+  * Fishbone — contributing factors bucketed into the six standard
+    ishikawa categories by keyword match against real factor text.
+  * Pareto — real root-cause assignment counts (`root_cause_trends`)
+    ranked with cumulative percentage.
+  * Trend Analysis — the same trends, split by finding type over time.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.apollo_quality import DISCLAIMER, FISHBONE_CATEGORIES
+from app.services import rca_engine_service, root_cause_service
+
+_FISHBONE_KEYWORDS: dict[str, list[str]] = {
+    "man": ["technician", "training", "competency", "staff", "supervisor"],
+    "machine": ["instrument", "washer", "sterilizer", "equipment", "device"],
+    "method": ["procedure", "sop", "process", "protocol", "workflow", "step"],
+    "material": ["chemistry", "detergent", "solution", "material", "supply"],
+    "measurement": ["coverage", "confidence", "indicator", "test", "inspection"],
+    "environment": ["storage", "temperature", "humidity", "facility", "environment"],
+}
+
+
+def five_whys_view(db: Session, tenant_id: str, draft_id: int) -> dict:
+    """Presents the RCA draft's real evidence and contributing factors as a
+    "why" ladder — the supervisor still has to answer each "why", this only
+    structures what's already on the draft."""
+    draft = rca_engine_service.get_draft(db, tenant_id, draft_id)
+    evidence = json.loads(draft.get("evidence_json") or "[]")
+    contributing_factors = json.loads(draft.get("contributing_factors_json") or "[]")
+
+    whys = []
+    if evidence:
+        whys.append({"level": 1, "question": "What happened?", "answer": evidence[0]})
+    for i, factor in enumerate(contributing_factors, start=2):
+        whys.append({"level": i, "question": "Why did that happen?", "answer": factor})
+    whys.append({
+        "level": len(whys) + 1,
+        "question": "What is the root cause?",
+        "answer": draft.get("approved_root_cause") or "Not yet determined — supervisor review required.",
+    })
+
+    return {
+        "draft_id": draft_id,
+        "methodology": "five_whys",
+        "whys": whys,
+        "status": draft.get("status"),
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def fishbone_view(db: Session, tenant_id: str, draft_id: int) -> dict:
+    """Buckets the draft's real contributing factors into the six standard
+    Ishikawa categories by keyword match. Factors that don't match any
+    category are listed under "uncategorized" rather than forced into a
+    bucket that doesn't fit."""
+    draft = rca_engine_service.get_draft(db, tenant_id, draft_id)
+    contributing_factors = json.loads(draft.get("contributing_factors_json") or "[]")
+
+    buckets: dict[str, list[str]] = {cat: [] for cat in FISHBONE_CATEGORIES}
+    uncategorized: list[str] = []
+    for factor in contributing_factors:
+        lowered = factor.lower()
+        matched = False
+        for category, keywords in _FISHBONE_KEYWORDS.items():
+            if any(kw in lowered for kw in keywords):
+                buckets[category].append(factor)
+                matched = True
+                break
+        if not matched:
+            uncategorized.append(factor)
+
+    return {
+        "draft_id": draft_id,
+        "methodology": "fishbone",
+        "categories": buckets,
+        "uncategorized": uncategorized,
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def pareto_view(db: Session, tenant_id: str) -> dict:
+    """Real root-cause assignment counts (never drafts) ranked with
+    cumulative percentage — the classic 80/20 Pareto chart."""
+    trends = root_cause_service.root_cause_trends(db, tenant_id)
+    overall = trends["overall"]
+    total = trends["total_assignments"]
+
+    ranked = sorted(overall.items(), key=lambda kv: kv[1], reverse=True)
+    rows = []
+    cumulative = 0
+    for root_cause, count in ranked:
+        cumulative += count
+        rows.append({
+            "root_cause": root_cause,
+            "count": count,
+            "pct_of_total": round(100 * count / total, 1) if total else None,
+            "cumulative_pct": round(100 * cumulative / total, 1) if total else None,
+        })
+
+    return {
+        "methodology": "pareto",
+        "total_assignments": total,
+        "rows": rows,
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def trend_view(db: Session, tenant_id: str) -> dict:
+    """Real root-cause counts split by finding type — recurring-pattern
+    detection across finding categories, not a time-series forecast (no
+    per-assignment timestamp bucketing exists to support one honestly)."""
+    trends = root_cause_service.root_cause_trends(db, tenant_id)
+    return {
+        "methodology": "trend_analysis",
+        "total_assignments": trends["total_assignments"],
+        "by_finding_type": trends["by_finding_type"],
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def rca_intelligence_summary(db: Session, tenant_id: str) -> dict:
+    """Composes the Pareto and Trend views (tenant-wide, no draft required)
+    plus a count of drafts still awaiting supervisor review."""
+    from app.models.quality_guardian import RCADraft
+
+    pending_drafts = (
+        db.query(RCADraft)
+        .filter(RCADraft.tenant_id == tenant_id, RCADraft.status == "draft")
+        .count()
+    )
+    return {
+        "pareto": pareto_view(db, tenant_id),
+        "trend_analysis": trend_view(db, tenant_id),
+        "pending_draft_count": pending_drafts,
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/apollo_standards_library_service.py
+++ b/backend/app/services/apollo_standards_library_service.py
@@ -1,0 +1,65 @@
+"""v4.7 — Project Apollo, Section 7: Standards Knowledge Library.
+
+Composes three pre-existing standards/publication systems into one library
+view — `regulatory_standards_catalogue.py` (AAMI/AORN/DNV/FDA/CMS/JC/ISO
+clause-level standards, now extended with ST91/AORN/DNV), `beacon_standards_
+service.py` (governed guidance/recommended-practice publications), and
+`p24_standards_service.py` (internal quality-classification standards). Every
+recommendation still shows its own source system — Apollo never re-derives
+or merges the underlying records, only groups them for one library view.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services import beacon_standards_service, p24_standards_service
+from app.services.apollo_policy_service import list_policies
+from app.services.regulatory_standards_catalogue import get_standards
+from app.models.apollo_quality import DISCLAIMER, POLICY_PUBLISHED
+
+
+def regulatory_catalogue_by_body(body: str | None = None) -> list[dict]:
+    """Clause-level regulatory standards (Section 7's AAMI/AORN/Manufacturer
+    IFU/regulatory references), sourced from `regulatory_standards_
+    catalogue.py` — the source system for every citation."""
+    standards = get_standards()
+    if body:
+        standards = [s for s in standards if s.body == body]
+    return [
+        {
+            "code": s.code, "body": s.body, "title": s.title, "description": s.description,
+            "category": s.category, "applicability": s.applicability, "source": "regulatory_standards_catalogue",
+        }
+        for s in standards
+    ]
+
+
+def standards_library_summary(db: Session, tenant_id: str) -> dict:
+    """One Standards Knowledge Library view composing all three existing
+    systems, each recommendation retaining its own `source` field."""
+    regulatory = regulatory_catalogue_by_body()
+    beacon = beacon_standards_service.standards_center_summary(db)
+    p24_internal_standards = p24_standards_service.get_quality_standards(db)
+    internal_sops = [
+        {**p, "source": "internal_quality_policy"}
+        for p in list_policies(db, tenant_id, status=POLICY_PUBLISHED)
+    ]
+
+    body_counts: dict[str, int] = {}
+    for s in regulatory:
+        body_counts[s["body"]] = body_counts.get(s["body"], 0) + 1
+
+    return {
+        "regulatory_standards": regulatory,
+        "regulatory_body_counts": body_counts,
+        "beacon_guidance": beacon["guidance"],
+        "beacon_recommended_practices": beacon["recommended_practices"],
+        "beacon_educational_content": beacon["educational_content"],
+        "beacon_reference_materials": beacon["reference_materials"],
+        "internal_classification_standards": [
+            {**s, "source": "p24_standards_service"} for s in p24_internal_standards
+        ],
+        "internal_sops": internal_sops,
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/athena_assistant_service.py
+++ b/backend/app/services/athena_assistant_service.py
@@ -1,0 +1,72 @@
+"""v4.8 — Project Athena, Section 9: Athena Assistant.
+
+Extends the existing `ai_knowledge_assistant_service.answer_question()`
+(v1.8) rather than building a second assistant — every answer is still
+deterministic and source-cited, never a call to an external LLM (this
+codebase has zero real LLM integration anywhere, confirmed by research).
+Adds three new query shapes named in the brief: recurring-issue
+investigation history, cross-time policy/guidance comparison, and
+workflow-version comparison — each dispatches to a real, already-built
+Athena service rather than fabricating a new answer path.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.athena_knowledge import DISCLAIMER
+from app.services import ai_knowledge_assistant_service, forge_workflow_service
+from app.services.athena_memory_timeline_service import build_memory_timeline
+from app.services.athena_search_service import organizational_search
+from app.services.clinical_mentor import FINDING_EDUCATION
+from app.services.knowledge_search_service import _matched_findings
+
+_RECURRING_KEYWORDS = ("recurring", "how we handled", "how did we handle")
+_LESSONS_KEYWORDS = ("lessons learned", "lesson learned")
+_POLICY_CHANGE_KEYWORDS = ("changed", "change", "ifu guidance", "over the past year", "over the last year")
+_WORKFLOW_COMPARE_KEYWORDS = ("compare", "last year's", "previous version")
+
+
+def _classify(q: str) -> str:
+    if any(k in q for k in _RECURRING_KEYWORDS):
+        return "recurring_investigation"
+    if any(k in q for k in _LESSONS_KEYWORDS):
+        return "lessons_learned_search"
+    if any(k in q for k in _WORKFLOW_COMPARE_KEYWORDS):
+        return "workflow_comparison"
+    if any(k in q for k in _POLICY_CHANGE_KEYWORDS):
+        return "policy_change_history"
+    return "general"
+
+
+def ask_athena(db: Session, tenant_id: str, question: str, *, instrument_type: str = "", workflow_id: int | None = None, actor: str = "") -> dict:
+    q = (question or "").strip().lower()
+    intent = _classify(q)
+    base = ai_knowledge_assistant_service.answer_question(db, tenant_id, question, instrument_type=instrument_type, actor=actor)
+
+    result: dict = {"question": question, "intent": intent, "base_answer": base}
+
+    if intent == "recurring_investigation":
+        findings = _matched_findings(q) or list(FINDING_EDUCATION.keys())
+        finding_type = findings[0] if findings else ""
+        if finding_type:
+            result["timeline"] = build_memory_timeline(db, tenant_id, finding_type=finding_type, instrument_type=instrument_type)
+
+    elif intent == "lessons_learned_search":
+        search_results = organizational_search(db, tenant_id, question, actor=actor)
+        lessons = [a for a in search_results["knowledge_articles"] if a.get("category") == "lesson_learned"]
+        result["lessons_learned"] = lessons
+
+    elif intent == "policy_change_history":
+        from app.services.apollo_policy_service import list_policies
+
+        result["policy_history"] = list_policies(db, tenant_id)
+
+    elif intent == "workflow_comparison":
+        if workflow_id is not None:
+            result["version_history"] = forge_workflow_service.version_history(db, workflow_id)
+        else:
+            result["note"] = "Provide workflow_id to compare a specific playbook's version history."
+
+    result["human_review_required"] = True
+    result["disclaimer"] = DISCLAIMER
+    return result

--- a/backend/app/services/athena_curator_service.py
+++ b/backend/app/services/athena_curator_service.py
@@ -1,0 +1,120 @@
+"""v4.8 — Project Athena, Section 6: AI Knowledge Curator.
+
+Extends `knowledge_analytics_service.py`'s existing deterministic-
+aggregation pattern (`knowledge_gaps`, `training_opportunities`) with four
+new checks — duplicate documents, outdated guidance, retirement
+candidates, and emerging best practices. Every check is a real
+threshold/keyword computation over `KnowledgeArticle`/`CompetencyEvent`
+rows, never a fabricated relevance score. All suggestions are for human
+review — nothing archives or merges an article automatically.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.competency_event import CompetencyEvent
+from app.models.knowledge import APPROVED, KnowledgeArticle
+from app.services import knowledge_analytics_service
+
+_DUPLICATE_SIMILARITY_THRESHOLD = 0.5
+_STALE_DAYS_DEFAULT = 365
+_EMERGING_MIN_MENTIONS = 3
+
+
+def _tokenize(text: str) -> set[str]:
+    return {w for w in (text or "").lower().split() if len(w) > 2}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def duplicate_candidates(db: Session, tenant_id: str, *, similarity_threshold: float = _DUPLICATE_SIMILARITY_THRESHOLD) -> list[dict]:
+    """Real title+body token-overlap (Jaccard) between article pairs — a
+    deterministic similarity measure, never a fabricated relevance score."""
+    rows = db.query(KnowledgeArticle).filter(KnowledgeArticle.tenant_id == tenant_id).all()
+    tokens = {r.id: _tokenize(r.title + " " + r.body) for r in rows}
+    pairs = []
+    for i, a in enumerate(rows):
+        for b in rows[i + 1:]:
+            score = _jaccard(tokens[a.id], tokens[b.id])
+            if score >= similarity_threshold:
+                pairs.append({
+                    "article_a_id": a.id, "article_a_title": a.title,
+                    "article_b_id": b.id, "article_b_title": b.title,
+                    "similarity": round(score, 2),
+                })
+    pairs.sort(key=lambda p: p["similarity"], reverse=True)
+    return pairs
+
+
+def outdated_guidance(db: Session, tenant_id: str, *, stale_days: int = _STALE_DAYS_DEFAULT) -> list[dict]:
+    """Approved articles never reviewed, or not reviewed within
+    `stale_days` — a real recency check against `last_reviewed_at`."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=stale_days)
+    rows = db.query(KnowledgeArticle).filter(
+        KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.approval_status == APPROVED,
+    ).all()
+    stale = [
+        r for r in rows
+        if r.last_reviewed_at is None or r.last_reviewed_at < cutoff
+    ]
+    return [
+        {
+            "id": r.id, "title": r.title, "category": r.category,
+            "last_reviewed_at": r.last_reviewed_at.isoformat() if r.last_reviewed_at else None,
+        }
+        for r in stale
+    ]
+
+
+def retirement_candidates(db: Session, tenant_id: str, *, stale_days: int = _STALE_DAYS_DEFAULT) -> list[dict]:
+    """Outdated *and* never viewed — a real, conservative retirement
+    signal (never auto-archived; a human still calls `archive_article`)."""
+    stale = {s["id"] for s in outdated_guidance(db, tenant_id, stale_days=stale_days)}
+    rows = db.query(KnowledgeArticle).filter(
+        KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.id.in_(stale), KnowledgeArticle.view_count == 0,
+    ).all()
+    return [{"id": r.id, "title": r.title, "category": r.category, "view_count": r.view_count} for r in rows]
+
+
+def emerging_best_practices(db: Session, tenant_id: str, *, min_mentions: int = _EMERGING_MIN_MENTIONS) -> list[dict]:
+    """Repeated `knowledge_contribution` topics (Apollo's CompetencyEvent
+    log) with no existing article covering that topic yet — a real
+    recurrence count, not a guessed trend."""
+    rows = (
+        db.query(CompetencyEvent)
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "knowledge_contribution")
+        .all()
+    )
+    counts: dict[str, int] = defaultdict(int)
+    for r in rows:
+        if r.finding_type:
+            counts[r.finding_type] += 1
+
+    existing_titles = {
+        a.title.lower() for a in db.query(KnowledgeArticle).filter(KnowledgeArticle.tenant_id == tenant_id).all()
+    }
+    return [
+        {"topic": topic, "mention_count": count}
+        for topic, count in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)
+        if count >= min_mentions and topic.lower() not in existing_titles
+    ]
+
+
+def curator_summary(db: Session, tenant_id: str) -> dict:
+    base = knowledge_analytics_service.knowledge_analytics(db, tenant_id)
+    return {
+        "knowledge_gaps": base["knowledge_gaps"],
+        "training_opportunities": base["training_opportunities"],
+        "duplicate_candidates": duplicate_candidates(db, tenant_id),
+        "outdated_guidance": outdated_guidance(db, tenant_id),
+        "retirement_candidates": retirement_candidates(db, tenant_id),
+        "emerging_best_practices": emerging_best_practices(db, tenant_id),
+        "human_review_required": True,
+    }

--- a/backend/app/services/athena_experience_graph_service.py
+++ b/backend/app/services/athena_experience_graph_service.py
@@ -1,0 +1,181 @@
+"""v4.8 — Project Athena, Section 3: Experience Graph.
+
+Extends the Knowledge Graph with a genuinely new, persisted node/edge
+structure — `knowledge_graph_service.py`'s `explore()`/`reasoning_chain()`
+are real but recomputed-on-read aggregations with no node/edge tables.
+The Finding -> Instrument -> Anatomy -> Recommendation segment of every
+chain built here is populated by calling `reasoning_chain()` directly
+rather than re-deriving that logic; only the new Person/Experience/
+Outcome/Evidence/Organization node types are Athena's own.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.athena_knowledge import (
+    DISCLAIMER,
+    EDGE_EVIDENCE_OWNED_BY_ORG,
+    EDGE_FOUND_ON_INSTRUMENT,
+    EDGE_HAS_EXPERIENCE,
+    EDGE_INSTRUMENT_HAS_ANATOMY,
+    EDGE_LED_TO_RECOMMENDATION,
+    EDGE_PRODUCED_OUTCOME,
+    EDGE_SUPPORTED_BY_EVIDENCE,
+    EDGE_YIELDED_FINDING,
+    NODE_ANATOMY,
+    NODE_EVIDENCE,
+    NODE_EXPERIENCE,
+    NODE_FINDING,
+    NODE_INSTRUMENT,
+    NODE_ORGANIZATION,
+    NODE_OUTCOME,
+    NODE_PERSON,
+    NODE_RECOMMENDATION,
+    ExperienceGraphEdge,
+    ExperienceGraphNode,
+)
+from app.services.knowledge_graph_service import reasoning_chain
+
+
+def _node(db: Session, tenant_id: str, node_type: str, label: str, *, source_type: str = "",
+          source_id: int | None = None, details: dict | None = None) -> ExperienceGraphNode:
+    row = ExperienceGraphNode(
+        tenant_id=tenant_id, node_type=node_type, label=label, source_type=source_type,
+        source_id=source_id, details_json=json.dumps(details or {}),
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def _edge(db: Session, tenant_id: str, from_node: ExperienceGraphNode, to_node: ExperienceGraphNode,
+          relationship: str, *, notes: str = "") -> ExperienceGraphEdge:
+    row = ExperienceGraphEdge(
+        tenant_id=tenant_id, from_node_id=from_node.id, to_node_id=to_node.id,
+        relationship=relationship, notes=notes,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def _node_to_dict(n: ExperienceGraphNode) -> dict:
+    return {
+        "id": n.id, "node_type": n.node_type, "label": n.label, "source_type": n.source_type,
+        "source_id": n.source_id, "details": json.loads(n.details_json or "{}"),
+        "created_at": n.created_at.isoformat(),
+    }
+
+
+def build_experience_chain(
+    db: Session, tenant_id: str, *, person: str, experience_label: str, instrument_type: str, finding_type: str,
+    manufacturer: str = "", model: str = "", outcome_label: str = "", evidence_label: str = "",
+    organization_label: str = "", source_type: str = "", source_id: int | None = None,
+) -> dict:
+    """Creates the full Person -> Experience -> Finding -> Instrument ->
+    Anatomy -> Recommendation -> Outcome -> Evidence -> Organization chain
+    in one call. The Finding/Instrument/Anatomy/Recommendation nodes come
+    directly from `reasoning_chain()` — never re-derived."""
+    chain = reasoning_chain(instrument_type, finding_type, manufacturer=manufacturer, model=model)
+    chain_by_node = {s["node"]: s for s in chain["chain"]}
+
+    person_node = _node(db, tenant_id, NODE_PERSON, person)
+    experience_node = _node(
+        db, tenant_id, NODE_EXPERIENCE, experience_label, source_type=source_type, source_id=source_id,
+    )
+    _edge(db, tenant_id, person_node, experience_node, EDGE_HAS_EXPERIENCE)
+
+    finding_node = _node(db, tenant_id, NODE_FINDING, finding_type, details=chain_by_node.get("Clinical Meaning"))
+    _edge(db, tenant_id, experience_node, finding_node, EDGE_YIELDED_FINDING)
+
+    instrument_node = _node(db, tenant_id, NODE_INSTRUMENT, instrument_type, details={
+        "manufacturer": manufacturer, "model": model, "family": chain["chain"][2]["value"],
+    })
+    _edge(db, tenant_id, finding_node, instrument_node, EDGE_FOUND_ON_INSTRUMENT)
+
+    anatomy_node = _node(db, tenant_id, NODE_ANATOMY, chain_by_node["Anatomy Zone"]["value"], details=chain_by_node["Anatomy Zone"])
+    _edge(db, tenant_id, instrument_node, anatomy_node, EDGE_INSTRUMENT_HAS_ANATOMY)
+
+    recommendation_text = chain_by_node["Recommended Action"]["value"]
+    recommendation_node = _node(db, tenant_id, NODE_RECOMMENDATION, recommendation_text, details=chain_by_node["Recommended Action"])
+    _edge(db, tenant_id, anatomy_node, recommendation_node, EDGE_LED_TO_RECOMMENDATION)
+
+    result: dict = {
+        "person_node": _node_to_dict(person_node), "experience_node": _node_to_dict(experience_node),
+        "finding_node": _node_to_dict(finding_node), "instrument_node": _node_to_dict(instrument_node),
+        "anatomy_node": _node_to_dict(anatomy_node), "recommendation_node": _node_to_dict(recommendation_node),
+        "narrative": chain["narrative"],
+    }
+
+    last_node = recommendation_node
+    if outcome_label:
+        outcome_node = _node(db, tenant_id, NODE_OUTCOME, outcome_label)
+        _edge(db, tenant_id, last_node, outcome_node, EDGE_PRODUCED_OUTCOME)
+        result["outcome_node"] = _node_to_dict(outcome_node)
+        last_node = outcome_node
+
+    if evidence_label:
+        evidence_node = _node(db, tenant_id, NODE_EVIDENCE, evidence_label)
+        _edge(db, tenant_id, last_node, evidence_node, EDGE_SUPPORTED_BY_EVIDENCE)
+        result["evidence_node"] = _node_to_dict(evidence_node)
+        last_node = evidence_node
+
+        if organization_label:
+            org_node = _node(db, tenant_id, NODE_ORGANIZATION, organization_label)
+            _edge(db, tenant_id, evidence_node, org_node, EDGE_EVIDENCE_OWNED_BY_ORG)
+            result["organization_node"] = _node_to_dict(org_node)
+
+    db.commit()
+    result["human_review_required"] = True
+    result["disclaimer"] = DISCLAIMER
+    return result
+
+
+def graph_for_person(db: Session, tenant_id: str, person: str) -> dict:
+    """Every experience chain recorded for a given person (Section 3's
+    "living Experience Graph")."""
+    person_nodes = (
+        db.query(ExperienceGraphNode)
+        .filter(ExperienceGraphNode.tenant_id == tenant_id, ExperienceGraphNode.node_type == NODE_PERSON,
+                ExperienceGraphNode.label == person)
+        .all()
+    )
+    chains = []
+    for pn in person_nodes:
+        chains.append(_walk_from(db, tenant_id, pn.id))
+    return {"person": person, "chains": chains, "human_review_required": True, "disclaimer": DISCLAIMER}
+
+
+def _walk_from(db: Session, tenant_id: str, node_id: int) -> list[dict]:
+    """Walks outgoing edges from a node to the end of the chain."""
+    path: list[dict] = []
+    current_id = node_id
+    visited: set[int] = set()
+    while current_id is not None and current_id not in visited:
+        visited.add(current_id)
+        node = db.query(ExperienceGraphNode).filter(ExperienceGraphNode.id == current_id).first()
+        if node is None:
+            break
+        path.append(_node_to_dict(node))
+        edge = (
+            db.query(ExperienceGraphEdge)
+            .filter(ExperienceGraphEdge.tenant_id == tenant_id, ExperienceGraphEdge.from_node_id == current_id)
+            .first()
+        )
+        current_id = edge.to_node_id if edge else None
+    return path
+
+
+def full_chain(db: Session, tenant_id: str, start_node_id: int) -> dict:
+    return {
+        "start_node_id": start_node_id, "chain": _walk_from(db, tenant_id, start_node_id),
+        "human_review_required": True,
+    }
+
+
+def graph_schema() -> dict:
+    from app.models.athena_knowledge import EDGE_RELATIONSHIPS, NODE_CHAIN_ORDER
+
+    return {"node_chain_order": NODE_CHAIN_ORDER, "edge_relationships": EDGE_RELATIONSHIPS}

--- a/backend/app/services/athena_expert_capture_service.py
+++ b/backend/app/services/athena_expert_capture_service.py
@@ -1,0 +1,75 @@
+"""v4.8 — Project Athena, Section 2: Expert Knowledge Capture.
+
+Wraps the existing `knowledge_repository_service.create_article` (v1.8) —
+every submission still enters as `draft` and follows the pre-existing
+`knowledge_governance_service` approval workflow unchanged. The only new
+capability is attaching photo/video/voice examples via
+`KnowledgeMediaAttachment`, since no media field existed on
+`KnowledgeArticle` before Athena.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.athena_knowledge import ATTACH_TO_ARTICLE, MEDIA_TYPES, KnowledgeMediaAttachment
+from app.services.knowledge_repository_service import article_to_dict, create_article
+
+
+class InvalidMediaTypeError(ValueError):
+    pass
+
+
+def submit_expert_contribution(
+    db: Session, tenant_id: str, *, category: str, title: str, body: str, author: str,
+    applicable_instruments: list[str] | None = None, applicable_findings: list[str] | None = None,
+    anatomy_zone: str = "", specialty: str = "",
+) -> dict:
+    """A best practice / inspection tip / cleaning technique / anatomy
+    insight / failure mode submission — enters the same draft ->
+    pending_review -> approved governance workflow every KnowledgeArticle
+    already follows."""
+    article = create_article(
+        db, tenant_id=tenant_id, category=category, title=title, body=body, author=author,
+        applicable_instruments=applicable_instruments, applicable_findings=applicable_findings,
+        anatomy_zone=anatomy_zone, specialty=specialty,
+    )
+    db.commit()
+    db.refresh(article)
+    return article_to_dict(article)
+
+
+def attach_media(
+    db: Session, tenant_id: str, article_id: int, *, media_type: str, url_or_ref: str,
+    caption: str = "", transcript: str = "", uploaded_by: str = "",
+) -> dict:
+    if media_type not in MEDIA_TYPES:
+        raise InvalidMediaTypeError(f"media_type must be one of {MEDIA_TYPES}")
+    attachment = KnowledgeMediaAttachment(
+        tenant_id=tenant_id, source_type=ATTACH_TO_ARTICLE, source_id=article_id, media_type=media_type,
+        url_or_ref=url_or_ref, caption=caption, transcript=transcript, uploaded_by=uploaded_by,
+    )
+    db.add(attachment)
+    db.commit()
+    db.refresh(attachment)
+    return {
+        "id": attachment.id, "source_type": attachment.source_type, "source_id": attachment.source_id,
+        "media_type": attachment.media_type, "url_or_ref": attachment.url_or_ref, "caption": attachment.caption,
+    }
+
+
+def list_media(db: Session, tenant_id: str, *, source_type: str, source_id: int) -> list[dict]:
+    rows = (
+        db.query(KnowledgeMediaAttachment)
+        .filter(
+            KnowledgeMediaAttachment.tenant_id == tenant_id, KnowledgeMediaAttachment.source_type == source_type,
+            KnowledgeMediaAttachment.source_id == source_id,
+        )
+        .all()
+    )
+    return [
+        {
+            "id": r.id, "media_type": r.media_type, "url_or_ref": r.url_or_ref, "caption": r.caption,
+            "transcript": r.transcript, "uploaded_by": r.uploaded_by, "created_at": r.created_at.isoformat(),
+        }
+        for r in rows
+    ]

--- a/backend/app/services/athena_memory_service.py
+++ b/backend/app/services/athena_memory_service.py
@@ -1,0 +1,160 @@
+"""v4.8 — Project Athena, Section 1: Institutional Memory Engine.
+
+Normalizes real records from six pre-existing stores into one searchable
+"memory entry" shape — clinical decisions/lessons learned/vendor/repair
+observations (`KnowledgeArticle`), CAPA outcomes (`capa_lifecycle_service`),
+Root Cause Analyses (`RootCauseAssignment`), workflow improvements
+(`ContinuousImprovementInitiative`), policy history (`QualityPolicy`), and
+education history (`CompetencyEvent`). No new "memory" table — every
+record here is a read of data that already exists elsewhere.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.athena_knowledge import DISCLAIMER
+from app.models.competency_event import CompetencyEvent
+from app.models.continuous_improvement import ContinuousImprovementInitiative
+from app.models.knowledge import KnowledgeArticle
+from app.models.root_cause import RootCauseAssignment
+from app.services import capa_lifecycle_service
+from app.services.apollo_policy_service import list_policies
+
+MEMORY_SOURCE_ARTICLE = "knowledge_article"
+MEMORY_SOURCE_CAPA = "capa"
+MEMORY_SOURCE_ROOT_CAUSE = "root_cause_analysis"
+MEMORY_SOURCE_IMPROVEMENT = "workflow_improvement"
+MEMORY_SOURCE_POLICY = "policy_history"
+MEMORY_SOURCE_EDUCATION = "education_history"
+MEMORY_SOURCE_TYPES = [
+    MEMORY_SOURCE_ARTICLE, MEMORY_SOURCE_CAPA, MEMORY_SOURCE_ROOT_CAUSE,
+    MEMORY_SOURCE_IMPROVEMENT, MEMORY_SOURCE_POLICY, MEMORY_SOURCE_EDUCATION,
+]
+
+
+def _articles_as_memory(db: Session, tenant_id: str) -> list[dict]:
+    rows = db.query(KnowledgeArticle).filter(KnowledgeArticle.tenant_id == tenant_id).all()
+    return [
+        {
+            "source_type": MEMORY_SOURCE_ARTICLE, "source_id": r.id, "title": r.title,
+            "summary": r.body[:280], "category": r.category, "created_at": r.created_at.isoformat(),
+            "status": r.approval_status,
+        }
+        for r in rows
+    ]
+
+
+def _capas_as_memory(tenant_id: str) -> list[dict]:
+    rows = capa_lifecycle_service.list_capas(tenant_id, limit=500)
+    return [
+        {
+            "source_type": MEMORY_SOURCE_CAPA, "source_id": r["id"], "title": r["title"],
+            "summary": r.get("description") or "", "category": r.get("recommendation_type") or "",
+            "created_at": r["created_at"], "status": r.get("lifecycle_status"),
+        }
+        for r in rows
+    ]
+
+
+def _root_causes_as_memory(db: Session, tenant_id: str) -> list[dict]:
+    rows = db.query(RootCauseAssignment).filter(RootCauseAssignment.tenant_id == tenant_id).all()
+    return [
+        {
+            "source_type": MEMORY_SOURCE_ROOT_CAUSE, "source_id": r.id,
+            "title": f"Root cause: {r.finding_type} -> {r.root_cause}",
+            "summary": f"Assigned by {r.assigned_by} for inspection {r.inspection_id}.",
+            "category": r.finding_type, "created_at": r.created_at.isoformat(), "status": "assigned",
+        }
+        for r in rows
+    ]
+
+
+def _improvements_as_memory(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(ContinuousImprovementInitiative)
+        .filter(ContinuousImprovementInitiative.tenant_id == tenant_id)
+        .all()
+    )
+    return [
+        {
+            "source_type": MEMORY_SOURCE_IMPROVEMENT, "source_id": r.id, "title": r.initiative,
+            "summary": r.expected_impact or "", "category": r.methodology or "",
+            "created_at": r.created_at.isoformat(), "status": r.status,
+        }
+        for r in rows
+    ]
+
+
+def _policies_as_memory(db: Session, tenant_id: str) -> list[dict]:
+    rows = list_policies(db, tenant_id)
+    return [
+        {
+            "source_type": MEMORY_SOURCE_POLICY, "source_id": r["id"], "title": r["title"],
+            "summary": f"Version {r['version']} — {r['status']}", "category": "policy",
+            "created_at": r["created_at"], "status": r["status"],
+        }
+        for r in rows
+    ]
+
+
+def _education_as_memory(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(CompetencyEvent)
+        .filter(
+            CompetencyEvent.tenant_id == tenant_id,
+            CompetencyEvent.event_type.in_(("education_completed", "annual_competency", "procedure_validation")),
+        )
+        .all()
+    )
+    return [
+        {
+            "source_type": MEMORY_SOURCE_EDUCATION, "source_id": r.id,
+            "title": f"{r.event_type.replace('_', ' ').title()}: {r.finding_type or 'general'}",
+            "summary": f"Technician: {r.technician}", "category": r.event_type,
+            "created_at": r.created_at.isoformat(), "status": "recorded",
+        }
+        for r in rows
+    ]
+
+
+def list_memory_entries(db: Session, tenant_id: str, *, source_types: list[str] | None = None) -> list[dict]:
+    """Every knowledge object, normalized and searchable (Section 1)."""
+    builders = {
+        MEMORY_SOURCE_ARTICLE: lambda: _articles_as_memory(db, tenant_id),
+        MEMORY_SOURCE_CAPA: lambda: _capas_as_memory(tenant_id),
+        MEMORY_SOURCE_ROOT_CAUSE: lambda: _root_causes_as_memory(db, tenant_id),
+        MEMORY_SOURCE_IMPROVEMENT: lambda: _improvements_as_memory(db, tenant_id),
+        MEMORY_SOURCE_POLICY: lambda: _policies_as_memory(db, tenant_id),
+        MEMORY_SOURCE_EDUCATION: lambda: _education_as_memory(db, tenant_id),
+    }
+    wanted = source_types or MEMORY_SOURCE_TYPES
+    entries: list[dict] = []
+    for source_type in wanted:
+        if source_type in builders:
+            entries.extend(builders[source_type]())
+    entries.sort(key=lambda e: e["created_at"], reverse=True)
+    return entries
+
+
+def search_memory(db: Session, tenant_id: str, query: str) -> dict:
+    """Keyword match across every normalized memory entry (Section 1's
+    "every knowledge object is searchable")."""
+    q = (query or "").strip().lower()
+    entries = list_memory_entries(db, tenant_id)
+    if q:
+        entries = [e for e in entries if q in e["title"].lower() or q in e["summary"].lower()]
+    return {
+        "query": query, "results": entries, "result_count": len(entries),
+        "human_review_required": True, "disclaimer": DISCLAIMER,
+    }
+
+
+def memory_summary(db: Session, tenant_id: str) -> dict:
+    entries = list_memory_entries(db, tenant_id)
+    by_source: dict[str, int] = {}
+    for e in entries:
+        by_source[e["source_type"]] = by_source.get(e["source_type"], 0) + 1
+    return {
+        "total_entries": len(entries), "by_source_type": by_source,
+        "recent_entries": entries[:10], "human_review_required": True,
+    }

--- a/backend/app/services/athena_memory_timeline_service.py
+++ b/backend/app/services/athena_memory_timeline_service.py
@@ -1,0 +1,86 @@
+"""v4.8 — Project Athena, Section 4: Institutional Memory Timeline.
+
+Composes Event -> Investigation -> CAPA -> Education -> Policy Change ->
+Outcome -> Verification -> Future Similar Cases from six pre-existing
+systems for a given finding type. There is no explicit foreign-key chain
+linking a `ClinicalCase` to its eventual `QualityPolicy` change across this
+codebase's existing models, so steps are joined by real, matching
+`finding_type` values (a keyword-level association, not a fabricated
+direct link) — each step is honestly labeled with its real source system.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.athena_knowledge import DISCLAIMER
+from app.models.competency_event import CompetencyEvent
+from app.models.knowledge import ClinicalCase
+from app.models.root_cause import RootCauseAssignment
+from app.services import capa_lifecycle_service
+from app.services.apollo_policy_service import list_policies
+from app.services.similar_case_finder_service import find_similar_cases
+
+
+def build_memory_timeline(db: Session, tenant_id: str, *, finding_type: str, instrument_type: str = "") -> dict:
+    q = finding_type.strip().lower()
+
+    events = (
+        db.query(ClinicalCase)
+        .filter(ClinicalCase.tenant_id == tenant_id, ClinicalCase.finding_type == finding_type)
+        .order_by(ClinicalCase.created_at.asc())
+        .all()
+    )
+    investigations = (
+        db.query(RootCauseAssignment)
+        .filter(RootCauseAssignment.tenant_id == tenant_id, RootCauseAssignment.finding_type == finding_type)
+        .order_by(RootCauseAssignment.created_at.asc())
+        .all()
+    )
+    all_capas = capa_lifecycle_service.list_capas(tenant_id, limit=500)
+    capas = [c for c in all_capas if q in (c.get("title") or "").lower() or q in (c.get("description") or "").lower()]
+
+    education_events = (
+        db.query(CompetencyEvent)
+        .filter(
+            CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.finding_type == finding_type,
+            CompetencyEvent.event_type == "education_completed",
+        )
+        .order_by(CompetencyEvent.created_at.asc())
+        .all()
+    )
+    all_policies = list_policies(db, tenant_id)
+    policy_changes = [p for p in all_policies if q in p["title"].lower()]
+
+    outcomes = [{"capa_id": c["id"], "lifecycle_status": c.get("lifecycle_status")} for c in capas
+                if c.get("lifecycle_status") in ("verified", "closed")]
+    verifications = [
+        {"capa_id": c["id"], "verified_by": c.get("verified_by"), "verified_at": c.get("verified_at")}
+        for c in capas if c.get("verified_at")
+    ]
+
+    future_similar_cases = (
+        find_similar_cases(db, tenant_id, instrument_type=instrument_type, finding_type=finding_type, limit=5)
+        if instrument_type else []
+    )
+
+    return {
+        "finding_type": finding_type,
+        "timeline": {
+            "event": [{"id": e.id, "title": e.title, "created_at": e.created_at.isoformat()} for e in events],
+            "investigation": [
+                {"id": r.id, "root_cause": r.root_cause, "assigned_by": r.assigned_by, "created_at": r.created_at.isoformat()}
+                for r in investigations
+            ],
+            "capa": [{"id": c["id"], "title": c["title"], "lifecycle_status": c.get("lifecycle_status")} for c in capas],
+            "education": [
+                {"id": r.id, "technician": r.technician, "created_at": r.created_at.isoformat()}
+                for r in education_events
+            ],
+            "policy_change": [{"id": p["id"], "title": p["title"], "version": p["version"], "status": p["status"]} for p in policy_changes],
+            "outcome": outcomes,
+            "verification": verifications,
+            "future_similar_cases": future_similar_cases,
+        },
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/athena_playbook_service.py
+++ b/backend/app/services/athena_playbook_service.py
@@ -1,0 +1,83 @@
+"""v4.8 — Project Athena, Section 5: Clinical Playbooks.
+
+Reuses Project Forge's `WorkflowDefinition`/`forge_workflow_service.py`
+(v4.1) directly — a playbook is a `WorkflowDefinition` row with
+`is_template=True` and `category` set to a clinical-scenario key. No
+parallel playbook model. Decision trees are the existing `nodes_json`/
+`edges_json`; version history and approval reuse Forge's existing
+`version_history`/`publish_workflow` unchanged. Evidence/photos/videos
+attach via `KnowledgeMediaAttachment` (source_type="workflow_definition");
+standards attach via the new `linked_standards_json` column added to
+`WorkflowDefinition` for this sprint.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.workflow_forge import WorkflowDefinition
+from app.services import forge_workflow_service
+
+# The six named clinical scenarios (Section 5) — three already existed in
+# Forge's TEMPLATE_CATEGORIES (loaner_instrument, vendor_tray,
+# robotic_instrument); three were added for Athena.
+CLINICAL_PLAYBOOK_CATEGORIES = [
+    "blood_detection_investigation", "corrosion_investigation", "loaner_instrument",
+    "joint_commission_preparation", "vendor_tray", "robotic_instrument",
+]
+
+
+class PlaybookNotFoundError(ValueError):
+    pass
+
+
+def create_playbook(
+    db: Session, tenant_id: str, *, name: str, category: str, description: str = "",
+    nodes: list[dict], edges: list[dict], author: str, linked_standards: list[str] | None = None,
+) -> dict:
+    if category not in CLINICAL_PLAYBOOK_CATEGORIES:
+        raise ValueError(f"category must be one of {CLINICAL_PLAYBOOK_CATEGORIES}")
+    created = forge_workflow_service.create_workflow(
+        db, tenant_id, name=name, description=description, category=category, nodes=nodes, edges=edges, author=author,
+    )
+    row = forge_workflow_service.get_workflow_row_or_404(db, created["id"])
+    row.is_template = True
+    row.linked_standards_json = json.dumps(linked_standards or [])
+    db.commit()
+    db.refresh(row)
+    return forge_workflow_service.get_workflow(db, row.id)
+
+
+def list_playbooks(db: Session, tenant_id: str, *, category: str = "") -> list[dict]:
+    q = db.query(WorkflowDefinition).filter(
+        (WorkflowDefinition.tenant_id == tenant_id) | (WorkflowDefinition.tenant_id == ""),
+        WorkflowDefinition.is_template.is_(True),
+        WorkflowDefinition.category.in_(CLINICAL_PLAYBOOK_CATEGORIES),
+        WorkflowDefinition.is_current.is_(True),
+    )
+    if category:
+        q = q.filter(WorkflowDefinition.category == category)
+    return [forge_workflow_service.workflow_row_to_dict(r) for r in q.order_by(WorkflowDefinition.id.desc()).all()]
+
+
+def get_playbook(db: Session, workflow_id: int) -> dict:
+    result = forge_workflow_service.get_workflow(db, workflow_id)
+    if result is None:
+        raise PlaybookNotFoundError(f"Playbook {workflow_id} not found.")
+    return result
+
+
+def attach_standard(db: Session, workflow_id: int, standard_code: str) -> dict:
+    row = forge_workflow_service.get_workflow_row_or_404(db, workflow_id)
+    standards = json.loads(row.linked_standards_json or "[]")
+    if standard_code not in standards:
+        standards.append(standard_code)
+    row.linked_standards_json = json.dumps(standards)
+    db.commit()
+    db.refresh(row)
+    return forge_workflow_service.workflow_row_to_dict(row)
+
+
+def playbook_version_history(db: Session, workflow_id: int) -> list[dict]:
+    return forge_workflow_service.version_history(db, workflow_id)

--- a/backend/app/services/athena_preservation_service.py
+++ b/backend/app/services/athena_preservation_service.py
@@ -1,0 +1,129 @@
+"""v4.8 — Project Athena, Section 10: Knowledge Preservation.
+
+No exit-interview, video/voice capture, or workflow-recording system
+existed anywhere in this codebase before Athena — genuinely new.
+`transcript_text` is always human-entered or human-reviewed; this module
+never claims to perform real speech-to-text transcription, matching this
+codebase's "never fabricate a capability" convention. Promoting a session
+into a structured `KnowledgeArticle` reuses `knowledge_repository_service.
+create_article` directly rather than a second article-creation path.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.athena_knowledge import (
+    ATTACH_TO_PRESERVATION_SESSION,
+    DISCLAIMER,
+    MEDIA_TYPES,
+    SESSION_STRUCTURED,
+    SESSION_TRANSCRIBED,
+    KnowledgeMediaAttachment,
+    KnowledgePreservationSession,
+)
+from app.services.knowledge_repository_service import article_to_dict, create_article
+
+
+class PreservationSessionNotFoundError(ValueError):
+    pass
+
+
+class InvalidMediaTypeError(ValueError):
+    pass
+
+
+def _to_dict(row: KnowledgePreservationSession) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "subject_name": row.subject_name,
+        "subject_role": row.subject_role, "session_type": row.session_type, "status": row.status,
+        "summary": row.summary, "transcript_text": row.transcript_text,
+        "topics": json.loads(row.topics_json or "[]"), "converted_article_id": row.converted_article_id,
+        "captured_by": row.captured_by, "human_review_required": True, "disclaimer": DISCLAIMER,
+    }
+
+
+def create_preservation_session(
+    db: Session, tenant_id: str, *, subject_name: str, session_type: str, subject_role: str = "",
+    summary: str = "", captured_by: str = "",
+) -> dict:
+    row = KnowledgePreservationSession(
+        tenant_id=tenant_id, subject_name=subject_name, subject_role=subject_role, session_type=session_type,
+        summary=summary, captured_by=captured_by,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def _get(db: Session, tenant_id: str, session_id: int) -> KnowledgePreservationSession:
+    row = (
+        db.query(KnowledgePreservationSession)
+        .filter(KnowledgePreservationSession.id == session_id, KnowledgePreservationSession.tenant_id == tenant_id)
+        .first()
+    )
+    if row is None:
+        raise PreservationSessionNotFoundError(f"Preservation session {session_id} not found for tenant {tenant_id}.")
+    return row
+
+
+def attach_media(
+    db: Session, tenant_id: str, session_id: int, *, media_type: str, url_or_ref: str,
+    caption: str = "", uploaded_by: str = "",
+) -> dict:
+    if media_type not in MEDIA_TYPES:
+        raise InvalidMediaTypeError(f"media_type must be one of {MEDIA_TYPES}")
+    _get(db, tenant_id, session_id)  # existence check
+    attachment = KnowledgeMediaAttachment(
+        tenant_id=tenant_id, source_type=ATTACH_TO_PRESERVATION_SESSION, source_id=session_id,
+        media_type=media_type, url_or_ref=url_or_ref, caption=caption, uploaded_by=uploaded_by,
+    )
+    db.add(attachment)
+    db.commit()
+    db.refresh(attachment)
+    return {"id": attachment.id, "media_type": attachment.media_type, "url_or_ref": attachment.url_or_ref}
+
+
+def add_transcript(db: Session, tenant_id: str, session_id: int, *, transcript_text: str, topics: list[str] | None = None) -> dict:
+    """Records a human-provided (or human-reviewed) transcript — never a
+    fabricated speech-to-text output."""
+    row = _get(db, tenant_id, session_id)
+    row.transcript_text = transcript_text
+    row.topics_json = json.dumps(topics or [])
+    row.status = SESSION_TRANSCRIBED
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def convert_to_knowledge_article(
+    db: Session, tenant_id: str, session_id: int, *, category: str, title: str, author: str,
+) -> dict:
+    """Promotes tacit knowledge into a structured, governed
+    `KnowledgeArticle` — enters the same draft approval workflow as any
+    other article (Section 2)."""
+    row = _get(db, tenant_id, session_id)
+    body = row.transcript_text or row.summary
+    if not body:
+        raise ValueError("Session has no transcript or summary to convert into an article.")
+    article = create_article(db, tenant_id=tenant_id, category=category, title=title, body=body, author=author)
+    db.commit()
+    db.refresh(article)
+    row.converted_article_id = article.id
+    row.status = SESSION_STRUCTURED
+    db.commit()
+    db.refresh(row)
+    return {"session": _to_dict(row), "article": article_to_dict(article)}
+
+
+def list_sessions(db: Session, tenant_id: str, *, status: str = "") -> list[dict]:
+    q = db.query(KnowledgePreservationSession).filter(KnowledgePreservationSession.tenant_id == tenant_id)
+    if status:
+        q = q.filter(KnowledgePreservationSession.status == status)
+    return [_to_dict(r) for r in q.order_by(KnowledgePreservationSession.created_at.desc()).all()]
+
+
+def get_session(db: Session, tenant_id: str, session_id: int) -> dict:
+    return _to_dict(_get(db, tenant_id, session_id))

--- a/backend/app/services/athena_search_service.py
+++ b/backend/app/services/athena_search_service.py
@@ -1,0 +1,109 @@
+"""v4.8 — Project Athena, Section 7: Organizational Search.
+
+Federates keyword search across every real source the brief names.
+Confirmed via grep: no embeddings/vector search/TF-IDF exists anywhere in
+this codebase — consistent with the platform-wide "deterministic,
+source-grounded, zero real LLM integration" convention, so this stays
+keyword/facet-based rather than introducing a fabricated semantic layer.
+`knowledge_search_service.smart_search` already covers Articles+Cases;
+this widens coverage to Policies/CAPAs/Digital Twins/Inspections/
+Playbooks/Research/Competencies, each result tagged with its real source
+system. "Meeting Notes" has no backing store anywhere in this codebase —
+rather than fabricate one, that source always returns an empty result set
+with an honest reason string.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.apollo_quality import QualityTwinSnapshot
+from app.models.competency_event import CompetencyEvent
+from app.services import capa_lifecycle_service
+from app.services.apollo_policy_service import list_policies
+from app.services.athena_playbook_service import list_playbooks
+from app.services.knowledge_search_service import smart_search
+from app.services.p24_standards_service import get_publications
+
+SOURCE_KNOWLEDGE_ARTICLES = "knowledge_articles"
+SOURCE_POLICIES = "policies"
+SOURCE_CAPAS = "capas"
+SOURCE_DIGITAL_TWINS = "digital_twins"
+SOURCE_INSPECTIONS = "inspections"
+SOURCE_PLAYBOOKS = "playbooks"
+SOURCE_RESEARCH = "research"
+SOURCE_COMPETENCIES = "competencies"
+SOURCE_MEETING_NOTES = "meeting_notes"
+SOURCE_TYPES = [
+    SOURCE_KNOWLEDGE_ARTICLES, SOURCE_POLICIES, SOURCE_CAPAS, SOURCE_DIGITAL_TWINS, SOURCE_INSPECTIONS,
+    SOURCE_PLAYBOOKS, SOURCE_RESEARCH, SOURCE_COMPETENCIES, SOURCE_MEETING_NOTES,
+]
+
+
+def _search_policies(db: Session, tenant_id: str, q: str) -> list[dict]:
+    return [p for p in list_policies(db, tenant_id) if q in p["title"].lower() or q in (p["content"] or "").lower()]
+
+
+def _search_capas(tenant_id: str, q: str) -> list[dict]:
+    rows = capa_lifecycle_service.list_capas(tenant_id, limit=500)
+    return [c for c in rows if q in (c.get("title") or "").lower() or q in (c.get("description") or "").lower()]
+
+
+def _search_digital_twins(db: Session, tenant_id: str, q: str) -> list[dict]:
+    rows = db.query(QualityTwinSnapshot).filter(QualityTwinSnapshot.tenant_id == tenant_id).all()
+    return [
+        {"id": r.id, "department": r.department, "overall_score": r.overall_score, "created_at": r.created_at.isoformat()}
+        for r in rows if q in r.department.lower()
+    ]
+
+
+def _search_inspections(db: Session, tenant_id: str, q: str) -> list[dict]:
+    rows = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id)
+        .order_by(models.Inspection.id.desc())
+        .limit(200)
+        .all()
+    )
+    return [
+        {"id": r.id, "instrument_type": r.instrument_type, "detected_issue": r.detected_issue, "created_at": r.created_at.isoformat()}
+        for r in rows if q in (r.instrument_type or "").lower() or q in (r.detected_issue or "").lower()
+    ]
+
+
+def _search_playbooks(db: Session, tenant_id: str, q: str) -> list[dict]:
+    return [p for p in list_playbooks(db, tenant_id) if q in p["name"].lower() or q in (p.get("description") or "").lower()]
+
+
+def _search_research(db: Session, q: str) -> list[dict]:
+    publications = get_publications(db)
+    return [p for p in publications if q in p["title"].lower() or q in (p.get("abstract") or "").lower()]
+
+
+def _search_competencies(db: Session, tenant_id: str, q: str) -> list[dict]:
+    rows = db.query(CompetencyEvent).filter(CompetencyEvent.tenant_id == tenant_id).all()
+    return [
+        {"id": r.id, "technician": r.technician, "event_type": r.event_type, "finding_type": r.finding_type}
+        for r in rows if q in (r.finding_type or "").lower() or q in r.technician.lower()
+    ]
+
+
+def organizational_search(db: Session, tenant_id: str, query: str, *, actor: str = "") -> dict:
+    q = (query or "").strip().lower()
+    core = smart_search(db, tenant_id, query, actor=actor)
+
+    return {
+        "query": query,
+        SOURCE_KNOWLEDGE_ARTICLES: core["articles"] + core["cases"],
+        SOURCE_POLICIES: _search_policies(db, tenant_id, q) if q else [],
+        SOURCE_CAPAS: _search_capas(tenant_id, q) if q else [],
+        SOURCE_DIGITAL_TWINS: _search_digital_twins(db, tenant_id, q) if q else [],
+        SOURCE_INSPECTIONS: _search_inspections(db, tenant_id, q) if q else [],
+        SOURCE_PLAYBOOKS: _search_playbooks(db, tenant_id, q) if q else [],
+        SOURCE_RESEARCH: _search_research(db, q) if q else [],
+        SOURCE_COMPETENCIES: _search_competencies(db, tenant_id, q) if q else [],
+        SOURCE_MEETING_NOTES: {
+            "results": [], "reason": "No meeting-notes store exists in this codebase yet — not fabricated.",
+        },
+        "human_review_required": True,
+    }

--- a/backend/app/services/athena_trust_service.py
+++ b/backend/app/services/athena_trust_service.py
@@ -1,0 +1,95 @@
+"""v4.8 — Project Athena, Section 8: Knowledge Trust Score.
+
+No trust/reputation/evidence-quality construct exists anywhere in this
+codebase (`beacon_standards_service.py`/`p24_standards_service.py` only
+carry `version`/`status`). Every component below is computed live from
+real `KnowledgeArticle` fields and Apollo's existing
+`competency_service.record_knowledge_contribution` log — never persisted
+as a fabricated number, and never claiming a precision this codebase's
+data doesn't support.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import APPROVED, KnowledgeArticle
+from app.services import competency_service
+
+# Equal weighting across the seven named components — documented here
+# since it's the one genuinely new scoring decision in this file.
+_APPROVAL_STATUS_SCORES = {"approved": 100.0, "pending_review": 50.0, "draft": 25.0, "rejected": 0.0, "archived": 10.0}
+_REVIEW_RECENCY_DAYS = 365
+
+
+def _evidence_quality(article: KnowledgeArticle) -> float:
+    body_score = min(100.0, 100 * len(article.body) / 500)
+    standards = json.loads(article.linked_standards_json or "[]")
+    standards_score = min(100.0, 25.0 * len(standards))
+    references_score = 100.0 if article.references.strip() else 0.0
+    return round((body_score + standards_score + references_score) / 3, 1)
+
+
+def _clinical_validation(article: KnowledgeArticle) -> float:
+    if article.approval_status != APPROVED:
+        return 0.0
+    return 100.0 if article.reviewer.strip() else 60.0
+
+
+def _usage(article: KnowledgeArticle) -> float:
+    return round(min(100.0, article.view_count * 5.0), 1)
+
+
+def _review_recency(article: KnowledgeArticle) -> float:
+    if article.last_reviewed_at is None:
+        return 0.0
+    age_days = (datetime.now(timezone.utc) - article.last_reviewed_at).days
+    if age_days <= 0:
+        return 100.0
+    return round(max(0.0, 100.0 - 100.0 * age_days / _REVIEW_RECENCY_DAYS), 1)
+
+
+def _approval_status_score(article: KnowledgeArticle) -> float:
+    return _APPROVAL_STATUS_SCORES.get(article.approval_status, 0.0)
+
+
+def _contributor_reputation(db: Session, article: KnowledgeArticle) -> float:
+    if not article.author:
+        return 0.0
+    summary = competency_service.competency_summary(db, article.author)
+    return round(min(100.0, 20.0 * summary["knowledge_contributions"]), 1)
+
+
+def _reference_strength(article: KnowledgeArticle) -> float:
+    standards = json.loads(article.linked_standards_json or "[]")
+    return round(min(100.0, 25.0 * len(standards)), 1)
+
+
+def compute_trust_score(db: Session, article: KnowledgeArticle) -> dict:
+    components = {
+        "evidence_quality": _evidence_quality(article),
+        "clinical_validation": _clinical_validation(article),
+        "usage": _usage(article),
+        "review_date_recency": _review_recency(article),
+        "approval_status": _approval_status_score(article),
+        "contributor_reputation": _contributor_reputation(db, article),
+        "reference_strength": _reference_strength(article),
+    }
+    overall = round(sum(components.values()) / len(components), 1)
+    return {
+        "article_id": article.id, "title": article.title, "components": components,
+        "overall_trust_score": overall, "human_review_required": True,
+    }
+
+
+def list_articles_with_trust(db: Session, tenant_id: str, *, min_trust: float | None = None) -> list[dict]:
+    """Every article's trust score, filterable by minimum trust level
+    (Section 8: "Organizations can filter by trust level")."""
+    rows = db.query(KnowledgeArticle).filter(KnowledgeArticle.tenant_id == tenant_id).all()
+    scored = [compute_trust_score(db, r) for r in rows]
+    if min_trust is not None:
+        scored = [s for s in scored if s["overall_trust_score"] >= min_trust]
+    scored.sort(key=lambda s: s["overall_trust_score"], reverse=True)
+    return scored

--- a/backend/app/services/capa_suggestion_service.py
+++ b/backend/app/services/capa_suggestion_service.py
@@ -7,6 +7,14 @@ These are suggestions for a human to review and act on (via
 POST /api/quality/capa-suggestions/{id}/create), never auto-created CAPAs —
 consistent with the platform-wide rule that AI output never bypasses human
 review.
+
+v4.7 — Project Apollo additive detectors (Section 2 of the Apollo brief):
+repeat repairs, supervisor overrides, AI confidence decline, inspection
+failures, and customer complaints. Each reuses an existing store
+(`RepairRequest`, `SupervisorReview`, `sentinel_ai_health_service`,
+`Inspection.disposition`, `CustomerComplaint`) rather than adding a new
+detection data model — consistent with this file's existing pattern of
+composing real recurrence counts, never a fabricated score.
 """
 from __future__ import annotations
 
@@ -16,7 +24,10 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
 
 from app.db import models
+from app.models.apollo_quality import CustomerComplaint
 from app.models.inspection_finding import InspectionFinding
+from app.models.or_connect import RepairRequest
+from app.models.supervisor_review import SupervisorReview
 from app.services.instrument_anatomy import resolve_family
 
 # A finding-type/zone or finding-type/family repeated at least this many times
@@ -25,6 +36,10 @@ _REPEAT_THRESHOLD = 3
 _LOOKBACK_DAYS = 90
 
 _CONDITION_TYPES = {"rust", "corrosion", "pitting", "crack", "insulation_damage", "missing_component"}
+
+# Apollo detectors reuse the same repeat threshold/lookback window as the
+# pre-existing detectors above for consistency.
+_FAILURE_DISPOSITIONS = {"REPROCESS", "REMOVE FROM SERVICE"}
 
 
 def generate_capa_suggestions(db: Session, tenant_id: str) -> list[dict]:
@@ -95,6 +110,108 @@ def generate_capa_suggestions(db: Session, tenant_id: str) -> list[dict]:
                 "suggested_title": f"CAPA: Image capture quality — {technician}",
                 "corrective_action": f"Schedule an image-capture refresher for {technician}.",
                 "preventive_action": "Add lighting/angle guidance to the guided-capture workflow.",
+            })
+
+    # v4.7 Apollo — repeated repairs on the same instrument identity.
+    repair_rows = (
+        db.query(RepairRequest)
+        .filter(RepairRequest.tenant_id == tenant_id, RepairRequest.created_at >= since)
+        .all()
+    )
+    repair_counts: dict[str, int] = defaultdict(int)
+    for rr in repair_rows:
+        if rr.instrument_identity:
+            repair_counts[rr.instrument_identity] += 1
+    for instrument_identity, count in repair_counts.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated repairs on {instrument_identity}",
+                "occurrences": count,
+                "recommendation": "Evaluate this instrument for retirement or root-cause failure analysis.",
+                "suggested_title": f"CAPA: Repeat repairs — {instrument_identity}",
+                "corrective_action": f"Perform a root-cause review of recurring repair requests for {instrument_identity}.",
+                "preventive_action": "Evaluate instrument for retirement/replacement and monitor repair recurrence.",
+            })
+
+    # v4.7 Apollo — repeated supervisor overrides/disagreements by technician.
+    review_rows = (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.tenant_id == tenant_id, SupervisorReview.created_at >= since)
+        .all()
+    )
+    override_counts: dict[str, int] = defaultdict(int)
+    for rv in review_rows:
+        if rv.agreement == "disagree" or rv.override_action:
+            override_counts[rv.reviewer_name or "unknown"] += 1
+    for reviewer_name, count in override_counts.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated supervisor overrides recorded by {reviewer_name}",
+                "occurrences": count,
+                "recommendation": "Review AI recommendation quality and technician training for the overridden findings.",
+                "suggested_title": f"CAPA: Repeated supervisor overrides — {reviewer_name}",
+                "corrective_action": "Review the overridden AI recommendations and underlying inspections for a common cause.",
+                "preventive_action": "Track override rate going forward and escalate if recurrence continues.",
+            })
+
+    # v4.7 Apollo — AI confidence decline (reuses sentinel_ai_health_service's
+    # real drift detection rather than re-deriving it).
+    from app.services.sentinel_ai_health_service import _detect_drift
+
+    drift_detected, drift_detail = _detect_drift(db, tenant_id)
+    if drift_detected:
+        suggestions.append({
+            "trigger": "AI confidence/agreement drift detected",
+            "occurrences": 1,
+            "recommendation": "Investigate the AI health drift signal before it affects clinical decisions.",
+            "suggested_title": "CAPA: AI confidence decline",
+            "corrective_action": f"Investigate root cause of drift: {drift_detail}",
+            "preventive_action": "Re-baseline AI health monitoring after root cause is addressed and monitor recurrence.",
+        })
+
+    # v4.7 Apollo — repeated inspection failures (REPROCESS/REMOVE FROM
+    # SERVICE disposition) on the same instrument type.
+    failure_rows = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id,
+            models.Inspection.created_at >= since,
+            models.Inspection.disposition.in_(_FAILURE_DISPOSITIONS),
+        )
+        .all()
+    )
+    failure_counts: dict[str, int] = defaultdict(int)
+    for r in failure_rows:
+        failure_counts[r.instrument_type or "unknown"] += 1
+    for instrument_type, count in failure_counts.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated inspection failures (reprocess/remove-from-service) on {instrument_type}",
+                "occurrences": count,
+                "recommendation": "Review manufacturing/cleaning/handling process for this instrument type.",
+                "suggested_title": f"CAPA: Repeated inspection failures — {instrument_type}",
+                "corrective_action": f"Investigate process contributing to reprocess/remove-from-service dispositions for {instrument_type}.",
+                "preventive_action": f"Add {instrument_type} to enhanced monitoring and re-audit after corrective action.",
+            })
+
+    # v4.7 Apollo — repeated customer complaints on the same instrument type.
+    complaint_rows = (
+        db.query(CustomerComplaint)
+        .filter(CustomerComplaint.tenant_id == tenant_id, CustomerComplaint.created_at >= since)
+        .all()
+    )
+    complaint_counts: dict[str, int] = defaultdict(int)
+    for c in complaint_rows:
+        complaint_counts[c.instrument_type or "unknown"] += 1
+    for instrument_type, count in complaint_counts.items():
+        if count >= _REPEAT_THRESHOLD:
+            suggestions.append({
+                "trigger": f"Repeated customer complaints on {instrument_type}",
+                "occurrences": count,
+                "recommendation": "Review customer complaint detail for a common contributing factor.",
+                "suggested_title": f"CAPA: Repeated customer complaints — {instrument_type}",
+                "corrective_action": f"Review complaint records and link relevant ones to this CAPA for {instrument_type}.",
+                "preventive_action": "Monitor complaint recurrence and close the loop with the reporting source.",
             })
 
     suggestions.sort(key=lambda s: s["occurrences"], reverse=True)

--- a/backend/app/services/competency_service.py
+++ b/backend/app/services/competency_service.py
@@ -76,6 +76,48 @@ def record_education_completed(db: Session, *, tenant_id: str, technician: str, 
             event_type="education_completed", finding_type=finding_type)
 
 
+# v4.7 Project Apollo — four new event types on this same log (Section 5:
+# Competency Center), reusing `finding_type` as the free-text subject label
+# (procedure name / competency cycle / scenario+outcome / contribution topic)
+# rather than adding new columns to CompetencyEvent.
+
+def record_annual_competency(db: Session, *, tenant_id: str, technician: str, competency_area: str) -> None:
+    """A technician completed their annual competency assessment for a given
+    area (e.g. "flexible endoscope reprocessing")."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="annual_competency", finding_type=competency_area[:40])
+
+
+def record_procedure_validation(db: Session, *, tenant_id: str, technician: str, procedure_name: str) -> None:
+    """A technician was validated on a specific reprocessing procedure."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="procedure_validation", finding_type=procedure_name[:40])
+
+
+def record_simulation_result(db: Session, *, tenant_id: str, technician: str, scenario: str, passed: bool) -> None:
+    """A technician completed a simulation-based training scenario. Result is
+    encoded in the event_type itself (simulation_passed/simulation_failed) —
+    never fabricated as a score with no basis."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="simulation_passed" if passed else "simulation_failed",
+            finding_type=scenario[:40])
+
+
+def record_knowledge_contribution(db: Session, *, tenant_id: str, technician: str, topic: str) -> None:
+    """A technician contributed to the Standards Knowledge Library (e.g. an
+    authored best-practice note or a reviewed article)."""
+    if not technician:
+        return
+    _record(db, tenant_id=tenant_id, technician=technician,
+            event_type="knowledge_contribution", finding_type=topic[:40])
+
+
 def _count(db: Session, technician: str, event_type: str) -> int:
     return (
         db.query(func.count(CompetencyEvent.id))
@@ -117,6 +159,13 @@ def competency_summary(db: Session, technician: str) -> dict:
         if supervisor_corrections else None
     )
 
+    # v4.7 Project Apollo — counts for the four new event types (Section 5).
+    annual_competencies = _count(db, technician, "annual_competency")
+    procedure_validations = _count(db, technician, "procedure_validation")
+    simulations_passed = _count(db, technician, "simulation_passed")
+    simulations_failed = _count(db, technician, "simulation_failed")
+    knowledge_contributions = _count(db, technician, "knowledge_contribution")
+
     return {
         "technician": technician,
         "findings_reviewed": findings_reviewed,
@@ -125,6 +174,11 @@ def competency_summary(db: Session, technician: str) -> dict:
         "education_completed": education_completed,
         "training_progress_pct": training_progress_pct,
         "has_activity": total_activity > 0,
+        "annual_competencies": annual_competencies,
+        "procedure_validations": procedure_validations,
+        "simulations_passed": simulations_passed,
+        "simulations_failed": simulations_failed,
+        "knowledge_contributions": knowledge_contributions,
     }
 
 

--- a/backend/app/services/continuous_improvement_service.py
+++ b/backend/app/services/continuous_improvement_service.py
@@ -11,6 +11,10 @@ from app.models.continuous_improvement import ContinuousImprovementInitiative
 def create_initiative(
     db: Session, *, tenant_id: str, initiative: str, owner: str = "",
     target_date: date | None = None, expected_impact: str = "",
+    # v4.7 Project Apollo — Continuous Improvement Portfolio fields.
+    methodology: str = "", cost_savings_usd: float | None = None,
+    quality_improvement_metric: str = "", risk_reduction_metric: str = "",
+    executive_visible: bool = False,
 ) -> ContinuousImprovementInitiative:
     row = ContinuousImprovementInitiative(
         tenant_id=tenant_id,
@@ -18,6 +22,11 @@ def create_initiative(
         owner=owner,
         target_date=target_date,
         expected_impact=expected_impact,
+        methodology=methodology,
+        cost_savings_usd=cost_savings_usd,
+        quality_improvement_metric=quality_improvement_metric,
+        risk_reduction_metric=risk_reduction_metric,
+        executive_visible=executive_visible,
     )
     db.add(row)
     return row
@@ -35,6 +44,9 @@ def list_initiatives(db: Session, tenant_id: str) -> list[ContinuousImprovementI
 def update_initiative(
     db: Session, *, initiative_id: int, tenant_id: str,
     status: str | None = None, actual_impact: str | None = None,
+    # v4.7 Project Apollo — Continuous Improvement Portfolio fields.
+    cost_savings_usd: float | None = None, quality_improvement_metric: str | None = None,
+    risk_reduction_metric: str | None = None, executive_visible: bool | None = None,
 ) -> ContinuousImprovementInitiative | None:
     row = (
         db.query(ContinuousImprovementInitiative)
@@ -50,4 +62,12 @@ def update_initiative(
         row.status = status
     if actual_impact is not None:
         row.actual_impact = actual_impact
+    if cost_savings_usd is not None:
+        row.cost_savings_usd = cost_savings_usd
+    if quality_improvement_metric is not None:
+        row.quality_improvement_metric = quality_improvement_metric
+    if risk_reduction_metric is not None:
+        row.risk_reduction_metric = risk_reduction_metric
+    if executive_visible is not None:
+        row.executive_visible = executive_visible
     return row

--- a/backend/app/services/forge_template_service.py
+++ b/backend/app/services/forge_template_service.py
@@ -43,6 +43,10 @@ _TEMPLATE_NAMES = {
     "orthopedic": "Orthopedic Workflow",
     "neurosurgery": "Neurosurgery Workflow",
     "custom_organization": "Custom Organization Workflow",
+    # v4.8 — Project Athena Clinical Playbooks (Section 5).
+    "blood_detection_investigation": "Blood Detection Investigation Workflow",
+    "corrosion_investigation": "Corrosion Investigation Workflow",
+    "joint_commission_preparation": "Joint Commission Preparation Workflow",
 }
 
 

--- a/backend/app/services/forge_workflow_service.py
+++ b/backend/app/services/forge_workflow_service.py
@@ -32,7 +32,7 @@ class InvalidWorkflowStateError(Exception):
     pass
 
 
-def _row_to_dict(obj) -> dict:
+def workflow_row_to_dict(obj) -> dict:
     result: dict = {}
     for col in obj.__table__.columns:
         val = getattr(obj, col.name)
@@ -68,7 +68,7 @@ def create_workflow(
     db.add(row)
     db.commit()
     db.refresh(row)
-    return _row_to_dict(row)
+    return workflow_row_to_dict(row)
 
 
 def get_workflow_row_or_404(db: Session, workflow_id: int) -> WorkflowDefinition:
@@ -80,7 +80,7 @@ def get_workflow_row_or_404(db: Session, workflow_id: int) -> WorkflowDefinition
 
 def get_workflow(db: Session, workflow_id: int) -> dict | None:
     row = db.query(WorkflowDefinition).filter(WorkflowDefinition.id == workflow_id).first()
-    return _row_to_dict(row) if row else None
+    return workflow_row_to_dict(row) if row else None
 
 
 def list_workflows(db: Session, tenant_id: str, *, category: str = "", current_only: bool = True) -> list[dict]:
@@ -91,7 +91,7 @@ def list_workflows(db: Session, tenant_id: str, *, category: str = "", current_o
         q = q.filter(WorkflowDefinition.category == category)
     if current_only:
         q = q.filter(WorkflowDefinition.is_current.is_(True))
-    return [_row_to_dict(r) for r in q.order_by(WorkflowDefinition.id.desc()).all()]
+    return [workflow_row_to_dict(r) for r in q.order_by(WorkflowDefinition.id.desc()).all()]
 
 
 def revise_workflow(
@@ -118,7 +118,7 @@ def revise_workflow(
         original.updated_at = datetime.now(timezone.utc)
         db.commit()
         db.refresh(original)
-        return _row_to_dict(original)
+        return workflow_row_to_dict(original)
 
     new_row = WorkflowDefinition(
         tenant_id=original.tenant_id, workflow_ref=original.workflow_ref,
@@ -134,7 +134,7 @@ def revise_workflow(
     db.add(new_row)
     db.commit()
     db.refresh(new_row)
-    return _row_to_dict(new_row)
+    return workflow_row_to_dict(new_row)
 
 
 def publish_workflow(db: Session, workflow_id: int, *, approved_by: str) -> dict:
@@ -147,7 +147,7 @@ def publish_workflow(db: Session, workflow_id: int, *, approved_by: str) -> dict
     row.effective_date = row.effective_date or datetime.now(timezone.utc)
     db.commit()
     db.refresh(row)
-    return _row_to_dict(row)
+    return workflow_row_to_dict(row)
 
 
 def archive_workflow(db: Session, workflow_id: int) -> dict:
@@ -156,7 +156,7 @@ def archive_workflow(db: Session, workflow_id: int) -> dict:
     row.is_current = False
     db.commit()
     db.refresh(row)
-    return _row_to_dict(row)
+    return workflow_row_to_dict(row)
 
 
 def version_history(db: Session, workflow_id: int) -> list[dict]:
@@ -184,7 +184,7 @@ def version_history(db: Session, workflow_id: int) -> list[dict]:
         current = db.query(WorkflowDefinition).filter(WorkflowDefinition.id == current_id).first()
         if current is None:
             break
-        chain.append(_row_to_dict(current))
+        chain.append(workflow_row_to_dict(current))
         successor = db.query(WorkflowDefinition).filter(WorkflowDefinition.supersedes_id == current_id).first()
         current_id = successor.id if successor else None
     return chain
@@ -212,4 +212,4 @@ def rollback_to_version(db: Session, workflow_id: int, target_version_id: int, *
     target.reviewer = rolled_back_by
     db.commit()
     db.refresh(target)
-    return _row_to_dict(target)
+    return workflow_row_to_dict(target)

--- a/backend/app/services/regulatory_standards_catalogue.py
+++ b/backend/app/services/regulatory_standards_catalogue.py
@@ -6,6 +6,10 @@ Standards covered:
 - FDA 21 CFR Part 820 (Quality System Regulation)
 - CMS Conditions of Participation
 - ISO 17664 (sterilization of health-care products)
+- v4.7 Project Apollo additions: AAMI ST91 (flexible/semi-rigid endoscope
+  reprocessing — distinct body code `aami_st91` from ST79's `aami`), AORN
+  (perioperative practice standards), DNV (accreditation body, alternative
+  to Joint Commission).
 """
 from __future__ import annotations
 from dataclasses import dataclass
@@ -101,6 +105,38 @@ STANDARDS: list[StandardDef] = [
         "ISO 17664-1: Sterilization — IFU for medical devices",
         "Manufacturers shall provide instructions for use (IFU) that describe validated decontamination and sterilization processes. Deviations from IFU are non-conformances.",
         "ifu_compliance", "SPD,Quality"),
+
+    # v4.7 Project Apollo — AAMI ST91 (flexible/semi-rigid endoscope
+    # reprocessing). Distinct body code from ST79's "aami".
+    StandardDef("AAMI-ST91-6", "aami_st91",
+        "ST91 Section 6: Point-of-use treatment and transport of flexible endoscopes",
+        "Flexible endoscopes shall receive point-of-use treatment immediately after the procedure and be transported in a manner that prevents drying of soil.",
+        "endoscope_reprocessing", "SPD,GI/Endo"),
+    StandardDef("AAMI-ST91-9", "aami_st91",
+        "ST91 Section 9: Manual cleaning and leak testing of flexible endoscopes",
+        "Flexible endoscopes shall undergo leak testing before manual cleaning; a failed leak test indicates internal damage and requires removal from service.",
+        "endoscope_reprocessing", "SPD,GI/Endo"),
+
+    # v4.7 Project Apollo — AORN perioperative practice standards.
+    StandardDef("AORN-INSTR-01", "aorn",
+        "AORN Guideline for Care and Cleaning of Surgical Instruments",
+        "Perioperative team members should collaborate with SPD on point-of-use treatment, transport, and instrument tray assembly to reduce the risk of instrument damage and contamination.",
+        "instrument_handling", "OR,SPD"),
+    StandardDef("AORN-COUNT-01", "aorn",
+        "AORN Guideline for Sharps Safety and Surgical Counts",
+        "Instrument, sponge, and sharps counts should be performed and documented per facility policy to prevent retained surgical items.",
+        "surgical_counts", "OR"),
+
+    # v4.7 Project Apollo — DNV accreditation standards (alternative to
+    # Joint Commission).
+    StandardDef("DNV-QM.3", "dnv",
+        "DNV NIAHO Quality Management System Standard QM.3",
+        "The organization shall establish a quality management system that identifies, monitors, and corrects nonconformances, including those affecting instrument reprocessing.",
+        "quality_management", "Enterprise,Quality"),
+    StandardDef("DNV-IC.4", "dnv",
+        "DNV NIAHO Infection Control Standard IC.4",
+        "The organization shall have a documented process for high-level disinfection and sterilization of reusable medical devices consistent with manufacturer IFU.",
+        "infection_control", "SPD,Quality"),
 ]
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -108,6 +108,7 @@ def _force_import_models():
         "app.models.catalyst_copilot",
         "app.models.orbit_readiness",
         "app.models.vanguard_intelligence",
+        "app.models.apollo_quality",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -109,6 +109,7 @@ def _force_import_models():
         "app.models.orbit_readiness",
         "app.models.vanguard_intelligence",
         "app.models.apollo_quality",
+        "app.models.athena_knowledge",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/test_apollo_quality.py
+++ b/backend/tests/test_apollo_quality.py
@@ -1,0 +1,494 @@
+"""v4.7 — LumenAI OS: Project Apollo — Autonomous Clinical Quality
+Management System (CQMS) tests.
+
+Covers: CAPA Engine, Root Cause Intelligence, Audit workflows, Competency
+Center, Policy Intelligence, Standards Library, Quality Digital Twin, and
+the Executive Quality Dashboard.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.apollo_quality import CustomerComplaint
+from app.models.inspection import Inspection
+from app.models.or_connect import RepairRequest
+from app.models.supervisor_review import SupervisorReview
+from app.services import (
+    apollo_audit_center_service,
+    apollo_capa_engine_service,
+    apollo_competency_center_service,
+    apollo_executive_quality_service,
+    apollo_improvement_portfolio_service,
+    apollo_policy_service,
+    apollo_quality_twin_service,
+    apollo_rca_intelligence_service,
+    apollo_standards_library_service,
+)
+from app.services.capa_suggestion_service import generate_capa_suggestions
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+# ── 1. CAPA Engine ────────────────────────────────────────────────────────────
+
+def test_capa_engine_summary_composes_lifecycle_and_suggestions():
+    tenant_id = uid("apollo-capa")
+    db = SessionLocal()
+    try:
+        result = apollo_capa_engine_service.capa_engine_summary(db, tenant_id)
+    finally:
+        db.close()
+    assert "lifecycle_counts" in result
+    assert "pending_suggestions" in result
+    assert result["human_review_required"] is True
+
+
+def test_repeat_repairs_detector_triggers_capa_suggestion():
+    tenant_id = uid("apollo-repairs")
+    db = SessionLocal()
+    try:
+        for _ in range(3):
+            db.add(RepairRequest(
+                tenant_id=tenant_id, inspection_id=1, instrument_identity="SCOPE-XYZ-001",
+                vendor_name="Acme Repairs", repair_type="general",
+            ))
+        db.commit()
+        suggestions = generate_capa_suggestions(db, tenant_id)
+    finally:
+        db.close()
+    triggers = [s["trigger"] for s in suggestions]
+    assert any("Repeated repairs" in t for t in triggers)
+
+
+def test_supervisor_overrides_detector_triggers_capa_suggestion():
+    tenant_id = uid("apollo-overrides")
+    db = SessionLocal()
+    try:
+        for i in range(3):
+            db.add(SupervisorReview(
+                inspection_id=i + 1, tenant_id=tenant_id, reviewer_name="Dr. Smith",
+                agreement="disagree", override_action="reprocess",
+            ))
+        db.commit()
+        suggestions = generate_capa_suggestions(db, tenant_id)
+    finally:
+        db.close()
+    triggers = [s["trigger"] for s in suggestions]
+    assert any("supervisor overrides" in t for t in triggers)
+
+
+def test_inspection_failures_detector_triggers_capa_suggestion():
+    tenant_id = uid("apollo-failures")
+    db = SessionLocal()
+    try:
+        for _ in range(3):
+            db.add(Inspection(
+                file_name="test.jpg", tenant_id=tenant_id, instrument_type="Kerrison Rongeur",
+                disposition="REMOVE FROM SERVICE",
+            ))
+        db.commit()
+        suggestions = generate_capa_suggestions(db, tenant_id)
+    finally:
+        db.close()
+    triggers = [s["trigger"] for s in suggestions]
+    assert any("inspection failures" in t for t in triggers)
+
+
+def test_customer_complaint_lifecycle():
+    tenant_id = uid("apollo-complaint")
+    db = SessionLocal()
+    try:
+        complaint = apollo_capa_engine_service.create_complaint(
+            db, tenant_id, source="clinical_staff", description="Instrument arrived damaged",
+            severity="high", instrument_type="Forceps",
+        )
+        assert complaint.status == "open"
+        linked = apollo_capa_engine_service.link_complaint_to_capa(db, tenant_id, complaint.id, capa_id="42")
+        assert linked.status == "linked_to_capa"
+        assert linked.linked_capa_id == "42"
+    finally:
+        db.close()
+
+
+def test_repeated_customer_complaints_detector_triggers_capa_suggestion():
+    tenant_id = uid("apollo-complaints-repeat")
+    db = SessionLocal()
+    try:
+        for _ in range(3):
+            db.add(CustomerComplaint(
+                tenant_id=tenant_id, source="clinic", description="damaged on arrival",
+                severity="medium", instrument_type="Retractor",
+            ))
+        db.commit()
+        suggestions = generate_capa_suggestions(db, tenant_id)
+    finally:
+        db.close()
+    triggers = [s["trigger"] for s in suggestions]
+    assert any("customer complaints" in t for t in triggers)
+
+
+def test_capa_summary_route_requires_auth():
+    tenant_id = uid("apollo-capa-route")
+    resp = client.get("/api/apollo/capa/summary", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 200
+    assert "lifecycle_counts" in resp.json()
+
+    resp_noauth = client.get("/api/apollo/capa/summary")
+    assert resp_noauth.status_code in (401, 403)
+
+
+# ── 2. Root Cause Intelligence ────────────────────────────────────────────────
+
+def test_pareto_view_returns_ranked_root_causes():
+    tenant_id = uid("apollo-rca-pareto")
+    db = SessionLocal()
+    try:
+        result = apollo_rca_intelligence_service.pareto_view(db, tenant_id)
+    finally:
+        db.close()
+    assert result["methodology"] == "pareto"
+    assert "rows" in result
+    assert result["human_review_required"] is True
+
+
+def test_trend_view_returns_by_finding_type():
+    tenant_id = uid("apollo-rca-trend")
+    db = SessionLocal()
+    try:
+        result = apollo_rca_intelligence_service.trend_view(db, tenant_id)
+    finally:
+        db.close()
+    assert result["methodology"] == "trend_analysis"
+    assert "by_finding_type" in result
+
+
+def test_rca_summary_composes_pareto_and_trend():
+    tenant_id = uid("apollo-rca-summary")
+    db = SessionLocal()
+    try:
+        result = apollo_rca_intelligence_service.rca_intelligence_summary(db, tenant_id)
+    finally:
+        db.close()
+    assert "pareto" in result
+    assert "trend_analysis" in result
+    assert "pending_draft_count" in result
+
+
+def test_rca_route_pareto():
+    tenant_id = uid("apollo-rca-route")
+    resp = client.get("/api/apollo/rca/pareto", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 200
+    assert resp.json()["methodology"] == "pareto"
+
+
+def test_five_whys_view_missing_draft_raises_404_via_route():
+    tenant_id = uid("apollo-rca-404")
+    resp = client.get("/api/apollo/rca/five-whys/999999", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 404
+
+
+# ── 3. Audit workflows ────────────────────────────────────────────────────────
+
+def test_audit_center_summary_lists_all_package_types():
+    tenant_id = uid("apollo-audit-summary")
+    db = SessionLocal()
+    try:
+        result = apollo_audit_center_service.audit_center_summary(db, tenant_id)
+    finally:
+        db.close()
+    for pkg_type in ("aami_st91", "aorn", "dnv", "internal", "vendor"):
+        assert pkg_type in result["supported_package_types"]
+
+
+def test_generate_audit_for_new_package_types():
+    tenant_id = uid("apollo-audit-gen")
+    db = SessionLocal()
+    try:
+        for package_type in ("aami_st91", "aorn", "dnv", "internal", "vendor"):
+            result = apollo_audit_center_service.generate_audit(
+                tenant_id, package_type=package_type, generated_by="tester", db=db,
+            )
+            assert result["package_type"] == package_type
+    finally:
+        db.close()
+
+
+def test_generate_audit_rejects_unsupported_package_type():
+    tenant_id = uid("apollo-audit-bad")
+    db = SessionLocal()
+    try:
+        try:
+            apollo_audit_center_service.generate_audit(tenant_id, package_type="not_a_real_body", db=db)
+            assert False, "expected UnsupportedAuditPackageTypeError"
+        except apollo_audit_center_service.UnsupportedAuditPackageTypeError:
+            pass
+    finally:
+        db.close()
+
+
+def test_audit_generate_route():
+    tenant_id = uid("apollo-audit-route")
+    resp = client.post(
+        "/api/apollo/audit/generate", json={"package_type": "dnv"}, headers=_headers(AUTH_MGR, tenant_id),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["package_type"] == "dnv"
+
+
+def test_audit_generate_route_forbidden_for_viewer():
+    tenant_id = uid("apollo-audit-viewer")
+    resp = client.post(
+        "/api/apollo/audit/generate", json={"package_type": "internal"}, headers=_headers(AUTH_VIEWER, tenant_id),
+    )
+    assert resp.status_code == 403
+
+
+# ── 4. Competencies ────────────────────────────────────────────────────────────
+
+def test_record_annual_competency_and_summary():
+    tenant_id = uid("apollo-competency")
+    db = SessionLocal()
+    try:
+        result = apollo_competency_center_service.record_annual_competency(
+            db, tenant_id=tenant_id, technician="tech-apollo-1", competency_area="endoscope reprocessing",
+        )
+        assert result["annual_competencies"] == 1
+    finally:
+        db.close()
+
+
+def test_record_simulation_result_pass_and_fail():
+    tenant_id = uid("apollo-sim")
+    db = SessionLocal()
+    try:
+        passed = apollo_competency_center_service.record_simulation_result(
+            db, tenant_id=tenant_id, technician="tech-apollo-2", scenario="mock_recall_drill", passed=True,
+        )
+        assert passed["simulations_passed"] == 1
+        failed = apollo_competency_center_service.record_simulation_result(
+            db, tenant_id=tenant_id, technician="tech-apollo-2", scenario="mock_recall_drill", passed=False,
+        )
+        assert failed["simulations_failed"] == 1
+    finally:
+        db.close()
+
+
+def test_record_knowledge_contribution():
+    tenant_id = uid("apollo-knowledge")
+    db = SessionLocal()
+    try:
+        result = apollo_competency_center_service.record_knowledge_contribution(
+            db, tenant_id=tenant_id, technician="tech-apollo-3", topic="Best practice: lumen brushing",
+        )
+        assert result["knowledge_contributions"] == 1
+    finally:
+        db.close()
+
+
+def test_competency_route_requires_leadership_role():
+    tenant_id = uid("apollo-competency-route")
+    resp = client.post(
+        "/api/apollo/competency/annual", json={"technician": "tech-route", "competency_area": "sterilization"},
+        headers=_headers(AUTH_VIEWER, tenant_id),
+    )
+    assert resp.status_code == 403
+
+    resp_admin = client.post(
+        "/api/apollo/competency/annual", json={"technician": "tech-route", "competency_area": "sterilization"},
+        headers=_headers(AUTH_ADMIN, tenant_id),
+    )
+    assert resp_admin.status_code == 200
+
+
+# ── 5. Policies ────────────────────────────────────────────────────────────────
+
+def test_create_and_publish_policy_versioning():
+    tenant_id = uid("apollo-policy")
+    db = SessionLocal()
+    try:
+        v1 = apollo_policy_service.create_policy(db, tenant_id, title="Endoscope Reprocessing Policy", owner="Quality Director")
+        assert v1["version"] == 1
+        assert v1["status"] == "draft"
+
+        published = apollo_policy_service.publish_policy(db, tenant_id, v1["id"], published_by="qa-lead")
+        assert published["status"] == "published"
+
+        v2 = apollo_policy_service.create_policy(
+            db, tenant_id, title="Endoscope Reprocessing Policy v2", owner="Quality Director", supersedes_id=v1["id"],
+        )
+        assert v2["version"] == 2
+        apollo_policy_service.publish_policy(db, tenant_id, v2["id"], published_by="qa-lead")
+
+        prior = apollo_policy_service.get_policy(db, tenant_id, v1["id"])
+        assert prior["status"] == "superseded"
+
+        history = apollo_policy_service.version_history(db, tenant_id, v2["id"])
+        assert len(history) == 2
+    finally:
+        db.close()
+
+
+def test_policies_due_for_review():
+    tenant_id = uid("apollo-policy-review")
+    db = SessionLocal()
+    try:
+        overdue = apollo_policy_service.create_policy(
+            db, tenant_id, title="Overdue Policy", owner="QA",
+            review_date=datetime.now(timezone.utc) - timedelta(days=5),
+        )
+        apollo_policy_service.publish_policy(db, tenant_id, overdue["id"], published_by="qa-lead")
+
+        due = apollo_policy_service.policies_due_for_review(db, tenant_id, within_days=30)
+        assert any(p["id"] == overdue["id"] for p in due)
+    finally:
+        db.close()
+
+
+def test_policy_route_create_and_list():
+    tenant_id = uid("apollo-policy-route")
+    resp = client.post(
+        "/api/apollo/policies", json={"title": "Route Policy", "owner": "QA"}, headers=_headers(AUTH_MGR, tenant_id),
+    )
+    assert resp.status_code == 201
+    resp_list = client.get("/api/apollo/policies", headers=_headers(AUTH_MGR, tenant_id))
+    assert resp_list.status_code == 200
+    assert len(resp_list.json()["policies"]) >= 1
+
+
+# ── 6. Standards ───────────────────────────────────────────────────────────────
+
+def test_regulatory_catalogue_includes_new_bodies():
+    from app.services.regulatory_standards_catalogue import get_standards
+
+    bodies = {s.body for s in get_standards()}
+    assert "aami_st91" in bodies
+    assert "aorn" in bodies
+    assert "dnv" in bodies
+
+
+def test_standards_library_summary_composes_all_sources():
+    tenant_id = uid("apollo-standards")
+    db = SessionLocal()
+    try:
+        result = apollo_standards_library_service.standards_library_summary(db, tenant_id)
+    finally:
+        db.close()
+    assert "regulatory_standards" in result
+    assert "beacon_guidance" in result
+    assert "internal_classification_standards" in result
+    assert result["regulatory_body_counts"].get("aorn", 0) >= 1
+
+
+def test_standards_library_route():
+    tenant_id = uid("apollo-standards-route")
+    resp = client.get("/api/apollo/standards/library", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 200
+    assert "regulatory_standards" in resp.json()
+
+
+# ── 7. Digital Twin ────────────────────────────────────────────────────────────
+
+def test_compute_quality_twin_returns_eight_dimensions():
+    tenant_id = uid("apollo-twin")
+    db = SessionLocal()
+    try:
+        result = apollo_quality_twin_service.compute_quality_twin(db, tenant_id, "sterile_processing")
+    finally:
+        db.close()
+    for key in (
+        "compliance_score", "competency_score", "audit_readiness_score", "policy_maturity_score",
+        "capa_health_score", "education_score", "knowledge_score", "continuous_improvement_score",
+    ):
+        assert key in result["scores"]
+    assert result["overall_score"] >= 0
+    assert result["human_review_required"] is True
+
+
+def test_quality_twin_history_returns_snapshots():
+    tenant_id = uid("apollo-twin-history")
+    db = SessionLocal()
+    try:
+        apollo_quality_twin_service.compute_quality_twin(db, tenant_id, "unspecified")
+        apollo_quality_twin_service.compute_quality_twin(db, tenant_id, "unspecified")
+        history = apollo_quality_twin_service.twin_history(db, tenant_id, "unspecified")
+    finally:
+        db.close()
+    assert len(history) == 2
+
+
+def test_quality_twin_route():
+    tenant_id = uid("apollo-twin-route")
+    resp = client.get("/api/apollo/quality-twin/unspecified", headers=_headers(AUTH_MGR, tenant_id))
+    assert resp.status_code == 200
+    assert "overall_score" in resp.json()
+
+
+# ── 8. Executive Dashboard ─────────────────────────────────────────────────────
+
+def test_executive_quality_dashboard_composes_command_center_and_governance():
+    tenant_id = uid("apollo-exec")
+    db = SessionLocal()
+    try:
+        result = apollo_executive_quality_service.executive_quality_dashboard(db, tenant_id)
+    finally:
+        db.close()
+    assert "quality_maturity_index" in result
+    assert "quality_maturity_index_weights" in result
+    assert "audit_readiness" in result
+    assert "continuous_improvement" in result
+    assert result["human_review_required"] is True
+
+
+def test_executive_quality_dashboard_index_within_bounds():
+    tenant_id = uid("apollo-exec-bounds")
+    db = SessionLocal()
+    try:
+        result = apollo_executive_quality_service.executive_quality_dashboard(db, tenant_id)
+    finally:
+        db.close()
+    assert 0 <= result["quality_maturity_index"] <= 100
+
+
+def test_executive_dashboard_route_requires_leadership():
+    tenant_id = uid("apollo-exec-route")
+    resp = client.get("/api/apollo/executive-dashboard", headers=_headers(AUTH_VIEWER, tenant_id))
+    assert resp.status_code == 403
+
+    resp_admin = client.get("/api/apollo/executive-dashboard", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp_admin.status_code == 200
+
+
+def test_improvement_portfolio_summary_used_by_executive_dashboard():
+    tenant_id = uid("apollo-portfolio")
+    db = SessionLocal()
+    try:
+        apollo_improvement_portfolio_service.create_project(
+            db, tenant_id=tenant_id, initiative="Reduce reprocessing cycle time", owner="Quality",
+            methodology="lean", cost_savings_usd=15000.0, executive_visible=True,
+        )
+        summary = apollo_improvement_portfolio_service.portfolio_summary(db, tenant_id)
+    finally:
+        db.close()
+    assert summary["total_projects"] == 1
+    assert summary["by_methodology"]["lean"] == 1
+    assert summary["total_cost_savings_usd"] == 15000.0
+    assert len(summary["executive_visible_projects"]) == 1

--- a/backend/tests/test_athena_knowledge.py
+++ b/backend/tests/test_athena_knowledge.py
@@ -1,0 +1,458 @@
+"""v4.8 — LumenAI OS: Project Athena — Healthcare Knowledge Intelligence &
+Institutional Memory tests.
+
+Covers: Institutional Memory, Experience Graph, Playbooks, Organizational
+(Semantic) Search, Knowledge Trust Score, AI Curator, Athena Assistant,
+and Governance (including the new tenant-membership authorization).
+"""
+from __future__ import annotations
+
+import time
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.athena_knowledge import DISCLAIMER
+from app.models.competency_event import CompetencyEvent
+from app.models.continuous_improvement import ContinuousImprovementInitiative
+from app.models.knowledge import KnowledgeArticle
+from app.models.root_cause import RootCauseAssignment
+from app.services import (
+    athena_curator_service,
+    athena_experience_graph_service,
+    athena_expert_capture_service,
+    athena_memory_service,
+    athena_memory_timeline_service,
+    athena_playbook_service,
+    athena_preservation_service,
+    athena_search_service,
+    athena_trust_service,
+)
+from app.services.athena_assistant_service import ask_athena
+from app.services.knowledge_repository_service import create_article
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    """Athena's routes use `require_tenant_roles`, which verifies a real
+    `TenantMembership` row — a stricter check than the header-only pattern
+    every prior sprint's tests relied on."""
+    db.add(models.TenantMembership(
+        tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True,
+    ))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+# ── 1. Institutional Memory ───────────────────────────────────────────────────
+
+def test_memory_entries_compose_across_six_sources():
+    tenant_id = uid("athena-memory")
+    db = SessionLocal()
+    try:
+        db.add(KnowledgeArticle(tenant_id=tenant_id, category="lesson_learned", title="Test Lesson", body="Body text."))
+        db.add(RootCauseAssignment(tenant_id=tenant_id, inspection_id=1, finding_type="blood", root_cause="process_deviation", assigned_by="qa"))
+        db.add(ContinuousImprovementInitiative(tenant_id=tenant_id, initiative="Reduce blood findings", methodology="lean"))
+        db.commit()
+
+        entries = athena_memory_service.list_memory_entries(db, tenant_id)
+        sources = {e["source_type"] for e in entries}
+        assert "knowledge_article" in sources
+        assert "root_cause_analysis" in sources
+        assert "workflow_improvement" in sources
+    finally:
+        db.close()
+
+
+def test_search_memory_matches_by_keyword():
+    tenant_id = uid("athena-memory-search")
+    db = SessionLocal()
+    try:
+        db.add(KnowledgeArticle(tenant_id=tenant_id, category="best_practice", title="Corrosion Prevention", body="Keep instruments dry."))
+        db.commit()
+        result = athena_memory_service.search_memory(db, tenant_id, "corrosion")
+    finally:
+        db.close()
+    assert result["result_count"] >= 1
+    assert result["disclaimer"] == DISCLAIMER
+
+
+def test_expert_contribution_enters_draft_governance():
+    tenant_id = uid("athena-expert")
+    db = SessionLocal()
+    try:
+        article = athena_expert_capture_service.submit_expert_contribution(
+            db, tenant_id, category="best_practice", title="Lumen Brushing Tip", body="Use the correct brush size.",
+            author="tech1",
+        )
+        assert article["approval_status"] == "draft"
+
+        media = athena_expert_capture_service.attach_media(
+            db, tenant_id, article["id"], media_type="photo", url_or_ref="s3://example/photo.jpg", caption="Before/after",
+        )
+        assert media["media_type"] == "photo"
+
+        listed = athena_expert_capture_service.list_media(db, tenant_id, source_type="knowledge_article", source_id=article["id"])
+        assert len(listed) == 1
+    finally:
+        db.close()
+
+
+def test_expert_contribution_rejects_invalid_media_type():
+    tenant_id = uid("athena-expert-badmedia")
+    db = SessionLocal()
+    try:
+        article = athena_expert_capture_service.submit_expert_contribution(
+            db, tenant_id, category="best_practice", title="Test", body="Body", author="tech1",
+        )
+        try:
+            athena_expert_capture_service.attach_media(db, tenant_id, article["id"], media_type="not_real", url_or_ref="x")
+            assert False, "expected InvalidMediaTypeError"
+        except athena_expert_capture_service.InvalidMediaTypeError:
+            pass
+    finally:
+        db.close()
+
+
+# ── 2. Experience Graph ────────────────────────────────────────────────────────
+
+def test_build_experience_chain_creates_full_node_sequence():
+    tenant_id = uid("athena-graph")
+    db = SessionLocal()
+    try:
+        result = athena_experience_graph_service.build_experience_chain(
+            db, tenant_id, person="Jane Tech", experience_label="Found blood residue on a Kerrison",
+            instrument_type="Kerrison Rongeur", finding_type="blood", outcome_label="Instrument reprocessed",
+            evidence_label="Photo evidence #123", organization_label="Main Hospital",
+        )
+    finally:
+        db.close()
+    for key in ("person_node", "experience_node", "finding_node", "instrument_node", "anatomy_node", "recommendation_node", "outcome_node", "evidence_node", "organization_node"):
+        assert key in result
+    assert result["human_review_required"] is True
+
+
+def test_graph_for_person_returns_recorded_chain():
+    tenant_id = uid("athena-graph-person")
+    db = SessionLocal()
+    try:
+        athena_experience_graph_service.build_experience_chain(
+            db, tenant_id, person="Dr. Smith", experience_label="Reviewed a corrosion case",
+            instrument_type="Orthopedic Drill", finding_type="corrosion",
+        )
+        result = athena_experience_graph_service.graph_for_person(db, tenant_id, "Dr. Smith")
+    finally:
+        db.close()
+    assert len(result["chains"]) == 1
+    assert result["chains"][0][0]["node_type"] == "person"
+
+
+def test_graph_schema_matches_brief_chain_order():
+    schema = athena_experience_graph_service.graph_schema()
+    assert schema["node_chain_order"][0] == "person"
+    assert schema["node_chain_order"][-1] == "organization"
+
+
+# ── 3. Playbooks ───────────────────────────────────────────────────────────────
+
+def test_create_playbook_reuses_workflow_definition():
+    tenant_id = uid("athena-playbook")
+    db = SessionLocal()
+    try:
+        playbook = athena_playbook_service.create_playbook(
+            db, tenant_id, name="Blood Detection Response", category="blood_detection_investigation",
+            nodes=[{"id": "n1", "type": "start"}], edges=[], author="qa-lead",
+            linked_standards=["AAMI-ST79-4"],
+        )
+        assert playbook["is_template"] is True
+        assert playbook["category"] == "blood_detection_investigation"
+
+        listed = athena_playbook_service.list_playbooks(db, tenant_id, category="blood_detection_investigation")
+        assert any(p["id"] == playbook["id"] for p in listed)
+
+        updated = athena_playbook_service.attach_standard(db, playbook["id"], "AORN-INSTR-01")
+        assert "AORN-INSTR-01" in updated["linked_standards"] if "linked_standards" in updated else True
+    finally:
+        db.close()
+
+
+def test_create_playbook_rejects_unknown_category():
+    tenant_id = uid("athena-playbook-bad")
+    db = SessionLocal()
+    try:
+        try:
+            athena_playbook_service.create_playbook(
+                db, tenant_id, name="Bad", category="not_a_real_category", nodes=[], edges=[], author="qa",
+            )
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+    finally:
+        db.close()
+
+
+def test_playbook_categories_include_all_six_named_scenarios():
+    for cat in (
+        "blood_detection_investigation", "corrosion_investigation", "loaner_instrument",
+        "joint_commission_preparation", "vendor_tray", "robotic_instrument",
+    ):
+        assert cat in athena_playbook_service.CLINICAL_PLAYBOOK_CATEGORIES
+
+
+# ── 4. Organizational (Semantic) Search ───────────────────────────────────────
+
+def test_organizational_search_federates_multiple_sources():
+    tenant_id = uid("athena-search")
+    db = SessionLocal()
+    try:
+        # "corrosion" is a recognized finding keyword, so smart_search resolves
+        # it via the `applicable_findings` facet rather than free-text match —
+        # matching this pre-existing service's real behavior, not a guess.
+        create_article(
+            db, tenant_id=tenant_id, category="best_practice", title="Corrosion Handling Guide", body="Details here.",
+            author="qa", approval_status="approved", applicable_findings=["corrosion"],
+        )
+        db.commit()
+        result = athena_search_service.organizational_search(db, tenant_id, "corrosion")
+    finally:
+        db.close()
+    assert result["knowledge_articles"]
+    assert "meeting_notes" in result
+    assert result["meeting_notes"]["results"] == []
+
+
+def test_organizational_search_covers_all_named_source_types():
+    for source in athena_search_service.SOURCE_TYPES:
+        assert source in athena_search_service.SOURCE_TYPES  # sanity: constant is well-formed
+    assert athena_search_service.SOURCE_MEETING_NOTES in athena_search_service.SOURCE_TYPES
+
+
+# ── 5. Knowledge Trust Score ───────────────────────────────────────────────────
+
+def test_compute_trust_score_returns_seven_components():
+    tenant_id = uid("athena-trust")
+    db = SessionLocal()
+    try:
+        article = create_article(
+            db, tenant_id=tenant_id, category="best_practice", title="Trust Test Article",
+            body="A" * 600, author="tech1", references="See AAMI ST79.", approval_status="approved",
+        )
+        article.reviewer = "qa-lead"
+        db.commit()
+        db.refresh(article)
+        score = athena_trust_service.compute_trust_score(db, article)
+    finally:
+        db.close()
+    for key in ("evidence_quality", "clinical_validation", "usage", "review_date_recency", "approval_status", "contributor_reputation", "reference_strength"):
+        assert key in score["components"]
+    assert 0 <= score["overall_trust_score"] <= 100
+
+
+def test_list_articles_with_trust_filters_by_min_trust():
+    tenant_id = uid("athena-trust-filter")
+    db = SessionLocal()
+    try:
+        create_article(db, tenant_id=tenant_id, category="faq", title="Low Trust", body="short", author="tech1")
+        db.commit()
+        high = athena_trust_service.list_articles_with_trust(db, tenant_id, min_trust=99.0)
+        low = athena_trust_service.list_articles_with_trust(db, tenant_id, min_trust=0.0)
+    finally:
+        db.close()
+    assert len(low) >= 1
+    assert len(high) <= len(low)
+
+
+# ── 6. AI Curator ──────────────────────────────────────────────────────────────
+
+def test_duplicate_candidates_detects_similar_articles():
+    tenant_id = uid("athena-curator-dup")
+    db = SessionLocal()
+    try:
+        create_article(db, tenant_id=tenant_id, category="best_practice", title="Kerrison cleaning technique guidance", body="Clean the Kerrison thoroughly with the correct brush.", author="a")
+        create_article(db, tenant_id=tenant_id, category="best_practice", title="Kerrison cleaning technique guide", body="Clean the Kerrison thoroughly using the correct brush.", author="b")
+        db.commit()
+        dupes = athena_curator_service.duplicate_candidates(db, tenant_id, similarity_threshold=0.3)
+    finally:
+        db.close()
+    assert len(dupes) >= 1
+
+
+def test_emerging_best_practices_requires_minimum_mentions():
+    tenant_id = uid("athena-curator-emerging")
+    db = SessionLocal()
+    try:
+        for _ in range(3):
+            db.add(CompetencyEvent(tenant_id=tenant_id, technician="tech1", event_type="knowledge_contribution", finding_type="novel_topic_xyz"))
+        db.commit()
+        emerging = athena_curator_service.emerging_best_practices(db, tenant_id, min_mentions=3)
+    finally:
+        db.close()
+    assert any(e["topic"] == "novel_topic_xyz" for e in emerging)
+
+
+def test_curator_summary_composes_all_checks():
+    tenant_id = uid("athena-curator-summary")
+    db = SessionLocal()
+    try:
+        summary = athena_curator_service.curator_summary(db, tenant_id)
+    finally:
+        db.close()
+    for key in ("knowledge_gaps", "duplicate_candidates", "outdated_guidance", "retirement_candidates", "emerging_best_practices"):
+        assert key in summary
+
+
+# ── 7. Athena Assistant ────────────────────────────────────────────────────────
+
+def test_ask_athena_classifies_recurring_investigation_intent():
+    tenant_id = uid("athena-assistant-recurring")
+    db = SessionLocal()
+    try:
+        result = ask_athena(db, tenant_id, "Show me how we handled recurring corrosion in orthopedic drills.")
+    finally:
+        db.close()
+    assert result["intent"] == "recurring_investigation"
+    assert "timeline" in result
+
+
+def test_ask_athena_classifies_lessons_learned_intent():
+    tenant_id = uid("athena-assistant-lessons")
+    db = SessionLocal()
+    try:
+        result = ask_athena(db, tenant_id, "Find all lessons learned related to rigid scope O-rings.")
+    finally:
+        db.close()
+    assert result["intent"] == "lessons_learned_search"
+    assert "lessons_learned" in result
+
+
+def test_ask_athena_classifies_policy_change_intent():
+    tenant_id = uid("athena-assistant-policy")
+    db = SessionLocal()
+    try:
+        result = ask_athena(db, tenant_id, "What changed in our IFU guidance over the past year?")
+    finally:
+        db.close()
+    assert result["intent"] == "policy_change_history"
+    assert "policy_history" in result
+
+
+def test_memory_timeline_builds_all_eight_stages():
+    tenant_id = uid("athena-timeline")
+    db = SessionLocal()
+    try:
+        result = athena_memory_timeline_service.build_memory_timeline(db, tenant_id, finding_type="blood")
+    finally:
+        db.close()
+    for stage in ("event", "investigation", "capa", "education", "policy_change", "outcome", "verification", "future_similar_cases"):
+        assert stage in result["timeline"]
+
+
+# ── 8. Knowledge Preservation ──────────────────────────────────────────────────
+
+def test_preservation_session_lifecycle_to_converted_article():
+    tenant_id = uid("athena-preservation")
+    db = SessionLocal()
+    try:
+        session = athena_preservation_service.create_preservation_session(
+            db, tenant_id, subject_name="Retiring Tech", session_type="exit_interview", summary="20 years of SPD experience.",
+        )
+        assert session["status"] == "captured"
+
+        transcribed = athena_preservation_service.add_transcript(
+            db, tenant_id, session["id"], transcript_text="Always check the O-ring before reassembly.", topics=["o_rings"],
+        )
+        assert transcribed["status"] == "transcribed"
+
+        converted = athena_preservation_service.convert_to_knowledge_article(
+            db, tenant_id, session["id"], category="lesson_learned", title="O-Ring Check Before Reassembly", author="qa-lead",
+        )
+        assert converted["session"]["status"] == "structured"
+        assert converted["article"]["approval_status"] == "draft"
+    finally:
+        db.close()
+
+
+def test_preservation_session_not_found_raises():
+    tenant_id = uid("athena-preservation-404")
+    db = SessionLocal()
+    try:
+        try:
+            athena_preservation_service.get_session(db, tenant_id, 999999)
+            assert False, "expected PreservationSessionNotFoundError"
+        except athena_preservation_service.PreservationSessionNotFoundError:
+            pass
+    finally:
+        db.close()
+
+
+# ── 9. Governance (tenant-membership authorization) ───────────────────────────
+
+def test_route_requires_tenant_membership_not_just_header():
+    """Athena's routes use require_tenant_roles — merely setting an
+    x-tenant-id header (no real TenantMembership row) must be rejected,
+    unlike the header-only pattern every prior sprint's routes use."""
+    tenant_id = uid("athena-governance-no-membership")
+    resp = client.get("/api/athena/memory/summary", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 403
+
+
+def test_route_succeeds_with_seeded_tenant_membership():
+    tenant_id = uid("athena-governance-member")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+    finally:
+        db.close()
+    resp = client.get("/api/athena/memory/summary", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 200
+    assert "total_entries" in resp.json()
+
+
+def test_leadership_route_rejects_non_leadership_member_role():
+    tenant_id = uid("athena-governance-role")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="viewer")
+    finally:
+        db.close()
+    resp = client.get("/api/athena/curator/summary", headers=_headers(AUTH_VIEWER, tenant_id))
+    assert resp.status_code == 403
+
+
+def test_leadership_route_succeeds_for_manager_member():
+    tenant_id = uid("athena-governance-manager")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="spd_manager")
+    finally:
+        db.close()
+    resp = client.get("/api/athena/curator/summary", headers=_headers(AUTH_MGR, tenant_id))
+    assert resp.status_code == 200
+
+
+def test_governance_summary_route():
+    tenant_id = uid("athena-governance-summary")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+    finally:
+        db.close()
+    resp = client.get("/api/athena/governance/summary", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 200
+    assert "total_articles" in resp.json()

--- a/docs/apollo/audit-center.md
+++ b/docs/apollo/audit-center.md
@@ -1,0 +1,44 @@
+# Project Apollo — Audit Center
+
+LumenAI OS v4.7, Section 4.
+
+## No second audit-package generator
+
+`accreditation_engine.py` and `regulatory_standards_catalogue.py` already
+covered Joint Commission, AAMI ST79, FDA, CMS, and ISO before Apollo. Apollo
+extends both rather than building a parallel system:
+
+* `regulatory_standards_catalogue.STANDARDS` gained AAMI ST91 (flexible/
+  semi-rigid endoscope reprocessing — body code `aami_st91`, distinct from
+  ST79's `aami`), AORN (perioperative practice standards), and DNV
+  (accreditation body, alternative to Joint Commission).
+* `accreditation_engine.generate_audit_package`'s `body_map` gained
+  `aami_st91`, `aorn`, `dnv`, `internal`, and `vendor` package types.
+  Internal and vendor audits aren't tied to one regulatory body's standards,
+  so — like `"full"` — they include the whole standards catalogue rather
+  than a single-body slice.
+
+## Every finding is linked to evidence
+
+Every `AccreditationFinding` on a generated audit package already carries
+its `standard_code`, `citation_text`, and `remediation_guidance` from the
+standards catalogue mapping — this was true before Apollo and remains true
+for every one of the 9 supported package types.
+
+## Supported audit types
+
+```
+joint_commission | aami | aami_st91 | fda | cms | aorn | dnv | internal | vendor | full
+```
+
+## API
+
+```
+GET   /api/apollo/audit/summary
+POST  /api/apollo/audit/generate   { "package_type": "aami_st91", ... }
+```
+
+`audit/summary` composes `accreditation_engine.compute_regulatory_
+dashboard` — readiness scores, standards summary, top findings — unchanged
+computation, just surfaced under Apollo's Audit Center tab. Audit package
+generation is audit-logged.

--- a/docs/apollo/capa-engine.md
+++ b/docs/apollo/capa-engine.md
@@ -1,0 +1,65 @@
+# Project Apollo — CAPA Engine
+
+LumenAI OS v4.7, Section 2.
+
+## No sixth CAPA store
+
+Before Apollo, this codebase already had:
+
+* `capa_service.py` — the canonical sqlite-backed `capas` table.
+* `capa_lifecycle_service.py` (v2.9) — the real
+  `open → assigned → in_progress → verified → closed` state machine, added
+  as additive columns on the same table.
+* `capa_suggestion_service.py` (v1.5) — auto-trigger detection from real
+  recurring patterns.
+* A legacy `EnterpriseCapa` table and `CAPARecommendation` suggestion queue.
+
+Apollo adds **no new CAPA store**. It extends `capa_suggestion_service.
+generate_capa_suggestions` with 5 new detectors the sprint brief names that
+didn't already exist — "Repeated Blood Findings" and "Repeated Corrosion"
+were already covered by the existing zone/condition-type counters.
+
+## The 5 new detectors
+
+| Trigger | Real signal used |
+|---|---|
+| Repeat repairs | `RepairRequest.instrument_identity` (from `or_connect.py`) — 3+ repair requests on the same instrument in 90 days |
+| Supervisor overrides | `SupervisorReview.agreement == "disagree"` or a non-empty `override_action` — 3+ per reviewer in 90 days |
+| AI confidence decline | Reuses `sentinel_ai_health_service._detect_drift` directly — never re-derived |
+| Inspection failures | `Inspection.disposition` in `{"REPROCESS", "REMOVE FROM SERVICE"}` — 3+ per instrument type in 90 days |
+| Customer complaints | The new `CustomerComplaint` model — 3+ per instrument type in 90 days |
+
+Every detector reuses the same `_REPEAT_THRESHOLD = 3` / `_LOOKBACK_DAYS =
+90` constants the pre-existing detectors already used, for consistency.
+
+## Owner / Root Cause / Actions / Verification / Effectiveness Review / Closure
+
+Every CAPA created from a suggestion (via
+`POST /api/apollo/capa/suggestions/create`) is materialized through the
+existing `capa_suggestion_service.create_capa_from_suggestion` — the human
+review step is unchanged. From there, the pre-existing
+`capa_lifecycle_service` lifecycle already tracks Owner (`assignee`),
+Root-Cause link (`root_cause_assignment_id`), Verification (`verified_by`/
+`verified_at`), and Closure (`closed_by`/`closed_at`).
+
+## Customer complaint intake
+
+`CustomerComplaint` (table `apollo_customer_complaints`) is the one
+genuinely new store in this section — a complaint intake never existed
+before. A complaint can be linked to a CAPA
+(`POST /api/apollo/capa/complaints/{id}/link`) or closed independently
+(`POST /api/apollo/capa/complaints/{id}/close`). Linking sets
+`linked_capa_id` and moves `status` to `linked_to_capa`.
+
+## API
+
+```
+GET   /api/apollo/capa/summary
+POST  /api/apollo/capa/suggestions/create
+POST  /api/apollo/capa/complaints
+GET   /api/apollo/capa/complaints
+POST  /api/apollo/capa/complaints/{id}/link
+POST  /api/apollo/capa/complaints/{id}/close
+```
+
+All CAPA/complaint mutations are audit-logged.

--- a/docs/apollo/competency-engine.md
+++ b/docs/apollo/competency-engine.md
@@ -1,0 +1,46 @@
+# Project Apollo — Competency Center
+
+LumenAI OS v4.7, Section 5.
+
+## No parallel competency model
+
+`competency_service.py`'s single `CompetencyEvent` log (table
+`competency_events`) already tracked `finding_reviewed`,
+`supervisor_correction`, `repeated_error`, and `education_completed`
+events before Apollo. `event_type` is an unconstrained `String(30)` column
+— there was never a DB-level enum to extend, so adding new event types is
+purely additive at the application layer.
+
+Apollo adds four new event types to the *same* log:
+
+| Event type | Recorded by | Notes |
+|---|---|---|
+| `annual_competency` | `record_annual_competency` | `finding_type` column reused to store the competency area label |
+| `procedure_validation` | `record_procedure_validation` | `finding_type` reused to store the procedure name |
+| `simulation_passed` / `simulation_failed` | `record_simulation_result` | Outcome is encoded in the event type itself — never a fabricated numeric score |
+| `knowledge_contribution` | `record_knowledge_contribution` | `finding_type` reused to store the contribution topic |
+
+`competency_summary` now also returns `annual_competencies`,
+`procedure_validations`, `simulations_passed`, `simulations_failed`, and
+`knowledge_contributions` counts alongside the pre-existing fields.
+
+## Managing Technicians / Supervisors / Managers
+
+The Competency Center tab composes the pre-existing
+`technician_quality_dashboard` (inspection counts, coverage quality,
+average AI confidence, supervisor agreement, repeat corrections, training
+progress) with the new event-type totals — no second aggregation of the
+same underlying events.
+
+## API
+
+```
+GET   /api/apollo/competency/summary
+POST  /api/apollo/competency/annual                { "technician": "...", "competency_area": "..." }
+POST  /api/apollo/competency/procedure-validation   { "technician": "...", "procedure_name": "..." }
+POST  /api/apollo/competency/simulation             { "technician": "...", "scenario": "...", "passed": true }
+POST  /api/apollo/competency/knowledge-contribution { "technician": "...", "topic": "..." }
+```
+
+Every write is audit-logged and updates the same user's real profile —
+nothing is scored automatically without an actual recorded event.

--- a/docs/apollo/policy-intelligence.md
+++ b/docs/apollo/policy-intelligence.md
@@ -1,0 +1,62 @@
+# Project Apollo — Policy Intelligence & Continuous Improvement Portfolio
+
+LumenAI OS v4.7, Sections 6 & 8.
+
+## Policy Intelligence (Section 6)
+
+`QualityPolicy` (table `apollo_quality_policies`) is a genuinely new table
+— no clinical/quality policy versioning system existed before Apollo
+(`RetentionPolicy`/`GovernanceSlaPolicy` are unrelated infrastructure
+policies). It follows the same `supersedes_id`/`status` self-FK chain
+Beacon's `StandardsPublication` and Forge's `WorkflowDefinition` already
+established, including the identical version-chain-walk pattern used by
+`beacon_standards_service.version_history`.
+
+Every policy tracks:
+
+* Review date (`review_date`) — the basis for `policies_due_for_review`.
+* Owner (`owner`).
+* References (`references_json`).
+* Linked standards (`linked_standards_json`).
+* Affected workflows (`affected_workflows_json`).
+* Affected competencies (`affected_competencies_json`).
+* Affected AI rules (`affected_ai_rules_json`).
+
+Publishing a new version (`POST /policies/{id}/publish` with a
+`supersedes_id`) automatically marks the prior published version
+`superseded` — mirroring Beacon's `publish_guidance`.
+
+```
+POST  /api/apollo/policies
+GET   /api/apollo/policies
+GET   /api/apollo/policies/{id}
+POST  /api/apollo/policies/{id}/publish
+GET   /api/apollo/policies/{id}/history
+GET   /api/apollo/policies/due-for-review?within_days=30
+```
+
+## Continuous Improvement Portfolio (Section 8)
+
+`ContinuousImprovementInitiative` (v1.5) already tracked named PI/Lean/Six
+Sigma/Kaizen initiatives from proposal through completion. Apollo adds
+additive columns rather than a new table:
+
+* `methodology` — one of `pi | lean | six_sigma | kaizen | other`.
+* `cost_savings_usd` — human-entered, never computed.
+* `quality_improvement_metric` / `risk_reduction_metric` — free-text,
+  human-entered, matching the existing `actual_impact` pattern (a
+  before/after delta requires human judgment about what changed and why,
+  not a raw metric diff).
+* `executive_visible` — flags a project for the Executive Quality
+  Dashboard's continuous-improvement tile.
+
+```
+POST   /api/apollo/improvement-projects
+GET    /api/apollo/improvement-projects
+GET    /api/apollo/improvement-projects/summary
+PATCH  /api/apollo/improvement-projects/{id}
+```
+
+`improvement-projects/summary` rolls up counts by methodology/status,
+total (human-entered) cost savings, and the completion rate used as an
+input to the Quality Maturity Index (see `quality-digital-twin.md`).

--- a/docs/apollo/quality-digital-twin.md
+++ b/docs/apollo/quality-digital-twin.md
@@ -1,0 +1,72 @@
+# Project Apollo — Quality Digital Twin & Executive Quality Dashboard
+
+LumenAI OS v4.7, Sections 9 & 10.
+
+## Quality Digital Twin (Section 9)
+
+`QualityTwinSnapshot` (table `apollo_quality_twin_snapshots`) is a
+genuinely new, department-scoped composite — no department-level quality
+twin existed before Apollo. It is explicitly distinct in kind from
+`digital_twin_engine.py`'s facility/instrument-scoped workflow telemetry
+twin: this tracks governance health, not instrument flow.
+
+Eight equally weighted dimensions compose the `overall_score`:
+
+| Dimension | Source | Department-scoped? |
+|---|---|---|
+| `compliance_score` | `accreditation_engine.compute_accreditation_readiness` | No — tenant-wide (accreditation has no department dimension) |
+| `audit_readiness_score` | same as compliance_score | No — tenant-wide |
+| `competency_score` | `competency_service.competency_summary` averaged across technicians who logged inspections in this department | Yes |
+| `education_score` | pct of department technicians with ≥1 completed education article | Yes |
+| `knowledge_score` | knowledge-contribution events per department technician | Yes |
+| `policy_maturity_score` | published-vs-total ratio across all `QualityPolicy` rows | No — policies aren't department-tagged |
+| `capa_health_score` | `capa_lifecycle_service.lifecycle_summary` closure rate | No — CAPAs aren't department-tagged |
+| `continuous_improvement_score` | Improvement Portfolio completion rate | No — initiatives aren't department-tagged |
+
+Where a dimension isn't natively department-scoped, the tenant-wide value
+is used as an honest proxy and `factors_json` explicitly records which
+sub-scores are department-scoped vs. tenant-wide — never a fabricated
+department split with no underlying data.
+
+```
+GET  /api/apollo/quality-twin/{department}
+GET  /api/apollo/quality-twin/{department}/history
+```
+
+Use `department=unspecified` for inspections with no `department` set
+(consistent with how other services handle optional groupings).
+
+## Executive Quality Dashboard (Section 10)
+
+Composes two pre-existing systems rather than re-deriving their numbers a
+third time:
+
+* `quality_command_center_service.quality_command_center_summary` (v2.9) —
+  recurring findings, CAPA lifecycle, root causes, first-pass yield,
+  education impact, technician/vendor/manufacturer trends.
+* `vanguard_governance_service.governance_dashboard` (v4.6) — policy
+  compliance, knowledge adoption, workflow compliance, audit readiness,
+  training completion.
+
+The only genuinely new computation is the **Quality Maturity Index** — a
+documented weighted composite:
+
+| Component | Weight | Source |
+|---|---|---|
+| Compliance / audit readiness | 0.30 | `governance.audit_readiness.overall_readiness_score` |
+| CAPA health | 0.20 | CAPA lifecycle closure rate |
+| Competency | 0.20 | `quality_command_center_summary.education_impact_avg_pct` |
+| Continuous improvement | 0.15 | Improvement Portfolio completion rate |
+| Policy currency | 0.15 | 100 minus 10 points per overdue policy review (an honest proxy — no independent "policy currency" metric exists) |
+
+```
+GET  /api/apollo/executive-dashboard
+```
+
+Returns `compliance_score`, `audit_readiness`, `open_capas`,
+`capa_closure_rate_pct`, `competency_status`, `high_risk_policies`
+(overdue reviews), `upcoming_reviews` (due within 30 days),
+`continuous_improvement`, `quality_maturity_index`, and
+`quality_maturity_index_weights` for full transparency into the composite.
+Every field carries `human_review_required: true` — nothing here
+authorizes an operational decision on its own.

--- a/docs/apollo/quality-management.md
+++ b/docs/apollo/quality-management.md
@@ -1,0 +1,58 @@
+# Project Apollo — Quality Management Center
+
+LumenAI OS v4.7 — the Autonomous Clinical Quality Management System (CQMS).
+
+## Naming disambiguation
+
+This codebase already had an extensive quality management ecosystem across
+five prior sprints before Apollo. Every one of the following was read in
+full before Apollo added a single line of code:
+
+| Concern | Pre-existing system | Apollo's relationship to it |
+|---|---|---|
+| `/api/quality` prefix | `app/routes/quality_dashboard.py` (v1.5) | Apollo mounts at `/api/apollo` instead |
+| `/quality-*` frontend routes | `/quality-command-center`, `/quality-intelligence`, `/quality-dashboard` | Apollo takes bare `/quality` — confirmed free, positioned as the unifying front door |
+| CAPA | `capa_service.py` + `capa_lifecycle_service.py` (canonical store + lifecycle) | Apollo extends `capa_suggestion_service.py`'s detectors; adds no 6th CAPA store |
+| Root cause | `RootCauseAssignment` + `RCADraft`/`rca_engine_service` | Apollo adds a structuring layer only (Five Whys/Fishbone/Pareto/Trend) |
+| Audits | `accreditation_engine.py` + `regulatory_standards_catalogue.py` | Apollo extends both with AAMI ST91/AORN/DNV/Internal/Vendor |
+| Standards | `beacon_standards_service.py` + `p24_standards_service.py` | Apollo composes both plus the regulatory catalogue |
+| Competencies | `competency_service.py`'s `CompetencyEvent` log | Apollo adds 4 new event types to the same log |
+| Continuous Improvement | `ContinuousImprovementInitiative` (v1.5) | Apollo adds methodology/cost-savings/executive-visibility columns |
+| Executive Quality Dashboard | `quality_command_center_service.py` + `vanguard_governance_service.py` | Apollo composes both, adding only the new Quality Maturity Index |
+
+## The Quality Management Center
+
+Frontend route `/quality` — 9 tabs, one unifying front door:
+
+1. **Quality Dashboard** — the Executive Quality Dashboard composite (see `quality-digital-twin.md` and `capa-engine.md`)
+2. **CAPA** — the CAPA Engine (`capa-engine.md`)
+3. **Audit Center** — Joint Commission/AAMI ST79/AAMI ST91/AORN/CMS/DNV/Internal/Vendor (`audit-center.md`)
+4. **Competencies** — Technician/Supervisor/Manager competency tracking (`competency-engine.md`)
+5. **Policies** — versioned quality policies (`policy-intelligence.md`)
+6. **Standards** — the Standards Knowledge Library (composed in `apollo_standards_library_service.py`)
+7. **Education** — per-technician education completion (part of the Competency Center)
+8. **Evidence** — Root Cause Intelligence's Pareto/Trend views (`apollo_rca_intelligence_service.py`)
+9. **Improvement Projects** — the Continuous Improvement Portfolio (part of `policy-intelligence.md`'s sibling service, `apollo_improvement_portfolio_service.py`)
+
+## New tables (genuinely new)
+
+Only three tables are genuinely new in `app/models/apollo_quality.py`:
+
+* `CustomerComplaint` — no complaint-intake model existed before Apollo.
+* `QualityPolicy` — no clinical/quality policy versioning system existed before Apollo. Follows the same `supersedes_id`/`status` self-FK chain established by Beacon's `StandardsPublication` and Forge's `WorkflowDefinition`.
+* `QualityTwinSnapshot` — no department-level quality composite existed. Distinct from `digital_twin_engine.py`'s facility/instrument-scoped workflow telemetry twin.
+
+Every other Apollo capability is an additive extension of a pre-existing
+file, or a pure composition service that reads real data from systems that
+already existed — nothing is a fabricated capability, and every advisory
+output carries `human_review_required: true` with the standard disclaimer.
+
+## Definition of Done
+
+LumenAI becomes a unified Clinical Quality Management System spanning CAPA,
+Root Cause Intelligence, Audits, Competencies, Policies, Standards,
+Continuous Improvement, and a department-level Quality Digital Twin, all
+surfaced through one Executive Quality Dashboard. Human oversight remains
+mandatory for all quality decisions — no CAPA closes, no root cause
+finalizes, no audit finding resolves, and no policy publishes without an
+explicit human action.

--- a/docs/athena/clinical-playbooks.md
+++ b/docs/athena/clinical-playbooks.md
@@ -1,0 +1,46 @@
+# Project Athena — Clinical Playbooks
+
+LumenAI OS v4.8, Section 5.
+
+## No parallel playbook model
+
+Project Forge's `WorkflowDefinition`/`WorkflowRule` (v4.1) already model a
+versioned, approved, nested-decision-tree workflow, with `is_template`
+and a `TEMPLATE_CATEGORIES` list that already included three of the six
+named scenarios (`loaner_instrument`, `vendor_tray`, `robotic_instrument`).
+Athena adds the three missing scenario keys —
+`blood_detection_investigation`, `corrosion_investigation`,
+`joint_commission_preparation` — to that same list, and one additive
+column (`linked_standards_json`) to `WorkflowDefinition`, rather than a
+second playbook table.
+
+`CustomerSuccessPlaybook` (a different, unrelated SaaS-renewal-risk
+domain — checked during research) is not a real collision.
+
+## What a playbook already gets, for free
+
+Because a Clinical Playbook *is* a `WorkflowDefinition`, every playbook
+automatically has:
+
+* **Decision trees** — the existing `nodes_json`/`edges_json`.
+* **Approval history** — the existing `author`/`reviewer`/`approved_by`/
+  `approved_at` + `WorkflowApprovalChain`/`WorkflowApprovalInstance` for
+  multi-step (Technician → Supervisor → Manager → Director) approval.
+* **Versioning** — the existing `supersedes_id`/`version`/`status` chain
+  and `forge_workflow_service.version_history`/`revise_workflow`.
+
+## What Athena adds
+
+* **Standards** — `linked_standards_json` (new column), managed via
+  `attach_standard`.
+* **Evidence, photos, videos** — attach via `KnowledgeMediaAttachment`
+  with `source_type="workflow_definition"` — no new column needed on
+  `WorkflowDefinition` itself.
+
+```
+POST /api/athena/playbooks
+GET  /api/athena/playbooks?category=blood_detection_investigation
+GET  /api/athena/playbooks/{id}
+POST /api/athena/playbooks/{id}/standards
+GET  /api/athena/playbooks/{id}/history
+```

--- a/docs/athena/experience-graph.md
+++ b/docs/athena/experience-graph.md
@@ -1,0 +1,62 @@
+# Project Athena — Experience Graph & Institutional Memory Timeline
+
+LumenAI OS v4.8, Sections 3 & 4.
+
+## Experience Graph (Section 3)
+
+`knowledge_graph_service.py`'s `explore()`/`reasoning_chain()` are real
+but recomputed-on-read aggregations over `Inspection`/`SupervisorReview`/
+static anatomy profiles — there is no persisted node/edge structure
+anywhere in this codebase. The Experience Graph is a genuinely new,
+persisted graph (`ExperienceGraphNode`/`ExperienceGraphEdge`), but the
+Finding → Instrument → Anatomy → Recommendation segment of every chain is
+populated by calling `knowledge_graph_service.reasoning_chain()` directly
+— never re-derived.
+
+The full chain, per the brief:
+
+```
+Person → Experience → Finding → Instrument → Anatomy → Recommendation → Outcome → Evidence → Organization
+```
+
+`athena_experience_graph_service.build_experience_chain` creates every
+node/edge in one call:
+
+1. **Person** / **Experience** — bare, human-supplied labels (the
+   technician/supervisor and what they observed).
+2. **Finding** / **Instrument** / **Anatomy** / **Recommendation** —
+   populated from `reasoning_chain(instrument_type, finding_type, ...)`'s
+   real output, with the node's `details_json` set to the matching chain
+   step.
+3. **Outcome** / **Evidence** / **Organization** — optional, human-
+   supplied labels for the resolution and its supporting evidence.
+
+```
+POST /api/athena/experience-graph/chains
+GET  /api/athena/experience-graph/person/{person}
+GET  /api/athena/experience-graph/nodes/{node_id}/chain
+GET  /api/athena/experience-graph/schema
+```
+
+Every chain is `human_review_required: true` — nothing here infers a
+root cause; it structures what a person already reported.
+
+## Institutional Memory Timeline (Section 4)
+
+`orbit_timeline_service.py` exists but is a different domain entirely —
+OR case logistics (Case Scheduled → ... → Procedure Complete). Athena's
+timeline is a new composition over six real systems, joined by matching
+`finding_type` values (a keyword-level association — there is no explicit
+foreign-key chain linking a `ClinicalCase` to its eventual `QualityPolicy`
+change anywhere in this codebase, so each step is honestly labeled with
+its real source rather than a fabricated direct link):
+
+```
+Event (ClinicalCase) → Investigation (RootCauseAssignment) → CAPA (capa_lifecycle_service)
+  → Education (CompetencyEvent) → Policy Change (QualityPolicy) → Outcome (CAPA lifecycle status)
+  → Verification (CAPA verified_at/verified_by) → Future Similar Cases (similar_case_finder_service)
+```
+
+```
+GET /api/athena/timeline?finding_type=blood&instrument_type=Kerrison%20Rongeur
+```

--- a/docs/athena/institutional-memory.md
+++ b/docs/athena/institutional-memory.md
@@ -1,0 +1,109 @@
+# Project Athena — Institutional Memory Engine
+
+LumenAI OS v4.8, Sections 1, 2, 6, 7 & 9.
+
+## Naming disambiguation
+
+Before writing any Athena code, every existing knowledge-adjacent surface
+was read in full — this codebase already had an extensive institutional-
+knowledge ecosystem before Athena:
+
+| Concern | Pre-existing system | Athena's relationship to it |
+|---|---|---|
+| `/api/knowledge` prefix | `app/routes/knowledge.py` (v1.8) | Athena mounts at `/api/athena` instead |
+| `/api/knowledge-graph` prefix | `app/routes/knowledge_graph.py` | Untouched |
+| Institutional knowledge store | `KnowledgeArticle`/`ClinicalCase` (v1.8) | Athena composes, adds only 2 new categories + 1 column |
+| Approval workflow | `knowledge_governance_service.py` | Reused directly, unchanged |
+| Knowledge search | `knowledge_search_service.smart_search` | Extended (widened source coverage) in `athena_search_service.py` |
+| AI Q&A | `ai_knowledge_assistant_service.answer_question` | Extended with 3 new query shapes in `athena_assistant_service.py` |
+| Knowledge analytics | `knowledge_analytics_service.py` | Extended with 4 new curator checks |
+| Clinical Playbooks | `workflow_forge.py`'s `WorkflowDefinition` | Reused directly — no parallel model |
+| Knowledge Graph | `knowledge_graph_service.py` | Composed for the Experience Graph's Finding/Instrument/Anatomy/Recommendation segments |
+
+## Institutional Memory Engine (Section 1)
+
+`athena_memory_service.py` normalizes real records from six pre-existing
+stores into one searchable "memory entry" shape — no new "memory" table:
+
+| Memory type | Real source |
+|---|---|
+| Clinical decisions / lessons learned / vendor & repair observations | `KnowledgeArticle` (2 new categories added: `vendor_observation`, `repair_observation` — everything else already had a category) |
+| CAPA outcomes | `capa_lifecycle_service.list_capas` |
+| Root Cause Analyses | `RootCauseAssignment` |
+| Workflow improvements | `ContinuousImprovementInitiative` |
+| Policy history | `QualityPolicy` (Apollo, v4.7) |
+| Education history | `CompetencyEvent` (education_completed/annual_competency/procedure_validation) |
+
+```
+GET  /api/athena/memory/entries?source_types=knowledge_article,capa,...
+GET  /api/athena/memory/search?q=...
+GET  /api/athena/memory/summary
+```
+
+## Expert Knowledge Capture (Section 2)
+
+`KnowledgeArticle`'s existing `approval_status` (draft → pending_review →
+approved/rejected → archived) and `knowledge_governance_service.py`
+already implement the full approval workflow — a submission from
+`POST /api/athena/expert-contributions` enters exactly the same pipeline
+as any other article. The one new capability is photo/video/voice
+attachments via `KnowledgeMediaAttachment` (source_type=
+`knowledge_article`), since no media field existed on `KnowledgeArticle`
+before Athena.
+
+```
+POST /api/athena/expert-contributions
+POST /api/athena/expert-contributions/{id}/media
+GET  /api/athena/expert-contributions/{id}/media
+```
+
+## AI Knowledge Curator (Section 6)
+
+`athena_curator_service.py` extends `knowledge_analytics_service.py`'s
+existing pattern with four new, entirely deterministic checks:
+
+* **Duplicate candidates** — title+body token-overlap (Jaccard similarity) between article pairs.
+* **Outdated guidance** — approved articles never reviewed, or not reviewed within a configurable staleness window.
+* **Retirement candidates** — outdated *and* zero views (a conservative, real signal — never auto-archived).
+* **Emerging best practices** — repeated `knowledge_contribution` topics (Apollo's `CompetencyEvent` log) with no matching article yet.
+
+Every suggestion is for human review; nothing archives, merges, or
+demotes an article automatically.
+
+```
+GET /api/athena/curator/summary
+```
+
+## Organizational Search (Section 7)
+
+No embeddings/vector search/TF-IDF exists anywhere in this codebase
+(confirmed by grep) — consistent with the platform-wide "deterministic,
+source-grounded, zero real LLM integration" convention.
+`athena_search_service.organizational_search` federates keyword search
+across Knowledge Articles/Cases (via the existing `smart_search`),
+Policies, CAPAs, Digital Twins, Inspections, Playbooks, Research
+(publications), and Competencies — each result tagged with its real
+source system. "Meeting Notes" has no backing store anywhere in this
+codebase; rather than fabricate one, that source always returns an empty
+result with an honest reason string.
+
+```
+GET /api/athena/search?q=...
+```
+
+## Athena Assistant (Section 9)
+
+`athena_assistant_service.ask_athena` extends `ai_knowledge_assistant_
+service.answer_question` (unchanged, still the grounded baseline answer)
+with three new query shapes:
+
+| Example question | Dispatches to |
+|---|---|
+| "Show me how we handled recurring corrosion..." | `athena_memory_timeline_service.build_memory_timeline` |
+| "Find all lessons learned related to..." | `athena_search_service.organizational_search`, filtered to `lesson_learned` |
+| "What changed in our IFU guidance over the past year?" | `apollo_policy_service.list_policies` (version/review-date history) |
+| "Compare our current workflow with last year's" | `forge_workflow_service.version_history` |
+
+```
+POST /api/athena/assistant/ask
+```

--- a/docs/athena/knowledge-preservation.md
+++ b/docs/athena/knowledge-preservation.md
@@ -1,0 +1,55 @@
+# Project Athena — Knowledge Preservation
+
+LumenAI OS v4.8, Section 10.
+
+No exit-interview, video/voice capture, or workflow-recording system
+existed anywhere in this codebase before Athena — genuinely new.
+`KnowledgePreservationSession` supports the five named capture types:
+
+```
+exit_interview | video_capture | voice_transcription | workflow_recording | procedure_demonstration
+```
+
+## Never fabricates a capability
+
+`transcript_text` is always human-entered or human-reviewed — this module
+never claims to perform real speech-to-text transcription (there is zero
+real ML/LLM integration anywhere in this codebase, confirmed repeatedly
+across every prior sprint's research). Recording a transcript moves a
+session from `captured` to `transcribed`; nothing auto-generates a
+transcript from an audio/video reference.
+
+## Converting tacit knowledge into structured knowledge
+
+`convert_to_knowledge_article` promotes a session's transcript (or
+summary, if no transcript exists) into a real `KnowledgeArticle` via the
+existing `knowledge_repository_service.create_article` — no second
+article-creation path. The new article enters the same `draft` →
+`pending_review` → `approved` governance workflow as any other
+contribution (`docs/athena/institutional-memory.md`, Section 2). The
+session records `converted_article_id` and moves to `structured`.
+
+Media (photos/videos captured during the session) attach via the same
+`KnowledgeMediaAttachment` table Expert Knowledge Capture and Clinical
+Playbooks use, with `source_type="preservation_session"`.
+
+```
+POST /api/athena/preservation/sessions
+POST /api/athena/preservation/sessions/{id}/media
+POST /api/athena/preservation/sessions/{id}/transcript
+POST /api/athena/preservation/sessions/{id}/convert
+GET  /api/athena/preservation/sessions
+GET  /api/athena/preservation/sessions/{id}
+```
+
+## Governance and tenant authorization
+
+All Athena routes — including Knowledge Preservation — use
+`tenant_authz.require_tenant_roles`, which verifies a real
+`TenantMembership` row for the authenticated user before granting access.
+This is a deliberate departure from the `_tenant()`/`require_roles()`
+pattern used by every prior sprint's routes (Catalyst through Apollo),
+which resolves the acting tenant from a client-supplied header with no
+membership check — a real cross-tenant authorization gap in those
+modules. Athena does not propagate that pattern into an 18th module; the
+other 16 modules still need the same retrofit, tracked separately.

--- a/docs/athena/knowledge-trust.md
+++ b/docs/athena/knowledge-trust.md
@@ -1,0 +1,33 @@
+# Project Athena — Knowledge Trust Score
+
+LumenAI OS v4.8, Section 8.
+
+No trust/reputation/evidence-quality construct existed anywhere in this
+codebase before Athena — `beacon_standards_service.py` and
+`p24_standards_service.py` only carry `version`/`status` fields. Every
+component below is computed **live** from real `KnowledgeArticle` fields
+(never persisted as a fabricated number), and Contributor Reputation
+reuses Apollo's existing `competency_service.record_knowledge_
+contribution`/`CompetencyEvent` log rather than re-deriving a contribution
+count.
+
+## The seven components (equal-weighted average → overall score)
+
+| Component | Real basis |
+|---|---|
+| Evidence Quality | Body length + linked-standards count (`linked_standards_json`, new column) + whether `references` is populated |
+| Clinical Validation | `approval_status == approved` and whether a `reviewer` is on record |
+| Usage | `view_count` |
+| Review Date Recency | Days since `last_reviewed_at`, decaying over a 1-year window |
+| Approval Status | Fixed score per `approval_status` value |
+| Contributor Reputation | The author's `knowledge_contribution` event count (Apollo's `CompetencyEvent` log) |
+| Reference Strength | Count of linked standard codes |
+
+```
+GET /api/athena/trust/articles?min_trust=70
+GET /api/athena/trust/articles/{article_id}
+```
+
+"Organizations can filter by trust level" (the brief's own words) is
+implemented via the `min_trust` query parameter — never a black-box
+relevance score, every component is visible in the response.

--- a/frontend/src/components/KnowledgeMemoryCenter.tsx
+++ b/frontend/src/components/KnowledgeMemoryCenter.tsx
@@ -1,0 +1,286 @@
+/**
+ * v4.8 — LumenAI OS: Project Athena — Healthcare Knowledge Intelligence &
+ * Institutional Memory.
+ *
+ * Frontend route `/knowledge-memory`, API prefix `/api/athena` —
+ * deliberately distinct from the pre-existing `/api/knowledge` (v1.8) and
+ * `/api/knowledge-graph` (see `app/models/athena_knowledge.py` for the
+ * naming-disambiguation note). Athena's routes require real tenant
+ * membership (`require_tenant_roles`), a stricter check than most other
+ * modules in this app use today.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+const TABS = [
+  "Memory Engine", "Expert Capture", "Experience Graph", "Timeline", "Playbooks",
+  "Curator", "Search", "Trust Score", "Assistant", "Preservation",
+] as const;
+type Tab = (typeof TABS)[number];
+
+const PLAYBOOK_CATEGORIES = [
+  "blood_detection_investigation", "corrosion_investigation", "loaner_instrument",
+  "joint_commission_preparation", "vendor_tray", "robotic_instrument",
+];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function Json({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function KnowledgeMemoryCenter() {
+  const [activeTab, setActiveTab] = useState<Tab>("Memory Engine");
+
+  const [memorySummary, setMemorySummary] = useState<Record<string, unknown> | null>(null);
+  const [contributionForm, setContributionForm] = useState({ category: "best_practice", title: "", body: "" });
+
+  const [personQuery, setPersonQuery] = useState("");
+  const [graphResult, setGraphResult] = useState<Record<string, unknown> | null>(null);
+  const [chainForm, setChainForm] = useState({ person: "", experience_label: "", instrument_type: "", finding_type: "" });
+
+  const [timelineFinding, setTimelineFinding] = useState("blood");
+  const [timeline, setTimeline] = useState<Record<string, unknown> | null>(null);
+
+  const [playbooks, setPlaybooks] = useState<Record<string, unknown>[] | null>(null);
+
+  const [curatorSummary, setCuratorSummary] = useState<Record<string, unknown> | null>(null);
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<Record<string, unknown> | null>(null);
+
+  const [trustArticles, setTrustArticles] = useState<Record<string, unknown>[] | null>(null);
+
+  const [assistantQuestion, setAssistantQuestion] = useState("");
+  const [assistantAnswer, setAssistantAnswer] = useState<Record<string, unknown> | null>(null);
+
+  const [sessions, setSessions] = useState<Record<string, unknown>[] | null>(null);
+  const [sessionForm, setSessionForm] = useState({ subject_name: "", session_type: "exit_interview", summary: "" });
+
+  useEffect(() => {
+    api.get("/api/athena/memory/summary").then(setMemorySummary).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === "Playbooks") api.get("/api/athena/playbooks").then((r: Record<string, unknown>) => setPlaybooks(r.playbooks as Record<string, unknown>[])).catch(() => {});
+    if (activeTab === "Curator") api.get("/api/athena/curator/summary").then(setCuratorSummary).catch(() => {});
+    if (activeTab === "Trust Score") api.get("/api/athena/trust/articles").then((r: Record<string, unknown>) => setTrustArticles(r.articles as Record<string, unknown>[])).catch(() => {});
+    if (activeTab === "Preservation") api.get("/api/athena/preservation/sessions").then((r: Record<string, unknown>) => setSessions(r.sessions as Record<string, unknown>[])).catch(() => {});
+  }, [activeTab]);
+
+  async function submitContribution() {
+    if (!contributionForm.title.trim()) return;
+    await api.post("/api/athena/expert-contributions", contributionForm);
+    setContributionForm({ category: "best_practice", title: "", body: "" });
+  }
+
+  async function submitChain() {
+    if (!chainForm.person.trim() || !chainForm.finding_type.trim()) return;
+    const res = await api.post<Record<string, unknown>>("/api/athena/experience-graph/chains", chainForm);
+    setGraphResult(res);
+  }
+
+  async function lookupPerson() {
+    if (!personQuery.trim()) return;
+    const res = await api.get<Record<string, unknown>>(`/api/athena/experience-graph/person/${encodeURIComponent(personQuery)}`);
+    setGraphResult(res);
+  }
+
+  async function loadTimeline() {
+    const res = await api.get<Record<string, unknown>>(`/api/athena/timeline?finding_type=${encodeURIComponent(timelineFinding)}`);
+    setTimeline(res);
+  }
+
+  async function runSearch() {
+    if (!searchQuery.trim()) return;
+    const res = await api.get<Record<string, unknown>>(`/api/athena/search?q=${encodeURIComponent(searchQuery)}`);
+    setSearchResults(res);
+  }
+
+  async function askAssistant() {
+    if (!assistantQuestion.trim()) return;
+    const res = await api.post<Record<string, unknown>>("/api/athena/assistant/ask", { question: assistantQuestion });
+    setAssistantAnswer(res);
+  }
+
+  async function createSession() {
+    if (!sessionForm.subject_name.trim()) return;
+    await api.post("/api/athena/preservation/sessions", sessionForm);
+    setSessionForm({ subject_name: "", session_type: "exit_interview", summary: "" });
+    api.get("/api/athena/preservation/sessions").then((r: Record<string, unknown>) => setSessions(r.sessions as Record<string, unknown>[])).catch(() => {});
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Knowledge Memory Center</h1>
+      <p className="text-xs text-slate-400">
+        LumenAI's permanent organizational memory — institutional knowledge, the Experience Graph, clinical
+        playbooks, the AI Knowledge Curator, organizational search, Knowledge Trust Scores, the Athena
+        Assistant, and knowledge preservation. Clinical expertise no longer depends on individual memory.
+      </p>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Memory Engine" && (
+        <Section title="Institutional Memory Summary">{memorySummary && <Json data={memorySummary} />}</Section>
+      )}
+
+      {activeTab === "Expert Capture" && (
+        <Section title="Submit Expert Contribution">
+          <div className="space-y-2 text-sm">
+            <select className="w-full rounded border border-slate-300 p-2" value={contributionForm.category}
+              onChange={(e) => setContributionForm({ ...contributionForm, category: e.target.value })}>
+              <option value="best_practice">Best Practice</option>
+              <option value="clinical_pearl">Clinical Pearl</option>
+              <option value="lesson_learned">Lesson Learned</option>
+              <option value="teaching_point">Teaching Point</option>
+              <option value="supervisor_experience">Supervisor Experience</option>
+              <option value="vendor_observation">Vendor Observation</option>
+              <option value="repair_observation">Repair Observation</option>
+            </select>
+            <input className="w-full rounded border border-slate-300 p-2" placeholder="Title" value={contributionForm.title}
+              onChange={(e) => setContributionForm({ ...contributionForm, title: e.target.value })} />
+            <textarea className="w-full rounded border border-slate-300 p-2" placeholder="Body" value={contributionForm.body}
+              onChange={(e) => setContributionForm({ ...contributionForm, body: e.target.value })} />
+            <button className="rounded bg-indigo-600 px-4 py-2 text-white" onClick={submitContribution}>Submit for Review</button>
+          </div>
+        </Section>
+      )}
+
+      {activeTab === "Experience Graph" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="Record an Experience Chain">
+            <div className="space-y-2 text-sm">
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Person" value={chainForm.person}
+                onChange={(e) => setChainForm({ ...chainForm, person: e.target.value })} />
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Experience label" value={chainForm.experience_label}
+                onChange={(e) => setChainForm({ ...chainForm, experience_label: e.target.value })} />
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Instrument type" value={chainForm.instrument_type}
+                onChange={(e) => setChainForm({ ...chainForm, instrument_type: e.target.value })} />
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Finding type (e.g. blood)" value={chainForm.finding_type}
+                onChange={(e) => setChainForm({ ...chainForm, finding_type: e.target.value })} />
+              <button className="rounded bg-indigo-600 px-4 py-2 text-white" onClick={submitChain}>Build Chain</button>
+            </div>
+          </Section>
+          <Section title="Look Up a Person's Graph">
+            <div className="mb-3 flex gap-2">
+              <input className="flex-1 rounded border border-slate-300 p-2 text-sm" placeholder="Person name" value={personQuery}
+                onChange={(e) => setPersonQuery(e.target.value)} />
+              <button className="rounded bg-indigo-600 px-4 py-1 text-sm text-white" onClick={lookupPerson}>Look Up</button>
+            </div>
+            {graphResult && <Json data={graphResult} />}
+          </Section>
+        </div>
+      )}
+
+      {activeTab === "Timeline" && (
+        <Section title="Institutional Memory Timeline">
+          <div className="mb-3 flex gap-2">
+            <input className="flex-1 rounded border border-slate-300 p-2 text-sm" placeholder="Finding type" value={timelineFinding}
+              onChange={(e) => setTimelineFinding(e.target.value)} />
+            <button className="rounded bg-indigo-600 px-4 py-1 text-sm text-white" onClick={loadTimeline}>Load Timeline</button>
+          </div>
+          {timeline && <Json data={timeline.timeline} />}
+        </Section>
+      )}
+
+      {activeTab === "Playbooks" && (
+        <Section title="Clinical Playbooks">
+          <p className="mb-2 text-xs text-slate-400">Categories: {PLAYBOOK_CATEGORIES.join(", ")}</p>
+          {playbooks?.map((p) => (
+            <div key={String(p.id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+              <span className="font-medium">{String(p.name)}</span> — {String(p.category)} (v{String(p.version)}, {String(p.status)})
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {activeTab === "Curator" && (
+        <Section title="AI Knowledge Curator">{curatorSummary && <Json data={curatorSummary} />}</Section>
+      )}
+
+      {activeTab === "Search" && (
+        <Section title="Organizational Search">
+          <div className="mb-3 flex gap-2">
+            <input className="flex-1 rounded border border-slate-300 p-2 text-sm" placeholder="Search everything..." value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)} onKeyDown={(e) => e.key === "Enter" && runSearch()} />
+            <button className="rounded bg-indigo-600 px-4 py-1 text-sm text-white" onClick={runSearch}>Search</button>
+          </div>
+          {searchResults && <Json data={searchResults} />}
+        </Section>
+      )}
+
+      {activeTab === "Trust Score" && (
+        <Section title="Knowledge Trust Scores">
+          {trustArticles?.map((a) => (
+            <div key={String(a.article_id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+              <span className="font-medium">{String(a.title)}</span> — Trust: {String(a.overall_trust_score)}/100
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {activeTab === "Assistant" && (
+        <Section title="Athena Assistant">
+          <div className="mb-3 flex gap-2">
+            <input
+              className="flex-1 rounded border border-slate-300 p-2 text-sm"
+              placeholder='e.g. "Show me how we handled recurring corrosion in orthopedic drills."'
+              value={assistantQuestion}
+              onChange={(e) => setAssistantQuestion(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && askAssistant()}
+            />
+            <button className="rounded bg-indigo-600 px-4 py-2 text-sm text-white" onClick={askAssistant}>Ask</button>
+          </div>
+          {assistantAnswer && <Json data={assistantAnswer} />}
+        </Section>
+      )}
+
+      {activeTab === "Preservation" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="Preservation Sessions">
+            {sessions?.map((s) => (
+              <div key={String(s.id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+                <span className="font-medium">{String(s.subject_name)}</span> — {String(s.session_type)} ({String(s.status)})
+              </div>
+            ))}
+          </Section>
+          <Section title="Capture a New Session">
+            <div className="space-y-2 text-sm">
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Subject name" value={sessionForm.subject_name}
+                onChange={(e) => setSessionForm({ ...sessionForm, subject_name: e.target.value })} />
+              <select className="w-full rounded border border-slate-300 p-2" value={sessionForm.session_type}
+                onChange={(e) => setSessionForm({ ...sessionForm, session_type: e.target.value })}>
+                <option value="exit_interview">Exit Interview</option>
+                <option value="video_capture">Video Capture</option>
+                <option value="voice_transcription">Voice Transcription</option>
+                <option value="workflow_recording">Workflow Recording</option>
+                <option value="procedure_demonstration">Procedure Demonstration</option>
+              </select>
+              <textarea className="w-full rounded border border-slate-300 p-2" placeholder="Summary" value={sessionForm.summary}
+                onChange={(e) => setSessionForm({ ...sessionForm, summary: e.target.value })} />
+              <button className="rounded bg-indigo-600 px-4 py-2 text-white" onClick={createSession}>Capture Session</button>
+            </div>
+          </Section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/QualityManagementCenter.tsx
+++ b/frontend/src/components/QualityManagementCenter.tsx
@@ -1,0 +1,251 @@
+/**
+ * v4.7 — LumenAI OS: Project Apollo — Autonomous Clinical Quality
+ * Management System (CQMS).
+ *
+ * Frontend route `/quality`, API prefix `/api/apollo` — deliberately
+ * distinct from the pre-existing `/api/quality` (owned by
+ * `quality_dashboard.py`) and the already-taken `/quality-command-center`,
+ * `/quality-intelligence`, `/quality-dashboard` pages (see
+ * `app/models/apollo_quality.py` for the full naming-disambiguation note).
+ * Positioned as the unifying Quality Management Center front door, not a
+ * fourth competing quality page.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+const TABS = [
+  "Quality Dashboard", "CAPA", "Audit Center", "Competencies", "Policies",
+  "Standards", "Education", "Evidence", "Improvement Projects",
+] as const;
+type Tab = (typeof TABS)[number];
+
+const AUDIT_PACKAGE_TYPES = ["joint_commission", "aami", "aami_st91", "fda", "cms", "aorn", "dnv", "internal", "vendor", "full"];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function Json({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function QualityManagementCenter() {
+  const [activeTab, setActiveTab] = useState<Tab>("Quality Dashboard");
+  const [executiveDashboard, setExecutiveDashboard] = useState<Record<string, unknown> | null>(null);
+
+  const [capaSummary, setCapaSummary] = useState<Record<string, unknown> | null>(null);
+  const [complaintForm, setComplaintForm] = useState({ source: "", description: "", severity: "medium", instrument_type: "" });
+
+  const [auditSummary, setAuditSummary] = useState<Record<string, unknown> | null>(null);
+  const [auditPackageType, setAuditPackageType] = useState("joint_commission");
+  const [generatedAudit, setGeneratedAudit] = useState<Record<string, unknown> | null>(null);
+
+  const [competencySummary, setCompetencySummary] = useState<Record<string, unknown> | null>(null);
+
+  const [policies, setPolicies] = useState<Record<string, unknown>[] | null>(null);
+  const [policyForm, setPolicyForm] = useState({ title: "", owner: "" });
+
+  const [standardsLibrary, setStandardsLibrary] = useState<Record<string, unknown> | null>(null);
+
+  const [rcaSummary, setRcaSummary] = useState<Record<string, unknown> | null>(null);
+
+  const [improvementProjects, setImprovementProjects] = useState<Record<string, unknown>[] | null>(null);
+  const [portfolioSummary, setPortfolioSummary] = useState<Record<string, unknown> | null>(null);
+  const [projectForm, setProjectForm] = useState({ initiative: "", owner: "", methodology: "pi" });
+
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    api.get("/api/apollo/executive-dashboard").then(setExecutiveDashboard).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === "CAPA") api.get("/api/apollo/capa/summary").then(setCapaSummary).catch(() => {});
+    if (activeTab === "Audit Center") api.get("/api/apollo/audit/summary").then(setAuditSummary).catch(() => {});
+    if (activeTab === "Competencies") api.get("/api/apollo/competency/summary").then(setCompetencySummary).catch(() => {});
+    if (activeTab === "Policies") api.get("/api/apollo/policies").then((r: Record<string, unknown>) => setPolicies(r.policies as Record<string, unknown>[])).catch(() => {});
+    if (activeTab === "Standards") api.get("/api/apollo/standards/library").then(setStandardsLibrary).catch(() => {});
+    if (activeTab === "Evidence") api.get("/api/apollo/rca/summary").then(setRcaSummary).catch(() => {});
+    if (activeTab === "Improvement Projects") {
+      api.get("/api/apollo/improvement-projects").then((r: Record<string, unknown>) => setImprovementProjects(r.projects as Record<string, unknown>[])).catch(() => {});
+      api.get("/api/apollo/improvement-projects/summary").then(setPortfolioSummary).catch(() => {});
+    }
+  }, [activeTab]);
+
+  async function submitComplaint() {
+    if (!complaintForm.description.trim()) return;
+    await api.post("/api/apollo/capa/complaints", complaintForm);
+    setComplaintForm({ source: "", description: "", severity: "medium", instrument_type: "" });
+    api.get("/api/apollo/capa/summary").then(setCapaSummary).catch(() => {});
+  }
+
+  async function generateAudit() {
+    try {
+      const res = await api.post<Record<string, unknown>>("/api/apollo/audit/generate", { package_type: auditPackageType });
+      setGeneratedAudit(res);
+      setError("");
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function createPolicy() {
+    if (!policyForm.title.trim()) return;
+    await api.post("/api/apollo/policies", policyForm);
+    setPolicyForm({ title: "", owner: "" });
+    api.get("/api/apollo/policies").then((r: Record<string, unknown>) => setPolicies(r.policies as Record<string, unknown>[])).catch(() => {});
+  }
+
+  async function createProject() {
+    if (!projectForm.initiative.trim()) return;
+    await api.post("/api/apollo/improvement-projects", projectForm);
+    setProjectForm({ initiative: "", owner: "", methodology: "pi" });
+    api.get("/api/apollo/improvement-projects").then((r: Record<string, unknown>) => setImprovementProjects(r.projects as Record<string, unknown>[])).catch(() => {});
+    api.get("/api/apollo/improvement-projects/summary").then(setPortfolioSummary).catch(() => {});
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Quality Management Center</h1>
+      <p className="text-xs text-slate-400">
+        Composes CAPA, Root Cause Intelligence, Audit Center, Competency Center, Policy Intelligence, Standards Library,
+        Continuous Improvement, and the Quality Digital Twin into one unified Clinical Quality Management System.
+        Human oversight remains mandatory for all quality decisions.
+      </p>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Quality Dashboard" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {executiveDashboard && (
+            <>
+              <Section title="Quality Maturity Index">
+                <p className="text-3xl font-bold text-indigo-600">{String(executiveDashboard.quality_maturity_index ?? "—")}</p>
+                <Json data={executiveDashboard.quality_maturity_index_weights} />
+              </Section>
+              <Section title="Compliance / Audit Readiness"><Json data={executiveDashboard.audit_readiness} /></Section>
+              <Section title="Open CAPAs"><Json data={{ open_capas: executiveDashboard.open_capas, closure_rate_pct: executiveDashboard.capa_closure_rate_pct }} /></Section>
+              <Section title="Competency Status"><Json data={executiveDashboard.competency_status} /></Section>
+              <Section title="High-Risk Policies / Upcoming Reviews">
+                <Json data={{ high_risk: executiveDashboard.high_risk_policies, upcoming: executiveDashboard.upcoming_reviews }} />
+              </Section>
+              <Section title="Continuous Improvement"><Json data={executiveDashboard.continuous_improvement} /></Section>
+            </>
+          )}
+        </div>
+      )}
+
+      {activeTab === "CAPA" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="CAPA Engine Summary">{capaSummary && <Json data={capaSummary} />}</Section>
+          <Section title="Log a Customer Complaint (CAPA trigger source)">
+            <div className="space-y-2 text-sm">
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Source" value={complaintForm.source}
+                onChange={(e) => setComplaintForm({ ...complaintForm, source: e.target.value })} />
+              <textarea className="w-full rounded border border-slate-300 p-2" placeholder="Description" value={complaintForm.description}
+                onChange={(e) => setComplaintForm({ ...complaintForm, description: e.target.value })} />
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Instrument type" value={complaintForm.instrument_type}
+                onChange={(e) => setComplaintForm({ ...complaintForm, instrument_type: e.target.value })} />
+              <select className="w-full rounded border border-slate-300 p-2" value={complaintForm.severity}
+                onChange={(e) => setComplaintForm({ ...complaintForm, severity: e.target.value })}>
+                <option value="low">low</option><option value="medium">medium</option><option value="high">high</option>
+              </select>
+              <button className="rounded bg-indigo-600 px-4 py-2 text-white" onClick={submitComplaint}>Submit Complaint</button>
+            </div>
+          </Section>
+        </div>
+      )}
+
+      {activeTab === "Audit Center" && (
+        <Section title="Audit Center">
+          {auditSummary && <Json data={auditSummary} />}
+          <div className="mt-3 flex gap-2">
+            <select className="rounded border border-slate-300 p-1 text-sm" value={auditPackageType} onChange={(e) => setAuditPackageType(e.target.value)}>
+              {AUDIT_PACKAGE_TYPES.map((p) => <option key={p} value={p}>{p.replace(/_/g, " ")}</option>)}
+            </select>
+            <button className="rounded bg-indigo-600 px-4 py-1 text-sm text-white" onClick={generateAudit}>Generate Audit Package</button>
+          </div>
+          {error && <p className="mt-2 text-xs text-amber-600">{error}</p>}
+          {generatedAudit && <div className="mt-3"><Json data={generatedAudit} /></div>}
+        </Section>
+      )}
+
+      {activeTab === "Competencies" && (
+        <Section title="Competency Center">{competencySummary && <Json data={competencySummary} />}</Section>
+      )}
+
+      {activeTab === "Policies" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="Quality Policies">
+            {policies?.map((p) => (
+              <div key={String(p.id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+                <span className="font-medium">{String(p.title)}</span> — v{String(p.version)} ({String(p.status)})
+              </div>
+            ))}
+          </Section>
+          <Section title="Draft a New Policy">
+            <div className="space-y-2 text-sm">
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Title" value={policyForm.title}
+                onChange={(e) => setPolicyForm({ ...policyForm, title: e.target.value })} />
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Owner" value={policyForm.owner}
+                onChange={(e) => setPolicyForm({ ...policyForm, owner: e.target.value })} />
+              <button className="rounded bg-indigo-600 px-4 py-2 text-white" onClick={createPolicy}>Create Draft</button>
+            </div>
+          </Section>
+        </div>
+      )}
+
+      {activeTab === "Standards" && (
+        <Section title="Standards Knowledge Library">{standardsLibrary && <Json data={standardsLibrary} />}</Section>
+      )}
+
+      {activeTab === "Education" && (
+        <Section title="Education">{competencySummary && <Json data={competencySummary.technicians} />}</Section>
+      )}
+
+      {activeTab === "Evidence" && (
+        <Section title="Root Cause Intelligence — Pareto / Trend Analysis">{rcaSummary && <Json data={rcaSummary} />}</Section>
+      )}
+
+      {activeTab === "Improvement Projects" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="Portfolio Summary">{portfolioSummary && <Json data={portfolioSummary} />}</Section>
+          <Section title="Projects">
+            {improvementProjects?.map((p) => (
+              <div key={String(p.id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+                <span className="font-medium">{String(p.initiative)}</span> — {String(p.methodology)} ({String(p.status)})
+              </div>
+            ))}
+            <div className="mt-3 space-y-2 text-sm">
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Initiative" value={projectForm.initiative}
+                onChange={(e) => setProjectForm({ ...projectForm, initiative: e.target.value })} />
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Owner" value={projectForm.owner}
+                onChange={(e) => setProjectForm({ ...projectForm, owner: e.target.value })} />
+              <select className="w-full rounded border border-slate-300 p-2" value={projectForm.methodology}
+                onChange={(e) => setProjectForm({ ...projectForm, methodology: e.target.value })}>
+                <option value="pi">PI</option><option value="lean">Lean</option><option value="six_sigma">Six Sigma</option>
+                <option value="kaizen">Kaizen</option><option value="other">Other</option>
+              </select>
+              <button className="rounded bg-indigo-600 px-4 py-2 text-white" onClick={createProject}>Create Project</button>
+            </div>
+          </Section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -86,6 +86,7 @@ const CopilotWorkspacePage = lazy(() => import("./pages/CopilotWorkspacePage"));
 const ExecutiveIntelligencePage = lazy(() => import("./pages/ExecutiveIntelligencePage"));
 const StrategicPlanningPage = lazy(() => import("./pages/StrategicPlanningPage"));
 const QualityManagementCenterPage = lazy(() => import("./pages/QualityManagementCenterPage"));
+const KnowledgeMemoryPage = lazy(() => import("./pages/KnowledgeMemoryPage"));
 const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
@@ -413,6 +414,7 @@ function App() {
                       <Route path="/executive" element={<Page name="ExecutiveIntelligence"><ExecutiveIntelligencePage /></Page>} />
                       <Route path="/strategy" element={<Page name="StrategicPlanning"><StrategicPlanningPage /></Page>} />
                       <Route path="/quality" element={<Page name="QualityManagementCenter"><QualityManagementCenterPage /></Page>} />
+                      <Route path="/knowledge-memory" element={<Page name="KnowledgeMemory"><KnowledgeMemoryPage /></Page>} />
                       <Route path="/agent-trace" element={<Page name="AgentTrace"><AgentTraceViewer /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -85,6 +85,7 @@ const PulseCommandCenterPage = lazy(() => import("./pages/PulseCommandCenterPage
 const CopilotWorkspacePage = lazy(() => import("./pages/CopilotWorkspacePage"));
 const ExecutiveIntelligencePage = lazy(() => import("./pages/ExecutiveIntelligencePage"));
 const StrategicPlanningPage = lazy(() => import("./pages/StrategicPlanningPage"));
+const QualityManagementCenterPage = lazy(() => import("./pages/QualityManagementCenterPage"));
 const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
@@ -411,6 +412,7 @@ function App() {
                       <Route path="/copilot-workspace" element={<Page name="CopilotWorkspace"><CopilotWorkspacePage /></Page>} />
                       <Route path="/executive" element={<Page name="ExecutiveIntelligence"><ExecutiveIntelligencePage /></Page>} />
                       <Route path="/strategy" element={<Page name="StrategicPlanning"><StrategicPlanningPage /></Page>} />
+                      <Route path="/quality" element={<Page name="QualityManagementCenter"><QualityManagementCenterPage /></Page>} />
                       <Route path="/agent-trace" element={<Page name="AgentTrace"><AgentTraceViewer /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />

--- a/frontend/src/pages/KnowledgeMemoryPage.tsx
+++ b/frontend/src/pages/KnowledgeMemoryPage.tsx
@@ -1,0 +1,5 @@
+import KnowledgeMemoryCenter from "@/components/KnowledgeMemoryCenter";
+
+export default function KnowledgeMemoryPage() {
+  return <KnowledgeMemoryCenter />;
+}

--- a/frontend/src/pages/QualityManagementCenterPage.tsx
+++ b/frontend/src/pages/QualityManagementCenterPage.tsx
@@ -1,0 +1,5 @@
+import QualityManagementCenter from "@/components/QualityManagementCenter";
+
+export default function QualityManagementCenterPage() {
+  return <QualityManagementCenter />;
+}


### PR DESCRIPTION
## Summary
This PR now contains two additive modules built sequentially on the same branch:

- **Project Apollo (v4.7)** — a unified Quality Management Center at `/quality` (API prefix `/api/apollo`) spanning CAPA, Root Cause Intelligence, Audit Center, Competency Center, Policy Intelligence, Standards Library, Continuous Improvement Portfolio, a department-scoped Quality Digital Twin, and an Executive Quality Dashboard.
- **Project Athena (v4.8)** — a Healthcare Knowledge Intelligence & Institutional Memory platform at `/knowledge-memory` (API prefix `/api/athena`), composing the existing Institutional Knowledge system, Knowledge Graph, and Forge workflow engine into an Institutional Memory Engine, Expert Knowledge Capture, Experience Graph, Institutional Memory Timeline, Clinical Playbooks, AI Knowledge Curator, Organizational Search, Knowledge Trust Score, Athena Assistant, and Knowledge Preservation.

These are the 16th and 17th additive modules in this sprint series. The prior 15 modules (Sentinel through Vanguard) are already merged into `main` via PR #88; this PR only contains Apollo's and Athena's changes on top of that.

## Why This Change
Both sprints are deliberately almost entirely composition-and-additive-extension work rather than parallel systems — see `docs/apollo/quality-management.md` and `docs/athena/institutional-memory.md` for the full naming-disambiguation tables researched before writing any code.

## Scope
**Apollo (see prior PR description, unchanged):** `apollo_quality.py` (3 new tables), 5 additively-extended pre-existing services, 9 new Apollo service files, routes at `/api/apollo`, frontend at `/quality`, `docs/apollo/*.md` (6 files), `test_apollo_quality.py` (34 tests).

**Athena (new in this update):**
- `athena_knowledge.py` — 4 new tables (`KnowledgeMediaAttachment`, `ExperienceGraphNode`, `ExperienceGraphEdge`, `KnowledgePreservationSession`).
- Additive extensions: `knowledge.py` (2 new article categories + `linked_standards_json`), `workflow_forge.py` (3 new template categories + `linked_standards_json`), `forge_template_service.py` (template names for the 3 new categories).
- 10 new Athena service files composing `knowledge_graph_service`, `ai_knowledge_assistant_service`, `knowledge_search_service`, `knowledge_analytics_service`, `forge_workflow_service`, `capa_lifecycle_service`, `root_cause_service`, `apollo_policy_service`, and `competency_service`.
- New routes at `/api/athena` (`backend/app/routes/athena_knowledge.py`) — **using `tenant_authz.require_tenant_roles` (real `TenantMembership` verification)** rather than the header-only tenant-resolution pattern every prior sprint's routes use. This is a deliberate, user-approved security improvement scoped to this module only; the other 16 modules still need the same retrofit.
- New frontend page at `/knowledge-memory` (`KnowledgeMemoryCenter.tsx`, 10 tabs).
- `docs/athena/*.md` (5 files) and `backend/tests/test_athena_knowledge.py` (28 tests covering all 8 named coverage areas, including tenant-membership authorization).

**Excluded:** No changes to any of the 15 already-merged modules' behavior. No parallel CAPA/RCA/playbook/knowledge-article store — everything reuses the existing systems.

## Testing
- [x] Unit tests — 34 Apollo + 28 Athena tests; full suite: `3098 passed, 1 failed (pre-existing time-of-day flake in test_or_connect.py, unrelated to this PR), 2 skipped`
- [x] Manual verification — `ruff check backend/app backend/tests` clean; `app.main` imports cleanly with all Apollo/Athena routes registered
- [x] Docker build — not applicable to this change
- [x] API/worker runtime validation — `npm run build` (frontend) succeeds; new `/api/apollo/*` and `/api/athena/*` routes confirmed registered via FastAPI route introspection

## Risks
Additive-only schema changes throughout. `forge_template_service.py`'s template-name dictionary needed completing for the 3 new playbook categories (caught by the full test suite and fixed in this PR — see commit message for detail). Athena's stricter tenant-authorization pattern means its tests seed `TenantMembership` rows explicitly rather than relying on a header alone, unlike every other module's tests.

## Rollback Plan
Revert the relevant commit(s) — all new tables/columns are additive and unused by any pre-existing code path, so a revert is a clean no-op for the other modules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVqKmNua8sWhTdLDHEPyzV)_