### PR TITLE
Project Phoenix (v4.9) + Project Infinity (v5.0)

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -106,6 +106,9 @@ from app.models.apollo_quality import (  # noqa: F401
 from app.models.athena_knowledge import (  # noqa: F401
     ExperienceGraphEdge, ExperienceGraphNode, KnowledgeMediaAttachment, KnowledgePreservationSession,
 )
+from app.models.phoenix_intelligence import (  # noqa: F401
+    AIInferenceLatencySample, ImprovementRecommendation, InnovationIdea, PlatformMaturitySnapshot, ValidationOutcome,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -109,6 +109,10 @@ from app.models.athena_knowledge import (  # noqa: F401
 from app.models.phoenix_intelligence import (  # noqa: F401
     AIInferenceLatencySample, ImprovementRecommendation, InnovationIdea, PlatformMaturitySnapshot, ValidationOutcome,
 )
+from app.models.infinity_platform import (  # noqa: F401
+    DeveloperAccount, DeveloperApiKey, DeveloperSandboxSession, MarketplaceInstallation,
+    MarketplaceListing, MarketplaceRevenueEvent, PartnerLicense,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1065,6 +1065,10 @@ from app.models import athena_knowledge as _athena_knowledge_models  # noqa: F40
 from app.routes.athena_knowledge import router as athena_knowledge_router
 app.include_router(athena_knowledge_router)
 
+from app.models import phoenix_intelligence as _phoenix_intelligence_models  # noqa: F401
+from app.routes.phoenix_intelligence import router as phoenix_intelligence_router
+app.include_router(phoenix_intelligence_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1069,6 +1069,10 @@ from app.models import phoenix_intelligence as _phoenix_intelligence_models  # n
 from app.routes.phoenix_intelligence import router as phoenix_intelligence_router
 app.include_router(phoenix_intelligence_router)
 
+from app.models import infinity_platform as _infinity_platform_models  # noqa: F401
+from app.routes.infinity_platform import router as infinity_platform_router
+app.include_router(infinity_platform_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/models/infinity_platform.py
+++ b/backend/app/models/infinity_platform.py
@@ -1,0 +1,368 @@
+"""v5.0 — LumenAI OS: Project Infinity — Healthcare AI Platform &
+Developer Ecosystem.
+
+## Naming disambiguation (read this first)
+
+Infinity is the 19th additive sprint, and by far the widest in surface
+area (platform, marketplace, billing, security). Every existing
+platform/marketplace/billing/API-versioning system was read in full
+before writing any code:
+
+  * **App/plugin registry**: Genesis's `platform_core.py` (v4.0) already
+    has `PlatformModule`/`PlatformModuleLicense`/`PlatformPlugin` — the
+    latter explicitly documented as "no plugin code is ever imported or
+    run by this table," a metadata-only registration surface with
+    `registered_routes_json`/`registered_menus_json`/
+    `registered_widgets_json`/`registered_dashboards_json`/
+    `registered_reports_json`. Infinity extends `PlatformPlugin` with the
+    five extension-point types the Plugin SDK names that it didn't yet
+    have (workflow nodes, AI skills, notifications, commands, analytics)
+    plus a link to a `DeveloperAccount`/`MarketplaceListing`, rather than
+    a second plugin-registration table. `MODULE_DEVELOPER`/
+    `MODULE_MARKETPLACE` module keys already reserved by Genesis are
+    reused as-is — Infinity does not invent new module keys.
+  * **Module Licensing (Section 8)**: `PlatformModuleLicense` (Genesis)
+    already tracks per-tenant module entitlement (enabled/disabled/
+    trial). Infinity composes it directly for "Module Licensing" — no
+    second license-per-module table.
+  * **Workflow marketplace**: Forge's `WorkflowDefinition.
+    marketplace_status` (`private/pending_review/published`,
+    `forge_marketplace_service.py`) is a real, narrow marketplace for
+    workflow templates only — no generic listing/author/pricing
+    abstraction. Infinity's `MarketplaceListing` is a genuinely new,
+    generic model for AI Skills and Applications, but reuses the exact
+    same three-state naming for consistency.
+  * **Versioned Public API**: Nexus's `/api/v1/*` gateway
+    (`nexus_api_gateway.py`, v3.2) is already the "first genuinely
+    versioned API prefix in this codebase," with dual bearer/API-key
+    auth (`require_gateway_auth`) covering Instruments/Inspections/
+    Digital-Twins/Knowledge/Enterprise. Infinity extends that same
+    router with the remaining named systems (Identity/Organizations/
+    Users/Analytics/Pulse/Sentinel/Forge/Catalyst/Orbit/Apollo/Athena/
+    Phoenix) — it does not stand up a second versioned gateway.
+  * **Secret API keys**: `nexus_credential_service.py`'s
+    `secrets.token_urlsafe(40)` + SHA-256-hash-only pattern (raw key
+    shown exactly once, never stored) is reused verbatim for
+    `DeveloperApiKey` — a new model because it is issued to a
+    `DeveloperAccount`, not a `NexusConnectorCredential`'s connector_id,
+    but the issuance/validation logic is byte-for-byte the same pattern.
+  * **Certification Program (Section 7)**: Forge's `WorkflowApprovalChain`/
+    `WorkflowApprovalInstance` (v4.1, `forge_approval_service.py`) stores
+    an arbitrary ordered list of role-string steps — already reused by
+    Athena (v4.8) and Phoenix's 6-stage Continuous Validation (v4.9).
+    Infinity reuses it a third time with 7 named gates (Security/
+    Performance/Clinical Safety/Explainability/Accessibility/
+    Documentation/Governance) — no new approval-chain model.
+  * **Identity for third parties**: `TenantMembership`/`tenant_authz.py`
+    model internal tenant staff only, resolved from a bearer JWT. Growth's
+    `StrategicPartnership` (P-era) is commercial/BD metadata with no
+    authentication linkage. Neither fits "a third-party developer
+    building an app" — `DeveloperAccount` is a genuinely new, first-class
+    identity, deliberately distinct from `TenantMembership`.
+  * **Billing**: P14's `TenantPlan`/`PaymentEvent`/`TenantUsageCounter`
+    are entirely inspection-volume subscription billing. There is no
+    existing home for Enterprise/Partner licensing terms or marketplace
+    revenue sharing — `PartnerLicense` and `MarketplaceRevenueEvent` are
+    genuinely new.
+  * **Sandbox**: `pilot_config.py`/`pilot_error_log.py` (v1.9) are a
+    different, older "pilot" concept (customer/site sales-pilot
+    configuration) — zero collision. `DeveloperSandboxSession` is
+    genuinely new: an isolated, synthetic tenant scope for third-party
+    development/testing/validation/certification with no production
+    impact.
+
+## Genuinely new tables in this file
+
+  * `DeveloperAccount` / `DeveloperApiKey` — third-party developer
+    identity and credentials, distinct from internal `TenantMembership`.
+  * `MarketplaceListing` — a generic AI-Skill/Application listing,
+    versioned, with a certification-chain link (reusing Forge's
+    approval-chain primitive) and a pricing model.
+  * `MarketplaceInstallation` — which tenant installed which listing.
+  * `MarketplaceRevenueEvent` — marketplace revenue-sharing ledger.
+  * `DeveloperSandboxSession` — an isolated dev/test/validation/
+    certification session, scoped to a synthetic tenant_id, never
+    production.
+  * `PartnerLicense` — enterprise/partner commercial licensing terms,
+    distinct from Genesis's per-module `PlatformModuleLicense`.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Developer / partner org categories (mirrors the Application
+# Marketplace's 7 named app categories, Section 5) ───────────────────────────
+DEV_TYPE_HOSPITAL = "hospital"
+DEV_TYPE_MANUFACTURER = "manufacturer"
+DEV_TYPE_REPAIR_VENDOR = "repair_vendor"
+DEV_TYPE_ACADEMIC = "academic"
+DEV_TYPE_RESEARCH = "research"
+DEV_TYPE_ENTERPRISE = "enterprise"
+DEV_TYPE_CONSULTING = "consulting"
+DEVELOPER_TYPES = [
+    DEV_TYPE_HOSPITAL, DEV_TYPE_MANUFACTURER, DEV_TYPE_REPAIR_VENDOR, DEV_TYPE_ACADEMIC,
+    DEV_TYPE_RESEARCH, DEV_TYPE_ENTERPRISE, DEV_TYPE_CONSULTING,
+]
+
+DEVELOPER_ACTIVE = "active"
+DEVELOPER_SUSPENDED = "suspended"
+DEVELOPER_STATUSES = [DEVELOPER_ACTIVE, DEVELOPER_SUSPENDED]
+
+# ── Marketplace listing types + AI Skill categories (Section 4) ─────────────
+LISTING_TYPE_AI_SKILL = "ai_skill"
+LISTING_TYPE_APPLICATION = "application"
+LISTING_TYPES = [LISTING_TYPE_AI_SKILL, LISTING_TYPE_APPLICATION]
+
+SKILL_CATEGORY_INSPECTION = "inspection"
+SKILL_CATEGORY_KNOWLEDGE = "knowledge"
+SKILL_CATEGORY_FORECAST = "forecast"
+SKILL_CATEGORY_REPORTING = "reporting"
+SKILL_CATEGORY_RESEARCH = "research"
+SKILL_CATEGORY_EDUCATION = "education"
+SKILL_CATEGORIES = [
+    SKILL_CATEGORY_INSPECTION, SKILL_CATEGORY_KNOWLEDGE, SKILL_CATEGORY_FORECAST,
+    SKILL_CATEGORY_REPORTING, SKILL_CATEGORY_RESEARCH, SKILL_CATEGORY_EDUCATION,
+]
+
+# Mirrors Forge's exact marketplace_status naming (workflow_forge.py) for
+# consistency across this codebase's marketplace concepts.
+LISTING_PRIVATE = "private"
+LISTING_PENDING_REVIEW = "pending_review"
+LISTING_PUBLISHED = "published"
+LISTING_STATUSES = [LISTING_PRIVATE, LISTING_PENDING_REVIEW, LISTING_PUBLISHED]
+
+PRICING_FREE = "free"
+PRICING_SUBSCRIPTION = "subscription"
+PRICING_ONE_TIME = "one_time"
+PRICING_REVENUE_SHARE = "revenue_share"
+PRICING_MODELS = [PRICING_FREE, PRICING_SUBSCRIPTION, PRICING_ONE_TIME, PRICING_REVENUE_SHARE]
+
+CERT_NOT_STARTED = "not_started"
+CERT_IN_PROGRESS = "in_progress"
+CERT_CERTIFIED = "certified"
+CERT_REJECTED = "rejected"
+CERTIFICATION_STATUSES = [CERT_NOT_STARTED, CERT_IN_PROGRESS, CERT_CERTIFIED, CERT_REJECTED]
+
+# ── Certification Program gates (Section 7) — the 7 named steps driven
+# through the reused Forge WorkflowApprovalChain primitive. ──────────────────
+GATE_SECURITY = "security"
+GATE_PERFORMANCE = "performance"
+GATE_CLINICAL_SAFETY = "clinical_safety"
+GATE_EXPLAINABILITY = "explainability"
+GATE_ACCESSIBILITY = "accessibility"
+GATE_DOCUMENTATION = "documentation"
+GATE_GOVERNANCE = "governance"
+CERTIFICATION_GATES = [
+    GATE_SECURITY, GATE_PERFORMANCE, GATE_CLINICAL_SAFETY, GATE_EXPLAINABILITY,
+    GATE_ACCESSIBILITY, GATE_DOCUMENTATION, GATE_GOVERNANCE,
+]
+
+INSTALLATION_INSTALLED = "installed"
+INSTALLATION_DISABLED = "disabled"
+INSTALLATION_STATUSES = [INSTALLATION_INSTALLED, INSTALLATION_DISABLED]
+
+# ── Developer Sandbox (Section 9) ────────────────────────────────────────────
+SANDBOX_DEVELOPMENT = "development"
+SANDBOX_TESTING = "testing"
+SANDBOX_VALIDATION = "validation"
+SANDBOX_CERTIFICATION = "certification"
+SANDBOX_PURPOSES = [SANDBOX_DEVELOPMENT, SANDBOX_TESTING, SANDBOX_VALIDATION, SANDBOX_CERTIFICATION]
+
+SANDBOX_ACTIVE = "active"
+SANDBOX_EXPIRED = "expired"
+SANDBOX_TERMINATED = "terminated"
+SANDBOX_STATUSES = [SANDBOX_ACTIVE, SANDBOX_EXPIRED, SANDBOX_TERMINATED]
+
+# ── Billing & Licensing (Section 8) ──────────────────────────────────────────
+LICENSE_TYPE_MODULE = "module"
+LICENSE_TYPE_ENTERPRISE = "enterprise"
+LICENSE_TYPE_PARTNER = "partner"
+PARTNER_LICENSE_TYPES = [LICENSE_TYPE_MODULE, LICENSE_TYPE_ENTERPRISE, LICENSE_TYPE_PARTNER]
+
+PARTNER_LICENSE_ACTIVE = "active"
+PARTNER_LICENSE_EXPIRED = "expired"
+PARTNER_LICENSE_REVOKED = "revoked"
+PARTNER_LICENSE_STATUSES = [PARTNER_LICENSE_ACTIVE, PARTNER_LICENSE_EXPIRED, PARTNER_LICENSE_REVOKED]
+
+REVENUE_EVENT_SUBSCRIPTION = "subscription_charge"
+REVENUE_EVENT_ONE_TIME = "one_time_purchase"
+REVENUE_EVENT_USAGE = "usage_fee"
+REVENUE_EVENT_TYPES = [REVENUE_EVENT_SUBSCRIPTION, REVENUE_EVENT_ONE_TIME, REVENUE_EVENT_USAGE]
+
+DISCLAIMER = (
+    "LumenAI Infinity extends the platform to trusted third-party developers and partner "
+    "organizations under governed certification, licensing, and sandboxing controls. No "
+    "marketplace listing, plugin, or extension ever executes third-party code inside this "
+    "platform's core process, and no listing reaches production tenants without passing every "
+    "certification gate and receiving explicit human approval."
+)
+
+
+class DeveloperAccount(Base):
+    """A third-party developer/partner organization's identity (Sections
+    1, 5) — deliberately distinct from `TenantMembership`, since a
+    developer building an app is not necessarily tenant staff."""
+
+    __tablename__ = "infinity_developer_accounts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    organization_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    developer_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(20), default=DEVELOPER_ACTIVE, nullable=False, index=True)
+    sandbox_only: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    approved_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class DeveloperApiKey(Base):
+    """A developer's API credential (Section 1 Authentication) — the
+    exact `secrets.token_urlsafe(40)` + SHA-256-hash-only pattern already
+    established in `nexus_credential_service.py`; the raw key is returned
+    exactly once at issuance and never stored or retrievable again."""
+
+    __tablename__ = "infinity_developer_api_keys"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    developer_account_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    key_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    scopes_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    sandbox_only: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    revoked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, index=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class MarketplaceListing(Base):
+    """One AI Skill or Application listing (Sections 4, 5) — a generic
+    model distinct from Forge's workflow-only marketplace. Certification
+    is tracked via a linked Forge `WorkflowApprovalChain`/`Instance`
+    (`certification_chain_id`/`certification_instance_id`), never a
+    second approval-chain model."""
+
+    __tablename__ = "infinity_marketplace_listings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+
+    developer_account_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    listing_type: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    category: Mapped[str] = mapped_column(String(30), default="", nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    version: Mapped[str] = mapped_column(String(20), default="0.1.0", nullable=False)
+
+    status: Mapped[str] = mapped_column(String(20), default=LISTING_PRIVATE, nullable=False, index=True)
+    pricing_model: Mapped[str] = mapped_column(String(20), default=PRICING_FREE, nullable=False)
+    price_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    certification_status: Mapped[str] = mapped_column(String(20), default=CERT_NOT_STARTED, nullable=False, index=True)
+    certification_chain_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    certification_instance_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    manifest_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+
+class MarketplaceInstallation(Base):
+    """Which tenant installed which listing (Section 5 — "Organizations
+    choose which apps to install")."""
+
+    __tablename__ = "infinity_marketplace_installations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    listing_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    installed_version: Mapped[str] = mapped_column(String(20), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), default=INSTALLATION_INSTALLED, nullable=False, index=True)
+    installed_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+
+class MarketplaceRevenueEvent(Base):
+    """One marketplace revenue-sharing ledger entry (Section 8) — a
+    genuinely new billing construct; no revenue-sharing concept existed
+    anywhere in P14's inspection-volume billing infrastructure."""
+
+    __tablename__ = "infinity_marketplace_revenue_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    listing_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    event_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+
+    gross_amount_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+    developer_share_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+    platform_share_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+class DeveloperSandboxSession(Base):
+    """An isolated development/testing/validation/certification session
+    (Section 9), scoped to a synthetic `sandbox_tenant_id` — never a real
+    production tenant. `sandbox_tenant_id` is generated with a fixed
+    prefix so it can never collide with, or be mistaken for, a real
+    tenant_id."""
+
+    __tablename__ = "infinity_developer_sandbox_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    developer_account_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    listing_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sandbox_tenant_id: Mapped[str] = mapped_column(String(120), nullable=False, unique=True, index=True)
+    purpose: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(20), default=SANDBOX_ACTIVE, nullable=False, index=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class PartnerLicense(Base):
+    """Enterprise/partner commercial licensing terms (Section 8) —
+    distinct from Genesis's per-module `PlatformModuleLicense`, which
+    only carries an enabled/disabled/trial flag, not commercial terms."""
+
+    __tablename__ = "infinity_partner_licenses"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    developer_account_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    tenant_id: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    license_type: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    licensed_module_keys_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    terms: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    revenue_share_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    status: Mapped[str] = mapped_column(String(20), default=PARTNER_LICENSE_ACTIVE, nullable=False, index=True)
+    effective_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expiration_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/phoenix_intelligence.py
+++ b/backend/app/models/phoenix_intelligence.py
@@ -1,0 +1,291 @@
+"""v4.9 — LumenAI OS: Project Phoenix — Self-Improving Healthcare
+Intelligence Platform.
+
+## Naming disambiguation (read this first)
+
+Phoenix is the 18th additive sprint. Before writing any code, every
+existing performance/analytics/maturity-adjacent system was read in full:
+
+  * **AI Performance Observatory (Section 3)**: `app/services/ml/
+    pilot_validation.py`'s `clinical_metrics`/`confidence_calibration`/
+    `zone_performance` and `sentinel_ai_health_service.compute_ai_health`
+    already compute precision/recall/F1/FP-FN rates/agreement/drift from
+    real `SupervisorReview` rows. Phoenix composes these directly — the
+    only genuinely new metrics are **Inference Latency** (nothing
+    anywhere measures AI scoring wall-clock time) and **Coverage** as "%
+    of inspections that received a real AI confidence score" (distinct
+    from `inspection_coverage.py`'s image/zone-capture-completeness
+    "coverage", a different concept with the same name).
+  * **Knowledge Evolution Center (Section 5)**: `athena_curator_service.
+    py` (v4.8) already detects duplicates/outdated guidance/retirement
+    candidates/emerging practices/knowledge gaps. Phoenix composes it
+    directly, adding only **contradictory guidance** detection — a
+    genuine gap (confirmed via grep: no "contradict" logic exists
+    anywhere in this codebase).
+  * **Competency Intelligence (Section 6)**: `competency_intelligence_
+    service.py` (v2.9) already detects coaching/team-education/
+    department-retraining opportunities via the shared `CompetencyOpportunity`
+    model. Two of that model's five `OPPORTUNITY_TYPES` — `annual_competency`
+    and `recurring_learning` — were defined but never produced by any
+    detector; Phoenix adds detectors for those plus three new types
+    (`simulation`, `mentoring`, `knowledge_sharing`) to the same table.
+  * **Workflow Optimization Engine (Section 4)**: `WorkflowExecution`
+    (`workflow_forge.py`, v4.1) already records real `execution_time_ms`/
+    `decision_path_json`, but no duration/bottleneck/queue-delay/rule-
+    complexity analytics exists anywhere over it — genuine gap. Phoenix
+    reads these rows directly; it does not duplicate the model, and any
+    optimization it recommends is surfaced as a *recommendation*, never
+    an automatic `revise_workflow` call.
+  * **Platform Maturity Index (Section 10)**: Apollo's
+    `apollo_quality_twin_service.compute_quality_twin` (v4.7) is already
+    an 8-dimension "Quality Maturity Index." Phoenix's 9-dimension
+    Platform Maturity Index takes that `overall_score` as its own
+    "Quality" dimension input rather than re-deriving CAPA/competency/
+    audit-readiness numbers a third time. "Executive Intelligence"
+    composes `vanguard_executive_intelligence_service`/`vanguard_
+    governance_service` (v4.6) the same way.
+  * **Continuous Validation (Section 9)**: `WorkflowApprovalChain`/
+    `WorkflowApprovalInstance` (`workflow_forge.py`, v4.1,
+    `forge_approval_service.py`) already implement exactly the ordered
+    multi-step approval primitive Phoenix's Review → Clinical Validation
+    → Technical Review → Pilot → Measurement → Production pipeline
+    needs. Phoenix creates one chain per recommendation with those six
+    steps and drives it via the existing `start_instance`/`decide_step`
+    — no second approval-chain model. Note: `app/models/pilot.py`/
+    `pilot_config.py`/`pilot_error_log.py` are a completely different,
+    older "pilot" concept (customer/site sales-pilot tracking) — zero
+    collision, but Phoenix avoids the bare word "pilot" as a table/field
+    name to prevent confusion.
+  * **Innovation Pipeline (Section 8)**: confirmed via grep — no Idea/
+    Evidence/ROI/Clinical-Impact/Roadmap model exists anywhere. Genuinely
+    new.
+
+## Genuinely new tables in this file
+
+  * `ImprovementRecommendation` — the core recommendation entity
+    (Section 2), carrying Evidence/Expected Benefit/Confidence/Impact
+    Assessment/Required Approvals, and its Continuous Validation stage.
+  * `ValidationOutcome` — per-stage outcomes and lessons learned for a
+    recommendation moving through the reused Forge approval chain.
+  * `InnovationIdea` — the Innovation Pipeline backlog (Section 8).
+  * `PlatformMaturitySnapshot` — the 9-dimension Platform Maturity Index,
+    tracked over time (Section 10).
+  * `AIInferenceLatencySample` — real, explicitly recorded latency
+    measurements (Section 3) — never a fabricated typical value; the
+    Observatory reports "insufficient data" when none exist.
+
+Phoenix never modifies production automatically — every recommendation
+and idea starts in a draft/proposal state and only advances through an
+explicit human decision at each stage.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Improvement Recommendation types (Section 2) ─────────────────────────────
+REC_IMPROVE_ANATOMY_MODEL = "improve_anatomy_model"
+REC_COLLECT_BASELINE_IMAGES = "collect_baseline_images"
+REC_UPDATE_WORKFLOW = "update_workflow"
+REC_REVISE_INSPECTION_GUIDANCE = "revise_inspection_guidance"
+REC_IMPROVE_KNOWLEDGE_GRAPH = "improve_knowledge_graph"
+REC_REVIEW_AI_CONFIDENCE = "review_ai_confidence"
+REC_CREATE_COMPETENCY = "create_competency"
+REC_UPDATE_SOP = "update_sop"
+RECOMMENDATION_TYPES = [
+    REC_IMPROVE_ANATOMY_MODEL, REC_COLLECT_BASELINE_IMAGES, REC_UPDATE_WORKFLOW,
+    REC_REVISE_INSPECTION_GUIDANCE, REC_IMPROVE_KNOWLEDGE_GRAPH, REC_REVIEW_AI_CONFIDENCE,
+    REC_CREATE_COMPETENCY, REC_UPDATE_SOP,
+]
+
+# The engine that generated a recommendation.
+SOURCE_AI_OBSERVATORY = "ai_observatory"
+SOURCE_WORKFLOW_OPTIMIZER = "workflow_optimizer"
+SOURCE_KNOWLEDGE_EVOLUTION = "knowledge_evolution"
+SOURCE_COMPETENCY_INTELLIGENCE = "competency_intelligence"
+RECOMMENDATION_SOURCES = [
+    SOURCE_AI_OBSERVATORY, SOURCE_WORKFLOW_OPTIMIZER, SOURCE_KNOWLEDGE_EVOLUTION, SOURCE_COMPETENCY_INTELLIGENCE,
+]
+
+# ── Continuous Validation pipeline stages (Section 9) — mirrors the six
+# steps driven through the reused Forge WorkflowApprovalChain primitive.
+STAGE_REVIEW = "review"
+STAGE_CLINICAL_VALIDATION = "clinical_validation"
+STAGE_TECHNICAL_REVIEW = "technical_review"
+STAGE_PILOT = "pilot"
+STAGE_MEASUREMENT = "measurement"
+STAGE_PRODUCTION = "production"
+VALIDATION_STAGES = [
+    STAGE_REVIEW, STAGE_CLINICAL_VALIDATION, STAGE_TECHNICAL_REVIEW, STAGE_PILOT, STAGE_MEASUREMENT, STAGE_PRODUCTION,
+]
+
+RECOMMENDATION_STATUSES = ["draft", *VALIDATION_STAGES, "rejected"]
+
+# ── Innovation Pipeline (Section 8) ───────────────────────────────────────────
+IMPACT_LOW = "low"
+IMPACT_MEDIUM = "medium"
+IMPACT_HIGH = "high"
+IMPACT_CRITICAL = "critical"
+CLINICAL_IMPACT_LEVELS = [IMPACT_LOW, IMPACT_MEDIUM, IMPACT_HIGH, IMPACT_CRITICAL]
+TECHNICAL_COMPLEXITY_LEVELS = [IMPACT_LOW, IMPACT_MEDIUM, IMPACT_HIGH]
+PRIORITY_LEVELS = [IMPACT_LOW, IMPACT_MEDIUM, IMPACT_HIGH, IMPACT_CRITICAL]
+
+IDEA_DRAFT = "draft"
+IDEA_APPROVED = "approved"
+IDEA_REJECTED = "rejected"
+IDEA_IN_PROGRESS = "in_progress"
+IDEA_COMPLETED = "completed"
+IDEA_APPROVAL_STATUSES = [IDEA_DRAFT, IDEA_APPROVED, IDEA_REJECTED, IDEA_IN_PROGRESS, IDEA_COMPLETED]
+
+# ── AI Observatory latency sample stages (Section 3) ─────────────────────────
+LATENCY_STAGE_DETECTION = "detection"
+LATENCY_STAGE_ANATOMY_MODEL = "anatomy_model"
+LATENCY_STAGE_FULL_PIPELINE = "full_pipeline"
+LATENCY_STAGES = [LATENCY_STAGE_DETECTION, LATENCY_STAGE_ANATOMY_MODEL, LATENCY_STAGE_FULL_PIPELINE]
+
+DISCLAIMER = (
+    "LumenAI Phoenix analyzes real platform performance, knowledge quality, AI accuracy, workflow "
+    "efficiency, and operational outcomes to surface evidence-based improvement recommendations — it "
+    "never modifies production automatically. Every recommendation, innovation idea, and maturity score "
+    "is decision support only and requires explicit human governance and approval at every stage."
+)
+
+
+class ImprovementRecommendation(Base):
+    """A single explainable improvement recommendation (Section 2),
+    carrying Evidence/Expected Benefit/Confidence/Impact Assessment/
+    Required Approvals, and its Continuous Validation stage (Section 9).
+    Never auto-applied — `status` only ever advances via an explicit
+    human decision recorded through the reused Forge approval chain."""
+
+    __tablename__ = "phoenix_improvement_recommendations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    recommendation_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    source: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+
+    evidence_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    expected_benefit: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    impact_assessment: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    required_approvals_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    status: Mapped[str] = mapped_column(String(30), default="draft", nullable=False, index=True)
+    approval_chain_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    approval_instance_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # A reference to whatever real record triggered this recommendation
+    # (e.g. a workflow_id, article_id, opportunity_id) — blank when the
+    # recommendation is tenant-wide rather than object-specific.
+    related_object_type: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    related_object_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)
+
+
+class ValidationOutcome(Base):
+    """Tracked outcome and lessons learned for one stage of a
+    recommendation's journey through Continuous Validation (Section 9)."""
+
+    __tablename__ = "phoenix_validation_outcomes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    recommendation_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    stage: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    outcome_notes: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    lessons_learned: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    measured_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    recorded_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+
+class InnovationIdea(Base):
+    """One Innovation Pipeline backlog entry (Section 8) — Ideas/Evidence/
+    Estimated ROI/Clinical Impact/Technical Complexity/Priority/Approval
+    Status/Roadmap Assignment."""
+
+    __tablename__ = "phoenix_innovation_ideas"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    evidence: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    estimated_roi_usd: Mapped[float | None] = mapped_column(Float, nullable=True)
+    clinical_impact: Mapped[str] = mapped_column(String(20), default=IMPACT_MEDIUM, nullable=False, index=True)
+    technical_complexity: Mapped[str] = mapped_column(String(20), default=IMPACT_MEDIUM, nullable=False, index=True)
+    priority: Mapped[str] = mapped_column(String(20), default=IMPACT_MEDIUM, nullable=False, index=True)
+    approval_status: Mapped[str] = mapped_column(String(20), default=IDEA_DRAFT, nullable=False, index=True)
+    roadmap_assignment: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+    submitted_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+
+class PlatformMaturitySnapshot(Base):
+    """A Platform Maturity Index snapshot (Section 10) across nine named
+    dimensions, tracked over time — a pure composition of real,
+    already-computed scores from prior sprints, plus Phoenix's own
+    Workflow/Analytics/AI-observatory-derived dimensions."""
+
+    __tablename__ = "phoenix_platform_maturity_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    inspection_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    knowledge_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    quality_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    workflow_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    analytics_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    education_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    digital_twins_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    governance_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    executive_intelligence_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+
+    overall_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    factors_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)
+
+
+class AIInferenceLatencySample(Base):
+    """A real, explicitly recorded AI-scoring latency measurement
+    (Section 3) — never a fabricated typical value. The Observatory
+    reports "insufficient data" when no samples exist for a stage rather
+    than inventing a number."""
+
+    __tablename__ = "phoenix_ai_inference_latency_samples"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), default="default-tenant", nullable=False, index=True)
+
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    stage: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    latency_ms: Mapped[float] = mapped_column(Float, nullable=False)

--- a/backend/app/models/platform_core.py
+++ b/backend/app/models/platform_core.py
@@ -202,6 +202,22 @@ class PlatformPlugin(Base):
     registered_dashboards_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
     registered_reports_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
 
+    # v5.0 — Project Infinity Plugin SDK (Section 3): the remaining
+    # extension-point types the SDK names that this table didn't yet
+    # have. Still metadata-only — no code is ever imported or run from
+    # any of these columns, same as the fields above.
+    registered_workflow_nodes_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    registered_ai_skills_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    registered_notifications_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    registered_commands_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    registered_analytics_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    # Links this plugin registration to the third-party developer/listing
+    # that published it, if any — blank/null for LumenAI's own core
+    # modules (`is_core=True` on `PlatformModule`).
+    developer_account_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    marketplace_listing_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+
     registered_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
 
 

--- a/backend/app/models/quality_guardian.py
+++ b/backend/app/models/quality_guardian.py
@@ -121,9 +121,16 @@ OPPORTUNITY_TEAM_EDUCATION = "team_education"
 OPPORTUNITY_DEPARTMENT_RETRAINING = "department_retraining"
 OPPORTUNITY_ANNUAL_COMPETENCY = "annual_competency"
 OPPORTUNITY_RECURRING_LEARNING = "recurring_learning"
+# v4.9 — Project Phoenix Competency Intelligence (Section 6). Three new
+# types; `annual_competency`/`recurring_learning` above were already
+# defined here but never produced by any detector until Phoenix.
+OPPORTUNITY_SIMULATION = "simulation"
+OPPORTUNITY_MENTORING = "mentoring"
+OPPORTUNITY_KNOWLEDGE_SHARING = "knowledge_sharing"
 OPPORTUNITY_TYPES = [
     OPPORTUNITY_COACHING, OPPORTUNITY_TEAM_EDUCATION, OPPORTUNITY_DEPARTMENT_RETRAINING,
     OPPORTUNITY_ANNUAL_COMPETENCY, OPPORTUNITY_RECURRING_LEARNING,
+    OPPORTUNITY_SIMULATION, OPPORTUNITY_MENTORING, OPPORTUNITY_KNOWLEDGE_SHARING,
 ]
 
 DISCLAIMER = (

--- a/backend/app/routes/infinity_platform.py
+++ b/backend/app/routes/infinity_platform.py
@@ -1,0 +1,525 @@
+"""v5.0 — LumenAI OS: Project Infinity — Healthcare AI Platform &
+Developer Ecosystem routes.
+
+Frontend routes: /developers, /marketplace.
+API prefix: /api/infinity — free namespace (confirmed via research). The
+versioned public API itself lives at `/api/v1/*`
+(`nexus_api_gateway.py`, extended for this sprint) — `/api/infinity` is
+the platform's own internal management surface for developer accounts,
+marketplace curation, certification, billing, and sandboxing.
+
+## Two distinct auth paths
+
+  * **Internal tenant staff** — `tenant_authz.require_tenant_roles` (real
+    `TenantMembership` verification), matching Athena (v4.8) and Phoenix
+    (v4.9). Used for admin-curation actions (approving developer
+    accounts, publishing listings, certification decisions, licensing)
+    and tenant-facing marketplace browsing/installation.
+  * **Third-party developers** — a `DeveloperApiKey` presented via the
+    `X-Infinity-Developer-Key` header, authenticated through
+    `infinity_developer_service.authenticate_api_key` (the same
+    hash-only pattern `nexus_credential_service.py` already established).
+    Used only for `/developer-portal/me`, the one endpoint a developer
+    calls about themselves — everything else that manages a developer
+    account is intentionally admin-gated, matching the brief's "trusted
+    third parties" framing rather than open self-service.
+
+  * GET  /developer-portal/api-explorer, /rate-limits, /tutorials,
+    GET  /developer-portal/me                                            — Section 1
+  * POST /developer-accounts, GET /developer-accounts,
+    GET  /developer-accounts/{id}, PATCH /developer-accounts/{id}/status,
+    POST /developer-accounts/{id}/api-keys,
+    GET  /developer-accounts/{id}/api-keys,
+    POST /developer-accounts/{id}/api-keys/{key_id}/revoke              — Section 1 (Auth)
+  * POST /plugins, GET /plugins, GET /plugins/{plugin_key},
+    POST /plugins/{plugin_key}/extensions,
+    POST /plugins/{plugin_key}/activate, POST /plugins/{plugin_key}/disable — Sections 3, 6
+  * POST /marketplace/listings, GET /marketplace/listings,
+    GET  /marketplace/listings/{id},
+    POST /marketplace/listings/{id}/submit-for-review,
+    POST /marketplace/listings/{id}/publish, /unpublish,
+    POST /marketplace/installations, GET /marketplace/installations,
+    POST /marketplace/installations/{id}/uninstall                       — Sections 4, 5
+  * POST /certification/listings/{id}/start, /advance,
+    GET  /certification/listings/{id}                                    — Section 7
+  * GET  /billing/module-licenses, POST /billing/partner-licenses,
+    GET  /billing/partner-licenses,
+    POST /billing/partner-licenses/{id}/revoke,
+    POST /billing/revenue-events,
+    GET  /billing/revenue-events/listings/{id}/summary                   — Section 8
+  * POST /sandbox/sessions, GET /sandbox/sessions,
+    GET  /sandbox/sessions/{id}, POST /sandbox/sessions/{id}/terminate,
+    POST /sandbox/sessions/expire-stale                                  — Section 9
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.deps import get_db
+from app.services import (
+    infinity_billing_service,
+    infinity_certification_service,
+    infinity_developer_portal_service,
+    infinity_developer_service,
+    infinity_extension_service,
+    infinity_marketplace_service,
+    infinity_sandbox_service,
+)
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/infinity", tags=["infinity"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+def _audit(db: Session, tenant_id: str, actor: str, action_type: str, resource_type: str, resource_id: str, details: dict) -> None:
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id, actor_email=actor, actor_role="",
+        action_type=action_type, resource_type=resource_type, resource_id=resource_id, details=details, compliance_flag=True,
+    )
+
+
+def require_developer_auth(request: Request, db: Session = Depends(get_db)) -> dict:
+    """Third-party developer auth via API key — never a tenant bearer
+    token, since a developer is not necessarily tenant staff."""
+    api_key = request.headers.get("X-Infinity-Developer-Key", "")
+    if not api_key:
+        raise HTTPException(status_code=401, detail="Missing X-Infinity-Developer-Key header.")
+    key_row = infinity_developer_service.authenticate_api_key(db, api_key)
+    if key_row is None:
+        raise HTTPException(status_code=401, detail="Invalid, revoked, or expired developer API key.")
+    return {"developer_account_id": key_row.developer_account_id}
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Developer Portal
+# ---------------------------------------------------------------------------
+
+
+@router.get("/developer-portal/api-explorer")
+def get_api_explorer():
+    return {"endpoints": infinity_developer_portal_service.api_explorer_catalog()}
+
+
+@router.get("/developer-portal/rate-limits")
+def get_rate_limits():
+    return infinity_developer_portal_service.rate_limit_policy()
+
+
+@router.get("/developer-portal/tutorials")
+def get_tutorials():
+    return {"tutorials": infinity_developer_portal_service.tutorials()}
+
+
+@router.get("/developer-portal/me")
+def get_my_developer_portal(db: Session = Depends(get_db), dev_auth: dict = Depends(require_developer_auth)):
+    return infinity_developer_portal_service.developer_portal_summary(db, dev_auth["developer_account_id"])
+
+
+# ---------------------------------------------------------------------------
+# Section 1 (Authentication) — Developer accounts & API keys
+# ---------------------------------------------------------------------------
+
+
+@router.post("/developer-accounts", status_code=201)
+def post_developer_account(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_developer_service.create_developer_account(
+            db, email=payload.get("email", ""), organization_name=payload.get("organization_name", ""),
+            developer_type=payload.get("developer_type", ""), approved_by=actor,
+            sandbox_only=bool(payload.get("sandbox_only", True)),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.developer_account_created", "infinity_developer_accounts", str(result["id"]), {"email": result["email"]})
+    return result
+
+
+@router.get("/developer-accounts")
+def get_developer_accounts(status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"accounts": infinity_developer_service.list_developer_accounts(db, status=status)}
+
+
+@router.get("/developer-accounts/{developer_account_id}")
+def get_developer_account(developer_account_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_developer_service.get_developer_account(db, developer_account_id)
+    except infinity_developer_service.DeveloperAccountNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.patch("/developer-accounts/{developer_account_id}/status")
+def patch_developer_account_status(developer_account_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_developer_service.set_developer_account_status(db, developer_account_id, status=payload.get("status", ""))
+    except infinity_developer_service.DeveloperAccountNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.developer_account_status_changed", "infinity_developer_accounts", str(developer_account_id), {"status": result["status"]})
+    return result
+
+
+@router.post("/developer-accounts/{developer_account_id}/api-keys", status_code=201)
+def post_developer_api_key(developer_account_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_developer_service.issue_api_key(
+            db, developer_account_id, scopes=payload.get("scopes"), sandbox_only=bool(payload.get("sandbox_only", True)),
+        )
+    except infinity_developer_service.DeveloperAccountNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.developer_api_key_issued", "infinity_developer_api_keys", str(result["id"]), {})
+    return result
+
+
+@router.get("/developer-accounts/{developer_account_id}/api-keys")
+def get_developer_api_keys(developer_account_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"api_keys": infinity_developer_service.list_api_keys(db, developer_account_id)}
+
+
+@router.post("/developer-accounts/{developer_account_id}/api-keys/{key_id}/revoke")
+def post_revoke_developer_api_key(developer_account_id: int, key_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = infinity_developer_service.revoke_api_key(db, developer_account_id, key_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"API key {key_id} not found for developer account {developer_account_id}.")
+    _audit(db, tenant_id, actor, "infinity.developer_api_key_revoked", "infinity_developer_api_keys", str(key_id), {})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Sections 3, 6 — Plugin SDK & Extension Framework
+# ---------------------------------------------------------------------------
+
+
+@router.post("/plugins", status_code=201)
+def post_plugin(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = infinity_extension_service.register_plugin(
+        db, plugin_key=payload.get("plugin_key", ""), name=payload.get("name", ""), version=payload.get("version", "0.1.0"),
+        developer_account_id=payload.get("developer_account_id"), marketplace_listing_id=payload.get("marketplace_listing_id"),
+        registered_by=actor,
+    )
+    _audit(db, tenant_id, actor, "infinity.plugin_registered", "platform_plugins", result["plugin_key"], {})
+    return result
+
+
+@router.get("/plugins")
+def get_plugins(status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"plugins": infinity_extension_service.list_plugins(db, status=status)}
+
+
+@router.get("/plugins/{plugin_key}")
+def get_plugin(plugin_key: str, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_extension_service.get_plugin(db, plugin_key)
+    except infinity_extension_service.PluginNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/plugins/{plugin_key}/extensions")
+def post_plugin_extension(plugin_key: str, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_extension_service.register_extension(
+            db, plugin_key, extension_type=payload.get("extension_type", ""), location=payload.get("location", ""),
+            item=payload.get("item", {}),
+        )
+    except infinity_extension_service.PluginNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (infinity_extension_service.InvalidExtensionTypeError, infinity_extension_service.InvalidExtensionLocationError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/plugins/{plugin_key}/activate")
+def post_activate_plugin(plugin_key: str, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_extension_service.activate_plugin(db, plugin_key)
+    except infinity_extension_service.PluginNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/plugins/{plugin_key}/disable")
+def post_disable_plugin(plugin_key: str, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_extension_service.disable_plugin(db, plugin_key)
+    except infinity_extension_service.PluginNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Sections 4, 5 — AI Skills Marketplace & Application Marketplace
+# ---------------------------------------------------------------------------
+
+
+@router.post("/marketplace/listings", status_code=201)
+def post_marketplace_listing(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_marketplace_service.create_listing(
+            db, payload.get("developer_account_id"), listing_type=payload.get("listing_type", ""),
+            name=payload.get("name", ""), category=payload.get("category", ""), description=payload.get("description", ""),
+            pricing_model=payload.get("pricing_model", "free"), price_cents=payload.get("price_cents"),
+            manifest=payload.get("manifest"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.marketplace_listing_created", "infinity_marketplace_listings", str(result["id"]), {"listing_type": result["listing_type"]})
+    return result
+
+
+@router.get("/marketplace/listings")
+def get_marketplace_listings(
+    listing_type: str = Query(""), category: str = Query(""), status: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return {"listings": infinity_marketplace_service.list_listings(db, listing_type=listing_type, category=category, status=status)}
+
+
+@router.get("/marketplace/listings/{listing_id}")
+def get_marketplace_listing(listing_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_marketplace_service.get_listing(db, listing_id)
+    except infinity_marketplace_service.ListingNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/marketplace/listings/{listing_id}/submit-for-review")
+def post_submit_listing_for_review(listing_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_marketplace_service.submit_for_review(db, listing_id)
+    except infinity_marketplace_service.ListingNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/marketplace/listings/{listing_id}/publish")
+def post_publish_listing(listing_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_marketplace_service.publish_listing(db, listing_id)
+    except infinity_marketplace_service.ListingNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except infinity_marketplace_service.ListingNotCertifiedError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.marketplace_listing_published", "infinity_marketplace_listings", str(listing_id), {})
+    return result
+
+
+@router.post("/marketplace/listings/{listing_id}/unpublish")
+def post_unpublish_listing(listing_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_marketplace_service.unpublish_listing(db, listing_id)
+    except infinity_marketplace_service.ListingNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/marketplace/installations", status_code=201)
+def post_marketplace_installation(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_marketplace_service.install_listing(db, tenant_id, payload.get("listing_id"), installed_by=actor)
+    except infinity_marketplace_service.ListingNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.marketplace_listing_installed", "infinity_marketplace_installations", str(result["id"]), {"listing_id": result["listing_id"]})
+    return result
+
+
+@router.get("/marketplace/installations")
+def get_marketplace_installations(status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {"installations": infinity_marketplace_service.list_installations(db, tenant_id, status=status)}
+
+
+@router.post("/marketplace/installations/{installation_id}/uninstall")
+def post_uninstall(installation_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_marketplace_service.uninstall(db, tenant_id, installation_id)
+    except infinity_marketplace_service.InstallationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.marketplace_listing_uninstalled", "infinity_marketplace_installations", str(installation_id), {})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Certification Program
+# ---------------------------------------------------------------------------
+
+
+@router.post("/certification/listings/{listing_id}/start")
+def post_start_certification(listing_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_certification_service.start_certification(db, listing_id)
+    except infinity_marketplace_service.ListingNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.certification_started", "infinity_marketplace_listings", str(listing_id), {})
+    return result
+
+
+@router.post("/certification/listings/{listing_id}/advance")
+def post_advance_certification(listing_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_certification_service.advance_certification(
+            db, listing_id, decided_by=actor, decided_role=payload.get("decided_role", ""),
+            decision=payload.get("decision", ""), notes=payload.get("notes", ""),
+        )
+    except infinity_marketplace_service.ListingNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.certification_advanced", "infinity_marketplace_listings", str(listing_id), {"decision": payload.get("decision", "")})
+    return result
+
+
+@router.get("/certification/listings/{listing_id}")
+def get_certification_status(listing_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_certification_service.get_certification_status(db, listing_id)
+    except infinity_marketplace_service.ListingNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Billing & Licensing
+# ---------------------------------------------------------------------------
+
+
+@router.get("/billing/module-licenses")
+def get_module_licenses(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return infinity_billing_service.module_licensing_summary(db, tenant_id)
+
+
+@router.post("/billing/partner-licenses", status_code=201)
+def post_partner_license(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_billing_service.create_partner_license(
+            db, license_type=payload.get("license_type", ""), developer_account_id=payload.get("developer_account_id"),
+            tenant_id=payload.get("tenant_id", ""), licensed_module_keys=payload.get("licensed_module_keys"),
+            terms=payload.get("terms", ""), revenue_share_pct=payload.get("revenue_share_pct"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.partner_license_created", "infinity_partner_licenses", str(result["id"]), {"license_type": result["license_type"]})
+    return result
+
+
+@router.get("/billing/partner-licenses")
+def get_partner_licenses(
+    developer_account_id: int = Query(None), tenant_id_filter: str = Query(""), status: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    return {"licenses": infinity_billing_service.list_partner_licenses(db, developer_account_id=developer_account_id, tenant_id=tenant_id_filter, status=status)}
+
+
+@router.post("/billing/partner-licenses/{license_id}/revoke")
+def post_revoke_partner_license(license_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = infinity_billing_service.revoke_partner_license(db, license_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Partner license {license_id} not found.")
+    _audit(db, tenant_id, actor, "infinity.partner_license_revoked", "infinity_partner_licenses", str(license_id), {})
+    return result
+
+
+@router.post("/billing/revenue-events", status_code=201)
+def post_revenue_event(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_billing_service.record_revenue_event(
+            db, payload.get("listing_id"), tenant_id, event_type=payload.get("event_type", ""),
+            gross_amount_cents=payload.get("gross_amount_cents", 0), developer_share_pct=payload.get("developer_share_pct"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.revenue_event_recorded", "infinity_marketplace_revenue_events", str(result["id"]), {"event_type": result["event_type"]})
+    return result
+
+
+@router.get("/billing/revenue-events/listings/{listing_id}/summary")
+def get_revenue_summary(listing_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return infinity_billing_service.revenue_summary_for_listing(db, listing_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Developer Sandbox
+# ---------------------------------------------------------------------------
+
+
+@router.post("/sandbox/sessions", status_code=201)
+def post_sandbox_session(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_sandbox_service.create_sandbox_session(
+            db, payload.get("developer_account_id"), purpose=payload.get("purpose", ""),
+            listing_id=payload.get("listing_id"), lifetime_hours=payload.get("lifetime_hours", 24),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.sandbox_session_created", "infinity_developer_sandbox_sessions", str(result["id"]), {"purpose": result["purpose"]})
+    return result
+
+
+@router.get("/sandbox/sessions")
+def get_sandbox_sessions(developer_account_id: int = Query(...), status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"sessions": infinity_sandbox_service.list_sandbox_sessions(db, developer_account_id, status=status)}
+
+
+@router.get("/sandbox/sessions/{session_id}")
+def get_sandbox_session(session_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        return infinity_sandbox_service.get_sandbox_session(db, session_id)
+    except infinity_sandbox_service.SandboxSessionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/sandbox/sessions/{session_id}/terminate")
+def post_terminate_sandbox_session(session_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = infinity_sandbox_service.terminate_sandbox_session(db, session_id)
+    except infinity_sandbox_service.SandboxSessionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "infinity.sandbox_session_terminated", "infinity_developer_sandbox_sessions", str(session_id), {})
+    return result
+
+
+@router.post("/sandbox/sessions/expire-stale")
+def post_expire_stale_sandbox_sessions(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"expired": infinity_sandbox_service.expire_stale_sessions(db)}

--- a/backend/app/routes/nexus_api_gateway.py
+++ b/backend/app/routes/nexus_api_gateway.py
@@ -14,6 +14,14 @@ key via the `X-Nexus-Api-Key` header (for machine-to-machine connector
 calls), matched by SHA-256 hash against `NexusConnectorCredential` — the
 same never-store-the-raw-key pattern used at issuance
 (`nexus_credential_service.py`).
+
+v5.0 — Project Infinity, Section 2 (Public Platform APIs): this file is
+extended (not duplicated) with the remaining named systems — Identity,
+Organizations, Users, Analytics, Pulse, Sentinel, Forge, Catalyst, Orbit,
+Apollo, Athena, Phoenix — using the exact same `require_gateway_auth`
+dependency and `api_version: "v1"` response shape as the five endpoints
+above, since a versioned gateway must speak one consistent auth contract
+across every endpoint in it.
 """
 from __future__ import annotations
 
@@ -134,3 +142,106 @@ def get_v1_enterprise(
     request: Request, system_id: str = Query(...), db: Session = Depends(get_db), auth=Depends(require_gateway_auth),
 ):
     return {"api_version": "v1", "enterprise": atlas_dashboard_service.enterprise_dashboard(db, system_id)}
+
+
+# ---------------------------------------------------------------------------
+# v5.0 — Project Infinity additions (Section 2)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/v1/identity")
+def get_v1_identity(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "auth_mode": auth["auth_mode"]}
+
+
+@router.get("/api/v1/organizations")
+def get_v1_organizations(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.platform_org_service import facility_for_tenant
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "organization": facility_for_tenant(db, tenant_id)}
+
+
+@router.get("/api/v1/users")
+def get_v1_users(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    tenant_id = auth["tenant_id"]
+    rows = db.query(models.TenantMembership).filter(models.TenantMembership.tenant_id == tenant_id).all()
+    return {
+        "api_version": "v1", "tenant_id": tenant_id,
+        "users": [{"user_email": r.user_email, "role": r.role, "is_enabled": r.is_enabled} for r in rows],
+    }
+
+
+@router.get("/api/v1/analytics")
+def get_v1_analytics(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.quality_command_center_service import quality_command_center_summary
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "analytics": quality_command_center_summary(db, tenant_id)}
+
+
+@router.get("/api/v1/pulse")
+def get_v1_pulse(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.pulse_command_center_service import pulse_command_center
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "pulse": pulse_command_center(db, tenant_id)}
+
+
+@router.get("/api/v1/sentinel")
+def get_v1_sentinel(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.sentinel_ai_health_service import compute_ai_health
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "ai_health": compute_ai_health(db, tenant_id)}
+
+
+@router.get("/api/v1/forge")
+def get_v1_forge(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.forge_workflow_service import list_workflows
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "workflows": list_workflows(db, tenant_id)}
+
+
+@router.get("/api/v1/catalyst")
+def get_v1_catalyst(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.catalyst_skills_service import ensure_skills_seeded, list_skills
+
+    ensure_skills_seeded(db)
+    return {"api_version": "v1", "tenant_id": auth["tenant_id"], "skills": list_skills(db)}
+
+
+@router.get("/api/v1/orbit")
+def get_v1_orbit(
+    request: Request, facility_id: str = Query(""), db: Session = Depends(get_db), auth=Depends(require_gateway_auth),
+):
+    from app.services.orbit_executive_service import executive_surgical_operations
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "orbit": executive_surgical_operations(db, tenant_id, facility_id=facility_id)}
+
+
+@router.get("/api/v1/apollo")
+def get_v1_apollo(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.apollo_executive_quality_service import executive_quality_dashboard
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "apollo": executive_quality_dashboard(db, tenant_id)}
+
+
+@router.get("/api/v1/athena")
+def get_v1_athena(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.athena_memory_service import memory_summary
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "athena": memory_summary(db, tenant_id)}
+
+
+@router.get("/api/v1/phoenix")
+def get_v1_phoenix(request: Request, db: Session = Depends(get_db), auth=Depends(require_gateway_auth)):
+    from app.services.phoenix_learning_engine_service import learning_engine_summary
+
+    tenant_id = auth["tenant_id"]
+    return {"api_version": "v1", "tenant_id": tenant_id, "phoenix": learning_engine_summary(db, tenant_id)}

--- a/backend/app/routes/phoenix_intelligence.py
+++ b/backend/app/routes/phoenix_intelligence.py
@@ -1,0 +1,347 @@
+"""v4.9 — LumenAI OS: Project Phoenix — Self-Improving Healthcare
+Intelligence Platform routes.
+
+Frontend routes: /phoenix, /platform-health.
+API prefix: /api/phoenix — free namespace (confirmed via research).
+
+## Tenant authorization
+
+Like Athena (v4.8), every route in this file uses `tenant_authz.
+require_tenant_roles` (real `TenantMembership` verification) rather than
+the header-only pattern the first 16 modules used. Phoenix is a new
+module, not a retrofit — it does not knowingly reintroduce the
+cross-tenant gap those modules still carry.
+
+  * GET  /learning-engine/summary                                        — Section 1
+  * POST /recommendations/generate, GET /recommendations,
+    GET  /recommendations/{id}                                            — Section 2
+  * GET  /observatory/summary, POST /observatory/latency,
+    GET  /observatory/latency, GET /observatory/coverage                  — Section 3
+  * GET  /workflow-optimization/summary,
+    GET  /workflow-optimization/{workflow_id}                             — Section 4
+  * GET  /knowledge-evolution/summary                                      — Section 5
+  * POST /competency-intelligence/run,
+    GET  /competency-intelligence/opportunities                            — Section 6
+  * GET  /platform-health/dashboard                                        — Section 7
+  * POST /innovation/ideas, GET /innovation/ideas, GET /innovation/ideas/{id},
+    PATCH /innovation/ideas/{id}/status, GET /innovation/summary            — Section 8
+  * POST /recommendations/{id}/validation/start,
+    POST /recommendations/{id}/validation/advance,
+    POST /recommendations/{id}/validation/outcomes,
+    GET  /recommendations/{id}/validation                                  — Section 9
+  * POST /maturity/compute, GET /maturity/history                          — Section 10
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.audit import log_audit_event
+from app.deps import get_db
+from app.services import (
+    phoenix_ai_observatory_service,
+    phoenix_competency_intelligence_service,
+    phoenix_innovation_pipeline_service,
+    phoenix_knowledge_evolution_service,
+    phoenix_learning_engine_service,
+    phoenix_maturity_index_service,
+    phoenix_platform_health_service,
+    phoenix_recommendation_engine,
+    phoenix_validation_pipeline_service,
+    phoenix_workflow_optimization_service,
+)
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/phoenix", tags=["phoenix"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+def _audit(db: Session, tenant_id: str, actor: str, action_type: str, resource_type: str, resource_id: str, details: dict) -> None:
+    log_audit_event(
+        db, tenant_id=tenant_id, tenant_name=tenant_id, actor_email=actor, actor_role="",
+        action_type=action_type, resource_type=resource_type, resource_id=resource_id, details=details, compliance_flag=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Phoenix Learning Engine
+# ---------------------------------------------------------------------------
+
+
+@router.get("/learning-engine/summary")
+def get_learning_engine_summary(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_learning_engine_service.learning_engine_summary(db, tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Improvement Recommendation Engine
+# ---------------------------------------------------------------------------
+
+
+@router.post("/recommendations/generate")
+def post_generate_recommendations(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = phoenix_recommendation_engine.generate_recommendations(db, tenant_id)
+    _audit(db, tenant_id, actor, "phoenix.recommendations_generated", "phoenix_improvement_recommendations", "", {"count": len(result)})
+    return {"recommendations": result}
+
+
+@router.get("/recommendations")
+def get_recommendations(status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {"recommendations": phoenix_recommendation_engine.list_recommendations(db, tenant_id, status=status)}
+
+
+@router.get("/recommendations/{recommendation_id}")
+def get_recommendation(recommendation_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    try:
+        return phoenix_recommendation_engine.get_recommendation(db, tenant_id, recommendation_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — AI Performance Observatory
+# ---------------------------------------------------------------------------
+
+
+@router.get("/observatory/summary")
+def get_observatory_summary(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_ai_observatory_service.observatory_summary(db, tenant_id)
+
+
+@router.post("/observatory/latency", status_code=201)
+def post_latency_sample(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    try:
+        return phoenix_ai_observatory_service.record_latency_sample(
+            db, tenant_id, stage=payload.get("stage", ""), latency_ms=payload.get("latency_ms", 0.0),
+            inspection_id=payload.get("inspection_id"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/observatory/latency")
+def get_latency_summary(stage: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_ai_observatory_service.latency_summary(db, tenant_id, stage=stage)
+
+
+@router.get("/observatory/coverage")
+def get_coverage_summary(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_ai_observatory_service.coverage_summary(db, tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Workflow Optimization Engine
+# ---------------------------------------------------------------------------
+
+
+@router.get("/workflow-optimization/summary")
+def get_workflow_optimization_summary(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_workflow_optimization_service.workflow_optimization_summary(db, tenant_id)
+
+
+@router.get("/workflow-optimization/{workflow_id}")
+def get_workflow_optimization_recommendation(workflow_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_workflow_optimization_service.recommend_workflow_optimization(db, tenant_id, workflow_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Knowledge Evolution Center
+# ---------------------------------------------------------------------------
+
+
+@router.get("/knowledge-evolution/summary")
+def get_knowledge_evolution_summary(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_knowledge_evolution_service.knowledge_evolution_summary(db, tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Competency Intelligence
+# ---------------------------------------------------------------------------
+
+
+@router.post("/competency-intelligence/run")
+def post_run_competency_intelligence(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    result = phoenix_competency_intelligence_service.run_all_detectors(db, tenant_id)
+    _audit(db, tenant_id, actor, "phoenix.competency_intelligence_run", "quality_competency_opportunities", "", {})
+    return result
+
+
+@router.get("/competency-intelligence/opportunities")
+def get_competency_opportunities(status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    from app.services.competency_intelligence_service import list_opportunities
+
+    return {"opportunities": list_opportunities(db, tenant_id, status=status)}
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Platform Health Dashboard
+# ---------------------------------------------------------------------------
+
+
+@router.get("/platform-health/dashboard")
+def get_platform_health_dashboard(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_platform_health_service.platform_health_dashboard(db, tenant_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Innovation Pipeline
+# ---------------------------------------------------------------------------
+
+
+@router.post("/innovation/ideas", status_code=201)
+def post_innovation_idea(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = phoenix_innovation_pipeline_service.create_idea(
+            db, tenant_id, title=payload.get("title", ""), description=payload.get("description", ""),
+            evidence=payload.get("evidence", ""), estimated_roi_usd=payload.get("estimated_roi_usd"),
+            clinical_impact=payload.get("clinical_impact", "medium"), technical_complexity=payload.get("technical_complexity", "medium"),
+            priority=payload.get("priority", "medium"), submitted_by=payload.get("submitted_by", actor),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "phoenix.innovation_idea_created", "phoenix_innovation_ideas", str(result["id"]), {"title": result["title"]})
+    return result
+
+
+@router.get("/innovation/ideas")
+def get_innovation_ideas(approval_status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {"ideas": phoenix_innovation_pipeline_service.list_ideas(db, tenant_id, approval_status=approval_status)}
+
+
+@router.get("/innovation/summary")
+def get_innovation_summary(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_innovation_pipeline_service.pipeline_summary(db, tenant_id)
+
+
+@router.get("/innovation/ideas/{idea_id}")
+def get_innovation_idea(idea_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    try:
+        return phoenix_innovation_pipeline_service.get_idea(db, tenant_id, idea_id)
+    except phoenix_innovation_pipeline_service.InnovationIdeaNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.patch("/innovation/ideas/{idea_id}/status")
+def patch_innovation_idea_status(idea_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = phoenix_innovation_pipeline_service.update_idea_status(
+            db, tenant_id, idea_id, approval_status=payload.get("approval_status", ""),
+            roadmap_assignment=payload.get("roadmap_assignment", ""),
+        )
+    except phoenix_innovation_pipeline_service.InnovationIdeaNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "phoenix.innovation_idea_status_changed", "phoenix_innovation_ideas", str(idea_id), {"approval_status": result["approval_status"]})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Continuous Validation
+# ---------------------------------------------------------------------------
+
+
+@router.post("/recommendations/{recommendation_id}/validation/start")
+def post_start_validation(recommendation_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = phoenix_validation_pipeline_service.start_validation(db, tenant_id, recommendation_id)
+    except phoenix_validation_pipeline_service.RecommendationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "phoenix.validation_started", "phoenix_improvement_recommendations", str(recommendation_id), {})
+    return result
+
+
+@router.post("/recommendations/{recommendation_id}/validation/advance")
+def post_advance_validation(recommendation_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        result = phoenix_validation_pipeline_service.advance_validation(
+            db, tenant_id, recommendation_id, decided_by=actor, decided_role=payload.get("decided_role", ""),
+            decision=payload.get("decision", ""), notes=payload.get("notes", ""),
+            outcome_notes=payload.get("outcome_notes", ""), lessons_learned=payload.get("lessons_learned", ""),
+            measured_impact=payload.get("measured_impact", ""),
+        )
+    except phoenix_validation_pipeline_service.RecommendationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _audit(db, tenant_id, actor, "phoenix.validation_advanced", "phoenix_improvement_recommendations", str(recommendation_id), {"decision": payload.get("decision", "")})
+    return result
+
+
+@router.post("/recommendations/{recommendation_id}/validation/outcomes", status_code=201)
+def post_validation_outcome(recommendation_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    actor = _actor(current_user)
+    try:
+        return phoenix_validation_pipeline_service.record_outcome(
+            db, tenant_id, recommendation_id, stage=payload.get("stage", ""), outcome_notes=payload.get("outcome_notes", ""),
+            lessons_learned=payload.get("lessons_learned", ""), measured_impact=payload.get("measured_impact", ""),
+            recorded_by=actor,
+        )
+    except phoenix_validation_pipeline_service.RecommendationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/recommendations/{recommendation_id}/validation")
+def get_validation_status(recommendation_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    try:
+        return phoenix_validation_pipeline_service.get_validation_status(db, tenant_id, recommendation_id)
+    except phoenix_validation_pipeline_service.RecommendationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Section 10 — Platform Maturity Index
+# ---------------------------------------------------------------------------
+
+
+@router.post("/maturity/compute")
+def post_compute_maturity_index(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return phoenix_maturity_index_service.compute_platform_maturity_index(db, tenant_id)
+
+
+@router.get("/maturity/history")
+def get_maturity_history(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {"history": phoenix_maturity_index_service.maturity_history(db, tenant_id)}

--- a/backend/app/services/infinity_billing_service.py
+++ b/backend/app/services/infinity_billing_service.py
@@ -1,0 +1,117 @@
+"""v5.0 — Project Infinity, Section 8: Billing & Licensing.
+
+"Module Licensing" composes Genesis's existing `platform_licensing_
+service.py` (`PlatformModuleLicense`) directly — no second per-module
+license table. Enterprise/Partner licensing and marketplace revenue
+sharing have no existing home anywhere in P14's inspection-volume billing
+infrastructure, so `PartnerLicense`/`MarketplaceRevenueEvent` are
+genuinely new, additive constructs.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.infinity_platform import (
+    PARTNER_LICENSE_STATUSES,
+    PARTNER_LICENSE_TYPES,
+    REVENUE_EVENT_TYPES,
+    MarketplaceRevenueEvent,
+    PartnerLicense,
+)
+from app.services import platform_licensing_service
+
+_DEFAULT_REVENUE_SHARE_PCT = 70.0  # developer's share, absent a PartnerLicense override
+
+
+def module_licensing_summary(db: Session, tenant_id: str) -> dict:
+    """Composes Genesis's existing module-licensing state directly."""
+    return {"tenant_id": tenant_id, "licenses": platform_licensing_service.tenant_licenses(db, tenant_id)}
+
+
+def _license_to_dict(row: PartnerLicense) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "developer_account_id": row.developer_account_id,
+        "tenant_id": row.tenant_id, "license_type": row.license_type,
+        "licensed_module_keys": json.loads(row.licensed_module_keys_json or "[]"), "terms": row.terms,
+        "revenue_share_pct": row.revenue_share_pct, "status": row.status,
+        "effective_date": row.effective_date.isoformat() if row.effective_date else None,
+        "expiration_date": row.expiration_date.isoformat() if row.expiration_date else None,
+    }
+
+
+def create_partner_license(
+    db: Session, *, license_type: str, developer_account_id: int | None = None, tenant_id: str = "",
+    licensed_module_keys: list[str] | None = None, terms: str = "", revenue_share_pct: float | None = None,
+    effective_date: datetime | None = None, expiration_date: datetime | None = None,
+) -> dict:
+    if license_type not in PARTNER_LICENSE_TYPES:
+        raise ValueError(f"license_type must be one of {PARTNER_LICENSE_TYPES}")
+    row = PartnerLicense(
+        developer_account_id=developer_account_id, tenant_id=tenant_id, license_type=license_type,
+        licensed_module_keys_json=json.dumps(licensed_module_keys or []), terms=terms,
+        revenue_share_pct=revenue_share_pct, effective_date=effective_date, expiration_date=expiration_date,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _license_to_dict(row)
+
+
+def list_partner_licenses(db: Session, *, developer_account_id: int | None = None, tenant_id: str = "", status: str = "") -> list[dict]:
+    q = db.query(PartnerLicense)
+    if developer_account_id is not None:
+        q = q.filter(PartnerLicense.developer_account_id == developer_account_id)
+    if tenant_id:
+        q = q.filter(PartnerLicense.tenant_id == tenant_id)
+    if status:
+        q = q.filter(PartnerLicense.status == status)
+    return [_license_to_dict(r) for r in q.order_by(PartnerLicense.created_at.desc()).all()]
+
+
+def revoke_partner_license(db: Session, license_id: int) -> dict | None:
+    row = db.query(PartnerLicense).filter(PartnerLicense.id == license_id).first()
+    if row is None:
+        return None
+    if row.status not in PARTNER_LICENSE_STATUSES:
+        raise ValueError(f"status must be one of {PARTNER_LICENSE_STATUSES}")
+    row.status = "revoked"
+    db.commit()
+    db.refresh(row)
+    return _license_to_dict(row)
+
+
+def record_revenue_event(
+    db: Session, listing_id: int, tenant_id: str, *, event_type: str, gross_amount_cents: int,
+    developer_share_pct: float | None = None,
+) -> dict:
+    if event_type not in REVENUE_EVENT_TYPES:
+        raise ValueError(f"event_type must be one of {REVENUE_EVENT_TYPES}")
+    share_pct = developer_share_pct if developer_share_pct is not None else _DEFAULT_REVENUE_SHARE_PCT
+    developer_share_cents = round(gross_amount_cents * share_pct / 100)
+    platform_share_cents = gross_amount_cents - developer_share_cents
+
+    row = MarketplaceRevenueEvent(
+        listing_id=listing_id, tenant_id=tenant_id, event_type=event_type, gross_amount_cents=gross_amount_cents,
+        developer_share_cents=developer_share_cents, platform_share_cents=platform_share_cents,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return {
+        "id": row.id, "listing_id": row.listing_id, "tenant_id": row.tenant_id, "event_type": row.event_type,
+        "gross_amount_cents": row.gross_amount_cents, "developer_share_cents": row.developer_share_cents,
+        "platform_share_cents": row.platform_share_cents,
+    }
+
+
+def revenue_summary_for_listing(db: Session, listing_id: int) -> dict:
+    rows = db.query(MarketplaceRevenueEvent).filter(MarketplaceRevenueEvent.listing_id == listing_id).all()
+    return {
+        "listing_id": listing_id, "event_count": len(rows),
+        "total_gross_cents": sum(r.gross_amount_cents for r in rows),
+        "total_developer_share_cents": sum(r.developer_share_cents for r in rows),
+        "total_platform_share_cents": sum(r.platform_share_cents for r in rows),
+    }

--- a/backend/app/services/infinity_certification_service.py
+++ b/backend/app/services/infinity_certification_service.py
@@ -1,0 +1,68 @@
+"""v5.0 — Project Infinity, Section 7: Certification Program.
+
+Reuses Project Forge's `WorkflowApprovalChain`/`WorkflowApprovalInstance`
+(`forge_approval_service.py`, v4.1) a third time — already reused by
+Athena (v4.8) and Phoenix's Continuous Validation (v4.9) — with the seven
+named gates (Security/Performance/Clinical Safety/Explainability/
+Accessibility/Documentation/Governance) as its ordered steps. No second
+approval-chain model. Marketplace listings are platform-global, not
+tenant-scoped, so certification chains use `tenant_id=""` — the same
+"global" convention Forge's own workflow templates already use.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.infinity_platform import CERT_CERTIFIED, CERT_IN_PROGRESS, CERT_REJECTED, CERTIFICATION_GATES
+from app.services import forge_approval_service
+from app.services.infinity_marketplace_service import get_listing_or_404
+
+_GLOBAL_TENANT = ""
+
+
+def start_certification(db: Session, listing_id: int) -> dict:
+    listing = get_listing_or_404(db, listing_id)
+    chain = forge_approval_service.create_chain(
+        db, _GLOBAL_TENANT, name=f"Certification: {listing.name} v{listing.version}", steps=CERTIFICATION_GATES,
+    )
+    instance = forge_approval_service.start_instance(db, _GLOBAL_TENANT, chain["id"])
+
+    listing.certification_chain_id = chain["id"]
+    listing.certification_instance_id = instance["id"]
+    listing.certification_status = CERT_IN_PROGRESS
+    db.commit()
+    db.refresh(listing)
+    return {"listing_id": listing.id, "chain": chain, "instance": instance}
+
+
+def advance_certification(
+    db: Session, listing_id: int, *, decided_by: str, decided_role: str, decision: str, notes: str = "",
+) -> dict:
+    listing = get_listing_or_404(db, listing_id)
+    if listing.certification_instance_id is None:
+        raise ValueError(f"Listing {listing_id} has not started certification yet.")
+
+    instance = forge_approval_service.decide_step(
+        db, listing.certification_instance_id, decided_by=decided_by, decided_role=decided_role,
+        decision=decision, notes=notes,
+    )
+
+    if decision == "rejected":
+        listing.certification_status = CERT_REJECTED
+    elif instance["status"] == "approved":
+        listing.certification_status = CERT_CERTIFIED
+    db.commit()
+    db.refresh(listing)
+    return {"listing_id": listing.id, "certification_status": listing.certification_status, "instance": instance}
+
+
+def get_certification_status(db: Session, listing_id: int) -> dict:
+    listing = get_listing_or_404(db, listing_id)
+    instance = (
+        forge_approval_service.get_instance(db, listing.certification_instance_id)
+        if listing.certification_instance_id else None
+    )
+    return {
+        "listing_id": listing.id, "certification_status": listing.certification_status,
+        "gates": CERTIFICATION_GATES, "instance": instance,
+    }

--- a/backend/app/services/infinity_developer_portal_service.py
+++ b/backend/app/services/infinity_developer_portal_service.py
@@ -1,0 +1,78 @@
+"""v5.0 — Project Infinity, Section 1: Developer Portal.
+
+Composes the Developer Portal's supporting surfaces — API Explorer
+catalog, rate-limit policy, and a per-developer dashboard summary. The
+API Explorer catalog is a static, documented reference list mirroring the
+real endpoints registered in `nexus_api_gateway.py` (never dynamically
+introspected from the FastAPI app, which would create a routes<->service
+circular import) — if a new `/api/v1/*` endpoint is added there, this
+list must be updated alongside it. Rate limits are a fixed, documented
+policy: no per-key request-counting infrastructure exists anywhere in
+this codebase, so this never reports a fabricated live usage number.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services import infinity_developer_service, infinity_sandbox_service
+
+API_EXPLORER_ENDPOINTS = [
+    {"path": "/api/v1/identity", "system": "Identity"},
+    {"path": "/api/v1/organizations", "system": "Organizations"},
+    {"path": "/api/v1/users", "system": "Users"},
+    {"path": "/api/v1/digital-twins", "system": "Digital Twins"},
+    {"path": "/api/v1/knowledge", "system": "Knowledge Graph"},
+    {"path": "/api/v1/instruments", "system": "Inspection"},
+    {"path": "/api/v1/inspections", "system": "Inspection"},
+    {"path": "/api/v1/analytics", "system": "Analytics"},
+    {"path": "/api/v1/pulse", "system": "Pulse"},
+    {"path": "/api/v1/sentinel", "system": "Sentinel"},
+    {"path": "/api/v1/forge", "system": "Forge"},
+    {"path": "/api/v1/catalyst", "system": "Catalyst"},
+    {"path": "/api/v1/orbit", "system": "Orbit"},
+    {"path": "/api/v1/apollo", "system": "Apollo"},
+    {"path": "/api/v1/athena", "system": "Athena"},
+    {"path": "/api/v1/phoenix", "system": "Phoenix"},
+    {"path": "/api/v1/enterprise", "system": "Organizations"},
+]
+
+# A fixed, documented policy — not a live counter (no request-metering
+# infrastructure exists anywhere in this codebase to back a real number).
+RATE_LIMIT_POLICY = {
+    "sandbox": {"requests_per_minute": 60, "requests_per_day": 5000},
+    "certified_partner": {"requests_per_minute": 300, "requests_per_day": 100000},
+    "note": "Fixed policy tiers — this platform has no live per-key request metering yet.",
+}
+
+TUTORIALS = [
+    {"title": "Issue your first API key and call the sandbox gateway", "topic": "authentication"},
+    {"title": "Build an AI Skill and submit it for certification", "topic": "ai_skills"},
+    {"title": "Register a dashboard widget via the Plugin SDK", "topic": "plugin_sdk"},
+    {"title": "Install an Application from the Marketplace", "topic": "marketplace"},
+]
+
+
+def api_explorer_catalog() -> list[dict]:
+    return API_EXPLORER_ENDPOINTS
+
+
+def rate_limit_policy() -> dict:
+    return RATE_LIMIT_POLICY
+
+
+def tutorials() -> list[dict]:
+    return TUTORIALS
+
+
+def developer_portal_summary(db: Session, developer_account_id: int) -> dict:
+    account = infinity_developer_service.get_developer_account(db, developer_account_id)
+    api_keys = infinity_developer_service.list_api_keys(db, developer_account_id)
+    sandbox_sessions = infinity_sandbox_service.list_sandbox_sessions(db, developer_account_id)
+    return {
+        "account": account,
+        "active_api_key_count": sum(1 for k in api_keys if not k["revoked"]),
+        "sandbox_session_count": len(sandbox_sessions),
+        "rate_limit_policy": RATE_LIMIT_POLICY["sandbox"] if account["sandbox_only"] else RATE_LIMIT_POLICY["certified_partner"],
+        "api_explorer": API_EXPLORER_ENDPOINTS,
+        "tutorials": TUTORIALS,
+    }

--- a/backend/app/services/infinity_developer_service.py
+++ b/backend/app/services/infinity_developer_service.py
@@ -1,0 +1,165 @@
+"""v5.0 — Project Infinity, Section 1: Developer accounts & API keys.
+
+`DeveloperAccount` is a deliberately new, first-class identity — distinct
+from `TenantMembership` — since a third-party developer building an app
+is not tenant staff. Account creation/approval is gated to internal
+platform admins (never fully open self-service), matching the brief's
+"trusted third parties" framing. `DeveloperApiKey` issuance reuses the
+exact `secrets.token_urlsafe(40)` + SHA-256-hash-only pattern already
+established in `nexus_credential_service.py` — the raw key is returned
+exactly once and never stored or retrievable again.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.infinity_platform import (
+    DEVELOPER_ACTIVE,
+    DEVELOPER_STATUSES,
+    DEVELOPER_TYPES,
+    DeveloperAccount,
+    DeveloperApiKey,
+)
+
+DEFAULT_KEY_LIFETIME_DAYS = 365
+
+
+class DeveloperAccountNotFoundError(ValueError):
+    pass
+
+
+def _account_to_dict(row: DeveloperAccount) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "email": row.email,
+        "organization_name": row.organization_name, "developer_type": row.developer_type,
+        "status": row.status, "sandbox_only": row.sandbox_only, "approved_by": row.approved_by,
+        "approved_at": row.approved_at.isoformat() if row.approved_at else None,
+    }
+
+
+def create_developer_account(
+    db: Session, *, email: str, organization_name: str, developer_type: str, approved_by: str, sandbox_only: bool = True,
+) -> dict:
+    if developer_type not in DEVELOPER_TYPES:
+        raise ValueError(f"developer_type must be one of {DEVELOPER_TYPES}")
+    row = DeveloperAccount(
+        email=email, organization_name=organization_name, developer_type=developer_type,
+        sandbox_only=sandbox_only, approved_by=approved_by, approved_at=datetime.now(timezone.utc),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _account_to_dict(row)
+
+
+def _get_account(db: Session, developer_account_id: int) -> DeveloperAccount:
+    row = db.query(DeveloperAccount).filter(DeveloperAccount.id == developer_account_id).first()
+    if row is None:
+        raise DeveloperAccountNotFoundError(f"Developer account {developer_account_id} not found.")
+    return row
+
+
+def get_developer_account(db: Session, developer_account_id: int) -> dict:
+    return _account_to_dict(_get_account(db, developer_account_id))
+
+
+def list_developer_accounts(db: Session, *, status: str = "") -> list[dict]:
+    q = db.query(DeveloperAccount)
+    if status:
+        q = q.filter(DeveloperAccount.status == status)
+    return [_account_to_dict(r) for r in q.order_by(DeveloperAccount.created_at.desc()).all()]
+
+
+def set_developer_account_status(db: Session, developer_account_id: int, *, status: str) -> dict:
+    if status not in DEVELOPER_STATUSES:
+        raise ValueError(f"status must be one of {DEVELOPER_STATUSES}")
+    row = _get_account(db, developer_account_id)
+    row.status = status
+    db.commit()
+    db.refresh(row)
+    return _account_to_dict(row)
+
+
+def _key_to_dict(row: DeveloperApiKey) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "developer_account_id": row.developer_account_id,
+        "scopes": json.loads(row.scopes_json or "[]"), "sandbox_only": row.sandbox_only,
+        "revoked": row.revoked, "revoked_at": row.revoked_at.isoformat() if row.revoked_at else None,
+        "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+    }
+
+
+def issue_api_key(
+    db: Session, developer_account_id: int, *, scopes: list[str] | None = None, sandbox_only: bool = True,
+    lifetime_days: int = DEFAULT_KEY_LIFETIME_DAYS,
+) -> dict:
+    account = _get_account(db, developer_account_id)
+    if account.status != DEVELOPER_ACTIVE:
+        raise ValueError(f"Developer account {developer_account_id} is not active ({account.status}).")
+
+    raw_key = secrets.token_urlsafe(40)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    row = DeveloperApiKey(
+        developer_account_id=developer_account_id, key_hash=key_hash, scopes_json=json.dumps(scopes or []),
+        sandbox_only=sandbox_only, expires_at=datetime.now(timezone.utc) + timedelta(days=lifetime_days),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    result = _key_to_dict(row)
+    result["api_key"] = raw_key  # shown ONCE — never retrievable again
+    return result
+
+
+def list_api_keys(db: Session, developer_account_id: int) -> list[dict]:
+    rows = (
+        db.query(DeveloperApiKey)
+        .filter(DeveloperApiKey.developer_account_id == developer_account_id)
+        .order_by(DeveloperApiKey.id.desc())
+        .all()
+    )
+    return [_key_to_dict(r) for r in rows]
+
+
+def revoke_api_key(db: Session, developer_account_id: int, key_id: int) -> dict | None:
+    row = (
+        db.query(DeveloperApiKey)
+        .filter(DeveloperApiKey.id == key_id, DeveloperApiKey.developer_account_id == developer_account_id)
+        .first()
+    )
+    if row is None:
+        return None
+    row.revoked = True
+    row.revoked_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(row)
+    return _key_to_dict(row)
+
+
+def _as_naive_utc(dt: datetime | None) -> datetime | None:
+    if dt is not None and dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def authenticate_api_key(db: Session, raw_key: str) -> DeveloperApiKey | None:
+    """Least-privilege auth: hash the presented key and match an active,
+    unrevoked, unexpired key against a non-suspended developer account —
+    never compares raw keys."""
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    row = db.query(DeveloperApiKey).filter(DeveloperApiKey.key_hash == key_hash).first()
+    if row is None or row.revoked:
+        return None
+    expires_at = _as_naive_utc(row.expires_at)
+    if expires_at is not None and expires_at < datetime.utcnow():
+        return None
+    account = db.query(DeveloperAccount).filter(DeveloperAccount.id == row.developer_account_id).first()
+    if account is None or account.status != DEVELOPER_ACTIVE:
+        return None
+    return row

--- a/backend/app/services/infinity_extension_service.py
+++ b/backend/app/services/infinity_extension_service.py
@@ -1,0 +1,137 @@
+"""v5.0 — Project Infinity, Sections 3 & 6: Plugin SDK & Extension
+Framework.
+
+Reuses Genesis's `PlatformPlugin` (v4.0) directly — extended additively
+with five new `registered_*_json` columns for the Plugin SDK's own named
+artifact types this table didn't yet have. Still metadata-only: no
+plugin code is ever imported or executed from this table, matching
+Genesis's own documented convention exactly.
+
+Two distinct dimensions, deliberately not conflated:
+  * **Extension type** (Section 3 — what kind of artifact): Applications,
+    Widgets, Dashboards, Reports, Workflow Nodes, AI Skills,
+    Notifications, Commands, Analytics — each maps 1:1 onto one of
+    `PlatformPlugin`'s `registered_*_json` columns.
+  * **Extension location** (Section 6 — where in the UI it attaches):
+    Menu, Navigation, Dashboard, Command Center, Copilot, Reports,
+    Digital Twin Panel, Knowledge Graph View, Simulation Model — recorded
+    as a `location` key inside each registered item, not a separate
+    column, since a single artifact type (e.g. a "dashboard" widget) can
+    attach at several different locations.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.platform_core import PLUGIN_ACTIVE, PLUGIN_DISABLED, PlatformPlugin
+
+SDK_EXTENSION_TYPES = [
+    "applications", "widgets", "dashboards", "reports", "workflow_nodes",
+    "ai_skills", "notifications", "commands", "analytics",
+]
+
+_TYPE_TO_COLUMN = {
+    "applications": "registered_routes_json",
+    "widgets": "registered_widgets_json",
+    "dashboards": "registered_dashboards_json",
+    "reports": "registered_reports_json",
+    "workflow_nodes": "registered_workflow_nodes_json",
+    "ai_skills": "registered_ai_skills_json",
+    "notifications": "registered_notifications_json",
+    "commands": "registered_commands_json",
+    "analytics": "registered_analytics_json",
+}
+
+EXTENSION_LOCATIONS = [
+    "menu", "navigation", "dashboard", "command_center", "copilot",
+    "reports", "digital_twin_panel", "knowledge_graph_view", "simulation_model",
+]
+
+
+class PluginNotFoundError(ValueError):
+    pass
+
+
+class InvalidExtensionTypeError(ValueError):
+    pass
+
+
+class InvalidExtensionLocationError(ValueError):
+    pass
+
+
+def _to_dict(row: PlatformPlugin) -> dict:
+    result: dict = {
+        "id": row.id, "created_at": row.created_at.isoformat(), "plugin_key": row.plugin_key, "name": row.name,
+        "version": row.version, "status": row.status, "developer_account_id": row.developer_account_id,
+        "marketplace_listing_id": row.marketplace_listing_id, "registered_by": row.registered_by,
+    }
+    for extension_type, column in _TYPE_TO_COLUMN.items():
+        result[extension_type] = json.loads(getattr(row, column) or "[]")
+    return result
+
+
+def register_plugin(
+    db: Session, *, plugin_key: str, name: str, version: str = "0.1.0", developer_account_id: int | None = None,
+    marketplace_listing_id: int | None = None, registered_by: str = "",
+) -> dict:
+    row = PlatformPlugin(
+        plugin_key=plugin_key, name=name, version=version, developer_account_id=developer_account_id,
+        marketplace_listing_id=marketplace_listing_id, registered_by=registered_by,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def _get_plugin(db: Session, plugin_key: str) -> PlatformPlugin:
+    row = db.query(PlatformPlugin).filter(PlatformPlugin.plugin_key == plugin_key).first()
+    if row is None:
+        raise PluginNotFoundError(f"Plugin '{plugin_key}' not found.")
+    return row
+
+
+def get_plugin(db: Session, plugin_key: str) -> dict:
+    return _to_dict(_get_plugin(db, plugin_key))
+
+
+def list_plugins(db: Session, *, status: str = "") -> list[dict]:
+    q = db.query(PlatformPlugin)
+    if status:
+        q = q.filter(PlatformPlugin.status == status)
+    return [_to_dict(r) for r in q.order_by(PlatformPlugin.created_at.desc()).all()]
+
+
+def register_extension(db: Session, plugin_key: str, *, extension_type: str, location: str, item: dict) -> dict:
+    if extension_type not in SDK_EXTENSION_TYPES:
+        raise InvalidExtensionTypeError(f"extension_type must be one of {SDK_EXTENSION_TYPES}")
+    if location not in EXTENSION_LOCATIONS:
+        raise InvalidExtensionLocationError(f"location must be one of {EXTENSION_LOCATIONS}")
+
+    row = _get_plugin(db, plugin_key)
+    column = _TYPE_TO_COLUMN[extension_type]
+    entries = json.loads(getattr(row, column) or "[]")
+    entries.append({**item, "location": location})
+    setattr(row, column, json.dumps(entries))
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def activate_plugin(db: Session, plugin_key: str) -> dict:
+    row = _get_plugin(db, plugin_key)
+    row.status = PLUGIN_ACTIVE
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def disable_plugin(db: Session, plugin_key: str) -> dict:
+    row = _get_plugin(db, plugin_key)
+    row.status = PLUGIN_DISABLED
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)

--- a/backend/app/services/infinity_marketplace_service.py
+++ b/backend/app/services/infinity_marketplace_service.py
@@ -1,0 +1,163 @@
+"""v5.0 — Project Infinity, Sections 4 & 5: AI Skills Marketplace &
+Application Marketplace.
+
+`MarketplaceListing` is a generic model for both AI Skills and
+Applications — distinct from Forge's workflow-only marketplace
+(`workflow_forge.py`'s `marketplace_status`), which this reuses only for
+its exact state-machine naming (`private/pending_review/published`), not
+its table. A listing can only reach `published` after its linked
+Certification Program chain (Section 7) reports `certified` — this is
+enforced here, not left to convention.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.infinity_platform import (
+    CERT_CERTIFIED,
+    INSTALLATION_DISABLED,
+    LISTING_PENDING_REVIEW,
+    LISTING_PRIVATE,
+    LISTING_PUBLISHED,
+    LISTING_TYPES,
+    PRICING_MODELS,
+    MarketplaceInstallation,
+    MarketplaceListing,
+)
+
+
+class ListingNotFoundError(ValueError):
+    pass
+
+
+class ListingNotCertifiedError(ValueError):
+    pass
+
+
+class InstallationNotFoundError(ValueError):
+    pass
+
+
+def _listing_to_dict(row: MarketplaceListing) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "developer_account_id": row.developer_account_id,
+        "listing_type": row.listing_type, "category": row.category, "name": row.name, "description": row.description,
+        "version": row.version, "status": row.status, "pricing_model": row.pricing_model, "price_cents": row.price_cents,
+        "certification_status": row.certification_status, "certification_chain_id": row.certification_chain_id,
+        "certification_instance_id": row.certification_instance_id, "manifest": json.loads(row.manifest_json or "{}"),
+    }
+
+
+def create_listing(
+    db: Session, developer_account_id: int, *, listing_type: str, name: str, category: str = "",
+    description: str = "", pricing_model: str = "free", price_cents: int | None = None, manifest: dict | None = None,
+) -> dict:
+    if listing_type not in LISTING_TYPES:
+        raise ValueError(f"listing_type must be one of {LISTING_TYPES}")
+    if pricing_model not in PRICING_MODELS:
+        raise ValueError(f"pricing_model must be one of {PRICING_MODELS}")
+    row = MarketplaceListing(
+        developer_account_id=developer_account_id, listing_type=listing_type, category=category, name=name,
+        description=description, pricing_model=pricing_model, price_cents=price_cents,
+        manifest_json=json.dumps(manifest or {}),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _listing_to_dict(row)
+
+
+def get_listing_or_404(db: Session, listing_id: int) -> MarketplaceListing:
+    row = db.query(MarketplaceListing).filter(MarketplaceListing.id == listing_id).first()
+    if row is None:
+        raise ListingNotFoundError(f"Listing {listing_id} not found.")
+    return row
+
+
+def get_listing(db: Session, listing_id: int) -> dict:
+    return _listing_to_dict(get_listing_or_404(db, listing_id))
+
+
+def list_listings(db: Session, *, listing_type: str = "", category: str = "", status: str = "") -> list[dict]:
+    q = db.query(MarketplaceListing)
+    if listing_type:
+        q = q.filter(MarketplaceListing.listing_type == listing_type)
+    if category:
+        q = q.filter(MarketplaceListing.category == category)
+    if status:
+        q = q.filter(MarketplaceListing.status == status)
+    return [_listing_to_dict(r) for r in q.order_by(MarketplaceListing.created_at.desc()).all()]
+
+
+def submit_for_review(db: Session, listing_id: int) -> dict:
+    row = get_listing_or_404(db, listing_id)
+    row.status = LISTING_PENDING_REVIEW
+    db.commit()
+    db.refresh(row)
+    return _listing_to_dict(row)
+
+
+def publish_listing(db: Session, listing_id: int) -> dict:
+    """A listing can only be published once its Certification Program
+    chain (Section 7) reports `certified` — every gate must have passed."""
+    row = get_listing_or_404(db, listing_id)
+    if row.certification_status != CERT_CERTIFIED:
+        raise ListingNotCertifiedError(
+            f"Listing {listing_id} cannot be published — certification_status is "
+            f"'{row.certification_status}', not 'certified'.",
+        )
+    row.status = LISTING_PUBLISHED
+    db.commit()
+    db.refresh(row)
+    return _listing_to_dict(row)
+
+
+def unpublish_listing(db: Session, listing_id: int) -> dict:
+    row = get_listing_or_404(db, listing_id)
+    row.status = LISTING_PRIVATE
+    db.commit()
+    db.refresh(row)
+    return _listing_to_dict(row)
+
+
+def _installation_to_dict(row: MarketplaceInstallation) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "tenant_id": row.tenant_id, "listing_id": row.listing_id,
+        "installed_version": row.installed_version, "status": row.status, "installed_by": row.installed_by,
+    }
+
+
+def install_listing(db: Session, tenant_id: str, listing_id: int, *, installed_by: str) -> dict:
+    listing = get_listing_or_404(db, listing_id)
+    if listing.status != LISTING_PUBLISHED:
+        raise ValueError(f"Listing {listing_id} is not published (status: {listing.status}).")
+    row = MarketplaceInstallation(
+        tenant_id=tenant_id, listing_id=listing_id, installed_version=listing.version, installed_by=installed_by,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _installation_to_dict(row)
+
+
+def list_installations(db: Session, tenant_id: str, *, status: str = "") -> list[dict]:
+    q = db.query(MarketplaceInstallation).filter(MarketplaceInstallation.tenant_id == tenant_id)
+    if status:
+        q = q.filter(MarketplaceInstallation.status == status)
+    return [_installation_to_dict(r) for r in q.order_by(MarketplaceInstallation.created_at.desc()).all()]
+
+
+def uninstall(db: Session, tenant_id: str, installation_id: int) -> dict:
+    row = (
+        db.query(MarketplaceInstallation)
+        .filter(MarketplaceInstallation.id == installation_id, MarketplaceInstallation.tenant_id == tenant_id)
+        .first()
+    )
+    if row is None:
+        raise InstallationNotFoundError(f"Installation {installation_id} not found for tenant {tenant_id}.")
+    row.status = INSTALLATION_DISABLED
+    db.commit()
+    db.refresh(row)
+    return _installation_to_dict(row)

--- a/backend/app/services/infinity_sandbox_service.py
+++ b/backend/app/services/infinity_sandbox_service.py
@@ -1,0 +1,98 @@
+"""v5.0 — Project Infinity, Section 9: Developer Sandbox.
+
+No sandbox/isolated-dev-environment concept existed anywhere in this
+codebase before Infinity (`pilot_config.py`/`pilot_error_log.py`, v1.9,
+are a different, older "pilot" concept — per-tenant sales-pilot
+configuration, not a developer sandbox). Every sandbox session is scoped
+to a synthetic `sandbox_tenant_id` with a fixed, unmistakable prefix so
+it can never collide with, or be confused for, a real production tenant.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.infinity_platform import SANDBOX_ACTIVE, SANDBOX_EXPIRED, SANDBOX_PURPOSES, SANDBOX_TERMINATED, DeveloperSandboxSession
+
+_SANDBOX_TENANT_PREFIX = "sandbox-"
+DEFAULT_SESSION_LIFETIME_HOURS = 24
+
+
+class SandboxSessionNotFoundError(ValueError):
+    pass
+
+
+def _to_dict(row: DeveloperSandboxSession) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "developer_account_id": row.developer_account_id,
+        "listing_id": row.listing_id, "sandbox_tenant_id": row.sandbox_tenant_id, "purpose": row.purpose,
+        "status": row.status, "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+    }
+
+
+def create_sandbox_session(
+    db: Session, developer_account_id: int, *, purpose: str, listing_id: int | None = None,
+    lifetime_hours: int = DEFAULT_SESSION_LIFETIME_HOURS,
+) -> dict:
+    if purpose not in SANDBOX_PURPOSES:
+        raise ValueError(f"purpose must be one of {SANDBOX_PURPOSES}")
+    sandbox_tenant_id = f"{_SANDBOX_TENANT_PREFIX}{developer_account_id}-{uuid.uuid4().hex[:12]}"
+    row = DeveloperSandboxSession(
+        developer_account_id=developer_account_id, listing_id=listing_id, sandbox_tenant_id=sandbox_tenant_id,
+        purpose=purpose, expires_at=datetime.now(timezone.utc) + timedelta(hours=lifetime_hours),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def _get(db: Session, session_id: int) -> DeveloperSandboxSession:
+    row = db.query(DeveloperSandboxSession).filter(DeveloperSandboxSession.id == session_id).first()
+    if row is None:
+        raise SandboxSessionNotFoundError(f"Sandbox session {session_id} not found.")
+    return row
+
+
+def get_sandbox_session(db: Session, session_id: int) -> dict:
+    return _to_dict(_get(db, session_id))
+
+
+def list_sandbox_sessions(db: Session, developer_account_id: int, *, status: str = "") -> list[dict]:
+    q = db.query(DeveloperSandboxSession).filter(DeveloperSandboxSession.developer_account_id == developer_account_id)
+    if status:
+        q = q.filter(DeveloperSandboxSession.status == status)
+    return [_to_dict(r) for r in q.order_by(DeveloperSandboxSession.created_at.desc()).all()]
+
+
+def terminate_sandbox_session(db: Session, session_id: int) -> dict:
+    row = _get(db, session_id)
+    row.status = SANDBOX_TERMINATED
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def expire_stale_sessions(db: Session) -> list[dict]:
+    """Marks sessions past `expires_at` as expired — never silently
+    treated as still active."""
+    now = datetime.now(timezone.utc)
+    rows = (
+        db.query(DeveloperSandboxSession)
+        .filter(DeveloperSandboxSession.status == SANDBOX_ACTIVE, DeveloperSandboxSession.expires_at < now)
+        .all()
+    )
+    for row in rows:
+        row.status = SANDBOX_EXPIRED
+    db.commit()
+    for row in rows:
+        db.refresh(row)
+    return [_to_dict(r) for r in rows]
+
+
+def is_sandbox_tenant(tenant_id: str) -> bool:
+    """Distinguishes a real production tenant_id from a synthetic sandbox
+    one — used anywhere a caller must guarantee no production impact."""
+    return tenant_id.startswith(_SANDBOX_TENANT_PREFIX)

--- a/backend/app/services/phoenix_ai_observatory_service.py
+++ b/backend/app/services/phoenix_ai_observatory_service.py
@@ -1,0 +1,96 @@
+"""v4.9 — Project Phoenix, Section 3: AI Performance Observatory.
+
+`ml/pilot_validation.py`'s `clinical_metrics`/`confidence_calibration` and
+`sentinel_ai_health_service.compute_ai_health` already compute precision,
+recall, F1, false-positive/negative rates, human agreement, and model
+drift from real `SupervisorReview` rows — composed here directly, never
+re-derived. The two genuinely new metrics are Inference Latency (nothing
+anywhere measures AI-scoring wall-clock time) and Coverage as "% of
+inspections that received a real AI confidence score" — a different
+concept from `inspection_coverage.py`'s image/zone-capture-completeness
+"coverage" of the same name.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.phoenix_intelligence import DISCLAIMER, LATENCY_STAGES, AIInferenceLatencySample
+from app.models.supervisor_review import SupervisorReview
+from app.services import sentinel_ai_health_service
+from app.services.ml.pilot_validation import clinical_metrics
+
+
+def record_latency_sample(db: Session, tenant_id: str, *, stage: str, latency_ms: float, inspection_id: int | None = None) -> dict:
+    if stage not in LATENCY_STAGES:
+        raise ValueError(f"stage must be one of {LATENCY_STAGES}")
+    row = AIInferenceLatencySample(tenant_id=tenant_id, stage=stage, latency_ms=latency_ms, inspection_id=inspection_id)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return {"id": row.id, "stage": row.stage, "latency_ms": row.latency_ms}
+
+
+def latency_summary(db: Session, tenant_id: str, *, stage: str = "") -> dict:
+    """Average/min/max real recorded latency — "insufficient data" (never
+    a fabricated typical value) when no samples exist for a stage."""
+    result: dict = {}
+    stages = [stage] if stage else LATENCY_STAGES
+    for s in stages:
+        rows = (
+            db.query(AIInferenceLatencySample)
+            .filter(AIInferenceLatencySample.tenant_id == tenant_id, AIInferenceLatencySample.stage == s)
+            .all()
+        )
+        if not rows:
+            result[s] = {"sample_size": 0, "note": "insufficient data — no latency samples recorded yet"}
+            continue
+        values = sorted(r.latency_ms for r in rows)
+        result[s] = {
+            "sample_size": len(values), "avg_ms": round(sum(values) / len(values), 2),
+            "min_ms": round(values[0], 2), "max_ms": round(values[-1], 2),
+        }
+    return result
+
+
+def coverage_summary(db: Session, tenant_id: str) -> dict:
+    """% of inspections that received a real AI confidence score — a
+    different "coverage" concept from image/zone capture completeness."""
+    total = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).count()
+    ai_scored = (
+        db.query(models.Inspection)
+        .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.ai_confidence.isnot(None))
+        .count()
+    )
+    return {
+        "total_inspections": total, "ai_scored_inspections": ai_scored,
+        "ai_participation_coverage_pct": round(100 * ai_scored / total, 1) if total else None,
+    }
+
+
+def observatory_summary(db: Session, tenant_id: str) -> dict:
+    """Composes real clinical metrics (precision/recall/F1/FP-FN/
+    agreement/calibration), `sentinel_ai_health_service`'s drift
+    detection, and Phoenix's two new metrics (latency, AI coverage)."""
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    metrics = clinical_metrics(reviews) if reviews else {}
+    ai_health = sentinel_ai_health_service.compute_ai_health(db, tenant_id)
+
+    return {
+        "precision": metrics.get("precision"),
+        "recall": metrics.get("recall"),
+        "f1": metrics.get("f1"),
+        "false_positive_rate": metrics.get("false_positive_rate"),
+        "false_negative_rate": metrics.get("false_negative_rate"),
+        "human_agreement_rate": metrics.get("supervisor_agreement_rate"),
+        "supervisor_override_rate": metrics.get("override_rate"),
+        "confidence_calibration": metrics.get("confidence_calibration"),
+        "model_drift_detected": ai_health.get("drift_detected"),
+        "model_drift_detail": ai_health.get("drift_detail"),
+        "ai_confidence_avg": ai_health.get("ai_confidence_avg"),
+        "sample_size": len(reviews),
+        "inference_latency": latency_summary(db, tenant_id),
+        "coverage": coverage_summary(db, tenant_id),
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/phoenix_competency_intelligence_service.py
+++ b/backend/app/services/phoenix_competency_intelligence_service.py
@@ -1,0 +1,206 @@
+"""v4.9 — Project Phoenix, Section 6: Competency Intelligence.
+
+`competency_intelligence_service.py` (v2.9) already detects coaching/
+team-education/department-retraining opportunities via the shared
+`CompetencyOpportunity` model. Two of that model's five `OPPORTUNITY_TYPES`
+— `annual_competency` and `recurring_learning` — were defined but never
+produced by any detector. Phoenix adds detectors for those plus three new
+types (`simulation`, `mentoring`, `knowledge_sharing`), all writing to the
+same `CompetencyOpportunity` table — no second competency-opportunity
+model.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.competency_event import CompetencyEvent
+from app.models.quality_guardian import (
+    OPPORTUNITY_ANNUAL_COMPETENCY,
+    OPPORTUNITY_KNOWLEDGE_SHARING,
+    OPPORTUNITY_MENTORING,
+    OPPORTUNITY_RECURRING_LEARNING,
+    OPPORTUNITY_SIMULATION,
+    CompetencyOpportunity,
+)
+from app.services import competency_intelligence_service
+
+_SIMULATION_FAILURE_THRESHOLD = 2
+_ANNUAL_COMPETENCY_WINDOW_DAYS = 365
+_RECURRING_LEARNING_WINDOW_DAYS = 90
+_RECURRING_LEARNING_MIN_WINDOWS = 2
+_MENTORING_MIN_CONTRIBUTIONS = 3
+
+
+def _row_to_dict(obj) -> dict:
+    result: dict = {}
+    for col in obj.__table__.columns:
+        val = getattr(obj, col.name)
+        if hasattr(val, "isoformat"):
+            val = val.isoformat()
+        result[col.name] = val
+    return result
+
+
+def _already_open(db: Session, tenant_id: str, *, scope_type: str, scope_value: str, opportunity_type: str) -> bool:
+    return (
+        db.query(CompetencyOpportunity.id)
+        .filter(
+            CompetencyOpportunity.tenant_id == tenant_id, CompetencyOpportunity.scope_type == scope_type,
+            CompetencyOpportunity.scope_value == scope_value, CompetencyOpportunity.opportunity_type == opportunity_type,
+            CompetencyOpportunity.status == "open",
+        )
+        .first()
+        is not None
+    )
+
+
+def detect_simulation_opportunities(db: Session, tenant_id: str) -> list[dict]:
+    """Technicians with repeated failed simulation scenarios (Apollo's
+    `simulation_failed` CompetencyEvent, v4.7) — a real recurrence count."""
+    rows = (
+        db.query(CompetencyEvent)
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "simulation_failed")
+        .all()
+    )
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r.technician] = counts.get(r.technician, 0) + 1
+
+    created = []
+    for technician, count in counts.items():
+        if count >= _SIMULATION_FAILURE_THRESHOLD and not _already_open(
+            db, tenant_id, scope_type="individual", scope_value=technician, opportunity_type=OPPORTUNITY_SIMULATION,
+        ):
+            row = CompetencyOpportunity(
+                tenant_id=tenant_id, scope_type="individual", scope_value=technician,
+                opportunity_type=OPPORTUNITY_SIMULATION,
+                rationale=f"{technician} has {count} failed simulation scenarios recorded.",
+            )
+            db.add(row)
+            created.append(row)
+    db.commit()
+    for row in created:
+        db.refresh(row)
+    return [_row_to_dict(r) for r in created]
+
+
+def detect_annual_competency_due(db: Session, tenant_id: str) -> list[dict]:
+    """Technicians with no `annual_competency` event in the last 365
+    days — a real recency check, not a guessed due date."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=_ANNUAL_COMPETENCY_WINDOW_DAYS)
+    all_technicians = {
+        r.technician for r in db.query(CompetencyEvent).filter(CompetencyEvent.tenant_id == tenant_id).all()
+    }
+    recently_certified = {
+        r.technician for r in db.query(CompetencyEvent).filter(
+            CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "annual_competency",
+            CompetencyEvent.created_at >= cutoff,
+        ).all()
+    }
+    due = all_technicians - recently_certified
+
+    created = []
+    for technician in due:
+        if not _already_open(db, tenant_id, scope_type="individual", scope_value=technician, opportunity_type=OPPORTUNITY_ANNUAL_COMPETENCY):
+            row = CompetencyOpportunity(
+                tenant_id=tenant_id, scope_type="individual", scope_value=technician,
+                opportunity_type=OPPORTUNITY_ANNUAL_COMPETENCY,
+                rationale=f"{technician} has no recorded annual competency within the last {_ANNUAL_COMPETENCY_WINDOW_DAYS} days.",
+            )
+            db.add(row)
+            created.append(row)
+    db.commit()
+    for row in created:
+        db.refresh(row)
+    return [_row_to_dict(r) for r in created]
+
+
+def detect_recurring_learning_needs(db: Session, tenant_id: str) -> list[dict]:
+    """A technician with `repeated_error` events on the same finding type
+    recurring across more than one 90-day window — a genuinely persistent
+    pattern, not a single spike."""
+    rows = (
+        db.query(CompetencyEvent)
+        .filter(CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "repeated_error")
+        .all()
+    )
+    if not rows:
+        return []
+
+    windows: dict[tuple[str, str], set[int]] = {}
+    earliest = min(r.created_at for r in rows)
+    for r in rows:
+        window_index = (r.created_at - earliest).days // _RECURRING_LEARNING_WINDOW_DAYS
+        windows.setdefault((r.technician, r.finding_type), set()).add(window_index)
+
+    created = []
+    for (technician, finding_type), window_set in windows.items():
+        if len(window_set) >= _RECURRING_LEARNING_MIN_WINDOWS and not _already_open(
+            db, tenant_id, scope_type="individual", scope_value=technician, opportunity_type=OPPORTUNITY_RECURRING_LEARNING,
+        ):
+            row = CompetencyOpportunity(
+                tenant_id=tenant_id, scope_type="individual", scope_value=technician,
+                opportunity_type=OPPORTUNITY_RECURRING_LEARNING, finding_type=finding_type,
+                rationale=f"{technician} has repeated-error events on '{finding_type}' across {len(window_set)} separate {_RECURRING_LEARNING_WINDOW_DAYS}-day windows.",
+            )
+            db.add(row)
+            created.append(row)
+    db.commit()
+    for row in created:
+        db.refresh(row)
+    return [_row_to_dict(r) for r in created]
+
+
+def detect_mentoring_and_knowledge_sharing(db: Session, tenant_id: str) -> list[dict]:
+    """Pairs a high-contribution technician (potential mentor / knowledge
+    source) with technicians who have open coaching opportunities
+    (potential mentees) — both signals are real, already-recorded events."""
+    contribution_counts: dict[str, int] = {}
+    for r in db.query(CompetencyEvent).filter(
+        CompetencyEvent.tenant_id == tenant_id, CompetencyEvent.event_type == "knowledge_contribution",
+    ).all():
+        contribution_counts[r.technician] = contribution_counts.get(r.technician, 0) + 1
+
+    mentors = [t for t, c in contribution_counts.items() if c >= _MENTORING_MIN_CONTRIBUTIONS]
+    coaching_open = competency_intelligence_service.list_opportunities(db, tenant_id, status="open")
+    mentees = {o["scope_value"] for o in coaching_open if o["opportunity_type"] == "coaching"}
+
+    created = []
+    for mentor in mentors:
+        if mentees and not _already_open(db, tenant_id, scope_type="individual", scope_value=mentor, opportunity_type=OPPORTUNITY_MENTORING):
+            row = CompetencyOpportunity(
+                tenant_id=tenant_id, scope_type="individual", scope_value=mentor,
+                opportunity_type=OPPORTUNITY_MENTORING,
+                rationale=f"{mentor} has {contribution_counts[mentor]} knowledge contributions and could mentor: {', '.join(sorted(mentees))}.",
+            )
+            db.add(row)
+            created.append(row)
+        if not _already_open(db, tenant_id, scope_type="individual", scope_value=mentor, opportunity_type=OPPORTUNITY_KNOWLEDGE_SHARING):
+            row = CompetencyOpportunity(
+                tenant_id=tenant_id, scope_type="individual", scope_value=mentor,
+                opportunity_type=OPPORTUNITY_KNOWLEDGE_SHARING,
+                rationale=f"{mentor}'s {contribution_counts[mentor]} knowledge contributions are candidates for formalizing into shared institutional knowledge.",
+            )
+            db.add(row)
+            created.append(row)
+    db.commit()
+    for row in created:
+        db.refresh(row)
+    return [_row_to_dict(r) for r in created]
+
+
+def run_all_detectors(db: Session, tenant_id: str) -> dict:
+    """Runs every Phoenix + pre-existing competency detector and returns a
+    combined summary — never auto-assigns training, only opens
+    `CompetencyOpportunity` rows for human review."""
+    existing = competency_intelligence_service.detect_competency_opportunities(db, tenant_id)
+    return {
+        "coaching_team_department": existing,
+        "simulation": detect_simulation_opportunities(db, tenant_id),
+        "annual_competency": detect_annual_competency_due(db, tenant_id),
+        "recurring_learning": detect_recurring_learning_needs(db, tenant_id),
+        "mentoring_and_knowledge_sharing": detect_mentoring_and_knowledge_sharing(db, tenant_id),
+        "human_review_required": True,
+    }

--- a/backend/app/services/phoenix_innovation_pipeline_service.py
+++ b/backend/app/services/phoenix_innovation_pipeline_service.py
@@ -1,0 +1,102 @@
+"""v4.9 — Project Phoenix, Section 8: Innovation Pipeline.
+
+No Idea/Evidence/ROI/Clinical-Impact/Roadmap backlog concept existed
+anywhere in this codebase before Phoenix (confirmed by grep) — genuinely
+new. Ideas never auto-advance to `in_progress`/`completed`; every status
+transition is an explicit human action.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.phoenix_intelligence import (
+    CLINICAL_IMPACT_LEVELS,
+    IDEA_APPROVAL_STATUSES,
+    PRIORITY_LEVELS,
+    TECHNICAL_COMPLEXITY_LEVELS,
+    InnovationIdea,
+)
+
+
+class InnovationIdeaNotFoundError(ValueError):
+    pass
+
+
+def _to_dict(row: InnovationIdea) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "title": row.title, "description": row.description,
+        "evidence": row.evidence, "estimated_roi_usd": row.estimated_roi_usd, "clinical_impact": row.clinical_impact,
+        "technical_complexity": row.technical_complexity, "priority": row.priority,
+        "approval_status": row.approval_status, "roadmap_assignment": row.roadmap_assignment,
+        "submitted_by": row.submitted_by,
+    }
+
+
+def create_idea(
+    db: Session, tenant_id: str, *, title: str, description: str = "", evidence: str = "",
+    estimated_roi_usd: float | None = None, clinical_impact: str = "medium", technical_complexity: str = "medium",
+    priority: str = "medium", submitted_by: str = "",
+) -> dict:
+    if clinical_impact not in CLINICAL_IMPACT_LEVELS:
+        raise ValueError(f"clinical_impact must be one of {CLINICAL_IMPACT_LEVELS}")
+    if technical_complexity not in TECHNICAL_COMPLEXITY_LEVELS:
+        raise ValueError(f"technical_complexity must be one of {TECHNICAL_COMPLEXITY_LEVELS}")
+    if priority not in PRIORITY_LEVELS:
+        raise ValueError(f"priority must be one of {PRIORITY_LEVELS}")
+
+    row = InnovationIdea(
+        tenant_id=tenant_id, title=title, description=description, evidence=evidence,
+        estimated_roi_usd=estimated_roi_usd, clinical_impact=clinical_impact,
+        technical_complexity=technical_complexity, priority=priority, submitted_by=submitted_by,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def list_ideas(db: Session, tenant_id: str, *, approval_status: str = "") -> list[dict]:
+    q = db.query(InnovationIdea).filter(InnovationIdea.tenant_id == tenant_id)
+    if approval_status:
+        q = q.filter(InnovationIdea.approval_status == approval_status)
+    return [_to_dict(r) for r in q.order_by(InnovationIdea.created_at.desc()).all()]
+
+
+def _get(db: Session, tenant_id: str, idea_id: int) -> InnovationIdea:
+    row = db.query(InnovationIdea).filter(InnovationIdea.id == idea_id, InnovationIdea.tenant_id == tenant_id).first()
+    if row is None:
+        raise InnovationIdeaNotFoundError(f"Innovation idea {idea_id} not found for tenant {tenant_id}.")
+    return row
+
+
+def update_idea_status(db: Session, tenant_id: str, idea_id: int, *, approval_status: str, roadmap_assignment: str = "") -> dict:
+    if approval_status not in IDEA_APPROVAL_STATUSES:
+        raise ValueError(f"approval_status must be one of {IDEA_APPROVAL_STATUSES}")
+    row = _get(db, tenant_id, idea_id)
+    row.approval_status = approval_status
+    if roadmap_assignment:
+        row.roadmap_assignment = roadmap_assignment
+    db.commit()
+    db.refresh(row)
+    return _to_dict(row)
+
+
+def get_idea(db: Session, tenant_id: str, idea_id: int) -> dict:
+    return _to_dict(_get(db, tenant_id, idea_id))
+
+
+def pipeline_summary(db: Session, tenant_id: str) -> dict:
+    rows = db.query(InnovationIdea).filter(InnovationIdea.tenant_id == tenant_id).all()
+    by_status: dict[str, int] = {}
+    by_priority: dict[str, int] = {}
+    total_estimated_roi = 0.0
+    for r in rows:
+        by_status[r.approval_status] = by_status.get(r.approval_status, 0) + 1
+        by_priority[r.priority] = by_priority.get(r.priority, 0) + 1
+        if r.estimated_roi_usd:
+            total_estimated_roi += r.estimated_roi_usd
+    return {
+        "total_ideas": len(rows), "by_status": by_status, "by_priority": by_priority,
+        "total_estimated_roi_usd": round(total_estimated_roi, 2) if total_estimated_roi else 0.0,
+        "human_review_required": True,
+    }

--- a/backend/app/services/phoenix_knowledge_evolution_service.py
+++ b/backend/app/services/phoenix_knowledge_evolution_service.py
@@ -1,0 +1,80 @@
+"""v4.9 — Project Phoenix, Section 5: Knowledge Evolution Center.
+
+`athena_curator_service.py` (v4.8) already detects duplicate documents,
+outdated guidance, retirement candidates, emerging best practices, and
+knowledge gaps — composed here directly, never re-derived. The one
+genuinely new check is **contradictory guidance**: no such detection
+exists anywhere in this codebase (confirmed by grep). It uses a real,
+deterministic keyword-conflict check — never a semantic/LLM judgment —
+so it only ever flags an *explicit* lexical conflict for human review.
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import APPROVED, KnowledgeArticle
+from app.models.phoenix_intelligence import DISCLAIMER
+from app.services import athena_curator_service
+
+# Deliberately non-overlapping keyword sets — an article containing only
+# strict-disposition language and another containing only lenient-
+# disposition language, for the same finding+zone, is a real, checkable
+# lexical conflict.
+_STRICT_KEYWORDS = ("remove from service", "reprocess", "quarantine", "do not use")
+_LENIENT_KEYWORDS = ("monitor", "acceptable", "no action needed", "continue use")
+
+
+def _disposition_signal(text: str) -> str:
+    lowered = text.lower()
+    has_strict = any(k in lowered for k in _STRICT_KEYWORDS)
+    has_lenient = any(k in lowered for k in _LENIENT_KEYWORDS)
+    if has_strict and not has_lenient:
+        return "strict"
+    if has_lenient and not has_strict:
+        return "lenient"
+    return "unclear"
+
+
+def contradictory_guidance(db: Session, tenant_id: str) -> list[dict]:
+    """Approved articles sharing a finding+zone but with opposite,
+    unambiguous disposition language."""
+    rows = db.query(KnowledgeArticle).filter(
+        KnowledgeArticle.tenant_id == tenant_id, KnowledgeArticle.approval_status == APPROVED,
+    ).all()
+
+    groups: dict[tuple[str, str], list[KnowledgeArticle]] = defaultdict(list)
+    for r in rows:
+        try:
+            findings = json.loads(r.applicable_findings or "[]")
+        except (TypeError, ValueError):
+            findings = []
+        for finding in findings or [""]:
+            if finding and r.anatomy_zone:
+                groups[(finding, r.anatomy_zone)].append(r)
+
+    conflicts = []
+    for (finding, zone), articles in groups.items():
+        if len(articles) < 2:
+            continue
+        signals = {a.id: _disposition_signal(a.body) for a in articles}
+        strict_ids = [aid for aid, s in signals.items() if s == "strict"]
+        lenient_ids = [aid for aid, s in signals.items() if s == "lenient"]
+        if strict_ids and lenient_ids:
+            conflicts.append({
+                "finding_type": finding, "anatomy_zone": zone,
+                "strict_article_ids": strict_ids, "lenient_article_ids": lenient_ids,
+            })
+    return conflicts
+
+
+def knowledge_evolution_summary(db: Session, tenant_id: str) -> dict:
+    curator = athena_curator_service.curator_summary(db, tenant_id)
+    return {
+        **curator,
+        "contradictory_guidance": contradictory_guidance(db, tenant_id),
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/phoenix_learning_engine_service.py
+++ b/backend/app/services/phoenix_learning_engine_service.py
@@ -1,0 +1,67 @@
+"""v4.9 — Project Phoenix, Section 1: Phoenix Learning Engine.
+
+The `/phoenix` dashboard's umbrella composition — continuously analyzes
+inspection outcomes, AI confidence, supervisor overrides, knowledge
+usage, workflow efficiency, Digital Twin health, enterprise trends, and
+education effectiveness by composing the real outputs of every other
+Phoenix engine plus `quality_command_center_service` (Guardian, v2.9) and
+`vanguard_executive_intelligence_service` (v4.6) — nothing here is
+re-derived, and nothing here modifies production; it only reads.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.phoenix_intelligence import DISCLAIMER
+from app.services import (
+    phoenix_ai_observatory_service,
+    phoenix_platform_health_service,
+    phoenix_workflow_optimization_service,
+    quality_command_center_service,
+    vanguard_executive_intelligence_service,
+)
+from app.services.knowledge_analytics_service import knowledge_analytics
+
+
+def learning_engine_summary(db: Session, tenant_id: str) -> dict:
+    command_center = quality_command_center_service.quality_command_center_summary(db, tenant_id)
+    ai_observatory = phoenix_ai_observatory_service.observatory_summary(db, tenant_id)
+    knowledge = knowledge_analytics(db, tenant_id)
+    workflow = phoenix_workflow_optimization_service.workflow_optimization_summary(db, tenant_id)
+    digital_twin = phoenix_platform_health_service.compute_digital_twin_health_score(db, tenant_id)
+    enterprise = vanguard_executive_intelligence_service.executive_intelligence_center(db, tenant_id)
+
+    return {
+        "inspection_outcomes": {
+            "quality_events": command_center["quality_events"],
+            "recurring_findings": command_center["recurring_findings"],
+            "capas": command_center["capas"],
+        },
+        "ai_confidence": {
+            "ai_confidence_avg": ai_observatory["ai_confidence_avg"],
+            "confidence_calibration": ai_observatory["confidence_calibration"],
+            "model_drift_detected": ai_observatory["model_drift_detected"],
+        },
+        "supervisor_overrides": {
+            "supervisor_override_rate": ai_observatory["supervisor_override_rate"],
+            "human_agreement_rate": ai_observatory["human_agreement_rate"],
+        },
+        "knowledge_usage": {
+            "most_viewed_articles": knowledge["most_viewed_articles"],
+            "most_common_questions": knowledge["most_common_questions"],
+            "knowledge_gaps": knowledge["knowledge_gaps"],
+        },
+        "workflow_efficiency": workflow["duration_analysis"],
+        "digital_twin_health": digital_twin,
+        "enterprise_trends": {
+            "enterprise_readiness": enterprise.get("enterprise_readiness"),
+            "enterprise_risk": enterprise.get("enterprise_risk"),
+            "knowledge_growth": enterprise.get("knowledge_growth"),
+        },
+        "education_effectiveness": {
+            "education_impact_avg_pct": command_center["education_impact_avg_pct"],
+            "technician_trends": command_center["technician_trends"],
+        },
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/phoenix_maturity_index_service.py
+++ b/backend/app/services/phoenix_maturity_index_service.py
@@ -1,0 +1,133 @@
+"""v4.9 — Project Phoenix, Section 10: Platform Maturity Index.
+
+Nine named dimensions, each a composition of a real, already-computed
+signal from a prior sprint — no dimension re-derives another system's
+math. "Quality" reuses Apollo's `apollo_quality_twin_service` (v4.7,
+itself an 8-dimension composite) as a single input rather than
+re-deriving CAPA/competency/audit-readiness numbers a third time.
+Progression over time is tracked via `PlatformMaturitySnapshot` rows,
+read back through `maturity_history`.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import KnowledgeQueryLog
+from app.models.phoenix_intelligence import DISCLAIMER, PlatformMaturitySnapshot
+from app.services import competency_service, phoenix_ai_observatory_service, phoenix_platform_health_service, vanguard_governance_service
+
+# A capped proxy: more logged queries indicates more active analytics
+# usage. No "correct" volume exists to compare against, so this is
+# reported as a bounded 0-100 usage-activity signal, not a benchmarked
+# maturity level.
+_ANALYTICS_USAGE_CAP = 200
+
+
+def _inspection_dimension(db: Session, tenant_id: str) -> float | None:
+    coverage = phoenix_ai_observatory_service.coverage_summary(db, tenant_id)
+    return coverage["ai_participation_coverage_pct"]
+
+
+def _analytics_dimension(db: Session, tenant_id: str) -> float | None:
+    count = db.query(KnowledgeQueryLog).filter(KnowledgeQueryLog.tenant_id == tenant_id).count()
+    if not count:
+        return None
+    return round(min(100.0, 100 * count / _ANALYTICS_USAGE_CAP), 1)
+
+
+def _education_dimension(db: Session, tenant_id: str) -> float | None:
+    dashboard = competency_service.technician_quality_dashboard(db, tenant_id)
+    values = [t["training_progress_pct"] for t in dashboard["technicians"] if t.get("training_progress_pct") is not None]
+    return round(sum(values) / len(values), 1) if values else None
+
+
+def _governance_dimension(db: Session, tenant_id: str) -> float | None:
+    dashboard = vanguard_governance_service.governance_dashboard(db, tenant_id)
+    compliance = dashboard["policy_compliance"]
+    if not compliance["total_policy_count"]:
+        return None
+    return round(100 * compliance["enabled_policy_count"] / compliance["total_policy_count"], 1)
+
+
+def _executive_intelligence_dimension(db: Session, tenant_id: str) -> float | None:
+    dashboard = vanguard_governance_service.governance_dashboard(db, tenant_id)
+    return dashboard["audit_readiness"].get("overall_readiness_score")
+
+
+def compute_platform_maturity_index(db: Session, tenant_id: str) -> dict:
+    factors: dict[str, str] = {}
+
+    inspection = _inspection_dimension(db, tenant_id)
+    factors["inspection_score"] = "% of inspections that received a real AI confidence score"
+
+    knowledge = phoenix_platform_health_service.compute_knowledge_health_score(db, tenant_id)["score"]
+    factors["knowledge_score"] = "reused from Platform Health's Knowledge Health"
+
+    quality = phoenix_platform_health_service.compute_quality_health_score(db, tenant_id)["score"]
+    factors["quality_score"] = "reused from Apollo's Quality Digital Twin overall_score"
+
+    workflow = phoenix_platform_health_service.compute_workflow_health_score(db, tenant_id)["score"]
+    factors["workflow_score"] = "reused from Platform Health's Workflow Health"
+
+    analytics = _analytics_dimension(db, tenant_id)
+    factors["analytics_score"] = "bounded knowledge-query usage-activity proxy, not a benchmarked level"
+
+    education = _education_dimension(db, tenant_id)
+    factors["education_score"] = "org-average technician training_progress_pct"
+
+    digital_twins = phoenix_platform_health_service.compute_digital_twin_health_score(db, tenant_id)["score"]
+    factors["digital_twins_score"] = "reused from Platform Health's Digital Twin Health"
+
+    governance = _governance_dimension(db, tenant_id)
+    factors["governance_score"] = "enabled-vs-total RetentionPolicy ratio (Vanguard governance dashboard)"
+
+    executive_intelligence = _executive_intelligence_dimension(db, tenant_id)
+    factors["executive_intelligence_score"] = "audit-readiness overall_readiness_score (Vanguard governance dashboard)"
+
+    scores = {
+        "inspection_score": inspection, "knowledge_score": knowledge, "quality_score": quality,
+        "workflow_score": workflow, "analytics_score": analytics, "education_score": education,
+        "digital_twins_score": digital_twins, "governance_score": governance,
+        "executive_intelligence_score": executive_intelligence,
+    }
+    present = [v for v in scores.values() if v is not None]
+    overall_score = round(sum(present) / len(present), 1) if present else 0.0
+
+    snapshot = PlatformMaturitySnapshot(
+        tenant_id=tenant_id, overall_score=overall_score, factors_json=json.dumps(factors),
+        **{k: (v or 0.0) for k, v in scores.items()},
+    )
+    db.add(snapshot)
+    db.commit()
+    db.refresh(snapshot)
+
+    return {
+        "id": snapshot.id, "created_at": snapshot.created_at.isoformat(), "scores": scores,
+        "overall_score": overall_score, "factors": factors,
+        "human_review_required": True, "disclaimer": DISCLAIMER,
+    }
+
+
+def maturity_history(db: Session, tenant_id: str, *, limit: int = 20) -> list[dict]:
+    rows = (
+        db.query(PlatformMaturitySnapshot)
+        .filter(PlatformMaturitySnapshot.tenant_id == tenant_id)
+        .order_by(PlatformMaturitySnapshot.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            "id": r.id, "created_at": r.created_at.isoformat(), "overall_score": r.overall_score,
+            "scores": {
+                "inspection_score": r.inspection_score, "knowledge_score": r.knowledge_score,
+                "quality_score": r.quality_score, "workflow_score": r.workflow_score,
+                "analytics_score": r.analytics_score, "education_score": r.education_score,
+                "digital_twins_score": r.digital_twins_score, "governance_score": r.governance_score,
+                "executive_intelligence_score": r.executive_intelligence_score,
+            },
+        }
+        for r in rows
+    ]

--- a/backend/app/services/phoenix_platform_health_service.py
+++ b/backend/app/services/phoenix_platform_health_service.py
@@ -1,0 +1,131 @@
+"""v4.9 — Project Phoenix, Section 7: Platform Health Dashboard.
+
+Composes seven named health areas from real, already-computed signals
+across prior sprints — no re-derivation. Where no clean existing signal
+exists (Security, Integration), Phoenix computes a real ratio from
+existing tables (`TenantMembership`, `TenantSubscriptionP14`,
+`ExternalSystemConnector`) rather than fabricating a score, and reports
+"insufficient data" when a tenant has no rows in the relevant table yet.
+Digital Twin Health reads the *instrument-flow* twin (`digital_twin_
+engine.py`) — a different twin from Apollo's Quality Digital Twin, which
+is instead this dashboard's real input for "Quality Health".
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.phoenix_intelligence import DISCLAIMER
+from app.services import phoenix_ai_observatory_service, phoenix_knowledge_evolution_service, phoenix_workflow_optimization_service
+from app.services.apollo_quality_twin_service import twin_history
+from app.services.knowledge_governance_service import governance_summary
+
+
+def compute_ai_health_score(db: Session, tenant_id: str) -> dict:
+    obs = phoenix_ai_observatory_service.observatory_summary(db, tenant_id)
+    if not obs["sample_size"]:
+        return {"score": None, "note": "insufficient data — no supervisor reviews recorded yet"}
+    agreement = obs["human_agreement_rate"] or 0.0
+    score = round(100 * agreement * (0.7 if obs["model_drift_detected"] else 1.0), 1)
+    return {"score": score, "sample_size": obs["sample_size"], "drift_detected": obs["model_drift_detected"]}
+
+
+def compute_knowledge_health_score(db: Session, tenant_id: str) -> dict:
+    gov = governance_summary(db, tenant_id)
+    if not gov["total_articles"]:
+        return {"score": None, "note": "insufficient data — no knowledge articles recorded yet"}
+    evolution = phoenix_knowledge_evolution_service.knowledge_evolution_summary(db, tenant_id)
+    penalty = min(50.0, 5.0 * (len(evolution["duplicate_candidates"]) + len(evolution["contradictory_guidance"]) + len(evolution["outdated_guidance"])))
+    approved_ratio = gov["by_approval_status"].get("approved", 0) / gov["total_articles"]
+    score = round(max(0.0, 100 * approved_ratio - penalty), 1)
+    return {"score": score, "total_articles": gov["total_articles"]}
+
+
+def compute_workflow_health_score(db: Session, tenant_id: str) -> dict:
+    opt = phoenix_workflow_optimization_service.workflow_optimization_summary(db, tenant_id)
+    duration = opt["duration_analysis"]
+    if not duration.get("sample_size"):
+        return {"score": None, "note": "insufficient data — no workflow executions recorded yet"}
+    failed = duration["by_status"].get("failed", 0)
+    penalty = min(60.0, 10.0 * failed + 5.0 * len(opt["approval_bottlenecks"]))
+    return {"score": round(max(0.0, 100 - penalty), 1), "sample_size": duration["sample_size"]}
+
+
+def compute_digital_twin_health_score(db: Session, tenant_id: str) -> dict:
+    try:
+        from app.services.digital_twin_engine import compute_twin_dashboard
+
+        dashboard = compute_twin_dashboard(tenant_id, "", db)
+    except Exception:
+        return {"score": None, "note": "insufficient data — digital twin unavailable for this tenant"}
+    if dashboard.data_source != "real":
+        # digital_twin_engine falls back to seeded-random mock data when no
+        # real flow/station rows exist for this tenant — that's a
+        # legitimate demo fallback for the twin's own dashboard, but never a
+        # real health signal, so Phoenix reports it as no data rather than
+        # scoring a fabricated number.
+        return {"score": None, "note": "insufficient data — no real digital twin data recorded for this tenant yet"}
+    utilization = dashboard.twin_state.utilization_pct
+    open_alerts = len(dashboard.open_alerts)
+    # A healthy utilization band is 40-85%; too low (idle) or too high
+    # (overloaded) both reduce the score, same as too many open alerts.
+    band_penalty = 0.0 if 40 <= utilization <= 85 else min(40.0, abs(utilization - 62.5))
+    alert_penalty = min(40.0, 10.0 * open_alerts)
+    score = round(max(0.0, 100 - band_penalty - alert_penalty), 1)
+    return {"score": score, "utilization_pct": utilization, "open_alerts": open_alerts, "data_source": dashboard.data_source}
+
+
+def compute_security_health_score(db: Session, tenant_id: str) -> dict:
+    total = db.query(models.TenantMembership).filter(models.TenantMembership.tenant_id == tenant_id).count()
+    if not total:
+        return {"score": None, "note": "insufficient data — no tenant memberships recorded yet"}
+    enabled = db.query(models.TenantMembership).filter(
+        models.TenantMembership.tenant_id == tenant_id, models.TenantMembership.is_enabled,
+    ).count()
+    from app.models.tenant_subscription_p14 import TenantSubscriptionP14
+
+    baa_signed = False
+    sub = db.query(TenantSubscriptionP14).filter_by(tenant_id=tenant_id).first()
+    if sub is not None:
+        baa_signed = sub.hipaa_baa_signed_at is not None
+    score = round(80 * (enabled / total) + (20 if baa_signed else 0), 1)
+    return {"score": score, "enabled_membership_ratio": round(enabled / total, 2), "hipaa_baa_signed": baa_signed}
+
+
+def compute_integration_health_score(db: Session, tenant_id: str) -> dict:
+    rows = db.query(models.ExternalSystemConnector).filter(models.ExternalSystemConnector.tenant_id == tenant_id).all()
+    if not rows:
+        return {"score": None, "note": "insufficient data — no external connectors configured yet"}
+    active = sum(1 for r in rows if r.connection_status == "active")
+    errored = sum(1 for r in rows if r.connection_status == "error")
+    score = round(max(0.0, 100 * (active / len(rows)) - 20 * errored), 1)
+    return {"score": score, "connector_count": len(rows), "active_count": active, "error_count": errored}
+
+
+def compute_quality_health_score(db: Session, tenant_id: str) -> dict:
+    """Reads the most recent Quality Digital Twin snapshot (Apollo,
+    v4.7) — never recomputes one here, since that would add a write
+    side-effect to a read-only health dashboard."""
+    history = twin_history(db, tenant_id, "unspecified", limit=1)
+    if not history:
+        return {"score": None, "note": "insufficient data — no Quality Digital Twin snapshot recorded yet"}
+    latest = history[0]
+    return {"score": latest["overall_score"], "snapshot_at": latest["created_at"]}
+
+
+def platform_health_dashboard(db: Session, tenant_id: str) -> dict:
+    areas = {
+        "ai_health": compute_ai_health_score(db, tenant_id),
+        "knowledge_health": compute_knowledge_health_score(db, tenant_id),
+        "workflow_health": compute_workflow_health_score(db, tenant_id),
+        "digital_twin_health": compute_digital_twin_health_score(db, tenant_id),
+        "security_health": compute_security_health_score(db, tenant_id),
+        "integration_health": compute_integration_health_score(db, tenant_id),
+        "quality_health": compute_quality_health_score(db, tenant_id),
+    }
+    scored = [a["score"] for a in areas.values() if a["score"] is not None]
+    overall = round(sum(scored) / len(scored), 1) if scored else None
+    return {
+        **areas, "overall_platform_maturity": overall,
+        "human_review_required": True, "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/phoenix_recommendation_engine.py
+++ b/backend/app/services/phoenix_recommendation_engine.py
@@ -1,0 +1,187 @@
+"""v4.9 — Project Phoenix, Section 2: Improvement Recommendation Engine.
+
+Scans the real outputs of the other Phoenix engines and Sentinel's AI
+health monitor, drafting an `ImprovementRecommendation` for each genuine
+signal found — never fabricated. Every recommendation starts as `draft`
+and enters Continuous Validation (Section 9) only via an explicit,
+separate human action (`phoenix_validation_pipeline_service.
+start_validation`) — generating a recommendation never auto-starts its
+approval chain.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.phoenix_intelligence import (
+    DISCLAIMER,
+    REC_COLLECT_BASELINE_IMAGES,
+    REC_CREATE_COMPETENCY,
+    REC_IMPROVE_ANATOMY_MODEL,
+    REC_IMPROVE_KNOWLEDGE_GRAPH,
+    REC_REVIEW_AI_CONFIDENCE,
+    REC_REVISE_INSPECTION_GUIDANCE,
+    REC_UPDATE_SOP,
+    REC_UPDATE_WORKFLOW,
+    SOURCE_AI_OBSERVATORY,
+    SOURCE_COMPETENCY_INTELLIGENCE,
+    SOURCE_KNOWLEDGE_EVOLUTION,
+    SOURCE_WORKFLOW_OPTIMIZER,
+    ImprovementRecommendation,
+)
+from app.models.supervisor_review import SupervisorReview
+from app.services import competency_intelligence_service, phoenix_ai_observatory_service, phoenix_knowledge_evolution_service, phoenix_workflow_optimization_service
+from app.services.ml.pilot_validation import zone_performance
+
+_LOW_CONFIDENCE_THRESHOLD = 0.7
+_HIGH_MISS_RATE_THRESHOLD = 0.2
+
+
+def _to_dict(row: ImprovementRecommendation) -> dict:
+    return {
+        "id": row.id, "created_at": row.created_at.isoformat(), "recommendation_type": row.recommendation_type,
+        "source": row.source, "title": row.title, "evidence": json.loads(row.evidence_json or "[]"),
+        "expected_benefit": row.expected_benefit, "confidence": row.confidence,
+        "impact_assessment": row.impact_assessment,
+        "required_approvals": json.loads(row.required_approvals_json or "[]"),
+        "status": row.status, "related_object_type": row.related_object_type, "related_object_id": row.related_object_id,
+        "human_review_required": True, "disclaimer": DISCLAIMER,
+    }
+
+
+def _create(
+    db: Session, tenant_id: str, *, recommendation_type: str, source: str, title: str, evidence: list[str],
+    expected_benefit: str, confidence: float, impact_assessment: str, required_approvals: list[str],
+    related_object_type: str = "", related_object_id: int | None = None,
+) -> ImprovementRecommendation:
+    row = ImprovementRecommendation(
+        tenant_id=tenant_id, recommendation_type=recommendation_type, source=source, title=title,
+        evidence_json=json.dumps(evidence), expected_benefit=expected_benefit, confidence=confidence,
+        impact_assessment=impact_assessment, required_approvals_json=json.dumps(required_approvals),
+        related_object_type=related_object_type, related_object_id=related_object_id,
+    )
+    db.add(row)
+    return row
+
+
+def generate_recommendations(db: Session, tenant_id: str) -> list[dict]:
+    created: list[ImprovementRecommendation] = []
+
+    # 1. AI confidence decline -> review_ai_confidence.
+    obs = phoenix_ai_observatory_service.observatory_summary(db, tenant_id)
+    if obs["model_drift_detected"]:
+        created.append(_create(
+            db, tenant_id, recommendation_type=REC_REVIEW_AI_CONFIDENCE, source=SOURCE_AI_OBSERVATORY,
+            title="Review AI confidence — drift detected",
+            evidence=[obs["model_drift_detail"] or "AI health drift signal is active."],
+            expected_benefit="Restores AI confidence calibration and reduces the risk of undetected accuracy regression.",
+            confidence=0.7, impact_assessment="Affects every future inspection until addressed.",
+            required_approvals=["spd_manager", "admin"],
+        ))
+
+    # 2. Low-confidence / high-miss-rate zones -> improve_anatomy_model / collect_baseline_images.
+    reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id).all()
+    if reviews:
+        zones = zone_performance(reviews)
+        for z in zones["lowest_confidence_zones"][:3]:
+            if z["avg_confidence"] is not None and z["avg_confidence"] < _LOW_CONFIDENCE_THRESHOLD:
+                created.append(_create(
+                    db, tenant_id, recommendation_type=REC_COLLECT_BASELINE_IMAGES, source=SOURCE_AI_OBSERVATORY,
+                    title=f"Collect more baseline images — {z['zone']}",
+                    evidence=[f"Average AI confidence in {z['zone']} is {z['avg_confidence']} across {z['n']} reviews."],
+                    expected_benefit="More labeled baseline examples typically improve confidence calibration in a low-confidence zone.",
+                    confidence=0.6, impact_assessment=f"Affects inspections touching the {z['zone']} zone.",
+                    required_approvals=["spd_manager"],
+                ))
+        for z in zones["highest_risk_zones"][:3]:
+            if z["miss_rate"] and z["miss_rate"] >= _HIGH_MISS_RATE_THRESHOLD:
+                created.append(_create(
+                    db, tenant_id, recommendation_type=REC_IMPROVE_ANATOMY_MODEL, source=SOURCE_AI_OBSERVATORY,
+                    title=f"Improve anatomy model — {z['zone']}",
+                    evidence=[f"Miss rate in {z['zone']} is {z['miss_rate']} across {z['n']} reviews."],
+                    expected_benefit="Reduces false negatives in a zone with an elevated real miss rate.",
+                    confidence=0.65, impact_assessment=f"Safety-relevant: missed findings in {z['zone']}.",
+                    required_approvals=["spd_manager", "admin"],
+                ))
+
+    # 3. Knowledge evolution -> revise_inspection_guidance / improve_knowledge_graph.
+    evolution = phoenix_knowledge_evolution_service.knowledge_evolution_summary(db, tenant_id)
+    for gap in evolution["knowledge_gaps"][:5]:
+        created.append(_create(
+            db, tenant_id, recommendation_type=REC_REVISE_INSPECTION_GUIDANCE, source=SOURCE_KNOWLEDGE_EVOLUTION,
+            title=f"Revise inspection guidance — {gap['finding_type']}",
+            evidence=[f"{gap['clinical_case_count']} clinical case(s) with no approved institutional article covering '{gap['finding_type']}'."],
+            expected_benefit="Closes a real documented knowledge gap for technicians handling this finding.",
+            confidence=0.6, impact_assessment="Affects future inspections of this finding type.",
+            required_approvals=["spd_manager"],
+        ))
+    for conflict in evolution["contradictory_guidance"][:5]:
+        created.append(_create(
+            db, tenant_id, recommendation_type=REC_UPDATE_SOP, source=SOURCE_KNOWLEDGE_EVOLUTION,
+            title=f"Resolve contradictory guidance — {conflict['finding_type']} / {conflict['anatomy_zone']}",
+            evidence=[f"Articles {conflict['strict_article_ids']} recommend strict disposition; articles {conflict['lenient_article_ids']} recommend lenient disposition for the same finding+zone."],
+            expected_benefit="Removes conflicting guidance that could lead to inconsistent technician decisions.",
+            confidence=0.7, impact_assessment="Safety-relevant: conflicting disposition guidance.",
+            required_approvals=["spd_manager", "admin"],
+        ))
+    if evolution["duplicate_candidates"] or evolution["retirement_candidates"]:
+        created.append(_create(
+            db, tenant_id, recommendation_type=REC_IMPROVE_KNOWLEDGE_GRAPH, source=SOURCE_KNOWLEDGE_EVOLUTION,
+            title="Consolidate duplicate and retire outdated knowledge articles",
+            evidence=[
+                f"{len(evolution['duplicate_candidates'])} duplicate candidate pair(s).",
+                f"{len(evolution['retirement_candidates'])} retirement candidate(s).",
+            ],
+            expected_benefit="A cleaner, less redundant Knowledge Graph improves search relevance and trust.",
+            confidence=0.55, impact_assessment="Improves knowledge discoverability platform-wide.",
+            required_approvals=["spd_manager"],
+        ))
+
+    # 4. Competency opportunities -> create_competency.
+    open_opportunities = competency_intelligence_service.list_opportunities(db, tenant_id, status="open")
+    if open_opportunities:
+        created.append(_create(
+            db, tenant_id, recommendation_type=REC_CREATE_COMPETENCY, source=SOURCE_COMPETENCY_INTELLIGENCE,
+            title="Create competency plan for open coaching/education opportunities",
+            evidence=[o["rationale"] for o in open_opportunities[:5]],
+            expected_benefit="Addresses recorded repeated-error patterns before they recur further.",
+            confidence=0.65, impact_assessment=f"Affects {len({o['scope_value'] for o in open_opportunities})} technician(s)/team(s).",
+            required_approvals=["spd_manager"],
+        ))
+
+    # 5. Workflow bottlenecks -> update_workflow.
+    workflow_opt = phoenix_workflow_optimization_service.workflow_optimization_summary(db, tenant_id)
+    for failure in workflow_opt["repeated_exceptions"][:3]:
+        created.append(_create(
+            db, tenant_id, recommendation_type=REC_UPDATE_WORKFLOW, source=SOURCE_WORKFLOW_OPTIMIZER,
+            title=f"Update workflow {failure['workflow_id']} — repeated failures",
+            evidence=[f"{failure['failure_count']} repeated failed executions recorded for workflow {failure['workflow_id']}."],
+            expected_benefit="Reduces recurring execution failures and manual rework.",
+            confidence=0.6, impact_assessment=f"Affects every future execution of workflow {failure['workflow_id']}.",
+            required_approvals=["spd_manager", "admin"], related_object_type="workflow_definition",
+            related_object_id=failure["workflow_id"],
+        ))
+
+    db.commit()
+    for row in created:
+        db.refresh(row)
+    return [_to_dict(r) for r in created]
+
+
+def list_recommendations(db: Session, tenant_id: str, *, status: str = "") -> list[dict]:
+    q = db.query(ImprovementRecommendation).filter(ImprovementRecommendation.tenant_id == tenant_id)
+    if status:
+        q = q.filter(ImprovementRecommendation.status == status)
+    return [_to_dict(r) for r in q.order_by(ImprovementRecommendation.created_at.desc()).all()]
+
+
+def get_recommendation(db: Session, tenant_id: str, recommendation_id: int) -> dict:
+    row = (
+        db.query(ImprovementRecommendation)
+        .filter(ImprovementRecommendation.id == recommendation_id, ImprovementRecommendation.tenant_id == tenant_id)
+        .first()
+    )
+    if row is None:
+        raise ValueError(f"Recommendation {recommendation_id} not found for tenant {tenant_id}.")
+    return _to_dict(row)

--- a/backend/app/services/phoenix_validation_pipeline_service.py
+++ b/backend/app/services/phoenix_validation_pipeline_service.py
@@ -1,0 +1,133 @@
+"""v4.9 — Project Phoenix, Section 9: Continuous Validation.
+
+Every recommendation moves through Review -> Clinical Validation ->
+Technical Review -> Pilot -> Measurement -> Production. Rather than a
+second approval-chain model, this reuses Project Forge's existing
+`WorkflowApprovalChain`/`WorkflowApprovalInstance` primitive
+(`forge_approval_service.py`, v4.1) directly — one chain per
+recommendation, with the six Phoenix stages as its ordered steps.
+A rejection at any stage ends the instance immediately (Forge's existing
+behavior) and the recommendation's `status` is set to `rejected` — no
+recommendation ever reaches `production` without an explicit approval at
+every stage.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.phoenix_intelligence import DISCLAIMER, STAGE_REVIEW, VALIDATION_STAGES, ImprovementRecommendation, ValidationOutcome
+from app.services import forge_approval_service
+
+
+class RecommendationNotFoundError(ValueError):
+    pass
+
+
+def _get_recommendation(db: Session, tenant_id: str, recommendation_id: int) -> ImprovementRecommendation:
+    row = (
+        db.query(ImprovementRecommendation)
+        .filter(ImprovementRecommendation.id == recommendation_id, ImprovementRecommendation.tenant_id == tenant_id)
+        .first()
+    )
+    if row is None:
+        raise RecommendationNotFoundError(f"Recommendation {recommendation_id} not found for tenant {tenant_id}.")
+    return row
+
+
+def start_validation(db: Session, tenant_id: str, recommendation_id: int) -> dict:
+    """Creates the six-stage approval chain for a recommendation and
+    starts its instance at stage 0 (Review)."""
+    rec = _get_recommendation(db, tenant_id, recommendation_id)
+    chain = forge_approval_service.create_chain(db, tenant_id, name=f"Validation: {rec.title}", steps=VALIDATION_STAGES)
+    instance = forge_approval_service.start_instance(db, tenant_id, chain["id"])
+
+    rec.approval_chain_id = chain["id"]
+    rec.approval_instance_id = instance["id"]
+    rec.status = STAGE_REVIEW
+    db.commit()
+    db.refresh(rec)
+    return {"recommendation_id": rec.id, "chain": chain, "instance": instance}
+
+
+def advance_validation(
+    db: Session, tenant_id: str, recommendation_id: int, *, decided_by: str, decided_role: str, decision: str,
+    notes: str = "", outcome_notes: str = "", lessons_learned: str = "", measured_impact: str = "",
+) -> dict:
+    """Records one stage's decision. On approval, advances to the next
+    stage (or `production` if this was the final stage); on rejection,
+    ends the pipeline immediately — matching Forge's existing
+    `decide_step` semantics exactly."""
+    rec = _get_recommendation(db, tenant_id, recommendation_id)
+    if rec.approval_instance_id is None:
+        raise ValueError(f"Recommendation {recommendation_id} has not started validation yet.")
+
+    current_stage = rec.status if rec.status in VALIDATION_STAGES else VALIDATION_STAGES[0]
+    instance = forge_approval_service.decide_step(
+        db, rec.approval_instance_id, decided_by=decided_by, decided_role=decided_role, decision=decision, notes=notes,
+    )
+
+    if decision == "rejected":
+        rec.status = "rejected"
+    elif instance["status"] == "approved":
+        rec.status = VALIDATION_STAGES[-1]
+    else:
+        rec.status = VALIDATION_STAGES[instance["current_step_index"]]
+    db.commit()
+    db.refresh(rec)
+
+    outcome = ValidationOutcome(
+        tenant_id=tenant_id, recommendation_id=recommendation_id, stage=current_stage,
+        outcome_notes=outcome_notes, lessons_learned=lessons_learned, measured_impact=measured_impact,
+        recorded_by=decided_by,
+    )
+    db.add(outcome)
+    db.commit()
+    db.refresh(outcome)
+
+    return {"recommendation_status": rec.status, "instance": instance, "outcome_id": outcome.id}
+
+
+def record_outcome(
+    db: Session, tenant_id: str, recommendation_id: int, *, stage: str, outcome_notes: str = "",
+    lessons_learned: str = "", measured_impact: str = "", recorded_by: str = "",
+) -> dict:
+    if stage not in VALIDATION_STAGES:
+        raise ValueError(f"stage must be one of {VALIDATION_STAGES}")
+    _get_recommendation(db, tenant_id, recommendation_id)  # existence check
+    row = ValidationOutcome(
+        tenant_id=tenant_id, recommendation_id=recommendation_id, stage=stage, outcome_notes=outcome_notes,
+        lessons_learned=lessons_learned, measured_impact=measured_impact, recorded_by=recorded_by,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return {
+        "id": row.id, "stage": row.stage, "outcome_notes": row.outcome_notes,
+        "lessons_learned": row.lessons_learned, "measured_impact": row.measured_impact,
+    }
+
+
+def list_outcomes(db: Session, tenant_id: str, recommendation_id: int) -> list[dict]:
+    rows = (
+        db.query(ValidationOutcome)
+        .filter(ValidationOutcome.tenant_id == tenant_id, ValidationOutcome.recommendation_id == recommendation_id)
+        .order_by(ValidationOutcome.created_at.asc())
+        .all()
+    )
+    return [
+        {
+            "id": r.id, "stage": r.stage, "outcome_notes": r.outcome_notes, "lessons_learned": r.lessons_learned,
+            "measured_impact": r.measured_impact, "recorded_by": r.recorded_by, "created_at": r.created_at.isoformat(),
+        }
+        for r in rows
+    ]
+
+
+def get_validation_status(db: Session, tenant_id: str, recommendation_id: int) -> dict:
+    rec = _get_recommendation(db, tenant_id, recommendation_id)
+    instance = forge_approval_service.get_instance(db, rec.approval_instance_id) if rec.approval_instance_id else None
+    return {
+        "recommendation_id": rec.id, "status": rec.status, "instance": instance,
+        "outcomes": list_outcomes(db, tenant_id, recommendation_id),
+        "human_review_required": True, "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/phoenix_workflow_optimization_service.py
+++ b/backend/app/services/phoenix_workflow_optimization_service.py
@@ -1,0 +1,141 @@
+"""v4.9 — Project Phoenix, Section 4: Workflow Optimization Engine.
+
+`WorkflowExecution` (`workflow_forge.py`, v4.1) already records real
+`execution_time_ms`/`decision_path_json`/`status`, but no duration/
+bottleneck/queue-delay/rule-complexity analytics existed anywhere over
+it before Phoenix — a genuine gap this module fills by reading those rows
+directly. Any optimization surfaced here is a *recommendation* — nothing
+calls `forge_workflow_service.revise_workflow` automatically.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.phoenix_intelligence import DISCLAIMER
+from app.models.workflow_forge import (
+    APPROVAL_PENDING,
+    EXECUTION_FAILED,
+    WorkflowApprovalInstance,
+    WorkflowExecution,
+    WorkflowRule,
+)
+
+_BOTTLENECK_THRESHOLD_HOURS = 24.0
+
+
+def duration_analysis(db: Session, tenant_id: str, *, workflow_id: int | None = None) -> dict:
+    q = db.query(WorkflowExecution).filter(
+        WorkflowExecution.tenant_id == tenant_id, WorkflowExecution.execution_time_ms.isnot(None),
+    )
+    if workflow_id is not None:
+        q = q.filter(WorkflowExecution.workflow_id == workflow_id)
+    rows = q.all()
+    if not rows:
+        return {"sample_size": 0, "note": "insufficient data — no completed executions with recorded duration yet"}
+    durations = sorted(r.execution_time_ms for r in rows)
+    by_status: dict[str, int] = {}
+    for r in rows:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+    return {
+        "sample_size": len(durations), "avg_execution_time_ms": round(sum(durations) / len(durations), 1),
+        "min_execution_time_ms": round(durations[0], 1), "max_execution_time_ms": round(durations[-1], 1),
+        "by_status": by_status,
+    }
+
+
+def approval_bottlenecks(db: Session, tenant_id: str, *, stale_hours: float = _BOTTLENECK_THRESHOLD_HOURS) -> list[dict]:
+    """Approval instances still pending after `stale_hours` — a real
+    queue-delay signal, not a fabricated SLA breach."""
+    now = datetime.now(timezone.utc)
+    rows = (
+        db.query(WorkflowApprovalInstance)
+        .filter(WorkflowApprovalInstance.tenant_id == tenant_id, WorkflowApprovalInstance.status == APPROVAL_PENDING)
+        .all()
+    )
+    bottlenecks = []
+    for r in rows:
+        age_hours = (now - r.created_at).total_seconds() / 3600
+        if age_hours >= stale_hours:
+            bottlenecks.append({
+                "instance_id": r.id, "chain_id": r.chain_id, "current_step_index": r.current_step_index,
+                "age_hours": round(age_hours, 1),
+            })
+    bottlenecks.sort(key=lambda b: b["age_hours"], reverse=True)
+    return bottlenecks
+
+
+def repeated_exceptions(db: Session, tenant_id: str, *, min_failures: int = 2) -> list[dict]:
+    """Workflows with repeated failed executions — a real recurrence
+    count, grouped by `workflow_id`."""
+    rows = (
+        db.query(WorkflowExecution)
+        .filter(WorkflowExecution.tenant_id == tenant_id, WorkflowExecution.status == EXECUTION_FAILED)
+        .all()
+    )
+    counts: dict[int, int] = {}
+    for r in rows:
+        counts[r.workflow_id] = counts.get(r.workflow_id, 0) + 1
+    return [
+        {"workflow_id": wf_id, "failure_count": count}
+        for wf_id, count in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)
+        if count >= min_failures
+    ]
+
+
+def _condition_complexity(condition: dict) -> int:
+    """Recursive node count of a nested AND/OR/NOT condition tree — a
+    real structural complexity measure, not a guessed difficulty score."""
+    if not isinstance(condition, dict):
+        return 0
+    if "conditions" in condition:
+        return 1 + sum(_condition_complexity(c) for c in condition.get("conditions", []))
+    return 1  # a leaf condition
+
+
+def rule_complexity(db: Session, tenant_id: str) -> list[dict]:
+    rows = db.query(WorkflowRule).filter(
+        (WorkflowRule.tenant_id == tenant_id) | (WorkflowRule.tenant_id == ""), WorkflowRule.is_current.is_(True),
+    ).all()
+    results = []
+    for r in rows:
+        try:
+            condition = json.loads(r.condition_json or "{}")
+        except (TypeError, ValueError):
+            condition = {}
+        results.append({"rule_id": r.id, "name": r.name, "complexity_score": _condition_complexity(condition)})
+    results.sort(key=lambda x: x["complexity_score"], reverse=True)
+    return results
+
+
+def recommend_workflow_optimization(db: Session, tenant_id: str, workflow_id: int) -> dict:
+    """Analyzes one workflow's real duration/failure/bottleneck signals
+    and returns an evidence-based optimization recommendation shape —
+    never calls `forge_workflow_service.revise_workflow` itself."""
+    duration = duration_analysis(db, tenant_id, workflow_id=workflow_id)
+    failures = [f for f in repeated_exceptions(db, tenant_id) if f["workflow_id"] == workflow_id]
+
+    evidence = []
+    if duration.get("sample_size"):
+        evidence.append(f"Average execution time: {duration['avg_execution_time_ms']} ms over {duration['sample_size']} runs.")
+    if failures:
+        evidence.append(f"{failures[0]['failure_count']} repeated failed executions recorded.")
+
+    return {
+        "workflow_id": workflow_id, "duration_analysis": duration, "repeated_failures": failures,
+        "evidence": evidence, "recommend_review": bool(failures) or duration.get("max_execution_time_ms", 0) > 0,
+        "human_review_required": True, "disclaimer": DISCLAIMER,
+    }
+
+
+def workflow_optimization_summary(db: Session, tenant_id: str) -> dict:
+    return {
+        "duration_analysis": duration_analysis(db, tenant_id),
+        "approval_bottlenecks": approval_bottlenecks(db, tenant_id),
+        "repeated_exceptions": repeated_exceptions(db, tenant_id),
+        "rule_complexity": rule_complexity(db, tenant_id),
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -111,6 +111,7 @@ def _force_import_models():
         "app.models.apollo_quality",
         "app.models.athena_knowledge",
         "app.models.phoenix_intelligence",
+        "app.models.infinity_platform",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -110,6 +110,7 @@ def _force_import_models():
         "app.models.vanguard_intelligence",
         "app.models.apollo_quality",
         "app.models.athena_knowledge",
+        "app.models.phoenix_intelligence",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/test_infinity_platform.py
+++ b/backend/tests/test_infinity_platform.py
@@ -1,0 +1,364 @@
+"""v5.0 — LumenAI OS: Project Infinity — Healthcare AI Platform &
+Developer Ecosystem tests.
+
+Covers: SDK, Plugins, Marketplace, Security, API Versioning, Licensing,
+Certification, and Sandbox.
+"""
+from __future__ import annotations
+
+import time
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.services import (
+    infinity_billing_service,
+    infinity_certification_service,
+    infinity_developer_portal_service,
+    infinity_developer_service,
+    infinity_extension_service,
+    infinity_marketplace_service,
+    infinity_sandbox_service,
+)
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    db.add(models.TenantMembership(tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+def _make_developer(db) -> dict:
+    return infinity_developer_service.create_developer_account(
+        db, email=f"dev-{uid('e')}@example.com", organization_name="Acme Repairs", developer_type="repair_vendor",
+        approved_by="admin@local.dev",
+    )
+
+
+# ── 1. SDK (Plugin SDK extension types) ───────────────────────────────────────
+
+def test_sdk_extension_types_map_to_plugin_columns():
+    db = SessionLocal()
+    try:
+        plugin = infinity_extension_service.register_plugin(db, plugin_key=uid("plugin"), name="Test Plugin", registered_by="admin")
+        result = infinity_extension_service.register_extension(
+            db, plugin["plugin_key"], extension_type="ai_skills", location="copilot",
+            item={"skill_key": "forecast-helper"},
+        )
+    finally:
+        db.close()
+    assert result["ai_skills"][0]["skill_key"] == "forecast-helper"
+    assert result["ai_skills"][0]["location"] == "copilot"
+
+
+def test_sdk_rejects_unknown_extension_type():
+    db = SessionLocal()
+    try:
+        plugin = infinity_extension_service.register_plugin(db, plugin_key=uid("plugin-bad"), name="Bad Plugin", registered_by="admin")
+        try:
+            infinity_extension_service.register_extension(db, plugin["plugin_key"], extension_type="not_a_type", location="menu", item={})
+            assert False, "expected InvalidExtensionTypeError"
+        except infinity_extension_service.InvalidExtensionTypeError:
+            pass
+    finally:
+        db.close()
+
+
+def test_developer_portal_api_explorer_lists_v1_endpoints():
+    catalog = infinity_developer_portal_service.api_explorer_catalog()
+    paths = {e["path"] for e in catalog}
+    for expected in ("/api/v1/phoenix", "/api/v1/athena", "/api/v1/apollo", "/api/v1/identity"):
+        assert expected in paths
+
+
+# ── 2. Plugins ─────────────────────────────────────────────────────────────────
+
+def test_register_and_activate_plugin():
+    db = SessionLocal()
+    try:
+        plugin = infinity_extension_service.register_plugin(db, plugin_key=uid("plugin-activate"), name="Widget Pack", registered_by="admin")
+        assert plugin["status"] == "draft"
+        activated = infinity_extension_service.activate_plugin(db, plugin["plugin_key"])
+        assert activated["status"] == "active"
+        disabled = infinity_extension_service.disable_plugin(db, plugin["plugin_key"])
+        assert disabled["status"] == "disabled"
+    finally:
+        db.close()
+
+
+def test_plugin_route_requires_membership():
+    tenant_id = uid("infinity-plugin-route")
+    resp_denied = client.get("/api/infinity/plugins", headers=_headers(AUTH_VIEWER, tenant_id))
+    assert resp_denied.status_code == 403
+
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="viewer")
+    finally:
+        db.close()
+    resp = client.get("/api/infinity/plugins", headers=_headers(AUTH_VIEWER, tenant_id))
+    assert resp.status_code == 200
+
+
+# ── 3. Marketplace ─────────────────────────────────────────────────────────────
+
+def test_marketplace_listing_lifecycle_requires_certification_before_publish():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        listing = infinity_marketplace_service.create_listing(
+            db, developer["id"], listing_type="ai_skill", name="Forecast Pro", category="forecast",
+        )
+        assert listing["status"] == "private"
+
+        try:
+            infinity_marketplace_service.publish_listing(db, listing["id"])
+            assert False, "expected ListingNotCertifiedError"
+        except infinity_marketplace_service.ListingNotCertifiedError:
+            pass
+
+        infinity_certification_service.start_certification(db, listing["id"])
+        for gate in ["security", "performance", "clinical_safety", "explainability", "accessibility", "documentation", "governance"]:
+            infinity_certification_service.advance_certification(
+                db, listing["id"], decided_by="admin@local.dev", decided_role=gate, decision="approved",
+            )
+        published = infinity_marketplace_service.publish_listing(db, listing["id"])
+        assert published["status"] == "published"
+    finally:
+        db.close()
+
+
+def test_marketplace_install_requires_published_listing():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        listing = infinity_marketplace_service.create_listing(db, developer["id"], listing_type="application", name="Unpublished App")
+        try:
+            infinity_marketplace_service.install_listing(db, uid("tenant"), listing["id"], installed_by="admin")
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+    finally:
+        db.close()
+
+
+def test_marketplace_route_install_and_uninstall():
+    tenant_id = uid("infinity-marketplace-route")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+        developer = _make_developer(db)
+        listing = infinity_marketplace_service.create_listing(db, developer["id"], listing_type="ai_skill", name="Route Skill", category="education")
+        infinity_certification_service.start_certification(db, listing["id"])
+        for gate in ["security", "performance", "clinical_safety", "explainability", "accessibility", "documentation", "governance"]:
+            infinity_certification_service.advance_certification(db, listing["id"], decided_by="admin", decided_role=gate, decision="approved")
+        infinity_marketplace_service.publish_listing(db, listing["id"])
+        listing_id = listing["id"]
+    finally:
+        db.close()
+
+    resp = client.post("/api/infinity/marketplace/installations", json={"listing_id": listing_id}, headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 201
+    installation_id = resp.json()["id"]
+
+    resp_uninstall = client.post(f"/api/infinity/marketplace/installations/{installation_id}/uninstall", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp_uninstall.status_code == 200
+    assert resp_uninstall.json()["status"] == "disabled"
+
+
+# ── 4. Security (developer API keys + tenant-membership auth) ────────────────
+
+def test_developer_api_key_issuance_and_authentication():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        issued = infinity_developer_service.issue_api_key(db, developer["id"], scopes=["marketplace:read"])
+        assert "api_key" in issued
+        raw_key = issued["api_key"]
+
+        authenticated = infinity_developer_service.authenticate_api_key(db, raw_key)
+        assert authenticated is not None
+        assert authenticated.developer_account_id == developer["id"]
+
+        revoked = infinity_developer_service.revoke_api_key(db, developer["id"], issued["id"])
+        assert revoked["revoked"] is True
+        assert infinity_developer_service.authenticate_api_key(db, raw_key) is None
+    finally:
+        db.close()
+
+
+def test_developer_portal_me_requires_developer_key():
+    resp_missing = client.get("/api/infinity/developer-portal/me")
+    assert resp_missing.status_code == 401
+
+    resp_invalid = client.get("/api/infinity/developer-portal/me", headers={"X-Infinity-Developer-Key": "not-a-real-key"})
+    assert resp_invalid.status_code == 401
+
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        issued = infinity_developer_service.issue_api_key(db, developer["id"])
+        raw_key = issued["api_key"]
+    finally:
+        db.close()
+
+    resp_valid = client.get("/api/infinity/developer-portal/me", headers={"X-Infinity-Developer-Key": raw_key})
+    assert resp_valid.status_code == 200
+    assert resp_valid.json()["account"]["id"] == developer["id"]
+
+
+def test_developer_account_route_requires_leadership_membership():
+    tenant_id = uid("infinity-security")
+    resp_no_member = client.post(
+        "/api/infinity/developer-accounts", json={"email": "x@example.com", "organization_name": "X", "developer_type": "hospital"},
+        headers=_headers(AUTH_ADMIN, tenant_id),
+    )
+    assert resp_no_member.status_code == 403
+
+
+# ── 5. API Versioning ──────────────────────────────────────────────────────────
+
+def test_v1_gateway_new_infinity_endpoints_require_auth():
+    resp = client.get("/api/v1/phoenix")
+    assert resp.status_code == 401
+
+
+def test_v1_gateway_new_endpoints_return_api_version():
+    tenant_id = uid("infinity-v1")
+    for path in ("/api/v1/identity", "/api/v1/users", "/api/v1/athena", "/api/v1/apollo"):
+        resp = client.get(path, headers=_headers(AUTH_VIEWER, tenant_id))
+        assert resp.status_code == 200, path
+        assert resp.json()["api_version"] == "v1"
+
+
+# ── 6. Licensing ───────────────────────────────────────────────────────────────
+
+def test_module_licensing_summary_composes_genesis_licensing():
+    tenant_id = uid("infinity-license")
+    db = SessionLocal()
+    try:
+        result = infinity_billing_service.module_licensing_summary(db, tenant_id)
+    finally:
+        db.close()
+    assert result["tenant_id"] == tenant_id
+    assert "licenses" in result
+
+
+def test_partner_license_create_and_revoke():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        license_row = infinity_billing_service.create_partner_license(
+            db, license_type="partner", developer_account_id=developer["id"], revenue_share_pct=80.0,
+        )
+        assert license_row["status"] == "active"
+        revoked = infinity_billing_service.revoke_partner_license(db, license_row["id"])
+        assert revoked["status"] == "revoked"
+    finally:
+        db.close()
+
+
+def test_revenue_event_splits_gross_amount():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        listing = infinity_marketplace_service.create_listing(db, developer["id"], listing_type="application", name="Revenue Test App")
+        event = infinity_billing_service.record_revenue_event(
+            db, listing["id"], uid("tenant"), event_type="subscription_charge", gross_amount_cents=10000, developer_share_pct=70.0,
+        )
+        assert event["developer_share_cents"] == 7000
+        assert event["platform_share_cents"] == 3000
+
+        summary = infinity_billing_service.revenue_summary_for_listing(db, listing["id"])
+        assert summary["total_gross_cents"] == 10000
+    finally:
+        db.close()
+
+
+# ── 7. Certification ───────────────────────────────────────────────────────────
+
+def test_certification_reuses_forge_approval_chain():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        listing = infinity_marketplace_service.create_listing(db, developer["id"], listing_type="ai_skill", name="Cert Test Skill")
+        started = infinity_certification_service.start_certification(db, listing["id"])
+        assert started["chain"]["steps"] == [
+            "security", "performance", "clinical_safety", "explainability", "accessibility", "documentation", "governance",
+        ]
+
+        status = infinity_certification_service.get_certification_status(db, listing["id"])
+        assert status["certification_status"] == "in_progress"
+    finally:
+        db.close()
+
+
+def test_certification_rejection_stops_the_chain():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        listing = infinity_marketplace_service.create_listing(db, developer["id"], listing_type="ai_skill", name="Rejected Skill")
+        infinity_certification_service.start_certification(db, listing["id"])
+        result = infinity_certification_service.advance_certification(
+            db, listing["id"], decided_by="admin", decided_role="security", decision="rejected", notes="Fails security scan.",
+        )
+        assert result["certification_status"] == "rejected"
+    finally:
+        db.close()
+
+
+# ── 8. Sandbox ──────────────────────────────────────────────────────────────────
+
+def test_sandbox_session_scoped_to_synthetic_tenant():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        session = infinity_sandbox_service.create_sandbox_session(db, developer["id"], purpose="development")
+        assert infinity_sandbox_service.is_sandbox_tenant(session["sandbox_tenant_id"])
+        assert session["status"] == "active"
+
+        terminated = infinity_sandbox_service.terminate_sandbox_session(db, session["id"])
+        assert terminated["status"] == "terminated"
+    finally:
+        db.close()
+
+
+def test_sandbox_session_rejects_invalid_purpose():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        try:
+            infinity_sandbox_service.create_sandbox_session(db, developer["id"], purpose="not_a_purpose")
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+    finally:
+        db.close()
+
+
+def test_expire_stale_sandbox_sessions():
+    db = SessionLocal()
+    try:
+        developer = _make_developer(db)
+        session = infinity_sandbox_service.create_sandbox_session(db, developer["id"], purpose="testing", lifetime_hours=-1)
+        expired = infinity_sandbox_service.expire_stale_sessions(db)
+    finally:
+        db.close()
+    assert any(s["id"] == session["id"] for s in expired)

--- a/backend/tests/test_phoenix_intelligence.py
+++ b/backend/tests/test_phoenix_intelligence.py
@@ -1,0 +1,462 @@
+"""v4.9 — LumenAI OS: Project Phoenix — Self-Improving Healthcare
+Intelligence Platform tests.
+
+Covers: Learning Engine, Recommendation generation, Workflow optimization,
+Knowledge evolution, Platform health, Innovation tracking, and Maturity
+scoring.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.competency_event import CompetencyEvent
+from app.models.knowledge import KnowledgeArticle
+from app.models.supervisor_review import SupervisorReview
+from app.models.workflow_forge import EXECUTION_FAILED, WorkflowExecution
+from app.services import (
+    phoenix_ai_observatory_service,
+    phoenix_competency_intelligence_service,
+    phoenix_innovation_pipeline_service,
+    phoenix_knowledge_evolution_service,
+    phoenix_learning_engine_service,
+    phoenix_maturity_index_service,
+    phoenix_platform_health_service,
+    phoenix_recommendation_engine,
+    phoenix_workflow_optimization_service,
+)
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_MGR = {"Authorization": "Bearer manager-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    db.add(models.TenantMembership(tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+# ── 1. Learning Engine ────────────────────────────────────────────────────────
+
+def test_learning_engine_summary_composes_eight_signals():
+    tenant_id = uid("phoenix-learning")
+    db = SessionLocal()
+    try:
+        result = phoenix_learning_engine_service.learning_engine_summary(db, tenant_id)
+    finally:
+        db.close()
+    for key in (
+        "inspection_outcomes", "ai_confidence", "supervisor_overrides", "knowledge_usage",
+        "workflow_efficiency", "digital_twin_health", "enterprise_trends", "education_effectiveness",
+    ):
+        assert key in result
+    assert result["human_review_required"] is True
+
+
+def test_learning_engine_route_requires_leadership_and_membership():
+    tenant_id = uid("phoenix-learning-route")
+    resp_no_member = client.get("/api/phoenix/learning-engine/summary", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp_no_member.status_code == 403
+
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+    finally:
+        db.close()
+    resp = client.get("/api/phoenix/learning-engine/summary", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 200
+
+
+# ── 2. Recommendation generation ──────────────────────────────────────────────
+
+def test_generate_recommendations_from_drift_signal():
+    tenant_id = uid("phoenix-rec-drift")
+    db = SessionLocal()
+    try:
+        now = datetime.now(timezone.utc)
+        for i in range(15):
+            db.add(SupervisorReview(
+                inspection_id=i + 1, tenant_id=tenant_id, agreement="agree", ai_confidence=0.9,
+                created_at=now - timedelta(days=45),
+            ))
+        for i in range(15):
+            db.add(SupervisorReview(
+                inspection_id=i + 100, tenant_id=tenant_id, agreement="disagree", ai_confidence=0.4,
+                created_at=now - timedelta(days=1),
+            ))
+        db.commit()
+        recs = phoenix_recommendation_engine.generate_recommendations(db, tenant_id)
+    finally:
+        db.close()
+    assert any(r["recommendation_type"] == "review_ai_confidence" for r in recs)
+    for r in recs:
+        assert r["status"] == "draft"
+        assert r["evidence"]
+
+
+def test_recommendation_route_generate_and_list():
+    tenant_id = uid("phoenix-rec-route")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="spd_manager")
+    finally:
+        db.close()
+    resp = client.post("/api/phoenix/recommendations/generate", headers=_headers(AUTH_MGR, tenant_id))
+    assert resp.status_code == 200
+    resp_list = client.get("/api/phoenix/recommendations", headers=_headers(AUTH_MGR, tenant_id))
+    assert resp_list.status_code == 200
+
+
+def test_ai_observatory_summary_composes_real_metrics():
+    tenant_id = uid("phoenix-observatory")
+    db = SessionLocal()
+    try:
+        for i in range(5):
+            db.add(SupervisorReview(inspection_id=i + 1, tenant_id=tenant_id, agreement="agree", ai_confidence=0.85))
+        db.commit()
+        result = phoenix_ai_observatory_service.observatory_summary(db, tenant_id)
+    finally:
+        db.close()
+    assert result["sample_size"] == 5
+    assert "precision" in result
+    assert result["coverage"]["total_inspections"] == 0
+
+
+def test_latency_sample_recorded_and_summarized():
+    tenant_id = uid("phoenix-latency")
+    db = SessionLocal()
+    try:
+        phoenix_ai_observatory_service.record_latency_sample(db, tenant_id, stage="detection", latency_ms=120.5)
+        phoenix_ai_observatory_service.record_latency_sample(db, tenant_id, stage="detection", latency_ms=90.0)
+        summary = phoenix_ai_observatory_service.latency_summary(db, tenant_id, stage="detection")
+    finally:
+        db.close()
+    assert summary["detection"]["sample_size"] == 2
+    assert summary["detection"]["avg_ms"] == 105.25
+
+
+def test_latency_sample_rejects_invalid_stage():
+    tenant_id = uid("phoenix-latency-bad")
+    db = SessionLocal()
+    try:
+        try:
+            phoenix_ai_observatory_service.record_latency_sample(db, tenant_id, stage="not_a_stage", latency_ms=1.0)
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+    finally:
+        db.close()
+
+
+# ── 3. Workflow optimization ───────────────────────────────────────────────────
+
+def test_duration_analysis_and_repeated_exceptions():
+    tenant_id = uid("phoenix-workflow")
+    db = SessionLocal()
+    try:
+        for _ in range(3):
+            db.add(WorkflowExecution(tenant_id=tenant_id, workflow_id=42, status=EXECUTION_FAILED, execution_time_ms=500.0))
+        db.add(WorkflowExecution(tenant_id=tenant_id, workflow_id=42, status="completed", execution_time_ms=200.0))
+        db.commit()
+        duration = phoenix_workflow_optimization_service.duration_analysis(db, tenant_id)
+        failures = phoenix_workflow_optimization_service.repeated_exceptions(db, tenant_id)
+    finally:
+        db.close()
+    assert duration["sample_size"] == 4
+    assert any(f["workflow_id"] == 42 and f["failure_count"] == 3 for f in failures)
+
+
+def test_recommend_workflow_optimization_cites_evidence():
+    tenant_id = uid("phoenix-workflow-rec")
+    db = SessionLocal()
+    try:
+        for _ in range(2):
+            db.add(WorkflowExecution(tenant_id=tenant_id, workflow_id=7, status=EXECUTION_FAILED, execution_time_ms=300.0))
+        db.commit()
+        result = phoenix_workflow_optimization_service.recommend_workflow_optimization(db, tenant_id, 7)
+    finally:
+        db.close()
+    assert result["recommend_review"] is True
+    assert result["evidence"]
+
+
+def test_rule_complexity_counts_nested_conditions():
+    tenant_id = uid("phoenix-rule-complexity")
+    db = SessionLocal()
+    try:
+        from app.services import forge_rule_engine
+
+        forge_rule_engine.create_rule(
+            db, tenant_id, name="Test Rule",
+            condition={"op": "and", "conditions": [
+                {"field": "finding", "operator": "eq", "value": "blood"},
+                {"field": "severity", "operator": "eq", "value": "high"},
+            ]},
+            actions=[{"type": "notify_supervisor"}], author="qa",
+        )
+        db.commit()
+        complexity = phoenix_workflow_optimization_service.rule_complexity(db, tenant_id)
+    finally:
+        db.close()
+    assert len(complexity) >= 1
+    assert complexity[0]["complexity_score"] >= 3
+
+
+def test_competency_intelligence_detects_simulation_and_annual_competency():
+    tenant_id = uid("phoenix-competency")
+    db = SessionLocal()
+    try:
+        for _ in range(2):
+            db.add(CompetencyEvent(tenant_id=tenant_id, technician="tech1", event_type="simulation_failed", finding_type="blood"))
+        db.add(CompetencyEvent(tenant_id=tenant_id, technician="tech2", event_type="knowledge_contribution"))
+        db.commit()
+        result = phoenix_competency_intelligence_service.run_all_detectors(db, tenant_id)
+    finally:
+        db.close()
+    assert any(o["scope_value"] == "tech1" for o in result["simulation"])
+    assert any(o["scope_value"] == "tech2" for o in result["annual_competency"])
+
+
+# ── 4. Knowledge evolution ─────────────────────────────────────────────────────
+
+def test_contradictory_guidance_detects_conflicting_articles():
+    tenant_id = uid("phoenix-knowledge-conflict")
+    db = SessionLocal()
+    try:
+        import json as _json
+
+        db.add(KnowledgeArticle(
+            tenant_id=tenant_id, category="best_practice", title="Strict Guidance",
+            body="If blood residue is found, remove from service immediately.",
+            applicable_findings=_json.dumps(["blood"]), anatomy_zone="box_lock", approval_status="approved",
+        ))
+        db.add(KnowledgeArticle(
+            tenant_id=tenant_id, category="best_practice", title="Lenient Guidance",
+            body="Blood residue in this area is generally acceptable; monitor and continue use.",
+            applicable_findings=_json.dumps(["blood"]), anatomy_zone="box_lock", approval_status="approved",
+        ))
+        db.commit()
+        conflicts = phoenix_knowledge_evolution_service.contradictory_guidance(db, tenant_id)
+    finally:
+        db.close()
+    assert len(conflicts) == 1
+    assert conflicts[0]["finding_type"] == "blood"
+
+
+def test_knowledge_evolution_summary_composes_athena_curator():
+    tenant_id = uid("phoenix-knowledge-summary")
+    db = SessionLocal()
+    try:
+        summary = phoenix_knowledge_evolution_service.knowledge_evolution_summary(db, tenant_id)
+    finally:
+        db.close()
+    for key in ("duplicate_candidates", "outdated_guidance", "retirement_candidates", "emerging_best_practices", "contradictory_guidance"):
+        assert key in summary
+
+
+# ── 5. Platform health ─────────────────────────────────────────────────────────
+
+def test_platform_health_dashboard_reports_insufficient_data_when_empty():
+    """A brand-new tenant has no supervisor reviews, knowledge articles,
+    workflow executions, memberships, connectors, or quality-twin
+    snapshots — all of those areas honestly report "insufficient data".
+    The instrument-flow Digital Twin is the one exception: `digital_twin_
+    engine` auto-bootstraps default station rows for any tenant on first
+    call, so it always has *some* real (data_source="real") signal to
+    report, and that's the only input feeding `overall_platform_maturity`
+    here — not a fabrication, a real quirk of that pre-existing engine."""
+    tenant_id = uid("phoenix-health-empty")
+    db = SessionLocal()
+    try:
+        result = phoenix_platform_health_service.platform_health_dashboard(db, tenant_id)
+    finally:
+        db.close()
+    assert result["ai_health"]["score"] is None
+    assert "insufficient data" in result["ai_health"]["note"]
+    for area in ("knowledge_health", "workflow_health", "security_health", "integration_health", "quality_health"):
+        assert result[area]["score"] is None
+    assert result["overall_platform_maturity"] == result["digital_twin_health"]["score"]
+
+
+def test_security_health_score_reflects_membership_ratio():
+    tenant_id = uid("phoenix-health-security")
+    db = SessionLocal()
+    try:
+        db.add(models.TenantMembership(tenant_id=tenant_id, user_email="a@local.dev", role="admin", is_enabled=True))
+        db.add(models.TenantMembership(tenant_id=tenant_id, user_email="b@local.dev", role="viewer", is_enabled=False))
+        db.commit()
+        score = phoenix_platform_health_service.compute_security_health_score(db, tenant_id)
+    finally:
+        db.close()
+    assert score["score"] is not None
+    assert score["enabled_membership_ratio"] == 0.5
+
+
+def test_platform_health_route_requires_membership():
+    tenant_id = uid("phoenix-health-route")
+    resp_denied = client.get("/api/phoenix/platform-health/dashboard", headers=_headers(AUTH_VIEWER, tenant_id))
+    assert resp_denied.status_code == 403
+
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+    finally:
+        db.close()
+    resp = client.get("/api/phoenix/platform-health/dashboard", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 200
+    assert "overall_platform_maturity" in resp.json()
+
+
+# ── 6. Innovation tracking ─────────────────────────────────────────────────────
+
+def test_create_and_update_innovation_idea():
+    tenant_id = uid("phoenix-innovation")
+    db = SessionLocal()
+    try:
+        idea = phoenix_innovation_pipeline_service.create_idea(
+            db, tenant_id, title="Automate loaner tray reminders", estimated_roi_usd=15000.0,
+            clinical_impact="medium", technical_complexity="low", priority="high", submitted_by="tech1",
+        )
+        assert idea["approval_status"] == "draft"
+
+        updated = phoenix_innovation_pipeline_service.update_idea_status(
+            db, tenant_id, idea["id"], approval_status="approved", roadmap_assignment="Q4 2026",
+        )
+        assert updated["approval_status"] == "approved"
+        assert updated["roadmap_assignment"] == "Q4 2026"
+
+        summary = phoenix_innovation_pipeline_service.pipeline_summary(db, tenant_id)
+        assert summary["total_ideas"] == 1
+        assert summary["total_estimated_roi_usd"] == 15000.0
+    finally:
+        db.close()
+
+
+def test_create_idea_rejects_invalid_priority():
+    tenant_id = uid("phoenix-innovation-bad")
+    db = SessionLocal()
+    try:
+        try:
+            phoenix_innovation_pipeline_service.create_idea(db, tenant_id, title="Bad idea", priority="not_a_level")
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+    finally:
+        db.close()
+
+
+def test_innovation_idea_not_found_raises():
+    tenant_id = uid("phoenix-innovation-404")
+    db = SessionLocal()
+    try:
+        try:
+            phoenix_innovation_pipeline_service.get_idea(db, tenant_id, 999999)
+            assert False, "expected InnovationIdeaNotFoundError"
+        except phoenix_innovation_pipeline_service.InnovationIdeaNotFoundError:
+            pass
+    finally:
+        db.close()
+
+
+# ── 7. Maturity scoring ────────────────────────────────────────────────────────
+
+def test_compute_platform_maturity_index_returns_nine_dimensions():
+    tenant_id = uid("phoenix-maturity")
+    db = SessionLocal()
+    try:
+        result = phoenix_maturity_index_service.compute_platform_maturity_index(db, tenant_id)
+    finally:
+        db.close()
+    for key in (
+        "inspection_score", "knowledge_score", "quality_score", "workflow_score", "analytics_score",
+        "education_score", "digital_twins_score", "governance_score", "executive_intelligence_score",
+    ):
+        assert key in result["scores"]
+    assert 0 <= result["overall_score"] <= 100
+
+
+def test_maturity_history_tracks_progression():
+    tenant_id = uid("phoenix-maturity-history")
+    db = SessionLocal()
+    try:
+        phoenix_maturity_index_service.compute_platform_maturity_index(db, tenant_id)
+        phoenix_maturity_index_service.compute_platform_maturity_index(db, tenant_id)
+        history = phoenix_maturity_index_service.maturity_history(db, tenant_id)
+    finally:
+        db.close()
+    assert len(history) == 2
+
+
+def test_maturity_route():
+    tenant_id = uid("phoenix-maturity-route")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+    finally:
+        db.close()
+    resp = client.post("/api/phoenix/maturity/compute", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert resp.status_code == 200
+    resp_history = client.get("/api/phoenix/maturity/history", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert len(resp_history.json()["history"]) == 1
+
+
+# ── Continuous Validation (Section 9, supporting Recommendation coverage) ─────
+
+def test_validation_pipeline_advances_through_stages_and_rejects():
+    tenant_id = uid("phoenix-validation")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+    finally:
+        db.close()
+
+    db = SessionLocal()
+    try:
+        from app.models.phoenix_intelligence import ImprovementRecommendation
+
+        row = ImprovementRecommendation(tenant_id=tenant_id, recommendation_type="update_sop", source="knowledge_evolution", title="Test rec")
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        rec_id = row.id
+    finally:
+        db.close()
+
+    start_resp = client.post(f"/api/phoenix/recommendations/{rec_id}/validation/start", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert start_resp.status_code == 200
+
+    advance_resp = client.post(
+        f"/api/phoenix/recommendations/{rec_id}/validation/advance",
+        json={"decided_role": "review", "decision": "approved"}, headers=_headers(AUTH_ADMIN, tenant_id),
+    )
+    assert advance_resp.status_code == 200
+    assert advance_resp.json()["recommendation_status"] == "clinical_validation"
+
+    reject_resp = client.post(
+        f"/api/phoenix/recommendations/{rec_id}/validation/advance",
+        json={"decided_role": "clinical_validation", "decision": "rejected", "outcome_notes": "Not clinically sound."},
+        headers=_headers(AUTH_ADMIN, tenant_id),
+    )
+    assert reject_resp.status_code == 200
+    assert reject_resp.json()["recommendation_status"] == "rejected"
+
+    status_resp = client.get(f"/api/phoenix/recommendations/{rec_id}/validation", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert status_resp.status_code == 200
+    assert len(status_resp.json()["outcomes"]) == 2

--- a/docs/infinity/billing.md
+++ b/docs/infinity/billing.md
@@ -1,0 +1,50 @@
+# Project Infinity — Billing & Licensing
+
+LumenAI OS v5.0, Section 8.
+
+## Module Licensing — reused, not rebuilt
+
+Genesis's `platform_licensing_service.py` (`PlatformModuleLicense`, v4.0)
+already tracks per-tenant module entitlement (`enabled`/`disabled`/
+`trial`). Infinity composes it directly for "Module Licensing" — no
+second per-module license table.
+
+```
+GET /api/infinity/billing/module-licenses
+```
+
+## Enterprise & Partner Licensing — genuinely new
+
+P14's billing infrastructure (`TenantPlan`/`PaymentEvent`/
+`TenantUsageCounter`) is entirely inspection-volume subscription billing
+— there was no home anywhere for commercial licensing *terms* (as
+opposed to a simple enabled/disabled flag). `PartnerLicense` is a new,
+additive table distinct from `PlatformModuleLicense`, covering
+`module` | `enterprise` | `partner` license types with real terms,
+effective/expiration dates, and an optional revenue-share percentage.
+
+```
+POST /api/infinity/billing/partner-licenses
+GET  /api/infinity/billing/partner-licenses
+POST /api/infinity/billing/partner-licenses/{id}/revoke
+```
+
+## Marketplace Revenue Sharing — genuinely new
+
+No revenue-sharing ledger concept existed anywhere in this codebase
+before Infinity. `MarketplaceRevenueEvent` records the real gross amount
+of a subscription charge, one-time purchase, or usage fee for a listing,
+and splits it into `developer_share_cents`/`platform_share_cents` using
+either the listing's `PartnerLicense.revenue_share_pct` override or a
+documented default split (70% developer / 30% platform) — the split
+percentage is always visible in the response, never a hidden
+computation.
+
+```
+POST /api/infinity/billing/revenue-events
+GET  /api/infinity/billing/revenue-events/listings/{id}/summary
+```
+
+Every total in `revenue_summary_for_listing` is summed only from real
+recorded `MarketplaceRevenueEvent` rows — nothing is projected or
+estimated.

--- a/docs/infinity/certification.md
+++ b/docs/infinity/certification.md
@@ -1,0 +1,54 @@
+# Project Infinity — Certification Program & Developer Sandbox
+
+LumenAI OS v5.0, Sections 7 & 9.
+
+## Certification Program (Section 7)
+
+Reuses Project Forge's `WorkflowApprovalChain`/`WorkflowApprovalInstance`
+(v4.1, `forge_approval_service.py`) a **third** time — already reused by
+Athena (v4.8) and Phoenix's 6-stage Continuous Validation (v4.9). The
+chain's `steps_json` is a generic ordered list of role strings, not a
+fixed-length schema, so Infinity instantiates it with the seven named
+gates:
+
+```
+Security → Performance → Clinical Safety → Explainability → Accessibility → Documentation → Governance
+```
+
+A rejection at any gate ends certification immediately (Forge's existing
+`decide_step` behavior) and the listing's `certification_status` becomes
+`rejected` — it can never reach `certified` without an explicit approval
+recorded at every one of the seven gates.
+
+```
+POST /api/infinity/certification/listings/{id}/start
+POST /api/infinity/certification/listings/{id}/advance
+GET  /api/infinity/certification/listings/{id}
+```
+
+## Developer Sandbox (Section 9)
+
+No isolated dev/test/validation/certification environment concept
+existed anywhere in this codebase before Infinity — `pilot_config.py`/
+`pilot_error_log.py` (v1.9) are a different, older "pilot" concept
+(per-tenant sales-pilot configuration), not a developer sandbox.
+
+Every `DeveloperSandboxSession` is scoped to a synthetic
+`sandbox_tenant_id` generated with a fixed, unmistakable `sandbox-`
+prefix (`infinity_sandbox_service.is_sandbox_tenant` distinguishes it
+from any real tenant_id) — this guarantees no production impact, since
+every other tenant-scoped query in this codebase filters by an exact
+`tenant_id` match and a sandbox tenant_id can never coincide with a real
+one.
+
+Sessions expire on a real timer (`expires_at`) and are marked `expired`
+— never silently treated as still active — via
+`expire_stale_sessions`, intended to run as a periodic maintenance task.
+
+```
+POST /api/infinity/sandbox/sessions
+GET  /api/infinity/sandbox/sessions?developer_account_id=...
+GET  /api/infinity/sandbox/sessions/{id}
+POST /api/infinity/sandbox/sessions/{id}/terminate
+POST /api/infinity/sandbox/sessions/expire-stale
+```

--- a/docs/infinity/developer-platform.md
+++ b/docs/infinity/developer-platform.md
@@ -1,0 +1,71 @@
+# Project Infinity — Developer Platform
+
+LumenAI OS v5.0, Sections 1 & 2.
+
+## Naming disambiguation
+
+Infinity is the 19th additive sprint, and the widest in surface area
+(platform, marketplace, billing, security). Every existing platform/
+marketplace/billing/API-versioning system was read in full before writing
+any code:
+
+| Concern | Pre-existing system | Infinity's relationship to it |
+|---|---|---|
+| App/plugin registry | Genesis's `PlatformModule`/`PlatformModuleLicense`/`PlatformPlugin` (v4.0) | `PlatformPlugin` extended additively (5 new extension-point columns); `PlatformModuleLicense` reused as-is for Module Licensing |
+| Workflow marketplace | Forge's `WorkflowDefinition.marketplace_status` (v4.1) | Reused only for its exact `private/pending_review/published` naming — a new, generic `MarketplaceListing` model, not a second use of Forge's table |
+| Versioned public API | Nexus's `/api/v1/*` gateway (v3.2) | Extended directly with 12 new endpoints — no second versioned gateway |
+| Secret API keys | `nexus_credential_service.py`'s hash-only pattern | Reused verbatim for `DeveloperApiKey` |
+| Certification approval | Forge's `WorkflowApprovalChain` (v4.1), already reused by Athena/Phoenix | Reused a third time with 7 named gates |
+| Third-party identity | `TenantMembership` (internal only) | New `DeveloperAccount`, deliberately distinct |
+| Billing | P14's inspection-volume `TenantPlan`/`PaymentEvent` | Module Licensing reuses Genesis; Enterprise/Partner licensing and revenue sharing are genuinely new (`PartnerLicense`, `MarketplaceRevenueEvent`) |
+| Sandbox | v1.9's `pilot_config.py` (a different, older sales-pilot concept) | Genuinely new `DeveloperSandboxSession` |
+
+## Developer Portal (Section 1)
+
+Frontend route `/developers`. Composes:
+
+* **API Explorer** — a documented catalog of every `/api/v1/*` endpoint (mirrors `nexus_api_gateway.py`; kept in sync manually, not dynamically introspected, to avoid a routes↔service circular import).
+* **Rate Limits** — a fixed, documented policy (sandbox vs. certified-partner tiers). This platform has no live per-key request-metering infrastructure, so this is never presented as a real-time counter.
+* **Tutorials** — a fixed reference list.
+* **Authentication** — `DeveloperAccount`/`DeveloperApiKey`, admin-provisioned (see below).
+* **Sandbox Environment** — see `docs/infinity/certification.md`.
+
+```
+GET /api/infinity/developer-portal/api-explorer
+GET /api/infinity/developer-portal/rate-limits
+GET /api/infinity/developer-portal/tutorials
+GET /api/infinity/developer-portal/me   (developer-API-key authenticated)
+```
+
+### Two distinct auth paths
+
+Internal tenant staff use `tenant_authz.require_tenant_roles` (real
+`TenantMembership` verification), matching Athena (v4.8) and Phoenix
+(v4.9). Third-party developers authenticate with a `DeveloperApiKey` via
+the `X-Infinity-Developer-Key` header — a genuinely separate identity
+path, since a developer building an app is not necessarily tenant staff.
+Account creation and API-key issuance are **admin-gated, not open
+self-service** — matching the brief's "trusted third parties" framing.
+
+```
+POST /api/infinity/developer-accounts
+POST /api/infinity/developer-accounts/{id}/api-keys
+```
+
+## Public Platform APIs (Section 2)
+
+`nexus_api_gateway.py`'s `/api/v1/*` router is extended (not duplicated)
+with the remaining named systems, using the exact same
+`require_gateway_auth` dependency (bearer token or `X-Nexus-Api-Key`) as
+its five pre-existing endpoints:
+
+```
+GET /api/v1/identity        GET /api/v1/organizations   GET /api/v1/users
+GET /api/v1/analytics       GET /api/v1/pulse           GET /api/v1/sentinel
+GET /api/v1/forge           GET /api/v1/catalyst        GET /api/v1/orbit
+GET /api/v1/apollo          GET /api/v1/athena          GET /api/v1/phoenix
+```
+
+Each composes its real, already-built summary function (e.g. `/api/v1/phoenix`
+calls `phoenix_learning_engine_service.learning_engine_summary`) — no
+re-derivation of any module's own logic.

--- a/docs/infinity/marketplace.md
+++ b/docs/infinity/marketplace.md
@@ -1,0 +1,45 @@
+# Project Infinity — AI Skills Marketplace & Application Marketplace
+
+LumenAI OS v5.0, Sections 4 & 5.
+
+## One generic listing model, not two
+
+Forge's `WorkflowDefinition.marketplace_status` (v4.1,
+`forge_marketplace_service.py`) is a real, narrow marketplace for
+workflow templates only — no author identity, no pricing, no generic
+listing abstraction. Infinity's `MarketplaceListing` is genuinely new and
+covers both marketplaces the brief names via a `listing_type`
+discriminator (`ai_skill` | `application`), reusing Forge's exact
+`private`/`pending_review`/`published` state names for consistency but
+not its table.
+
+| AI Skill categories (Section 4) | Application categories (Section 5) |
+|---|---|
+| Inspection, Knowledge, Forecast, Reporting, Research, Education | Hospital, Manufacturer, Repair Vendor, Academic, Research, Enterprise, Consulting |
+
+## Publication is gated by certification
+
+A listing can only move from `pending_review` to `published` once its
+linked Certification Program chain (`docs/infinity/certification.md`)
+reports `certified` — enforced in code (`publish_listing` raises
+`ListingNotCertifiedError` otherwise), not left to convention.
+
+```
+POST /api/infinity/marketplace/listings
+GET  /api/infinity/marketplace/listings?listing_type=ai_skill
+GET  /api/infinity/marketplace/listings/{id}
+POST /api/infinity/marketplace/listings/{id}/submit-for-review
+POST /api/infinity/marketplace/listings/{id}/publish
+POST /api/infinity/marketplace/listings/{id}/unpublish
+```
+
+## Organizations choose what to install
+
+`MarketplaceInstallation` tracks which tenant installed which listing, at
+which version — installing an unpublished listing is rejected.
+
+```
+POST /api/infinity/marketplace/installations
+GET  /api/infinity/marketplace/installations
+POST /api/infinity/marketplace/installations/{id}/uninstall
+```

--- a/docs/infinity/plugin-framework.md
+++ b/docs/infinity/plugin-framework.md
@@ -1,0 +1,42 @@
+# Project Infinity — Extension Framework
+
+LumenAI OS v5.0, Section 6.
+
+## Two orthogonal dimensions, deliberately not conflated
+
+* **Extension type** (`docs/infinity/sdk.md`, Section 3) — *what kind* of
+  artifact a plugin registers (Application, Widget, Dashboard, Report,
+  Workflow Node, AI Skill, Notification, Command, Analytics). Each maps
+  1:1 onto one of `PlatformPlugin`'s `registered_*_json` columns.
+* **Extension location** (Section 6) — *where in the UI* it attaches:
+  Menu, Navigation, Dashboard, Command Center, Copilot, Reports, Digital
+  Twin Panel, Knowledge Graph View, Simulation Model.
+
+A location is recorded as a `location` key inside each registered JSON
+item, not as a separate table or column — a single "dashboard" widget
+can attach at several different locations (e.g. both the Command Center
+and a Digital Twin Panel), so location is a property of the registration,
+not a second classification axis on the plugin itself.
+
+```
+POST /api/infinity/plugins/{plugin_key}/extensions
+{
+  "extension_type": "dashboards",
+  "location": "digital_twin_panel",
+  "item": {"widget_key": "vendor-uptime-panel", "title": "Vendor Uptime"}
+}
+```
+
+`infinity_extension_service.py` validates both `extension_type` (against
+the 9 SDK types) and `location` (against the 9 named framework locations)
+before appending — an unrecognized value on either axis is rejected with
+a 422, never silently accepted into an unstructured registry.
+
+No frontend widget-registry or dynamic component-loading mechanism
+existed anywhere before Infinity (confirmed by grep — `PlatformAdmin
+Dashboard.tsx` only renders a read-only list of `PlatformPlugin` rows).
+This sprint establishes the backend registration surface; a future
+sprint would need to build the actual frontend renderer that reads these
+manifests and mounts real components at each location — that renderer is
+explicitly out of scope here, matching the metadata-only convention
+`PlatformPlugin` already established.

--- a/docs/infinity/sdk.md
+++ b/docs/infinity/sdk.md
@@ -1,0 +1,43 @@
+# Project Infinity — Plugin SDK
+
+LumenAI OS v5.0, Section 3.
+
+## No modification of platform core required
+
+`PlatformPlugin` (Genesis, v4.0) is a **metadata-only registration
+surface** — the table's own docstring is explicit: "no plugin code is
+ever imported or run by this table." Infinity's Plugin SDK extends it
+additively with five new `registered_*_json` columns for the artifact
+types the SDK names that it didn't yet have, rather than a second
+plugin-registration table:
+
+| SDK extension type | `PlatformPlugin` column |
+|---|---|
+| Applications | `registered_routes_json` (pre-existing) |
+| Widgets | `registered_widgets_json` (pre-existing) |
+| Dashboards | `registered_dashboards_json` (pre-existing) |
+| Reports | `registered_reports_json` (pre-existing) |
+| Workflow Nodes | `registered_workflow_nodes_json` (new) |
+| AI Skills | `registered_ai_skills_json` (new) |
+| Notifications | `registered_notifications_json` (new) |
+| Commands | `registered_commands_json` (new) |
+| Analytics | `registered_analytics_json` (new) |
+
+Every registration is a JSON manifest entry — never executable code
+imported into the platform process. A plugin can optionally link to a
+`DeveloperAccount` and a `MarketplaceListing` (two new nullable columns),
+so a marketplace-published skill/app and its plugin registration stay
+connected.
+
+```
+POST /api/infinity/plugins
+GET  /api/infinity/plugins
+GET  /api/infinity/plugins/{plugin_key}
+POST /api/infinity/plugins/{plugin_key}/extensions
+POST /api/infinity/plugins/{plugin_key}/activate
+POST /api/infinity/plugins/{plugin_key}/disable
+```
+
+See `docs/infinity/plugin-framework.md` for the Extension Framework
+(Section 6) — a second, orthogonal dimension (*where* an extension
+attaches in the UI) layered on top of these same registrations.

--- a/docs/phoenix/improvement-engine.md
+++ b/docs/phoenix/improvement-engine.md
@@ -1,0 +1,111 @@
+# Project Phoenix — Improvement Recommendation Engine & Continuous Validation
+
+LumenAI OS v4.9, Sections 2, 3, 4, 6 & 9.
+
+## Improvement Recommendation Engine (Section 2)
+
+`phoenix_recommendation_engine.generate_recommendations` scans the real
+outputs of every other Phoenix engine and drafts an
+`ImprovementRecommendation` for each genuine signal found:
+
+| Trigger | Real signal | Recommendation type |
+|---|---|---|
+| AI health drift detected | `sentinel_ai_health_service._detect_drift` (via the AI Observatory) | `review_ai_confidence` |
+| Low-confidence anatomy zone | `ml/pilot_validation.zone_performance`'s `lowest_confidence_zones` | `collect_baseline_images` |
+| High-miss-rate anatomy zone | `zone_performance`'s `highest_risk_zones` | `improve_anatomy_model` |
+| Documented knowledge gap | Knowledge Evolution Center | `revise_inspection_guidance` |
+| Contradictory guidance | Knowledge Evolution Center | `update_sop` |
+| Duplicate/retirement candidates | Knowledge Evolution Center | `improve_knowledge_graph` |
+| Open coaching/education opportunities | Competency Intelligence | `create_competency` |
+| Repeated workflow execution failures | Workflow Optimization Engine | `update_workflow` |
+
+Every recommendation carries **Evidence** (the exact real records that
+triggered it), **Expected Benefit**, **Confidence** (0-1), **Impact
+Assessment**, and **Required Approvals** (role names). A recommendation
+starts as `draft` and never auto-enters Continuous Validation.
+
+```
+POST /api/phoenix/recommendations/generate
+GET  /api/phoenix/recommendations?status=draft
+GET  /api/phoenix/recommendations/{id}
+```
+
+## AI Performance Observatory (Section 3)
+
+See `docs/phoenix/learning-engine.md`'s disambiguation table.
+`phoenix_ai_observatory_service.py` adds two genuinely new metrics on top
+of the composed `clinical_metrics`/`compute_ai_health` figures:
+
+* **Inference Latency** — real, explicitly recorded samples
+  (`AIInferenceLatencySample`); reports "insufficient data" rather than a
+  fabricated typical value when none exist.
+* **Coverage** — "% of inspections that received a real AI confidence
+  score," a different concept from `inspection_coverage.py`'s image/zone
+  capture-completeness metric of the same name.
+
+```
+GET  /api/phoenix/observatory/summary
+POST /api/phoenix/observatory/latency
+GET  /api/phoenix/observatory/latency
+GET  /api/phoenix/observatory/coverage
+```
+
+## Workflow Optimization Engine (Section 4)
+
+`WorkflowExecution` already records real `execution_time_ms`, but no
+duration/bottleneck/queue-delay/rule-complexity analytics existed over it
+before Phoenix. `phoenix_workflow_optimization_service.py` reads these
+rows directly:
+
+* **Duration analysis** — avg/min/max `execution_time_ms`, grouped by status.
+* **Approval bottlenecks** — `WorkflowApprovalInstance` rows pending longer than a threshold.
+* **Repeated exceptions** — workflows with recurring failed executions.
+* **Rule complexity** — a real recursive node-count of each `WorkflowRule`'s nested condition tree.
+
+Recommending an optimized workflow "through Project Forge" (the brief's
+own words) means the recommendation names the real `WorkflowDefinition`
+and cites this evidence — it never calls `forge_workflow_service.
+revise_workflow` itself.
+
+```
+GET /api/phoenix/workflow-optimization/summary
+GET /api/phoenix/workflow-optimization/{workflow_id}
+```
+
+## Competency Intelligence (Section 6)
+
+See `docs/phoenix/learning-engine.md` — extends `competency_intelligence_
+service.py` with detectors for the two previously-unused `annual_
+competency`/`recurring_learning` types plus three new types (`simulation`,
+`mentoring`, `knowledge_sharing`), all on the same `CompetencyOpportunity`
+table.
+
+```
+POST /api/phoenix/competency-intelligence/run
+GET  /api/phoenix/competency-intelligence/opportunities
+```
+
+## Continuous Validation (Section 9)
+
+Every recommendation moves through:
+
+```
+Review → Clinical Validation → Technical Review → Pilot → Measurement → Production
+```
+
+Rather than a second approval-chain model, this reuses Project Forge's
+existing `WorkflowApprovalChain`/`WorkflowApprovalInstance`
+(`forge_approval_service.py`, v4.1) directly — one chain per
+recommendation, with these six stages as its ordered steps. A rejection
+at any stage ends the pipeline immediately (Forge's existing behavior);
+`ValidationOutcome` rows track outcomes and lessons learned at each stage.
+
+```
+POST /api/phoenix/recommendations/{id}/validation/start
+POST /api/phoenix/recommendations/{id}/validation/advance
+POST /api/phoenix/recommendations/{id}/validation/outcomes
+GET  /api/phoenix/recommendations/{id}/validation
+```
+
+No recommendation reaches `production` without an explicit human approval
+recorded at every one of the six stages.

--- a/docs/phoenix/innovation-pipeline.md
+++ b/docs/phoenix/innovation-pipeline.md
@@ -1,0 +1,39 @@
+# Project Phoenix — Innovation Pipeline
+
+LumenAI OS v4.9, Section 8.
+
+No Idea/Evidence/ROI/Clinical-Impact/Roadmap backlog concept existed
+anywhere in this codebase before Phoenix (confirmed by grep — the word
+"backlog" was already used elsewhere only for unrelated operational queue
+counts, e.g. `supervisor_backlog`/`repair_backlog`). `InnovationIdea` is a
+genuinely new table.
+
+## Fields
+
+Every idea tracks exactly what the brief names:
+
+* **Ideas** — `title`/`description`.
+* **Evidence** — free-text supporting evidence.
+* **Estimated ROI** — `estimated_roi_usd`, nullable (never a fabricated dollar figure when no estimate exists).
+* **Clinical Impact** — `low | medium | high | critical`.
+* **Technical Complexity** — `low | medium | high`.
+* **Priority** — `low | medium | high | critical`.
+* **Approval Status** — `draft | approved | rejected | in_progress | completed`.
+* **Roadmap Assignment** — free text (e.g. "Q3 2026", "backlog").
+
+An idea never auto-advances between approval statuses — every transition
+in `update_idea_status` is an explicit call, intended to be driven by a
+human decision in the UI.
+
+```
+POST  /api/phoenix/innovation/ideas
+GET   /api/phoenix/innovation/ideas?approval_status=draft
+GET   /api/phoenix/innovation/ideas/{id}
+PATCH /api/phoenix/innovation/ideas/{id}/status
+GET   /api/phoenix/innovation/summary
+```
+
+`innovation/summary` rolls up counts by status/priority and total
+(human-entered) estimated ROI across the backlog — the same "never
+fabricate a total from partial data" convention used throughout this
+codebase: ideas with no ROI estimate simply don't contribute to the sum.

--- a/docs/phoenix/learning-engine.md
+++ b/docs/phoenix/learning-engine.md
@@ -1,0 +1,54 @@
+# Project Phoenix — Learning Engine
+
+LumenAI OS v4.9, Section 1.
+
+## Naming disambiguation
+
+Phoenix is the 18th additive sprint. Every existing performance/
+analytics-adjacent system was read in full before writing any code:
+
+| Concern | Pre-existing system | Phoenix's relationship to it |
+|---|---|---|
+| Precision/recall/F1/FP-FN/agreement | `ml/pilot_validation.py::clinical_metrics` | Composed directly in `phoenix_ai_observatory_service.py` |
+| Model drift | `sentinel_ai_health_service.compute_ai_health` | Composed directly |
+| Duplicate/outdated/emerging knowledge | `athena_curator_service.py` (v4.8) | Composed directly; only "contradictory guidance" is new |
+| Coaching/team-education opportunities | `competency_intelligence_service.py` (v2.9) | Composed directly; 5 new detector types added to the same `CompetencyOpportunity` model |
+| Quality Maturity Index | `apollo_quality_twin_service.py` (v4.7) | Reused as the "Quality" input dimension of Phoenix's own 9-dimension index |
+| Multi-step approval | `WorkflowApprovalChain`/`WorkflowApprovalInstance` (Forge, v4.1) | Reused directly for Continuous Validation — no second approval-chain model |
+| Executive rollups | `vanguard_executive_intelligence_service`/`vanguard_governance_service` (v4.6) | Composed for "enterprise trends" and the "Executive Intelligence" maturity dimension |
+
+`/api/phoenix` and the frontend routes `/phoenix`/`/platform-health` were
+confirmed free.
+
+## The Learning Engine
+
+`phoenix_learning_engine_service.learning_engine_summary` composes eight
+real, continuously-updated signals — no re-derivation of any of them:
+
+* Inspection outcomes — `quality_command_center_service` (quality events, recurring findings, CAPAs)
+* AI confidence — `phoenix_ai_observatory_service` (confidence average, calibration, drift)
+* Supervisor overrides — the same observatory's override/agreement rates
+* Knowledge usage — `knowledge_analytics_service` (most-viewed articles, common questions, gaps)
+* Workflow efficiency — `phoenix_workflow_optimization_service`
+* Digital Twin health — `digital_twin_engine` (instrument-flow twin, via Platform Health's scoring)
+* Enterprise trends — `vanguard_executive_intelligence_service`
+* Education effectiveness — `quality_command_center_service`'s education-impact figures
+
+```
+GET /api/phoenix/learning-engine/summary
+```
+
+## Never modifies production automatically
+
+Every Phoenix output that could inform a change — a recommendation, a
+workflow-optimization suggestion, a competency opportunity — is read-only
+decision support. The only way a recommendation moves forward is through
+an explicit human decision recorded via the Continuous Validation
+pipeline (`docs/phoenix/improvement-engine.md`).
+
+## Tenant authorization
+
+Like Athena (v4.8), every Phoenix route uses `tenant_authz.
+require_tenant_roles` (real `TenantMembership` verification) — Phoenix is
+a new module and does not knowingly reintroduce the header-only
+cross-tenant gap the first 16 modules still carry.

--- a/docs/phoenix/maturity-model.md
+++ b/docs/phoenix/maturity-model.md
@@ -1,0 +1,44 @@
+# Project Phoenix — Platform Maturity Index
+
+LumenAI OS v4.9, Section 10.
+
+## No re-derivation of Apollo's Quality Maturity Index
+
+Apollo's `apollo_quality_twin_service.compute_quality_twin` (v4.7) is
+already an 8-dimension "Quality Maturity Index." Phoenix's 9-dimension
+Platform Maturity Index takes that composite's `overall_score` as its own
+**Quality** dimension input, rather than re-deriving CAPA/competency/
+audit-readiness numbers a third time.
+
+## The nine dimensions
+
+| Dimension | Real source |
+|---|---|
+| Inspection | % of inspections with a real AI confidence score (`phoenix_ai_observatory_service.coverage_summary`) |
+| Knowledge | Approved-article ratio minus a penalty for duplicates/contradictions/outdated guidance (Platform Health's Knowledge Health) |
+| Quality | Apollo's Quality Digital Twin `overall_score` (most recent snapshot) |
+| Workflow | Platform Health's Workflow Health (execution failures + approval bottlenecks) |
+| Analytics | A bounded knowledge-query usage-activity proxy (`KnowledgeQueryLog` volume) — explicitly documented as a usage signal, not a benchmarked maturity level |
+| Education | Org-average technician `training_progress_pct` (`competency_service.technician_quality_dashboard`) |
+| Digital Twins | Platform Health's Digital Twin Health (instrument-flow twin utilization + open alerts) |
+| Governance | Enabled-vs-total `RetentionPolicy` ratio (`vanguard_governance_service.governance_dashboard`) |
+| Executive Intelligence | Audit-readiness `overall_readiness_score` (same governance dashboard) |
+
+`overall_score` is the average of whichever dimensions have real data —
+a tenant with zero workflow executions or zero external connectors isn't
+penalized for missing data; that dimension is simply excluded from the
+average rather than scored as zero.
+
+## Progression over time
+
+Every computation persists a `PlatformMaturitySnapshot` row, so maturity
+progression is a real historical series, not a single point-in-time
+number:
+
+```
+POST /api/phoenix/maturity/compute
+GET  /api/phoenix/maturity/history
+```
+
+Every snapshot's `factors` field documents exactly which real
+composition or proxy backs each of the nine scores.

--- a/docs/phoenix/platform-health.md
+++ b/docs/phoenix/platform-health.md
@@ -1,0 +1,25 @@
+# Project Phoenix — Platform Health Dashboard
+
+LumenAI OS v4.9, Section 7.
+
+Frontend route `/platform-health`. Seven named health areas, each a real
+composition — never a fabricated score — plus an Overall Platform
+Maturity figure (the average of whichever areas have real data).
+
+| Health area | Real source | Honest fallback |
+|---|---|---|
+| AI Health | `phoenix_ai_observatory_service` (agreement rate, drift) | "insufficient data" if no supervisor reviews exist |
+| Knowledge Health | `knowledge_governance_service` + Knowledge Evolution Center | "insufficient data" if no articles exist |
+| Workflow Health | `phoenix_workflow_optimization_service` (duration, failures, bottlenecks) | "insufficient data" if no executions exist |
+| Digital Twin Health | `digital_twin_engine.compute_twin_dashboard` (utilization, open alerts) — the *instrument-flow* twin, distinct from Apollo's Quality Digital Twin | "insufficient data" if the twin is unavailable for the tenant |
+| Security Health | `TenantMembership` enabled ratio + `TenantSubscriptionP14.hipaa_baa_signed_at` | "insufficient data" if no memberships exist |
+| Integration Health | `ExternalSystemConnector` connection-status ratio | "insufficient data" if no connectors are configured |
+| Quality Health | The most recent Apollo `QualityTwinSnapshot.overall_score` (read-only — never recomputes one, since a health-check dashboard should not have a write side effect) | "insufficient data" if no snapshot has been recorded yet |
+
+```
+GET /api/phoenix/platform-health/dashboard
+```
+
+Every score is bounded 0-100 and derived from a documented, real formula
+— never a black-box number. Areas with genuinely no data report
+`"insufficient data"` rather than defaulting to a fabricated midpoint.

--- a/frontend/src/components/DeveloperPortal.tsx
+++ b/frontend/src/components/DeveloperPortal.tsx
@@ -1,0 +1,146 @@
+/**
+ * v5.0 — LumenAI OS: Project Infinity — Developer Portal.
+ *
+ * Frontend route `/developers`, API prefix `/api/infinity`. Third-party
+ * developer accounts are admin-provisioned ("trusted third parties"),
+ * not open self-service — this portal's account/key management tabs are
+ * for internal platform admins curating the developer ecosystem.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+const TABS = ["API Explorer", "Rate Limits", "Tutorials", "Developer Accounts", "Plugins", "Sandbox"] as const;
+type Tab = (typeof TABS)[number];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function Json({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function DeveloperPortal() {
+  const [activeTab, setActiveTab] = useState<Tab>("API Explorer");
+
+  const [apiExplorer, setApiExplorer] = useState<Record<string, unknown>[] | null>(null);
+  const [rateLimits, setRateLimits] = useState<Record<string, unknown> | null>(null);
+  const [tutorials, setTutorials] = useState<Record<string, unknown>[] | null>(null);
+  const [accounts, setAccounts] = useState<Record<string, unknown>[] | null>(null);
+  const [accountForm, setAccountForm] = useState({ email: "", organization_name: "", developer_type: "hospital" });
+  const [plugins, setPlugins] = useState<Record<string, unknown>[] | null>(null);
+
+  useEffect(() => {
+    if (activeTab === "API Explorer") api.get("/api/infinity/developer-portal/api-explorer").then((r: Record<string, unknown>) => setApiExplorer(r.endpoints as Record<string, unknown>[])).catch(() => {});
+    if (activeTab === "Rate Limits") api.get("/api/infinity/developer-portal/rate-limits").then(setRateLimits).catch(() => {});
+    if (activeTab === "Tutorials") api.get("/api/infinity/developer-portal/tutorials").then((r: Record<string, unknown>) => setTutorials(r.tutorials as Record<string, unknown>[])).catch(() => {});
+    if (activeTab === "Developer Accounts") api.get("/api/infinity/developer-accounts").then((r: Record<string, unknown>) => setAccounts(r.accounts as Record<string, unknown>[])).catch(() => {});
+    if (activeTab === "Plugins") api.get("/api/infinity/plugins").then((r: Record<string, unknown>) => setPlugins(r.plugins as Record<string, unknown>[])).catch(() => {});
+  }, [activeTab]);
+
+  async function createAccount() {
+    if (!accountForm.email.trim()) return;
+    await api.post("/api/infinity/developer-accounts", accountForm);
+    setAccountForm({ email: "", organization_name: "", developer_type: "hospital" });
+    api.get("/api/infinity/developer-accounts").then((r: Record<string, unknown>) => setAccounts(r.accounts as Record<string, unknown>[])).catch(() => {});
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Developer Portal</h1>
+      <p className="text-xs text-slate-400">
+        Documentation, SDKs, the API Explorer, sample apps, tutorials, authentication, rate limits, and a
+        sandbox environment for trusted third-party developers and partner organizations.
+      </p>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "API Explorer" && (
+        <Section title="Public Platform API — /api/v1/*">
+          {apiExplorer?.map((e) => (
+            <div key={String(e.path)} className="mb-1 text-sm">
+              <code className="text-indigo-600">{String(e.path)}</code> — {String(e.system)}
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {activeTab === "Rate Limits" && (
+        <Section title="Rate Limit Policy">{rateLimits && <Json data={rateLimits} />}</Section>
+      )}
+
+      {activeTab === "Tutorials" && (
+        <Section title="Tutorials">
+          {tutorials?.map((t) => (
+            <div key={String(t.title)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+              <span className="font-medium">{String(t.title)}</span> — {String(t.topic)}
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {activeTab === "Developer Accounts" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="Registered Developer Accounts">
+            {accounts?.map((a) => (
+              <div key={String(a.id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+                <span className="font-medium">{String(a.organization_name)}</span> — {String(a.developer_type)} ({String(a.status)})
+              </div>
+            ))}
+          </Section>
+          <Section title="Provision a Developer Account">
+            <div className="space-y-2 text-sm">
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Email" value={accountForm.email}
+                onChange={(e) => setAccountForm({ ...accountForm, email: e.target.value })} />
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Organization name" value={accountForm.organization_name}
+                onChange={(e) => setAccountForm({ ...accountForm, organization_name: e.target.value })} />
+              <select className="w-full rounded border border-slate-300 p-2" value={accountForm.developer_type}
+                onChange={(e) => setAccountForm({ ...accountForm, developer_type: e.target.value })}>
+                <option value="hospital">Hospital</option><option value="manufacturer">Manufacturer</option>
+                <option value="repair_vendor">Repair Vendor</option><option value="academic">Academic</option>
+                <option value="research">Research</option><option value="enterprise">Enterprise</option>
+                <option value="consulting">Consulting</option>
+              </select>
+              <button className="rounded bg-indigo-600 px-4 py-2 text-white" onClick={createAccount}>Create Account</button>
+            </div>
+          </Section>
+        </div>
+      )}
+
+      {activeTab === "Plugins" && (
+        <Section title="Registered Plugins">
+          {plugins?.map((p) => (
+            <div key={String(p.plugin_key)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+              <span className="font-medium">{String(p.name)}</span> — v{String(p.version)} ({String(p.status)})
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {activeTab === "Sandbox" && (
+        <Section title="Developer Sandbox">
+          <p className="text-xs text-slate-400">
+            Isolated development, testing, validation, and certification sessions scoped to a synthetic
+            sandbox tenant — no production impact. Manage sessions from the Developer Accounts tab's
+            provisioning flow.
+          </p>
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PhoenixIntelligenceCenter.tsx
+++ b/frontend/src/components/PhoenixIntelligenceCenter.tsx
@@ -1,0 +1,174 @@
+/**
+ * v4.9 — LumenAI OS: Project Phoenix — Self-Improving Healthcare
+ * Intelligence Platform.
+ *
+ * Frontend route `/phoenix`, API prefix `/api/phoenix`. Phoenix never
+ * modifies production automatically — every recommendation and
+ * innovation idea requires an explicit human decision at every stage.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+const TABS = [
+  "Learning Engine", "Recommendations", "AI Observatory", "Workflow Optimization",
+  "Knowledge Evolution", "Competency Intelligence", "Innovation Pipeline", "Maturity Index",
+] as const;
+type Tab = (typeof TABS)[number];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function Json({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function PhoenixIntelligenceCenter() {
+  const [activeTab, setActiveTab] = useState<Tab>("Learning Engine");
+
+  const [learningEngine, setLearningEngine] = useState<Record<string, unknown> | null>(null);
+  const [recommendations, setRecommendations] = useState<Record<string, unknown>[] | null>(null);
+  const [observatory, setObservatory] = useState<Record<string, unknown> | null>(null);
+  const [workflowOpt, setWorkflowOpt] = useState<Record<string, unknown> | null>(null);
+  const [knowledgeEvolution, setKnowledgeEvolution] = useState<Record<string, unknown> | null>(null);
+  const [competencyResult, setCompetencyResult] = useState<Record<string, unknown> | null>(null);
+  const [ideas, setIdeas] = useState<Record<string, unknown>[] | null>(null);
+  const [ideaForm, setIdeaForm] = useState({ title: "", description: "", clinical_impact: "medium", technical_complexity: "medium", priority: "medium" });
+  const [maturityHistory, setMaturityHistory] = useState<Record<string, unknown>[] | null>(null);
+
+  useEffect(() => {
+    api.get("/api/phoenix/learning-engine/summary").then(setLearningEngine).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === "Recommendations") api.get("/api/phoenix/recommendations").then((r: Record<string, unknown>) => setRecommendations(r.recommendations as Record<string, unknown>[])).catch(() => {});
+    if (activeTab === "AI Observatory") api.get("/api/phoenix/observatory/summary").then(setObservatory).catch(() => {});
+    if (activeTab === "Workflow Optimization") api.get("/api/phoenix/workflow-optimization/summary").then(setWorkflowOpt).catch(() => {});
+    if (activeTab === "Knowledge Evolution") api.get("/api/phoenix/knowledge-evolution/summary").then(setKnowledgeEvolution).catch(() => {});
+    if (activeTab === "Innovation Pipeline") api.get("/api/phoenix/innovation/ideas").then((r: Record<string, unknown>) => setIdeas(r.ideas as Record<string, unknown>[])).catch(() => {});
+    if (activeTab === "Maturity Index") api.get("/api/phoenix/maturity/history").then((r: Record<string, unknown>) => setMaturityHistory(r.history as Record<string, unknown>[])).catch(() => {});
+  }, [activeTab]);
+
+  async function generateRecommendations() {
+    const res = await api.post<Record<string, unknown>>("/api/phoenix/recommendations/generate", {});
+    setRecommendations(res.recommendations as Record<string, unknown>[]);
+  }
+
+  async function runCompetencyIntelligence() {
+    const res = await api.post<Record<string, unknown>>("/api/phoenix/competency-intelligence/run", {});
+    setCompetencyResult(res);
+  }
+
+  async function createIdea() {
+    if (!ideaForm.title.trim()) return;
+    await api.post("/api/phoenix/innovation/ideas", ideaForm);
+    setIdeaForm({ title: "", description: "", clinical_impact: "medium", technical_complexity: "medium", priority: "medium" });
+    api.get("/api/phoenix/innovation/ideas").then((r: Record<string, unknown>) => setIdeas(r.ideas as Record<string, unknown>[])).catch(() => {});
+  }
+
+  async function computeMaturity() {
+    await api.post("/api/phoenix/maturity/compute", {});
+    api.get("/api/phoenix/maturity/history").then((r: Record<string, unknown>) => setMaturityHistory(r.history as Record<string, unknown>[])).catch(() => {});
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Phoenix — Self-Improving Intelligence</h1>
+      <p className="text-xs text-slate-400">
+        Continuously analyzes platform performance, knowledge quality, AI accuracy, workflow efficiency, and
+        operational outcomes. Phoenix never modifies production automatically — every recommendation requires
+        human governance and approval at every stage.
+      </p>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Learning Engine" && (
+        <Section title="Phoenix Learning Engine">{learningEngine && <Json data={learningEngine} />}</Section>
+      )}
+
+      {activeTab === "Recommendations" && (
+        <Section title="Improvement Recommendations">
+          <button className="mb-3 rounded bg-indigo-600 px-4 py-1 text-sm text-white" onClick={generateRecommendations}>
+            Generate Recommendations
+          </button>
+          {recommendations?.map((r) => (
+            <div key={String(r.id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+              <span className="font-medium">{String(r.title)}</span> — {String(r.recommendation_type)} (confidence {String(r.confidence)}, status {String(r.status)})
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {activeTab === "AI Observatory" && (
+        <Section title="AI Performance Observatory">{observatory && <Json data={observatory} />}</Section>
+      )}
+
+      {activeTab === "Workflow Optimization" && (
+        <Section title="Workflow Optimization Engine">{workflowOpt && <Json data={workflowOpt} />}</Section>
+      )}
+
+      {activeTab === "Knowledge Evolution" && (
+        <Section title="Knowledge Evolution Center">{knowledgeEvolution && <Json data={knowledgeEvolution} />}</Section>
+      )}
+
+      {activeTab === "Competency Intelligence" && (
+        <Section title="Competency Intelligence">
+          <button className="mb-3 rounded bg-indigo-600 px-4 py-1 text-sm text-white" onClick={runCompetencyIntelligence}>
+            Run Detectors
+          </button>
+          {competencyResult && <Json data={competencyResult} />}
+        </Section>
+      )}
+
+      {activeTab === "Innovation Pipeline" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="Innovation Backlog">
+            {ideas?.map((idea) => (
+              <div key={String(idea.id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+                <span className="font-medium">{String(idea.title)}</span> — {String(idea.priority)} priority ({String(idea.approval_status)})
+              </div>
+            ))}
+          </Section>
+          <Section title="Submit an Idea">
+            <div className="space-y-2 text-sm">
+              <input className="w-full rounded border border-slate-300 p-2" placeholder="Title" value={ideaForm.title}
+                onChange={(e) => setIdeaForm({ ...ideaForm, title: e.target.value })} />
+              <textarea className="w-full rounded border border-slate-300 p-2" placeholder="Description" value={ideaForm.description}
+                onChange={(e) => setIdeaForm({ ...ideaForm, description: e.target.value })} />
+              <select className="w-full rounded border border-slate-300 p-2" value={ideaForm.priority}
+                onChange={(e) => setIdeaForm({ ...ideaForm, priority: e.target.value })}>
+                <option value="low">Low priority</option><option value="medium">Medium priority</option>
+                <option value="high">High priority</option><option value="critical">Critical priority</option>
+              </select>
+              <button className="rounded bg-indigo-600 px-4 py-2 text-white" onClick={createIdea}>Submit Idea</button>
+            </div>
+          </Section>
+        </div>
+      )}
+
+      {activeTab === "Maturity Index" && (
+        <Section title="Platform Maturity Index">
+          <button className="mb-3 rounded bg-indigo-600 px-4 py-1 text-sm text-white" onClick={computeMaturity}>
+            Compute New Snapshot
+          </button>
+          {maturityHistory && <Json data={maturityHistory} />}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PlatformHealthDashboard.tsx
+++ b/frontend/src/components/PlatformHealthDashboard.tsx
@@ -1,0 +1,60 @@
+/**
+ * v4.9 — LumenAI OS: Project Phoenix — Platform Health Dashboard.
+ *
+ * Frontend route `/platform-health`, API prefix `/api/phoenix`.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+function ScoreTile({ label, area }: { label: string; area: Record<string, unknown> | undefined }) {
+  const score = area?.score;
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="text-sm font-semibold text-slate-700">{label}</h3>
+      {score === null || score === undefined ? (
+        <p className="mt-2 text-xs text-slate-400">{String(area?.note ?? "insufficient data")}</p>
+      ) : (
+        <p className="mt-2 text-3xl font-bold text-indigo-600">{String(score)}</p>
+      )}
+    </div>
+  );
+}
+
+export default function PlatformHealthDashboard() {
+  const [health, setHealth] = useState<Record<string, unknown> | null>(null);
+
+  useEffect(() => {
+    api.get("/api/phoenix/platform-health/dashboard").then(setHealth).catch(() => {});
+  }, []);
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Platform Health Dashboard</h1>
+      <p className="text-xs text-slate-400">
+        Seven health areas plus overall platform maturity, composed from real signals across the platform.
+        Areas with no recorded data yet show "insufficient data" rather than a fabricated score.
+      </p>
+
+      {health && (
+        <>
+          <div className="rounded-lg border-2 border-indigo-300 bg-indigo-50 p-4">
+            <h3 className="text-sm font-semibold text-indigo-800">Overall Platform Maturity</h3>
+            <p className="mt-2 text-4xl font-bold text-indigo-700">
+              {health.overall_platform_maturity === null ? "—" : String(health.overall_platform_maturity)}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <ScoreTile label="AI Health" area={health.ai_health as Record<string, unknown>} />
+            <ScoreTile label="Knowledge Health" area={health.knowledge_health as Record<string, unknown>} />
+            <ScoreTile label="Workflow Health" area={health.workflow_health as Record<string, unknown>} />
+            <ScoreTile label="Digital Twin Health" area={health.digital_twin_health as Record<string, unknown>} />
+            <ScoreTile label="Security Health" area={health.security_health as Record<string, unknown>} />
+            <ScoreTile label="Integration Health" area={health.integration_health as Record<string, unknown>} />
+            <ScoreTile label="Quality Health" area={health.quality_health as Record<string, unknown>} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PlatformMarketplace.tsx
+++ b/frontend/src/components/PlatformMarketplace.tsx
@@ -1,0 +1,119 @@
+/**
+ * v5.0 — LumenAI OS: Project Infinity — AI Skills Marketplace &
+ * Application Marketplace.
+ *
+ * Frontend route `/marketplace`, API prefix `/api/infinity`. A listing
+ * can only be published once every Certification Program gate (Section
+ * 7) has passed — installing an unpublished listing is rejected.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+const TABS = ["Browse Listings", "My Installations", "Certification"] as const;
+type Tab = (typeof TABS)[number];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+export default function PlatformMarketplace() {
+  const [activeTab, setActiveTab] = useState<Tab>("Browse Listings");
+  const [listingType, setListingType] = useState("");
+  const [listings, setListings] = useState<Record<string, unknown>[] | null>(null);
+  const [installations, setInstallations] = useState<Record<string, unknown>[] | null>(null);
+  const [certListingId, setCertListingId] = useState("");
+  const [certStatus, setCertStatus] = useState<Record<string, unknown> | null>(null);
+
+  useEffect(() => {
+    if (activeTab === "Browse Listings") {
+      const q = listingType ? `?listing_type=${listingType}` : "";
+      api.get(`/api/infinity/marketplace/listings${q}`).then((r: Record<string, unknown>) => setListings(r.listings as Record<string, unknown>[])).catch(() => {});
+    }
+    if (activeTab === "My Installations") {
+      api.get("/api/infinity/marketplace/installations").then((r: Record<string, unknown>) => setInstallations(r.installations as Record<string, unknown>[])).catch(() => {});
+    }
+  }, [activeTab, listingType]);
+
+  async function install(listingId: number) {
+    await api.post("/api/infinity/marketplace/installations", { listing_id: listingId });
+    api.get("/api/infinity/marketplace/installations").then((r: Record<string, unknown>) => setInstallations(r.installations as Record<string, unknown>[])).catch(() => {});
+  }
+
+  async function checkCertification() {
+    if (!certListingId.trim()) return;
+    const res = await api.get<Record<string, unknown>>(`/api/infinity/certification/listings/${certListingId}`);
+    setCertStatus(res);
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Marketplace</h1>
+      <p className="text-xs text-slate-400">
+        AI Skills and Applications from Hospital, Manufacturer, Repair Vendor, Academic, Research, Enterprise,
+        and Consulting developers — every listing is versioned and certified before publication.
+      </p>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Browse Listings" && (
+        <Section title="Published Listings">
+          <select className="mb-3 rounded border border-slate-300 p-1 text-sm" value={listingType} onChange={(e) => setListingType(e.target.value)}>
+            <option value="">All types</option>
+            <option value="ai_skill">AI Skills</option>
+            <option value="application">Applications</option>
+          </select>
+          {listings?.map((l) => (
+            <div key={String(l.id)} className="mb-2 flex items-center justify-between border-b border-slate-100 pb-2 text-sm">
+              <div>
+                <span className="font-medium">{String(l.name)}</span> — {String(l.listing_type)} / {String(l.category)}
+                {" "}(v{String(l.version)}, {String(l.status)})
+              </div>
+              <button className="rounded bg-indigo-600 px-3 py-1 text-xs text-white" onClick={() => install(Number(l.id))}>Install</button>
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {activeTab === "My Installations" && (
+        <Section title="Installed Listings">
+          {installations?.map((i) => (
+            <div key={String(i.id)} className="mb-2 border-b border-slate-100 pb-2 text-sm">
+              Listing #{String(i.listing_id)} — v{String(i.installed_version)} ({String(i.status)})
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {activeTab === "Certification" && (
+        <Section title="Check Certification Status">
+          <div className="mb-3 flex gap-2">
+            <input className="flex-1 rounded border border-slate-300 p-2 text-sm" placeholder="Listing ID" value={certListingId}
+              onChange={(e) => setCertListingId(e.target.value)} />
+            <button className="rounded bg-indigo-600 px-4 py-1 text-sm text-white" onClick={checkCertification}>Check</button>
+          </div>
+          {certStatus && (
+            <div className="text-sm">
+              <p>Status: <span className="font-medium">{String(certStatus.certification_status)}</span></p>
+              <p className="mt-2 text-xs text-slate-400">Gates: {(certStatus.gates as string[])?.join(" → ")}</p>
+            </div>
+          )}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -87,6 +87,8 @@ const ExecutiveIntelligencePage = lazy(() => import("./pages/ExecutiveIntelligen
 const StrategicPlanningPage = lazy(() => import("./pages/StrategicPlanningPage"));
 const QualityManagementCenterPage = lazy(() => import("./pages/QualityManagementCenterPage"));
 const KnowledgeMemoryPage = lazy(() => import("./pages/KnowledgeMemoryPage"));
+const PhoenixIntelligencePage = lazy(() => import("./pages/PhoenixIntelligencePage"));
+const PlatformHealthPage = lazy(() => import("./pages/PlatformHealthPage"));
 const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
@@ -415,6 +417,8 @@ function App() {
                       <Route path="/strategy" element={<Page name="StrategicPlanning"><StrategicPlanningPage /></Page>} />
                       <Route path="/quality" element={<Page name="QualityManagementCenter"><QualityManagementCenterPage /></Page>} />
                       <Route path="/knowledge-memory" element={<Page name="KnowledgeMemory"><KnowledgeMemoryPage /></Page>} />
+                      <Route path="/phoenix" element={<Page name="Phoenix"><PhoenixIntelligencePage /></Page>} />
+                      <Route path="/platform-health" element={<Page name="PlatformHealth"><PlatformHealthPage /></Page>} />
                       <Route path="/agent-trace" element={<Page name="AgentTrace"><AgentTraceViewer /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -89,6 +89,8 @@ const QualityManagementCenterPage = lazy(() => import("./pages/QualityManagement
 const KnowledgeMemoryPage = lazy(() => import("./pages/KnowledgeMemoryPage"));
 const PhoenixIntelligencePage = lazy(() => import("./pages/PhoenixIntelligencePage"));
 const PlatformHealthPage = lazy(() => import("./pages/PlatformHealthPage"));
+const DeveloperPortalPage = lazy(() => import("./pages/DeveloperPortalPage"));
+const PlatformMarketplacePage = lazy(() => import("./pages/PlatformMarketplacePage"));
 const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
@@ -419,6 +421,8 @@ function App() {
                       <Route path="/knowledge-memory" element={<Page name="KnowledgeMemory"><KnowledgeMemoryPage /></Page>} />
                       <Route path="/phoenix" element={<Page name="Phoenix"><PhoenixIntelligencePage /></Page>} />
                       <Route path="/platform-health" element={<Page name="PlatformHealth"><PlatformHealthPage /></Page>} />
+                      <Route path="/developers" element={<Page name="DeveloperPortal"><DeveloperPortalPage /></Page>} />
+                      <Route path="/marketplace" element={<Page name="Marketplace"><PlatformMarketplacePage /></Page>} />
                       <Route path="/agent-trace" element={<Page name="AgentTrace"><AgentTraceViewer /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />

--- a/frontend/src/pages/DeveloperPortalPage.tsx
+++ b/frontend/src/pages/DeveloperPortalPage.tsx
@@ -1,0 +1,5 @@
+import DeveloperPortal from "@/components/DeveloperPortal";
+
+export default function DeveloperPortalPage() {
+  return <DeveloperPortal />;
+}

--- a/frontend/src/pages/PhoenixIntelligencePage.tsx
+++ b/frontend/src/pages/PhoenixIntelligencePage.tsx
@@ -1,0 +1,5 @@
+import PhoenixIntelligenceCenter from "@/components/PhoenixIntelligenceCenter";
+
+export default function PhoenixIntelligencePage() {
+  return <PhoenixIntelligenceCenter />;
+}

--- a/frontend/src/pages/PlatformHealthPage.tsx
+++ b/frontend/src/pages/PlatformHealthPage.tsx
@@ -1,0 +1,5 @@
+import PlatformHealthDashboard from "@/components/PlatformHealthDashboard";
+
+export default function PlatformHealthPage() {
+  return <PlatformHealthDashboard />;
+}

--- a/frontend/src/pages/PlatformMarketplacePage.tsx
+++ b/frontend/src/pages/PlatformMarketplacePage.tsx
@@ -1,0 +1,5 @@
+import PlatformMarketplace from "@/components/PlatformMarketplace";
+
+export default function PlatformMarketplacePage() {
+  return <PlatformMarketplace />;
+}


### PR DESCRIPTION
## Summary
Adds two additive modules on top of the 18 already-merged modules (Sentinel through Athena, merged via PR #89):

- **Project Phoenix (v4.9)** — a continuous learning and improvement engine at `/phoenix` and `/platform-health` (`/api/phoenix`) analyzing platform performance, knowledge quality, AI accuracy, workflow efficiency, Digital Twin health, and operational outcomes. Every recommendation requires human governance/approval.
- **Project Infinity (v5.0)** — a third-party developer platform and ecosystem at `/developers` and `/marketplace` (`/api/infinity`, plus 12 new `/api/v1/*` gateway endpoints): Developer Portal & Plugin SDK, an AI Skills + Application Marketplace gated by a 7-gate Certification Program, an Extension Framework, a Developer Sandbox, and Partner Licensing / marketplace revenue sharing.

## Why This Change
Both sprints were built composition-first: every existing performance/analytics/marketplace/approval-chain system was read before writing new code, to avoid duplicating primitives that already exist. See `docs/phoenix/learning-engine.md` and `docs/infinity/*.md` for full naming-disambiguation notes.

## Scope

**Phoenix (included):**
- `phoenix_intelligence.py` — 5 new tables (`ImprovementRecommendation`, `ValidationOutcome`, `InnovationIdea`, `PlatformMaturitySnapshot`, `AIInferenceLatencySample`).
- Additive extension: `quality_guardian.py`'s `OPPORTUNITY_TYPES` gains 3 new types (`simulation`, `mentoring`, `knowledge_sharing`).
- 10 new service files (Learning Engine, Recommendation Engine, AI Performance Observatory, Workflow Optimization, Knowledge Evolution, Competency Intelligence, Platform Health Dashboard, Innovation Pipeline, Continuous Validation reusing Forge's `WorkflowApprovalChain`, Platform Maturity Index).
- Routes at `/api/phoenix` using `require_tenant_roles` (real `TenantMembership` verification).
- Frontend: `/phoenix`, `/platform-health`.
- `docs/phoenix/*.md` (5 files), `backend/tests/test_phoenix_intelligence.py` (23 tests).

**Infinity (included):**
- `infinity_platform.py` — 7 new tables (`DeveloperAccount`, `DeveloperApiKey`, `MarketplaceListing`, `MarketplaceInstallation`, `MarketplaceRevenueEvent`, `DeveloperSandboxSession`, `PartnerLicense`).
- Additive extensions: `platform_core.py`'s `PlatformPlugin` gains 5 `registered_*_json` columns plus developer/marketplace linkage; `nexus_api_gateway.py` gains 12 new `/api/v1/*` read endpoints composing existing module summaries.
- 7 new service files (Developer accounts/API keys with one-time-issued SHA-256-hashed secrets, Marketplace with certification-gated publish, Certification reusing Forge's approval chain a third time, Extension Framework, Developer Sandbox scoped to synthetic `sandbox-` tenant ids, Billing/Licensing with transparent revenue-sharing, Developer Portal).
- Routes at `/api/infinity` using `require_tenant_roles` for tenant/admin endpoints and a new `require_developer_auth` (API-key) dependency for the developer-facing `/developer-portal/me` endpoint.
- Frontend: `/developers`, `/marketplace`.
- `docs/infinity/*.md` (6 files), `backend/tests/test_infinity_platform.py` (21 tests).

**Excluded:** No changes to any of the 18 already-merged modules' behavior beyond the additive extensions listed above. No second CAPA/RCA/knowledge/approval-chain/quality-twin/plugin model — everything reuses existing systems where one already fits.

## Testing
- [x] Unit tests — 23 Phoenix tests + 21 Infinity tests; full suite: `3143 passed, 2 skipped, 0 failed`
- [x] Manual verification — `ruff check backend/app backend/tests` clean; `app.main` imports cleanly with all Phoenix and Infinity routes registered
- [x] Docker build — not applicable to this change
- [x] API/worker runtime validation — `npm run build` (frontend) succeeds; new `/api/phoenix/*`, `/api/infinity/*`, and `/api/v1/*` routes confirmed registered via FastAPI route introspection

## Risks
Additive-only schema changes throughout — 12 new tables total across both sprints, plus additive column/enum extensions to `PlatformPlugin` and `quality_guardian.py` (no migrations needed, all nullable/new columns). Marketplace publication is enforced in code to require `certified` status (`ListingNotCertifiedError`), not left to convention. Developer identity is intentionally separate from `TenantMembership` and admin-gated (no open self-service signup) per the brief's "trusted third parties" framing.

## Rollback Plan
Revert this commit — all new tables are additive and unused by any pre-existing code path, so a revert is a clean no-op for the other 18 modules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVqKmNua8sWhTdLDHEPyzV)_