### PR TITLE
Project Vulcan + Sage + Veritas + Sentinel-X + Maestro + Council

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -138,6 +138,9 @@ from app.models.veritas_evidence import (  # noqa: F401
     VeritasEvidenceProvenanceRecord, VeritasEvidenceReadinessAssessment, VeritasFeedback,
     VeritasTrainingDatasetEntry,
 )
+from app.models.sentinelx_risk import (  # noqa: F401
+    SentinelXPatientSafetyAlert, SentinelXRiskAssessment, SentinelXSupervisorOverride,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -126,6 +126,9 @@ from app.models.genesis_ai_intelligence_cloud import (  # noqa: F401
 from app.models.nova_agent_platform import (  # noqa: F401
     AgentCollaborationRequest, AgentDefinition, AgentMemoryEntry, AgentMessage, AgentTaskRun,
 )
+from app.models.vulcan_reliability import (  # noqa: F401
+    VulcanFeedback, VulcanReliabilityAssessment, VulcanRepairEffectivenessAssessment,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -145,6 +145,10 @@ from app.models.maestro_orchestration import (  # noqa: F401
     MaestroDailyBrief, MaestroDecisionJournalEntry, MaestroOperationalHealthSnapshot,
     MaestroPriorityItem, MaestroRecommendation,
 )
+from app.models.council_leadership import (  # noqa: F401
+    CouncilCase, CouncilDecisionOption, CouncilDissentRecord, CouncilHumanDecision,
+    CouncilMeetingNotes, CouncilOutcomeReview, CouncilSpecialistAssessment, CouncilTeamConfig,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -129,6 +129,10 @@ from app.models.nova_agent_platform import (  # noqa: F401
 from app.models.vulcan_reliability import (  # noqa: F401
     VulcanFeedback, VulcanReliabilityAssessment, VulcanRepairEffectivenessAssessment,
 )
+from app.models.sage_education import (  # noqa: F401
+    SageAssessment, SageEducationImageEntry, SageEffectivenessAssessment, SageFeedback,
+    SageKnowledgeGap, SageLearningPlan, SageMicrolearningModule,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -141,6 +141,10 @@ from app.models.veritas_evidence import (  # noqa: F401
 from app.models.sentinelx_risk import (  # noqa: F401
     SentinelXPatientSafetyAlert, SentinelXRiskAssessment, SentinelXSupervisorOverride,
 )
+from app.models.maestro_orchestration import (  # noqa: F401
+    MaestroDailyBrief, MaestroDecisionJournalEntry, MaestroOperationalHealthSnapshot,
+    MaestroPriorityItem, MaestroRecommendation,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -133,6 +133,11 @@ from app.models.sage_education import (  # noqa: F401
     SageAssessment, SageEducationImageEntry, SageEffectivenessAssessment, SageFeedback,
     SageKnowledgeGap, SageLearningPlan, SageMicrolearningModule,
 )
+from app.models.veritas_evidence import (  # noqa: F401
+    VeritasBaselineGovernanceAction, VeritasBaselineResolution, VeritasEvidenceConflict,
+    VeritasEvidenceProvenanceRecord, VeritasEvidenceReadinessAssessment, VeritasFeedback,
+    VeritasTrainingDatasetEntry,
+)
 
 
 class TenantMembership(Base):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1089,6 +1089,10 @@ from app.models import nova_agent_platform as _nova_agent_platform_models  # noq
 from app.routes.nova_agent_platform import router as nova_agent_platform_router
 app.include_router(nova_agent_platform_router)
 
+from app.models import vulcan_reliability as _vulcan_reliability_models  # noqa: F401
+from app.routes.vulcan_reliability import router as vulcan_reliability_router
+app.include_router(vulcan_reliability_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1097,6 +1097,10 @@ from app.models import sage_education as _sage_education_models  # noqa: F401
 from app.routes.sage_education import router as sage_education_router
 app.include_router(sage_education_router)
 
+from app.models import veritas_evidence as _veritas_evidence_models  # noqa: F401
+from app.routes.veritas_evidence import router as veritas_evidence_router
+app.include_router(veritas_evidence_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1109,6 +1109,10 @@ from app.models import maestro_orchestration as _maestro_orchestration_models  #
 from app.routes.maestro_orchestration import router as maestro_orchestration_router
 app.include_router(maestro_orchestration_router)
 
+from app.models import council_leadership as _council_leadership_models  # noqa: F401
+from app.routes.council_leadership import router as council_leadership_router
+app.include_router(council_leadership_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1105,6 +1105,10 @@ from app.models import sentinelx_risk as _sentinelx_risk_models  # noqa: F401
 from app.routes.sentinelx_risk import router as sentinelx_risk_router
 app.include_router(sentinelx_risk_router)
 
+from app.models import maestro_orchestration as _maestro_orchestration_models  # noqa: F401
+from app.routes.maestro_orchestration import router as maestro_orchestration_router
+app.include_router(maestro_orchestration_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1101,6 +1101,10 @@ from app.models import veritas_evidence as _veritas_evidence_models  # noqa: F40
 from app.routes.veritas_evidence import router as veritas_evidence_router
 app.include_router(veritas_evidence_router)
 
+from app.models import sentinelx_risk as _sentinelx_risk_models  # noqa: F401
+from app.routes.sentinelx_risk import router as sentinelx_risk_router
+app.include_router(sentinelx_risk_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1093,6 +1093,10 @@ from app.models import vulcan_reliability as _vulcan_reliability_models  # noqa:
 from app.routes.vulcan_reliability import router as vulcan_reliability_router
 app.include_router(vulcan_reliability_router)
 
+from app.models import sage_education as _sage_education_models  # noqa: F401
+from app.routes.sage_education import router as sage_education_router
+app.include_router(sage_education_router)
+
 from fastapi.openapi.utils import get_openapi
 
 def custom_openapi():

--- a/backend/app/models/council_leadership.py
+++ b/backend/app/models/council_leadership.py
@@ -1,0 +1,461 @@
+"""LumenAI AI Leadership Platform — Project Council: Multi-Agent Leadership
+Teams & Governed Consensus Intelligence.
+
+## Naming disambiguation
+
+**"Council" already exists** in one unrelated context: Olympus's Network
+Governance Council (`olympus_governance_council_service.py`,
+`NetworkGovernanceCase` in `app/models/olympus_network.py`) -- a
+cross-hospital, network-level governance body for intelligence-sharing
+disputes between member sites. Project Council is a different,
+single-tenant concept: structured AI leadership *teams* composed of
+already-built LumenAI specialists, convened to review one operational or
+clinical issue and produce a transparent, dissent-preserving
+recommendation for human leadership. This file uses a distinct
+`council_` prefix throughout and never touches `NetworkGovernanceCase` or
+any Olympus table. `/council` and `/api/council` were unclaimed before
+this sprint.
+
+## What Council composes rather than duplicates
+
+Council does not run its own clinical/operational analysis. Each
+specialist's Council assessment is derived from that specialist's own,
+already-built real service:
+
+  * **Veritas** — `veritas_evidence_agent_service.run_evidence_assessment`
+  * **Aegis** — `vulcan_aegis_integration_service.
+    compute_process_variation_signal`
+  * **Vulcan** — `vulcan_reliability_agent_service.
+    run_reliability_assessment`
+  * **Sage** — `sage_knowledge_gap_service.list_gaps`
+  * **Sentinel-X** — `sentinelx_risk_agent_service.run_risk_assessment`
+  * **Apollo** — `apollo_capa_engine_service.capa_engine_summary`
+  * **Athena** — `athena_search_service.organizational_search`
+  * **Pulse** — `pulse_command_center_service.pulse_command_center`
+  * **Phoenix** — `phoenix_maturity_index_service.
+    compute_platform_maturity_index`
+  * **Maestro** — `maestro_priority_engine_service.latest_priorities`
+  * **Research Agent** — `horizon_research_portal_service.
+    research_portal_summary` (network-wide research/dataset activity;
+    read-only reference for the Research and Innovation Council)
+
+Reports reuse Veritas's already-generic `veritas_reports_service.
+build_report_pdf_bytes` / `build_report_csv_bytes` / `build_report_xlsx_bytes`
+rather than a new export library. Decision Journal integration reuses
+Maestro's `maestro_decision_journal_service.record_decision` directly.
+
+## What is genuinely new in this file
+
+Eight tables: `CouncilTeamConfig` (Sections 2, 15), `CouncilCase`
+(Section 3), `CouncilSpecialistAssessment` (Section 4),
+`CouncilDissentRecord` (Section 6), `CouncilDecisionOption` (Section 7),
+`CouncilHumanDecision` (Section 8), `CouncilMeetingNotes` (Section 12),
+`CouncilOutcomeReview` (Section 14). Specialist performance (Section 17)
+is computed on the fly from these tables -- never a separate,
+independently-drifting scoreboard.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Section 2 & 15: Leadership Team Registry ─────────────────────────────────
+TEAM_CLINICAL_QUALITY = "clinical_quality"
+TEAM_OPERATIONS = "operations"
+TEAM_EDUCATION = "education"
+TEAM_RELIABILITY = "reliability"
+TEAM_EXECUTIVE = "executive"
+TEAM_RESEARCH_INNOVATION = "research_innovation"
+COUNCIL_TEAM_KEYS = [
+    TEAM_CLINICAL_QUALITY, TEAM_OPERATIONS, TEAM_EDUCATION,
+    TEAM_RELIABILITY, TEAM_EXECUTIVE, TEAM_RESEARCH_INNOVATION,
+]
+
+# Specialist keys used throughout Council (map onto real specialist services).
+SPECIALIST_VERITAS = "veritas"
+SPECIALIST_AEGIS = "aegis"
+SPECIALIST_VULCAN = "vulcan"
+SPECIALIST_SAGE = "sage"
+SPECIALIST_SENTINELX = "sentinelx"
+SPECIALIST_APOLLO = "apollo"
+SPECIALIST_ATHENA = "athena"
+SPECIALIST_PULSE = "pulse"
+SPECIALIST_PHOENIX = "phoenix"
+SPECIALIST_MAESTRO = "maestro"
+SPECIALIST_RESEARCH_AGENT = "research_agent"
+
+# Specialists whose unresolved dissent can never be majority-overridden
+# (Section 5, 16) -- the safety- and evidence-integrity specialists.
+SAFETY_VETO_SPECIALISTS = {SPECIALIST_SENTINELX, SPECIALIST_VERITAS}
+
+DEFAULT_TEAM_DEFINITIONS = {
+    TEAM_CLINICAL_QUALITY: {
+        "team_name": "Clinical Quality Council",
+        "required_specialists": [SPECIALIST_SENTINELX, SPECIALIST_VERITAS, SPECIALIST_APOLLO, SPECIALIST_ATHENA, SPECIALIST_VULCAN],
+        "optional_specialists": [],
+        "decision_scope": "High-risk findings, evidence quality, clinical significance, quality implications, institutional guidance.",
+    },
+    TEAM_OPERATIONS: {
+        "team_name": "Operations Council",
+        "required_specialists": [SPECIALIST_MAESTRO, SPECIALIST_AEGIS, SPECIALIST_PULSE, SPECIALIST_VULCAN, SPECIALIST_SENTINELX],
+        "optional_specialists": [],
+        "decision_scope": "Workload prioritization, workflow risk, repair impact, staffing pressure, immediate operational response.",
+    },
+    TEAM_EDUCATION: {
+        "team_name": "Education Council",
+        "required_specialists": [SPECIALIST_SAGE, SPECIALIST_AEGIS, SPECIALIST_ATHENA, SPECIALIST_APOLLO, SPECIALIST_VERITAS],
+        "optional_specialists": [],
+        "decision_scope": "Knowledge gaps, competency needs, approved educational content, effectiveness measurement.",
+    },
+    TEAM_RELIABILITY: {
+        "team_name": "Reliability Council",
+        "required_specialists": [SPECIALIST_VULCAN, SPECIALIST_VERITAS, SPECIALIST_SENTINELX, SPECIALIST_AEGIS, SPECIALIST_MAESTRO],
+        "optional_specialists": [],
+        "decision_scope": "Recurring instrument failure, repair recurrence, process exposure, clinical risk, disposition options.",
+    },
+    TEAM_EXECUTIVE: {
+        "team_name": "Executive Council",
+        "required_specialists": [SPECIALIST_MAESTRO, SPECIALIST_SENTINELX, SPECIALIST_PULSE, SPECIALIST_PHOENIX, SPECIALIST_APOLLO, SPECIALIST_AEGIS],
+        "optional_specialists": [],
+        "decision_scope": "Enterprise priorities, executive risks, resource options, quality priorities, strategic recommendations.",
+    },
+    TEAM_RESEARCH_INNOVATION: {
+        "team_name": "Research and Innovation Council",
+        "required_specialists": [SPECIALIST_PHOENIX, SPECIALIST_ATHENA, SPECIALIST_VERITAS, SPECIALIST_SENTINELX, SPECIALIST_RESEARCH_AGENT],
+        "optional_specialists": [],
+        "decision_scope": "New hypotheses, model improvements, evidence needs, pilots, research proposals, innovation opportunities.",
+    },
+}
+
+# ── Section 3: Council Case types ────────────────────────────────────────────
+CASE_HIGH_RISK_INSPECTION = "high_risk_inspection"
+CASE_RECURRING_CONTAMINATION = "recurring_contamination"
+CASE_RECURRING_INSTRUMENT_FAILURE = "recurring_instrument_failure"
+CASE_REPAIR_RECURRENCE = "repair_recurrence"
+CASE_PROCESS_VARIATION = "process_variation"
+CASE_EDUCATION_NEED = "education_need"
+CASE_CAPA_ESCALATION = "capa_escalation"
+CASE_WORKFLOW_BOTTLENECK = "workflow_bottleneck"
+CASE_ENTERPRISE_TREND = "enterprise_trend"
+CASE_MODEL_PERFORMANCE_ISSUE = "model_performance_issue"
+CASE_EVIDENCE_CONFLICT = "evidence_conflict"
+CASE_INNOVATION_PROPOSAL = "innovation_proposal"
+CASE_TYPES = [
+    CASE_HIGH_RISK_INSPECTION, CASE_RECURRING_CONTAMINATION, CASE_RECURRING_INSTRUMENT_FAILURE,
+    CASE_REPAIR_RECURRENCE, CASE_PROCESS_VARIATION, CASE_EDUCATION_NEED, CASE_CAPA_ESCALATION,
+    CASE_WORKFLOW_BOTTLENECK, CASE_ENTERPRISE_TREND, CASE_MODEL_PERFORMANCE_ISSUE,
+    CASE_EVIDENCE_CONFLICT, CASE_INNOVATION_PROPOSAL,
+]
+
+# Default team routed to for each case type -- organizations may override
+# per-tenant via CouncilTeamConfig, but this is the out-of-the-box mapping.
+CASE_TYPE_DEFAULT_TEAM = {
+    CASE_HIGH_RISK_INSPECTION: TEAM_CLINICAL_QUALITY,
+    CASE_RECURRING_CONTAMINATION: TEAM_CLINICAL_QUALITY,
+    CASE_RECURRING_INSTRUMENT_FAILURE: TEAM_RELIABILITY,
+    CASE_REPAIR_RECURRENCE: TEAM_RELIABILITY,
+    CASE_PROCESS_VARIATION: TEAM_OPERATIONS,
+    CASE_EDUCATION_NEED: TEAM_EDUCATION,
+    CASE_CAPA_ESCALATION: TEAM_CLINICAL_QUALITY,
+    CASE_WORKFLOW_BOTTLENECK: TEAM_OPERATIONS,
+    CASE_ENTERPRISE_TREND: TEAM_EXECUTIVE,
+    CASE_MODEL_PERFORMANCE_ISSUE: TEAM_RESEARCH_INNOVATION,
+    CASE_EVIDENCE_CONFLICT: TEAM_CLINICAL_QUALITY,
+    CASE_INNOVATION_PROPOSAL: TEAM_RESEARCH_INNOVATION,
+}
+
+CASE_STATUS_OPEN = "open"
+CASE_STATUS_AWAITING_EVIDENCE = "awaiting_evidence"
+CASE_STATUS_AWAITING_DECISION = "awaiting_decision"
+CASE_STATUS_RESOLVED = "resolved"
+CASE_STATUS_CLOSED = "closed"
+CASE_STATUSES = [
+    CASE_STATUS_OPEN, CASE_STATUS_AWAITING_EVIDENCE, CASE_STATUS_AWAITING_DECISION,
+    CASE_STATUS_RESOLVED, CASE_STATUS_CLOSED,
+]
+
+# ── Section 5: Consensus Engine outcomes ─────────────────────────────────────
+CONSENSUS_UNANIMOUS = "UNANIMOUS"
+CONSENSUS_STRONG = "STRONG_CONSENSUS"
+CONSENSUS_CONDITIONAL = "CONDITIONAL_CONSENSUS"
+CONSENSUS_SPLIT = "SPLIT_DECISION"
+CONSENSUS_INSUFFICIENT_EVIDENCE = "INSUFFICIENT_EVIDENCE"
+CONSENSUS_SAFETY_DISSENT = "SAFETY_DISSENT"
+CONSENSUS_STATUSES = [
+    CONSENSUS_UNANIMOUS, CONSENSUS_STRONG, CONSENSUS_CONDITIONAL,
+    CONSENSUS_SPLIT, CONSENSUS_INSUFFICIENT_EVIDENCE, CONSENSUS_SAFETY_DISSENT,
+]
+
+# ── Section 8: Human decision authority ──────────────────────────────────────
+# LumenAI's actual RBAC has four roles (admin/spd_manager/operator/viewer).
+# Council layers the brief's five-tier authority scale on top of them: a
+# case's `required_approval_tier` is checked against the deciding user's
+# tenant role, mapped through ROLE_AUTHORITY_TIER below.
+APPROVER_TECHNICIAN = "technician"
+APPROVER_SUPERVISOR = "supervisor"
+APPROVER_SPD_MANAGER = "spd_manager"
+APPROVER_DIRECTOR = "director"
+APPROVER_CLINICAL_QUALITY_GOVERNANCE = "clinical_quality_governance"
+APPROVAL_TIER_BY_ROLE_NAME = {
+    APPROVER_TECHNICIAN: 0,
+    APPROVER_SUPERVISOR: 1,
+    APPROVER_SPD_MANAGER: 2,
+    APPROVER_DIRECTOR: 3,
+    APPROVER_CLINICAL_QUALITY_GOVERNANCE: 4,
+}
+# Tenant role (`current_user["role"]`) -> maximum authority tier it holds.
+# viewer/operator are technician-equivalent (view only, tier 0); spd_manager
+# covers supervisor+manager scope (tier 2); admin covers director +
+# clinical/quality governance (tier 4, the ceiling).
+ROLE_AUTHORITY_TIER = {"viewer": 0, "operator": 0, "spd_manager": 2, "admin": 4}
+
+# ── Section 14: Outcome Effectiveness classifications ────────────────────────
+OUTCOME_EFFECTIVE = "effective"
+OUTCOME_PARTIALLY_EFFECTIVE = "partially_effective"
+OUTCOME_INEFFECTIVE = "ineffective"
+OUTCOME_UNINTENDED_CONSEQUENCE = "unintended_consequence"
+OUTCOME_INSUFFICIENT_FOLLOW_UP = "insufficient_follow_up_data"
+OUTCOME_CLASSIFICATIONS = [
+    OUTCOME_EFFECTIVE, OUTCOME_PARTIALLY_EFFECTIVE, OUTCOME_INEFFECTIVE,
+    OUTCOME_UNINTENDED_CONSEQUENCE, OUTCOME_INSUFFICIENT_FOLLOW_UP,
+]
+
+COUNCIL_AGENT_VERSION = "1.0.0"
+
+DISCLAIMER = (
+    "Council convenes LumenAI's specialist agents as a structured leadership team to synthesize evidence, "
+    "surface agreement and disagreement, and evaluate tradeoffs. Council does not replace leadership -- "
+    "no recommendation may hide specialist disagreement, and every final decision requires human approval "
+    "at the appropriate authority level."
+)
+
+
+class CouncilTeamConfig(Base):
+    """A configurable AI leadership team (Sections 2, 15) -- append-only
+    versioned: updating a team's configuration inserts a new row with an
+    incremented `version` rather than mutating history, the same
+    append-only audit pattern used by Veritas's baseline governance
+    actions."""
+
+    __tablename__ = "council_team_configs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    team_key: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    team_name: Mapped[str] = mapped_column(String(200), default="", nullable=False)
+    required_specialists_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    optional_specialists_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    decision_scope: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    escalation_rules: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    quorum_requirement: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    safety_veto_enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    evidence_requirements: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    review_frequency: Mapped[str] = mapped_column(String(50), default="quarterly", nullable=False)
+
+    version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    approval_status: Mapped[str] = mapped_column(String(30), default="approved", nullable=False)
+    owner: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    is_current: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False, index=True)
+
+
+class CouncilCase(Base):
+    """The typed Council Case (Section 3) -- the durable record a
+    leadership team convenes around."""
+
+    __tablename__ = "council_cases"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    facility_id: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+
+    case_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    source_event: Mapped[str] = mapped_column(String(300), default="", nullable=False)
+    inspection_ids_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    instrument_ids_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    digital_twin_refs_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    evidence_package_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    risk_level: Mapped[str] = mapped_column(String(20), default="", nullable=False, index=True)
+    urgency: Mapped[str] = mapped_column(String(20), default="routine", nullable=False)
+    requested_decision: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    team_key: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    participating_specialists_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    consensus_status: Mapped[str] = mapped_column(String(30), default="", nullable=False, index=True)
+    recommended_action: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    required_human_approver: Mapped[str] = mapped_column(String(50), default=APPROVER_SUPERVISOR, nullable=False)
+    required_approval_tier: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+
+    status: Mapped[str] = mapped_column(String(30), default=CASE_STATUS_OPEN, nullable=False, index=True)
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    agent_version: Mapped[str] = mapped_column(String(20), default=COUNCIL_AGENT_VERSION, nullable=False)
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)
+
+
+class CouncilSpecialistAssessment(Base):
+    """One specialist's independent assessment of a Council Case (Section
+    4) -- immutable once submitted. If a specialist revises its
+    conclusion after seeing other assessments, the original row is never
+    edited; a new row is inserted with `is_revision=True` and
+    `supersedes_assessment_id` pointing back to it."""
+
+    __tablename__ = "council_specialist_assessments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    council_case_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    specialist_key: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+
+    conclusion: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    evidence_used_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    evidence_limitations: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    significance: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    recommended_action: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    alternative_explanation: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    urgency: Mapped[str] = mapped_column(String(20), default="routine", nullable=False)
+    human_role_required: Mapped[str] = mapped_column(String(50), default=APPROVER_SUPERVISOR, nullable=False)
+
+    is_revision: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    supersedes_assessment_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+
+
+class CouncilDissentRecord(Base):
+    """A dissent record (Section 6) -- always displayed prominently, never
+    hidden from the final report."""
+
+    __tablename__ = "council_dissent_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    council_case_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    dissenting_specialist: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    disputed_conclusion: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    evidence_supporting_dissent: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    risk_if_ignored: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    additional_evidence_required: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    proposed_alternative_action: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    escalation_level: Mapped[str] = mapped_column(String(20), default="standard", nullable=False)
+
+
+class CouncilDecisionOption(Base):
+    """One decision option with tradeoffs (Section 7). `financial_impact`
+    is left empty unless a real, supportable estimate exists -- Council
+    never fabricates a financial figure."""
+
+    __tablename__ = "council_decision_options"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    council_case_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    option_label: Mapped[str] = mapped_column(String(20), nullable=False)
+    option_title: Mapped[str] = mapped_column(String(300), nullable=False)
+    benefits: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    risks: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    clinical_risk: Mapped[str] = mapped_column(String(20), default="", nullable=False)
+    operational_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    financial_impact: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    evidence_strength: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    reversibility: Mapped[str] = mapped_column(String(20), default="reversible", nullable=False)
+    required_authority: Mapped[str] = mapped_column(String(50), default=APPROVER_SUPERVISOR, nullable=False)
+    expected_time_to_resolution: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+
+
+class CouncilHumanDecision(Base):
+    """The final human decision on a Council Case (Section 8) --
+    Council's own output is only ever a recommendation until this row
+    exists."""
+
+    __tablename__ = "council_human_decisions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    council_case_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    approver: Mapped[str] = mapped_column(String(255), nullable=False)
+    approver_role: Mapped[str] = mapped_column(String(50), nullable=False)
+    decision: Mapped[str] = mapped_column(Text, nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    conditions: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    decided_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False,
+    )
+
+
+class CouncilMeetingNotes(Base):
+    """Structured Council Meeting Mode record (Section 12).
+    `discussion_notes` is human-authored only -- Council never presents
+    AI-generated discussion as human meeting content, enforced by
+    requiring a non-empty `recorded_by` for any notes to be saved."""
+
+    __tablename__ = "council_meeting_notes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    council_case_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    agenda_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    discussion_notes: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    action_items_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    owner: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    review_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    recorded_by: Mapped[str] = mapped_column(String(255), nullable=False)
+
+
+class CouncilOutcomeReview(Base):
+    """Outcome Effectiveness Review (Section 14) -- links back to the
+    original Council Case and recommendation to close the learning
+    loop."""
+
+    __tablename__ = "council_outcome_reviews"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    council_case_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    issue_resolved: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    recurred: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    risk_decreased: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    operational_performance_improved: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    recommendation_followed: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    dissent_valid: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    additional_evidence_changed_decision: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    knowledge_update_recommended: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    classification: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    notes: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/backend/app/models/maestro_orchestration.py
+++ b/backend/app/models/maestro_orchestration.py
@@ -1,0 +1,252 @@
+"""LumenAI AI Specialist — Project Maestro: Operational Orchestration &
+Decision Intelligence.
+
+## Naming disambiguation (read this first)
+
+"Orchestrator"/"orchestration" is already used by two unrelated, existing
+systems: Phase 22's `app/agents/orchestrator.py` (`run_pipeline`, the
+hardcoded 10-step per-inspection agent pipeline) and Nova's
+`nova_orchestration_service.py` (`AgentTaskRun`, a configurable ordered
+pipeline of `agent_key`s for Nova's own task platform). Maestro is a
+**different, higher-level concept** -- an executive layer that reads the
+*outputs* of every specialist (including both of those) to rank operational
+priorities for SPD leadership. `maestro_orchestration_service.py` never
+touches or extends either existing orchestration system.
+
+## What Maestro composes rather than duplicates
+
+Maestro is a pure read-and-synthesize layer over already-built specialists:
+
+  * **Vision/Anatomy/Clinical Reasoning** — `app.agents.orchestrator.
+    run_pipeline(db, inspection, tenant_id)` (Phase 22), computed live,
+    never cached or re-derived.
+  * **Knowledge** — `knowledge_graph_service.learning_confidence`.
+  * **Digital Twin** — `instrument_condition_service.
+    instrument_condition_history` (condition_trend).
+  * **Veritas** — `veritas_evidence_agent_service.run_evidence_assessment`.
+  * **Aegis** — `vulcan_aegis_integration_service.
+    compute_process_variation_signal`.
+  * **Vulcan** — `vulcan_reliability_agent_service.
+    run_reliability_assessment`.
+  * **Sage** — `sage_knowledge_gap_service.list_gaps` /
+    `sage_learning_plan_service.list_plans`.
+  * **Sentinel-X** — `sentinelx_risk_agent_service.run_risk_assessment` /
+    `sentinelx_dashboard_service.risk_dashboard_summary` /
+    `sentinelx_supervisor_workspace_service.supervisor_workspace_summary`.
+  * **Pulse** — `pulse_command_center_service.pulse_command_center`.
+  * **Phoenix** — `phoenix_maturity_index_service.
+    compute_platform_maturity_index`.
+  * **Forge** — `forge_approval_service` (the generic ordered-role approval
+    chain, reused for executive-decision approval rather than a new gate)
+    and `capa_suggestion_service.generate_capa_suggestions`/
+    `create_capa_from_suggestion` for the "Generate CAPA draft"
+    recommendation.
+  * **Catalyst** — read-only reference; Maestro does not call Catalyst's
+    conversational query engine, it produces its own structured
+    recommendations.
+
+## What is genuinely new in this file
+
+Five tables: `MaestroPriorityItem` (Section 2), `MaestroRecommendation`
+(Sections 3, 5), `MaestroDailyBrief` (Section 4), `MaestroOperationalHealthSnapshot`
+(Section 7), `MaestroDecisionJournalEntry` (Section 8). The Strategy
+Timeline (Section 6) is a query over `MaestroRecommendation`, not a
+separate table.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Section 2: Priority Engine categories ────────────────────────────────────
+PRIORITY_HIGHEST_RISK_INSTRUMENT = "highest_risk_instrument"
+PRIORITY_HIGHEST_RISK_WORKFLOW = "highest_risk_workflow"
+PRIORITY_HIGHEST_RISK_FACILITY = "highest_risk_facility"
+PRIORITY_HIGHEST_RISK_TECHNICIAN_EDUCATION_NEED = "highest_risk_technician_education_need"
+PRIORITY_HIGHEST_RISK_EQUIPMENT = "highest_risk_equipment"
+PRIORITY_HIGHEST_PRIORITY_CAPA = "highest_priority_capa"
+PRIORITY_HIGHEST_PRIORITY_INSPECTION = "highest_priority_inspection"
+PRIORITY_HIGHEST_PRIORITY_REPAIR = "highest_priority_repair"
+PRIORITY_HIGHEST_PRIORITY_EXECUTIVE_ISSUE = "highest_priority_executive_issue"
+PRIORITY_CATEGORIES = [
+    PRIORITY_HIGHEST_RISK_INSTRUMENT, PRIORITY_HIGHEST_RISK_WORKFLOW, PRIORITY_HIGHEST_RISK_FACILITY,
+    PRIORITY_HIGHEST_RISK_TECHNICIAN_EDUCATION_NEED, PRIORITY_HIGHEST_RISK_EQUIPMENT,
+    PRIORITY_HIGHEST_PRIORITY_CAPA, PRIORITY_HIGHEST_PRIORITY_INSPECTION, PRIORITY_HIGHEST_PRIORITY_REPAIR,
+    PRIORITY_HIGHEST_PRIORITY_EXECUTIVE_ISSUE,
+]
+
+# ── Section 3 & 5: Recommendation types ──────────────────────────────────────
+RECOMMENDATION_MOVE_SUPERVISOR = "move_supervisor"
+RECOMMENDATION_SCHEDULE_COMPETENCY = "schedule_competency"
+RECOMMENDATION_REVIEW_CORROSION_TREND = "review_corrosion_trend"
+RECOMMENDATION_ESCALATE_REPAIR_BACKLOG = "escalate_repair_backlog"
+RECOMMENDATION_PUBLISH_BASELINE = "publish_baseline"
+RECOMMENDATION_GENERATE_CAPA_DRAFT = "generate_capa_draft"
+RECOMMENDATION_RESOURCE_ALLOCATION = "resource_allocation"
+RECOMMENDATION_STAFFING_CHANGES = "staffing_changes"
+RECOMMENDATION_INSPECTION_PRIORITIES = "inspection_priorities"
+RECOMMENDATION_EQUIPMENT_UTILIZATION = "equipment_utilization"
+RECOMMENDATION_EDUCATION_PRIORITIES = "education_priorities"
+RECOMMENDATION_QUALITY_INITIATIVES = "quality_initiatives"
+RECOMMENDATION_TYPES = [
+    RECOMMENDATION_MOVE_SUPERVISOR, RECOMMENDATION_SCHEDULE_COMPETENCY, RECOMMENDATION_REVIEW_CORROSION_TREND,
+    RECOMMENDATION_ESCALATE_REPAIR_BACKLOG, RECOMMENDATION_PUBLISH_BASELINE, RECOMMENDATION_GENERATE_CAPA_DRAFT,
+    RECOMMENDATION_RESOURCE_ALLOCATION, RECOMMENDATION_STAFFING_CHANGES, RECOMMENDATION_INSPECTION_PRIORITIES,
+    RECOMMENDATION_EQUIPMENT_UTILIZATION, RECOMMENDATION_EDUCATION_PRIORITIES, RECOMMENDATION_QUALITY_INITIATIVES,
+]
+
+# Section 6: Strategy Timeline tracking states.
+DECISION_STATUS_PENDING = "pending"
+DECISION_STATUS_COMPLETED = "completed"
+DECISION_STATUS_BLOCKED = "blocked"
+DECISION_STATUS_ESCALATED = "escalated"
+DECISION_STATUS_DISMISSED = "dismissed"
+DECISION_STATUSES = [
+    DECISION_STATUS_PENDING, DECISION_STATUS_COMPLETED, DECISION_STATUS_BLOCKED,
+    DECISION_STATUS_ESCALATED, DECISION_STATUS_DISMISSED,
+]
+
+# Section 6 timeline horizons.
+TIMELINE_TODAY = "today"
+TIMELINE_THIS_WEEK = "this_week"
+TIMELINE_THIS_MONTH = "this_month"
+TIMELINE_QUARTER = "quarter"
+TIMELINE_YEAR = "year"
+TIMELINE_HORIZONS = [TIMELINE_TODAY, TIMELINE_THIS_WEEK, TIMELINE_THIS_MONTH, TIMELINE_QUARTER, TIMELINE_YEAR]
+
+# ── Section 4: Daily Operational Brief types ─────────────────────────────────
+BRIEF_MORNING = "morning_brief"
+BRIEF_AFTERNOON = "afternoon_update"
+BRIEF_END_OF_DAY = "end_of_day_summary"
+BRIEF_WEEKEND_READINESS = "weekend_readiness"
+BRIEF_SHIFT_HANDOFF = "shift_handoff"
+BRIEF_TYPES = [BRIEF_MORNING, BRIEF_AFTERNOON, BRIEF_END_OF_DAY, BRIEF_WEEKEND_READINESS, BRIEF_SHIFT_HANDOFF]
+
+MAESTRO_AGENT_VERSION = "1.0.0"
+
+DISCLAIMER = (
+    "Maestro continuously coordinates all LumenAI specialists to recommend operational priorities for "
+    "SPD leaders. It never replaces human leadership -- every recommendation is explainable, "
+    "evidence-based, auditable, role-aware, and subject to human approval."
+)
+
+
+class MaestroPriorityItem(Base):
+    """One ranked priority (Section 2) -- a persisted snapshot each time the
+    Priority Engine runs, citing the real specialist output it was ranked
+    from."""
+
+    __tablename__ = "maestro_priority_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    category: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    subject: Mapped[str] = mapped_column(String(300), default="", nullable=False, index=True)
+    priority_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    rank: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    source_specialist: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+
+class MaestroRecommendation(Base):
+    """A leadership recommendation (Sections 3, 5) -- always advisory;
+    `status` starts `pending` and only a human decision (recorded via the
+    Decision Journal) moves it forward."""
+
+    __tablename__ = "maestro_recommendations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    priority_item_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    recommendation_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    subject: Mapped[str] = mapped_column(String(300), default="", nullable=False, index=True)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    specialists_consulted_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    timeline_horizon: Mapped[str] = mapped_column(String(20), default=TIMELINE_TODAY, nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(20), default=DECISION_STATUS_PENDING, nullable=False, index=True)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    agent_version: Mapped[str] = mapped_column(String(20), default=MAESTRO_AGENT_VERSION, nullable=False)
+
+
+class MaestroDailyBrief(Base):
+    """A generated operational brief (Section 4)."""
+
+    __tablename__ = "maestro_daily_briefs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    brief_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    content_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    narrative: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+
+class MaestroOperationalHealthSnapshot(Base):
+    """Operational Health Index (Section 7) -- composite across every named
+    dimension, each a real, already-computed signal."""
+
+    __tablename__ = "maestro_operational_health_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    quality_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    workflow_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    education_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    equipment_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    digital_twin_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    knowledge_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    enterprise_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    breakdown_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+
+class MaestroDecisionJournalEntry(Base):
+    """Decision Journal (Section 8) -- every recommendation's evidence,
+    consulted specialists, confidence, the leader's actual decision, the
+    outcome, and lessons learned. This is the leadership knowledge base."""
+
+    __tablename__ = "maestro_decision_journal_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    recommendation_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    specialists_consulted_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+
+    leader_decision: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    outcome: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    lessons_learned: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    decided_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    decided_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/models/sage_education.py
+++ b/backend/app/models/sage_education.py
@@ -1,0 +1,451 @@
+"""LumenAI AI Specialist — Project Sage: SPD Education, Competency &
+Workforce Intelligence.
+
+## Naming disambiguation (read this first)
+
+Sage composes existing, real workforce/education signal rather than
+inventing a parallel competency store:
+
+  * **Competency events (Section 2, 9)** — `CompetencyEvent`
+    (`app/models/competency_event.py`) already logs
+    finding_reviewed/supervisor_correction/repeated_error/
+    education_completed/annual_competency/procedure_validation/
+    simulation_passed/simulation_failed/knowledge_contribution per
+    technician. Sage reads this log (via `competency_service.py`) rather
+    than re-deriving a second competency ledger.
+  * **Supervisor ground truth (Sections 3, 9)** — `SupervisorReview`
+    (`app/models/supervisor_review.py`) already carries `agreement`,
+    `finding_correct`, `zone_correct`, `instrument_family_correct`,
+    `ground_truth` -- the real evidence Sage's gap-detection reads.
+  * **Coverage / AI confidence (Section 9)** — `Inspection.coverage_pct`
+    and `Inspection.ai_confidence` are real, already-persisted per-
+    inspection fields Sage's before/after effectiveness comparison reads
+    directly.
+  * **Educational content (Sections 1, 6)** — `clinical_mentor.py`'s
+    `FINDING_EDUCATION`/`STANDARDS_GUIDANCE` and `education_library.py`'s
+    articles are the platform's one approved-content source; Sage's
+    microlearning generator composes them (plus `InstrumentKnowledge` for
+    anatomy) rather than authoring new unsupported clinical guidance.
+  * **Institutional knowledge (Section 15)** — Athena's own composition
+    services (`athena_memory_service.py`, `KnowledgeArticle`/
+    `ClinicalCase` in `app/models/knowledge.py`, `WorkflowDefinition`
+    playbooks in `workflow_forge.py`) are called through, never re-
+    queried from their underlying tables directly.
+  * **Competency/CAPA/audit records (Section 15)** — Apollo's
+    `QualityTwinSnapshot` (`competency_score`/`education_score`) and CAPA/
+    RCA services are read for evidence; Sage never duplicates them.
+  * **Image library (Section 8)** — `RetainedImage`/`ImageLabel`
+    (`app/models/retained_image.py`) is the real, already-governed
+    (EXIF-stripped, consent-gated, gold-labeled) image store. Rather than
+    duplicate image bytes or ML-training label lifecycle, `SageEducationImageEntry`
+    (below) is a thin curation layer that references an existing
+    `RetainedImage`/`ImageLabel` pair by ID and adds only the
+    education-specific fields those tables don't carry (anatomy zone,
+    dataset version, usage rights, PHI review status for education use).
+  * **Aegis / Vulcan (Sections 13, 14)** — `vulcan_aegis_integration_service.
+    compute_process_variation_signal` and `vulcan_reliability_agent_service.
+    run_reliability_assessment` are called directly; their conclusions are
+    referenced by ID/JSON snapshot in `SageKnowledgeGap.evidence_json`,
+    never copied into a duplicate store, and never overwritten by Sage's
+    own recommendation.
+
+## What is genuinely new in this file
+
+Seven tables: `SageKnowledgeGap`, `SageLearningPlan`,
+`SageMicrolearningModule`, `SageAssessment`, `SageEducationImageEntry`,
+`SageEffectivenessAssessment`, `SageFeedback`. Nothing else in this
+codebase tracks adaptive learning plans, microlearning modules,
+configurable competency assessments, or education-specific effectiveness
+comparisons.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Section 2: Competency Taxonomy ───────────────────────────────────────────
+COMPETENCY_MANUFACTURER_RECOGNITION = "manufacturer_recognition"
+COMPETENCY_INSTRUMENT_FAMILY_RECOGNITION = "instrument_family_recognition"
+COMPETENCY_MODEL_RECOGNITION = "model_recognition"
+COMPETENCY_INSTRUMENT_DIFFERENTIATION = "instrument_differentiation"
+COMPETENCY_RIGID_VS_FLEXIBLE_SCOPE = "rigid_scope_vs_flexible_endoscope"
+COMPETENCY_POWERED_VS_MANUAL = "powered_vs_manual_instrument"
+
+COMPETENCY_SERRATIONS = "serrations"
+COMPETENCY_GROOVES = "grooves"
+COMPETENCY_BOX_LOCKS = "box_locks"
+COMPETENCY_HINGES = "hinges"
+COMPETENCY_RATCHETS = "ratchets"
+COMPETENCY_DRILL_BIT_FLUTES = "drill_bit_flutes"
+COMPETENCY_THREADED_REGIONS = "threaded_regions"
+COMPETENCY_LUMENS = "lumens"
+COMPETENCY_CANNULATED_CHANNELS = "cannulated_channels"
+COMPETENCY_O_RING_AREAS = "o_ring_areas"
+COMPETENCY_SCOPE_PORTS = "scope_ports"
+COMPETENCY_INSULATION_EDGES = "insulation_edges"
+COMPETENCY_HANDLE_SEAMS = "handle_seams"
+
+COMPETENCY_VISUAL_INSPECTION = "visual_inspection"
+COMPETENCY_MAGNIFICATION = "magnification"
+COMPETENCY_BORESCOPE_INSPECTION = "borescope_inspection"
+COMPETENCY_ARTICULATION_ACTUATION = "articulation_and_actuation"
+COMPETENCY_IMAGE_CAPTURE = "image_capture"
+COMPETENCY_LIGHTING = "lighting"
+COMPETENCY_FOCUS = "focus"
+COMPETENCY_ANGLE_SELECTION = "angle_selection"
+COMPETENCY_INSPECTION_COVERAGE = "inspection_coverage"
+
+COMPETENCY_BLOOD = "blood"
+COMPETENCY_BONE = "bone"
+COMPETENCY_TISSUE = "tissue"
+COMPETENCY_ORGANIC_RESIDUE = "organic_residue"
+COMPETENCY_DEBRIS = "debris"
+
+COMPETENCY_RUST = "rust"
+COMPETENCY_CORROSION = "corrosion"
+COMPETENCY_DISCOLORATION = "discoloration"
+COMPETENCY_PITTING = "pitting"
+COMPETENCY_CRACK = "crack"
+COMPETENCY_WEAR = "wear"
+COMPETENCY_MISSING_COMPONENTS = "missing_components"
+COMPETENCY_INSULATION_DAMAGE = "insulation_damage"
+
+COMPETENCY_RECLEAN = "reclean"
+COMPETENCY_REPEAT_INSPECTION = "repeat_inspection"
+COMPETENCY_SUPERVISOR_REVIEW_DECISION = "supervisor_review_decision"
+COMPETENCY_REPAIR_EVALUATION_DECISION = "repair_evaluation_decision"
+COMPETENCY_MANUFACTURER_EVALUATION_DECISION = "manufacturer_evaluation_decision"
+COMPETENCY_REMOVE_FROM_SERVICE_DECISION = "remove_from_service_decision"
+
+COMPETENCY_INSPECTION_EVIDENCE_DOC = "inspection_evidence_documentation"
+COMPETENCY_SUPERVISOR_NOTES_DOC = "supervisor_notes_documentation"
+COMPETENCY_BASELINE_SELECTION_DOC = "baseline_selection_documentation"
+COMPETENCY_ANATOMY_ZONE_LABELING_DOC = "anatomy_zone_labeling_documentation"
+COMPETENCY_FINAL_DISPOSITION_DOC = "final_disposition_documentation"
+
+COMPETENCY_DOMAIN_INSTRUMENT_ID = "instrument_identification"
+COMPETENCY_DOMAIN_ANATOMY = "anatomy_recognition"
+COMPETENCY_DOMAIN_TECHNIQUE = "inspection_technique"
+COMPETENCY_DOMAIN_CONTAMINATION = "contamination_recognition"
+COMPETENCY_DOMAIN_CONDITION = "condition_recognition"
+COMPETENCY_DOMAIN_CLINICAL_DECISION = "clinical_decision_support"
+COMPETENCY_DOMAIN_DOCUMENTATION = "documentation"
+
+COMPETENCY_TAXONOMY: dict[str, list[str]] = {
+    COMPETENCY_DOMAIN_INSTRUMENT_ID: [
+        COMPETENCY_MANUFACTURER_RECOGNITION, COMPETENCY_INSTRUMENT_FAMILY_RECOGNITION,
+        COMPETENCY_MODEL_RECOGNITION, COMPETENCY_INSTRUMENT_DIFFERENTIATION,
+        COMPETENCY_RIGID_VS_FLEXIBLE_SCOPE, COMPETENCY_POWERED_VS_MANUAL,
+    ],
+    COMPETENCY_DOMAIN_ANATOMY: [
+        COMPETENCY_SERRATIONS, COMPETENCY_GROOVES, COMPETENCY_BOX_LOCKS, COMPETENCY_HINGES,
+        COMPETENCY_RATCHETS, COMPETENCY_DRILL_BIT_FLUTES, COMPETENCY_THREADED_REGIONS,
+        COMPETENCY_LUMENS, COMPETENCY_CANNULATED_CHANNELS, COMPETENCY_O_RING_AREAS,
+        COMPETENCY_SCOPE_PORTS, COMPETENCY_INSULATION_EDGES, COMPETENCY_HANDLE_SEAMS,
+    ],
+    COMPETENCY_DOMAIN_TECHNIQUE: [
+        COMPETENCY_VISUAL_INSPECTION, COMPETENCY_MAGNIFICATION, COMPETENCY_BORESCOPE_INSPECTION,
+        COMPETENCY_ARTICULATION_ACTUATION, COMPETENCY_IMAGE_CAPTURE, COMPETENCY_LIGHTING,
+        COMPETENCY_FOCUS, COMPETENCY_ANGLE_SELECTION, COMPETENCY_INSPECTION_COVERAGE,
+    ],
+    COMPETENCY_DOMAIN_CONTAMINATION: [
+        COMPETENCY_BLOOD, COMPETENCY_BONE, COMPETENCY_TISSUE, COMPETENCY_ORGANIC_RESIDUE, COMPETENCY_DEBRIS,
+    ],
+    COMPETENCY_DOMAIN_CONDITION: [
+        COMPETENCY_RUST, COMPETENCY_CORROSION, COMPETENCY_DISCOLORATION, COMPETENCY_PITTING,
+        COMPETENCY_CRACK, COMPETENCY_WEAR, COMPETENCY_MISSING_COMPONENTS, COMPETENCY_INSULATION_DAMAGE,
+    ],
+    COMPETENCY_DOMAIN_CLINICAL_DECISION: [
+        COMPETENCY_RECLEAN, COMPETENCY_REPEAT_INSPECTION, COMPETENCY_SUPERVISOR_REVIEW_DECISION,
+        COMPETENCY_REPAIR_EVALUATION_DECISION, COMPETENCY_MANUFACTURER_EVALUATION_DECISION,
+        COMPETENCY_REMOVE_FROM_SERVICE_DECISION,
+    ],
+    COMPETENCY_DOMAIN_DOCUMENTATION: [
+        COMPETENCY_INSPECTION_EVIDENCE_DOC, COMPETENCY_SUPERVISOR_NOTES_DOC,
+        COMPETENCY_BASELINE_SELECTION_DOC, COMPETENCY_ANATOMY_ZONE_LABELING_DOC,
+        COMPETENCY_FINAL_DISPOSITION_DOC,
+    ],
+}
+
+# ── Section 3/4: Gap scope + Section 18 aggregation scopes ───────────────────
+SCOPE_INDIVIDUAL = "individual"
+SCOPE_SHIFT = "shift"
+SCOPE_DEPARTMENT = "department"
+SCOPE_FACILITY = "facility"
+SCOPE_INSTRUMENT_FAMILY = "instrument_family"
+SCOPE_ANATOMY_ZONE = "anatomy_zone"
+SCOPE_FINDING_CATEGORY = "finding_category"
+SCOPE_SERVICE_LINE = "service_line"
+GAP_SCOPES = [
+    SCOPE_INDIVIDUAL, SCOPE_SHIFT, SCOPE_DEPARTMENT, SCOPE_FACILITY, SCOPE_INSTRUMENT_FAMILY,
+    SCOPE_ANATOMY_ZONE, SCOPE_FINDING_CATEGORY, SCOPE_SERVICE_LINE,
+]
+
+# ── Section 5: Learning plan completion status ───────────────────────────────
+PLAN_STATUS_ASSIGNED = "assigned"
+PLAN_STATUS_IN_PROGRESS = "in_progress"
+PLAN_STATUS_COMPLETED = "completed"
+PLAN_STATUS_OVERDUE = "overdue"
+PLAN_STATUS_CANCELLED = "cancelled"
+PLAN_STATUSES = [
+    PLAN_STATUS_ASSIGNED, PLAN_STATUS_IN_PROGRESS, PLAN_STATUS_COMPLETED,
+    PLAN_STATUS_OVERDUE, PLAN_STATUS_CANCELLED,
+]
+
+# ── Section 7: Assessment formats ────────────────────────────────────────────
+ASSESSMENT_KNOWLEDGE_QUESTIONS = "knowledge_questions"
+ASSESSMENT_IMAGE_CLASSIFICATION = "image_classification"
+ASSESSMENT_ANATOMY_ZONE_IDENTIFICATION = "anatomy_zone_identification"
+ASSESSMENT_CASE_REVIEW = "case_review"
+ASSESSMENT_WORKFLOW_SIMULATION = "workflow_simulation"
+ASSESSMENT_SUPERVISED_RETURN_DEMONSTRATION = "supervised_return_demonstration"
+ASSESSMENT_SUPERVISOR_OBSERVATION = "supervisor_observation"
+ASSESSMENT_PRACTICAL_CHECKLIST = "practical_checklist"
+ASSESSMENT_FORMATS = [
+    ASSESSMENT_KNOWLEDGE_QUESTIONS, ASSESSMENT_IMAGE_CLASSIFICATION,
+    ASSESSMENT_ANATOMY_ZONE_IDENTIFICATION, ASSESSMENT_CASE_REVIEW, ASSESSMENT_WORKFLOW_SIMULATION,
+    ASSESSMENT_SUPERVISED_RETURN_DEMONSTRATION, ASSESSMENT_SUPERVISOR_OBSERVATION,
+    ASSESSMENT_PRACTICAL_CHECKLIST,
+]
+
+# ── Section 9: Learning effectiveness classification ────────────────────────
+EFFECTIVENESS_IMPROVED = "improved"
+EFFECTIVENESS_PARTIALLY_IMPROVED = "partially_improved"
+EFFECTIVENESS_UNCHANGED = "unchanged"
+EFFECTIVENESS_DECLINED = "declined"
+EFFECTIVENESS_INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+EFFECTIVENESS_CLASSIFICATIONS = [
+    EFFECTIVENESS_IMPROVED, EFFECTIVENESS_PARTIALLY_IMPROVED, EFFECTIVENESS_UNCHANGED,
+    EFFECTIVENESS_DECLINED, EFFECTIVENESS_INSUFFICIENT_EVIDENCE,
+]
+
+SAGE_AGENT_VERSION = "1.0.0"
+
+DISCLAIMER = (
+    "Sage supports technicians, supervisors, educators, and SPD leaders with evidence-based, "
+    "confidence-scored education and competency recommendations. Sage does not discipline "
+    "employees, independently determine competency, or replace supervisor and educator judgment. "
+    "Language such as 'targeted education may be beneficial' or 'competency verification is "
+    "recommended' reflects a possible pattern only -- never a conclusion that an individual is "
+    "incompetent. Every recommendation requires human (educator/supervisor) approval before "
+    "assignment or any workforce action."
+)
+
+
+class SageKnowledgeGap(Base):
+    """A possible competency gap detected from validated patterns (Sections
+    1, 3). Never a conclusion of incompetence -- `narrative` always uses
+    non-punitive language, and `human_review_required` is always True."""
+
+    __tablename__ = "sage_knowledge_gaps"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    competency_domain: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    scope_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    scope_value: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    finding_category: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+
+    occurrence_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    narrative: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    recommended_education: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    status: Mapped[str] = mapped_column(String(20), default="open", nullable=False, index=True)
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    agent_version: Mapped[str] = mapped_column(String(20), default=SAGE_AGENT_VERSION, nullable=False)
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)
+
+
+class SageLearningPlan(Base):
+    """An adaptive learning plan (Section 5) -- requires approval by an
+    authorized educator, supervisor, or manager before assignment. Vulcan/
+    Sage terminology mirrors `recommended_disposition`/`final_disposition`:
+    Sage's own recommendation never becomes an assigned plan without a
+    human `approved_by`."""
+
+    __tablename__ = "sage_learning_plans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    knowledge_gap_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    learner_or_group: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    scope_type: Mapped[str] = mapped_column(String(30), default=SCOPE_INDIVIDUAL, nullable=False, index=True)
+
+    identified_need: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    supporting_evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    learning_objective: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    finding_category: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+
+    education_content: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    microlearning_module_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    practice_activity: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    return_demonstration_required: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    return_demonstration_validated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    evaluator: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    due_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completion_status: Mapped[str] = mapped_column(String(20), default=PLAN_STATUS_ASSIGNED, nullable=False, index=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    effectiveness_assessment_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    approved_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    override_reason: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    created_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    agent_version: Mapped[str] = mapped_column(String(20), default=SAGE_AGENT_VERSION, nullable=False)
+
+
+class SageMicrolearningModule(Base):
+    """A short educational module (Section 6), composed only from approved
+    Knowledge Graph / IFU / policy / institutional sources -- never
+    unsupported clinical guidance."""
+
+    __tablename__ = "sage_microlearning_modules"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    title: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    learning_objective: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    why_it_matters: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    anatomy_overview: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    common_findings_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    inspection_steps_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    corrective_actions_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    knowledge_check_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    source_refs_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    competency_domain: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+
+    approval_status: Mapped[str] = mapped_column(String(20), default="draft", nullable=False, index=True)
+    approved_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    version: Mapped[str] = mapped_column(String(20), default="1.0.0", nullable=False)
+
+
+class SageAssessment(Base):
+    """A configurable competency assessment (Section 7). Results remain
+    advisory until validated by an authorized evaluator."""
+
+    __tablename__ = "sage_assessments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    learning_plan_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    assessment_format: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    target_learner: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    competency_domain: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+
+    content_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    result_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    result_status: Mapped[str] = mapped_column(String(20), default="advisory", nullable=False, index=True)
+
+    validated_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    validated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class SageEducationImageEntry(Base):
+    """Education-curation metadata for one existing `RetainedImage`/
+    `ImageLabel` pair (Section 8) -- references by ID, never duplicates
+    the image bytes or the ML-training label lifecycle those tables own."""
+
+    __tablename__ = "sage_education_image_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    retained_image_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    image_label_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    finding_category: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    severity: Mapped[str] = mapped_column(String(30), default="", nullable=False)
+
+    supervisor_validated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    usage_rights: Mapped[str] = mapped_column(String(100), default="internal_education_use", nullable=False)
+    dataset_version: Mapped[str] = mapped_column(String(20), default="1.0.0", nullable=False)
+    phi_review_status: Mapped[str] = mapped_column(String(20), default="pending", nullable=False, index=True)
+
+
+class SageEffectivenessAssessment(Base):
+    """Learning Effectiveness Engine result (Section 9) -- compares real
+    before/after metrics (coverage, supervisor correction rate, image
+    quality, finding/anatomy accuracy, workflow compliance). Never claims
+    causation without adequate evidence."""
+
+    __tablename__ = "sage_effectiveness_assessments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    learning_plan_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    learner_or_group: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+
+    before_metrics_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    after_metrics_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    effectiveness: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    narrative: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+
+class SageFeedback(Base):
+    """Educator/supervisor action on a Sage recommendation or learning plan
+    (Section 12) -- approve/reject/edit/assign/observe/validate/close/
+    review/comment. `override_reason` is required when overriding a
+    high-confidence recommendation (enforced at the service layer)."""
+
+    __tablename__ = "sage_feedback"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    learning_plan_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    knowledge_gap_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    action: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    comment: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    override_reason: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    submitted_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    submitted_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/models/sentinelx_risk.py
+++ b/backend/app/models/sentinelx_risk.py
@@ -1,0 +1,246 @@
+"""LumenAI AI Specialist — Project Sentinel-X: Clinical Risk Intelligence &
+Patient Safety Agent.
+
+## Naming disambiguation (read this first)
+
+**"Sentinel" already exists as a major, unrelated system in this codebase**
+-- "Project Sentinel" v3.0 ("Autonomous Clinical Intelligence Orchestration"):
+`app/models/sentinel_orchestration.py` (`SentinelRiskSignal`,
+`ClinicalWatchlistEntry`, `DigitalTwinFlag`, `SentinelAlert`,
+`SentinelRecommendation`, `SentinelHealthSnapshot`), routes at
+`/api/sentinel`, frontend route `/sentinel`, and nine `sentinel_*.py`
+services. Project Sentinel-X (this file) is a **different, newer sprint**
+and deliberately uses a distinct `sentinelx_` file/model/route prefix
+(`/api/sentinelx`) everywhere to avoid any collision or confusion with that
+established system -- it never touches or duplicates `sentinel_
+orchestration.py`'s tables. The brief's own frontend route (`/risk`) is
+used as-is since it does not collide with `/sentinel`.
+
+## What Sentinel-X composes rather than duplicates
+
+  * **Instrument reliability** — `vulcan_reliability_agent_service.
+    run_reliability_assessment` / `VulcanReliabilityAssessment`
+    (`reliability_score`, `progression`, `recurrence_count`,
+    `failure_category`, `anatomy_zone`).
+  * **Process variation** — `vulcan_aegis_integration_service.
+    compute_process_variation_signal`.
+  * **Evidence readiness** — `veritas_evidence_agent_service.
+    run_evidence_assessment` / `VeritasEvidenceReadinessAssessment`
+    (`readiness_score`, `readiness_category`, `coverage_status`,
+    `image_quality_status`).
+  * **Education/competency gaps** — `sage_gap_detection_service`/
+    `sage_knowledge_gap_service` (repeated corrections/errors as a
+    workflow-risk signal).
+  * **Digital Twin condition** — the real per-instrument condition trend
+    lives in `instrument_condition_service.instrument_condition_history`
+    (`condition_trend`: improving/stable/declining/insufficient_data) --
+    *not* `digital_twin_engine.py`, which tracks SPD workflow/throughput
+    twins, a different concept. Sentinel-X reads `condition_trend` directly
+    rather than re-deriving instrument condition.
+  * **Knowledge confidence** — `knowledge_graph_service.learning_confidence`
+    (`knowledge_confidence`/`clinical_recommendation_confidence`, derived
+    live from `SupervisorReview`).
+  * **Per-finding data** — `InspectionFinding` (finding_type, zone,
+    severity_index), the same shared log Vulcan/Sage/Veritas already read.
+
+## What is genuinely new in this file
+
+Three tables: `SentinelXRiskAssessment` (the composite risk assessment),
+`SentinelXPatientSafetyAlert` (proactive alerts, Section 5 -- distinct from
+the existing `SentinelAlert` table), `SentinelXSupervisorOverride` (Section
+10/13 auditable supervisor overrides).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Section 2: Risk Taxonomy ─────────────────────────────────────────────────
+RISK_CATEGORY_PATIENT_SAFETY = "patient_safety"
+RISK_CATEGORY_CLINICAL_QUALITY = "clinical_quality"
+RISK_CATEGORY_INSPECTION_QUALITY = "inspection_quality"
+RISK_CATEGORY_INSTRUMENT_INTEGRITY = "instrument_integrity"
+RISK_CATEGORY_WORKFLOW = "workflow"
+RISK_CATEGORY_OPERATIONAL = "operational"
+RISK_CATEGORY_EDUCATION = "education"
+RISK_CATEGORY_COMPLIANCE = "compliance"
+RISK_CATEGORY_ENTERPRISE = "enterprise"
+RISK_CATEGORIES = [
+    RISK_CATEGORY_PATIENT_SAFETY, RISK_CATEGORY_CLINICAL_QUALITY, RISK_CATEGORY_INSPECTION_QUALITY,
+    RISK_CATEGORY_INSTRUMENT_INTEGRITY, RISK_CATEGORY_WORKFLOW, RISK_CATEGORY_OPERATIONAL,
+    RISK_CATEGORY_EDUCATION, RISK_CATEGORY_COMPLIANCE, RISK_CATEGORY_ENTERPRISE,
+]
+
+# ── Section 3: SPD Risk Matrix (per-finding-type weight tiers) ───────────────
+RISK_WEIGHT_HIGHEST = "highest"
+RISK_WEIGHT_MEDIUM = "medium"
+RISK_WEIGHT_LOW = "low"
+
+# Real finding_type strings (this codebase's actual CV/taxonomy vocabulary --
+# see baseline_comparison_scoring_service.KPI_LABELS and
+# vulcan_reliability.FAILURE_TAXONOMY) mapped onto the brief's three tiers.
+SPD_RISK_MATRIX: dict[str, str] = {
+    "blood": RISK_WEIGHT_HIGHEST,
+    "bone": RISK_WEIGHT_HIGHEST,
+    "tissue": RISK_WEIGHT_HIGHEST,
+    "other_organic_residue": RISK_WEIGHT_HIGHEST,
+    "debris": RISK_WEIGHT_HIGHEST,
+    "corrosion": RISK_WEIGHT_HIGHEST,
+    "rust": RISK_WEIGHT_HIGHEST,
+    "crack": RISK_WEIGHT_HIGHEST,
+    "insulation_damage": RISK_WEIGHT_HIGHEST,
+    "insulation_breach": RISK_WEIGHT_HIGHEST,
+    "missing_component": RISK_WEIGHT_HIGHEST,
+    "damaged_o_ring": RISK_WEIGHT_HIGHEST,
+    "obstruction": RISK_WEIGHT_HIGHEST,
+    "wear": RISK_WEIGHT_MEDIUM,
+    "worn_cutting_edge": RISK_WEIGHT_MEDIUM,
+    "pitting": RISK_WEIGHT_MEDIUM,
+    "loose_joint": RISK_WEIGHT_MEDIUM,
+    "damaged_hinge": RISK_WEIGHT_MEDIUM,
+    "damaged_ratchet": RISK_WEIGHT_MEDIUM,
+    "discoloration": RISK_WEIGHT_LOW,
+    "staining": RISK_WEIGHT_LOW,
+    "surface_degradation": RISK_WEIGHT_LOW,
+}
+
+_RISK_WEIGHT_VALUE = {RISK_WEIGHT_HIGHEST: 3, RISK_WEIGHT_MEDIUM: 2, RISK_WEIGHT_LOW: 1}
+
+
+def spd_risk_weight(finding_type: str) -> str:
+    """Configurable SPD-specific weighting for one finding_type -- unknown
+    types default to 'medium' rather than silently 'low', since an
+    unrecognized finding should never be under-weighted."""
+    return SPD_RISK_MATRIX.get((finding_type or "").strip().lower(), RISK_WEIGHT_MEDIUM)
+
+
+def spd_risk_weight_value(finding_type: str) -> int:
+    return _RISK_WEIGHT_VALUE[spd_risk_weight(finding_type)]
+
+
+# ── Section 4: Dynamic Risk Scoring bands ────────────────────────────────────
+# Higher score = higher risk (the inverse convention of Vulcan's reliability
+# score / Veritas's readiness score, both of which score "higher is better").
+RISK_LEVEL_VERY_LOW = "very_low"
+RISK_LEVEL_LOW = "low"
+RISK_LEVEL_MODERATE = "moderate"
+RISK_LEVEL_HIGH = "high"
+RISK_LEVEL_CRITICAL = "critical"
+RISK_LEVELS = [RISK_LEVEL_VERY_LOW, RISK_LEVEL_LOW, RISK_LEVEL_MODERATE, RISK_LEVEL_HIGH, RISK_LEVEL_CRITICAL]
+
+
+def risk_level(score: float) -> str:
+    if score >= 80:
+        return RISK_LEVEL_CRITICAL
+    if score >= 60:
+        return RISK_LEVEL_HIGH
+    if score >= 40:
+        return RISK_LEVEL_MODERATE
+    if score >= 20:
+        return RISK_LEVEL_LOW
+    return RISK_LEVEL_VERY_LOW
+
+
+SENTINELX_AGENT_VERSION = "1.0.0"
+
+DISCLAIMER = (
+    "Sentinel-X continuously evaluates clinical, operational, and inspection risk before an "
+    "instrument proceeds through the pre-sterilization workflow. It does not replace human "
+    "clinical judgment -- it prioritizes risk and explains why. Every assessment is "
+    "explainable, evidence-based, confidence-scored, auditable, and subject to human review."
+)
+
+
+class SentinelXRiskAssessment(Base):
+    """The composite clinical risk assessment (Sections 1, 2, 4) -- composes
+    Veritas/Aegis/Vulcan/Sage/Knowledge-Graph/Digital-Twin signal into one
+    explainable risk score. Never a replacement for supervisor review
+    (`human_review_required` is always True)."""
+
+    __tablename__ = "sentinelx_risk_assessments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    instrument_identity: Mapped[str] = mapped_column(String(300), default="", nullable=False, index=True)
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    manufacturer_name: Mapped[str] = mapped_column(String(255), default="", nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    facility_name: Mapped[str] = mapped_column(String(255), default="", nullable=False, index=True)
+    department: Mapped[str] = mapped_column(String(255), default="", nullable=False, index=True)
+    service_line: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+
+    risk_categories_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    risk_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    risk_level: Mapped[str] = mapped_column(String(20), default=RISK_LEVEL_MODERATE, nullable=False, index=True)
+    score_breakdown_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    contamination_severity: Mapped[str] = mapped_column(String(20), default="", nullable=False)
+    finding_type: Mapped[str] = mapped_column(String(50), default="", nullable=False, index=True)
+    recurrence_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    digital_twin_condition_trend: Mapped[str] = mapped_column(String(30), default="insufficient_data", nullable=False)
+
+    vulcan_assessment_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    veritas_assessment_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    reasoning_narrative: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    agent_version: Mapped[str] = mapped_column(String(20), default=SENTINELX_AGENT_VERSION, nullable=False)
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)
+
+
+class SentinelXPatientSafetyAlert(Base):
+    """Proactive patient-safety alert (Section 5) -- distinct from the
+    pre-existing `SentinelAlert` (Project Sentinel v3.0). Fires from a real,
+    repeated pattern (recurrence_count/escalation), never a single event."""
+
+    __tablename__ = "sentinelx_patient_safety_alerts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    alert_type: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    instrument_identity: Mapped[str] = mapped_column(String(300), default="", nullable=False, index=True)
+    severity: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    narrative: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    acknowledged: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    acknowledged_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    acknowledged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class SentinelXSupervisorOverride(Base):
+    """An auditable supervisor action on a Sentinel-X risk assessment
+    (Sections 10, 13) -- Sentinel-X's own risk level is always advisory;
+    this is the only place a human-authorized override is recorded."""
+
+    __tablename__ = "sentinelx_supervisor_overrides"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    assessment_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    original_risk_level: Mapped[str] = mapped_column(String(20), default="", nullable=False)
+    overridden_risk_level: Mapped[str] = mapped_column(String(20), default="", nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False)
+
+    submitted_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    submitted_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/models/veritas_evidence.py
+++ b/backend/app/models/veritas_evidence.py
@@ -1,0 +1,493 @@
+"""LumenAI AI Specialist — Project Veritas: Baseline Governance, Evidence
+Integrity & Clinical Data Quality.
+
+## Naming disambiguation (read this first)
+
+Veritas composes real, already-built baseline/coverage/image/provenance
+infrastructure rather than inventing a parallel evidence store:
+
+  * **Baseline resolution (Section 2)** — `baseline_comparison_scoring_
+    service.resolve_baseline(db, instrument_type, tenant_id)` already
+    implements manufacturer -> vendor -> hospital priority across both real
+    baseline sources (`BaselineLibraryEntry` in `app/models/baseline_
+    library.py`, network baselines; `EnterpriseVendorBaselineSubscription`
+    in `app/models/enterprise_quality.py`, the table the actual upload/
+    approval UI writes to). Veritas's own hierarchy names five tiers
+    (manufacturer / manufacturer-authorized / vendor / organization /
+    instrument-specific historical); this codebase's real baseline sources
+    only distinguish manufacturer / vendor / hospital(organization) --
+    "manufacturer-authorized" and "instrument-specific historical" are
+    honestly folded into the nearest real tier rather than fabricated as
+    separately tracked. `veritas_baseline_resolution_service.py` calls
+    `resolve_baseline` directly and enriches the result; it never
+    re-implements resolution.
+  * **Baseline governance status (Section 3)** — three real, divergent
+    vocabularies already exist (`BaselineLibraryEntry.approval_status`:
+    pending/approved/deprecated; `EnterpriseVendorBaselineSubscription`:
+    baseline_status/approval_status with its own `_APPROVED_VALUES` set;
+    `Inspection.baseline_status`: not_checked/approved_baseline_found/
+    pending_baseline_review/no_approved_baseline/baseline_not_available/
+    approved). None of the three matches this brief's seven-status
+    vocabulary. Rather than rewrite any of those tables (each belongs to
+    an established feature), `VeritasBaselineGovernanceAction` is a new,
+    append-only governance-action log keyed to (source_type, source_id) of
+    whichever real baseline was resolved -- Veritas's canonical seven-
+    status vocabulary is the *effective* status computed from the latest
+    action in this log, never a mutation of the source tables.
+  * **Coverage (Section 6)** — `inspection_coverage.compute_coverage`
+    already returns required/inspected/missing zones and a quality band
+    (not_assessed/complete/acceptable/incomplete/insufficient) that maps
+    almost 1:1 onto this brief's coverage statuses. Reused directly.
+  * **Image quality (Section 5)** — confirmed via repo-wide search: no
+    real CV-based focus/blur/lighting/glare/exposure/obstruction/framing/
+    magnification/orientation/duplication/compression-artifact detector
+    exists anywhere in this codebase. Rather than fabricate these metrics,
+    `veritas_image_quality_service.py` reports per-signal availability
+    honestly (`"available": false"` for anything not actually measured,
+    the same discipline as Nova's observability summary) and derives
+    `quality_status` only from real proxy signals (image presence,
+    historical `image_view_correct` supervisor corrections).
+  * **Evidence provenance (Section 7)** — `guardianx_assurance.
+    EvidenceLedgerEntry` is a *different* concept (what evidence backed an
+    AI-assurance conclusion: knowledge/model/workflow versions + digital
+    signature) -- not per-inspection-image provenance. The real per-image
+    store is `RetainedImage`/`ImageLabel` (`app/models/retained_image.py`).
+    `VeritasEvidenceProvenanceRecord` (below) references those by ID
+    (never duplicating bytes/labels) and adds the file-hash/storage-
+    location/modification-history/usage-scope fields neither existing
+    table carries -- the same reference-by-ID pattern Sage's
+    `SageEducationImageEntry` already established.
+  * **Model/dataset versions (Section 1, 8)** — `app/models/model_
+    registry.py`'s `ModelRegistryEntry` already carries first-class
+    `model_version`/`dataset_version` columns; Veritas reads these rather
+    than inventing new version fields.
+  * **Training dataset assurance (Section 15)** — mirrors Sage's
+    `SageEducationImageEntry` gate pattern (supervisor_validated +
+    phi_review_status + usage_rights) exactly, adding the training-
+    specific checks (instrument family/anatomy zone/finding/severity
+    confirmed, duplicate detection) the brief names.
+  * **Aegis / Vulcan / Sage (Section 16)** — read their real outputs
+    (`vulcan_aegis_integration_service.compute_process_variation_signal`,
+    `VulcanReliabilityAssessment`, `SageEducationImageEntry`) by reference
+    only; Veritas never overwrites another specialist's conclusion, and no
+    specialist may overwrite Veritas's own evidence findings.
+
+## What is genuinely new in this file
+
+Seven tables: `VeritasBaselineResolution`, `VeritasBaselineGovernanceAction`,
+`VeritasEvidenceProvenanceRecord`, `VeritasEvidenceReadinessAssessment`,
+`VeritasEvidenceConflict`, `VeritasTrainingDatasetEntry`, `VeritasFeedback`.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Section 2: Baseline Resolution Hierarchy ─────────────────────────────────
+BASELINE_TIER_MANUFACTURER = "manufacturer"
+BASELINE_TIER_MANUFACTURER_AUTHORIZED = "manufacturer_authorized"
+BASELINE_TIER_VENDOR = "vendor"
+BASELINE_TIER_ORGANIZATION = "organization"
+BASELINE_TIER_INSTRUMENT_HISTORICAL = "instrument_specific_historical"
+BASELINE_TIER_NONE = "none"
+BASELINE_TIERS = [
+    BASELINE_TIER_MANUFACTURER, BASELINE_TIER_MANUFACTURER_AUTHORIZED, BASELINE_TIER_VENDOR,
+    BASELINE_TIER_ORGANIZATION, BASELINE_TIER_INSTRUMENT_HISTORICAL, BASELINE_TIER_NONE,
+]
+
+RESOLUTION_STATUS_RESOLVED = "resolved"
+RESOLUTION_STATUS_SUPERVISOR_REVIEW_REQUIRED = "SUPERVISOR_REVIEW_REQUIRED"
+NO_APPROVED_BASELINE_MESSAGE = (
+    "No approved baseline is available for this instrument and anatomy zone. "
+    "A final baseline-dependent score cannot be issued."
+)
+
+# ── Section 3: Baseline Governance Rules (Veritas's canonical vocabulary) ────
+BASELINE_STATUS_DRAFT = "draft"
+BASELINE_STATUS_PENDING_REVIEW = "pending_review"
+BASELINE_STATUS_APPROVED = "approved"
+BASELINE_STATUS_CONDITIONALLY_APPROVED = "conditionally_approved"
+BASELINE_STATUS_SUPERSEDED = "superseded"
+BASELINE_STATUS_REJECTED = "rejected"
+BASELINE_STATUS_ARCHIVED = "archived"
+BASELINE_STATUSES = [
+    BASELINE_STATUS_DRAFT, BASELINE_STATUS_PENDING_REVIEW, BASELINE_STATUS_APPROVED,
+    BASELINE_STATUS_CONDITIONALLY_APPROVED, BASELINE_STATUS_SUPERSEDED, BASELINE_STATUS_REJECTED,
+    BASELINE_STATUS_ARCHIVED,
+]
+# Only these statuses may influence a clinical recommendation.
+BASELINE_STATUSES_USABLE_FOR_SCORING = {BASELINE_STATUS_APPROVED, BASELINE_STATUS_CONDITIONALLY_APPROVED}
+
+# Section 13 governance actions (each logged row is its own audit event).
+GOVERNANCE_ACTION_APPROVE = "approve"
+GOVERNANCE_ACTION_CONDITIONALLY_APPROVE = "conditionally_approve"
+GOVERNANCE_ACTION_REJECT = "reject"
+GOVERNANCE_ACTION_SUPERSEDE = "supersede"
+GOVERNANCE_ACTION_ARCHIVE = "archive"
+GOVERNANCE_ACTION_REQUEST_ADDITIONAL_IMAGES = "request_additional_images"
+GOVERNANCE_ACTIONS = [
+    GOVERNANCE_ACTION_APPROVE, GOVERNANCE_ACTION_CONDITIONALLY_APPROVE, GOVERNANCE_ACTION_REJECT,
+    GOVERNANCE_ACTION_SUPERSEDE, GOVERNANCE_ACTION_ARCHIVE, GOVERNANCE_ACTION_REQUEST_ADDITIONAL_IMAGES,
+]
+_GOVERNANCE_ACTION_TO_STATUS = {
+    GOVERNANCE_ACTION_APPROVE: BASELINE_STATUS_APPROVED,
+    GOVERNANCE_ACTION_CONDITIONALLY_APPROVE: BASELINE_STATUS_CONDITIONALLY_APPROVED,
+    GOVERNANCE_ACTION_REJECT: BASELINE_STATUS_REJECTED,
+    GOVERNANCE_ACTION_SUPERSEDE: BASELINE_STATUS_SUPERSEDED,
+    GOVERNANCE_ACTION_ARCHIVE: BASELINE_STATUS_ARCHIVED,
+}
+
+
+def status_for_action(action: str) -> str:
+    """The canonical status a governance action resolves to. Actions that
+    don't themselves change status (e.g. request_additional_images) return
+    an empty string -- the caller keeps the prior effective status."""
+    return _GOVERNANCE_ACTION_TO_STATUS.get(action, "")
+
+
+# ── Section 4: Instrument-to-Baseline Matching ───────────────────────────────
+MATCH_EXACT = "exact"
+MATCH_COMPATIBLE = "compatible"
+MATCH_PARTIAL = "partial"
+MATCH_UNCERTAIN = "uncertain"
+MATCH_MISMATCH = "mismatch"
+MATCH_UNAVAILABLE = "unavailable"
+MATCH_CLASSIFICATIONS = [MATCH_EXACT, MATCH_COMPATIBLE, MATCH_PARTIAL, MATCH_UNCERTAIN, MATCH_MISMATCH, MATCH_UNAVAILABLE]
+
+# ── Section 5: Image Quality Assessment ──────────────────────────────────────
+IMAGE_QUALITY_EXCELLENT = "excellent"
+IMAGE_QUALITY_ACCEPTABLE = "acceptable"
+IMAGE_QUALITY_LIMITED = "limited"
+IMAGE_QUALITY_INSUFFICIENT = "insufficient"
+IMAGE_QUALITY_STATUSES = [IMAGE_QUALITY_EXCELLENT, IMAGE_QUALITY_ACCEPTABLE, IMAGE_QUALITY_LIMITED, IMAGE_QUALITY_INSUFFICIENT]
+
+# ── Section 6: Inspection Coverage Assurance ─────────────────────────────────
+COVERAGE_COMPLETE = "complete"
+COVERAGE_ACCEPTABLE = "acceptable"
+COVERAGE_INCOMPLETE = "incomplete"
+COVERAGE_INSUFFICIENT = "insufficient"
+COVERAGE_NOT_ASSESSED = "not_assessed"
+COVERAGE_STATUSES = [COVERAGE_COMPLETE, COVERAGE_ACCEPTABLE, COVERAGE_INCOMPLETE, COVERAGE_INSUFFICIENT, COVERAGE_NOT_ASSESSED]
+
+# ── Section 7: Evidence Provenance Ledger ────────────────────────────────────
+EVIDENCE_TYPE_INSPECTION_IMAGE = "inspection_image"
+EVIDENCE_TYPE_MANUFACTURER_BASELINE = "manufacturer_baseline"
+EVIDENCE_TYPE_VENDOR_BASELINE = "vendor_baseline"
+EVIDENCE_TYPE_ORGANIZATION_BASELINE = "organization_baseline"
+EVIDENCE_TYPE_SUPERVISOR_ANNOTATION = "supervisor_annotation"
+EVIDENCE_TYPE_REPAIR_RECORD = "repair_record"
+EVIDENCE_TYPE_IFU_REFERENCE = "ifu_reference"
+EVIDENCE_TYPE_KNOWLEDGE_ARTICLE = "knowledge_article"
+EVIDENCE_TYPE_MODEL_PREDICTION = "model_prediction"
+EVIDENCE_TYPE_FINAL_DISPOSITION = "final_disposition"
+EVIDENCE_TYPES = [
+    EVIDENCE_TYPE_INSPECTION_IMAGE, EVIDENCE_TYPE_MANUFACTURER_BASELINE, EVIDENCE_TYPE_VENDOR_BASELINE,
+    EVIDENCE_TYPE_ORGANIZATION_BASELINE, EVIDENCE_TYPE_SUPERVISOR_ANNOTATION, EVIDENCE_TYPE_REPAIR_RECORD,
+    EVIDENCE_TYPE_IFU_REFERENCE, EVIDENCE_TYPE_KNOWLEDGE_ARTICLE, EVIDENCE_TYPE_MODEL_PREDICTION,
+    EVIDENCE_TYPE_FINAL_DISPOSITION,
+]
+
+# ── Section 8: Evidence Readiness Score bands ────────────────────────────────
+READINESS_STRONG = "strong_evidence"
+READINESS_MODERATE = "moderate_evidence"
+READINESS_LIMITED = "limited_evidence"
+READINESS_INSUFFICIENT = "insufficient_evidence"
+
+
+def readiness_category(score: float) -> str:
+    if score >= 90:
+        return READINESS_STRONG
+    if score >= 75:
+        return READINESS_MODERATE
+    if score >= 50:
+        return READINESS_LIMITED
+    return READINESS_INSUFFICIENT
+
+
+# ── Section 9: Conflict types ─────────────────────────────────────────────────
+CONFLICT_INSTRUMENT_FAMILY_DIFFERS = "instrument_family_differs_from_baseline"
+CONFLICT_IMAGE_TAG_DIFFERS = "image_tag_differs_from_predicted_zone"
+CONFLICT_MANUFACTURER_DIFFERS = "manufacturer_differs_from_baseline_owner"
+CONFLICT_MULTIPLE_ACTIVE_BASELINES = "multiple_active_approved_baselines"
+CONFLICT_SUPERVISOR_LABEL_CONFLICT = "supervisor_label_conflicts_with_ai_label"
+CONFLICT_MODEL_NOT_APPROVED = "model_not_approved_for_instrument_family"
+CONFLICT_BASELINE_SUPERSEDED_AFTER_INSPECTION = "baseline_superseded_after_inspection"
+CONFLICT_DUPLICATE_IMAGE_DIFFERENT_ZONES = "duplicate_image_different_zones"
+CONFLICT_EVIDENCE_TIMESTAMP_INCONSISTENCY = "evidence_timestamp_inconsistency"
+CONFLICT_TYPES = [
+    CONFLICT_INSTRUMENT_FAMILY_DIFFERS, CONFLICT_IMAGE_TAG_DIFFERS, CONFLICT_MANUFACTURER_DIFFERS,
+    CONFLICT_MULTIPLE_ACTIVE_BASELINES, CONFLICT_SUPERVISOR_LABEL_CONFLICT, CONFLICT_MODEL_NOT_APPROVED,
+    CONFLICT_BASELINE_SUPERSEDED_AFTER_INSPECTION, CONFLICT_DUPLICATE_IMAGE_DIFFERENT_ZONES,
+    CONFLICT_EVIDENCE_TIMESTAMP_INCONSISTENCY,
+]
+
+# ── Section 10: Evidence Gate outcomes ───────────────────────────────────────
+GATE_PROCEED_WITH_ANALYSIS = "PROCEED_WITH_ANALYSIS"
+GATE_PROCEED_WITH_LIMITATIONS = "PROCEED_WITH_LIMITATIONS"
+GATE_ADDITIONAL_IMAGE_REQUIRED = "ADDITIONAL_IMAGE_REQUIRED"
+GATE_BASELINE_REVIEW_REQUIRED = "BASELINE_REVIEW_REQUIRED"
+GATE_SUPERVISOR_REVIEW_REQUIRED = "SUPERVISOR_REVIEW_REQUIRED"
+GATE_EVIDENCE_CONFLICT = "EVIDENCE_CONFLICT"
+GATE_ANALYSIS_BLOCKED = "ANALYSIS_BLOCKED"
+GATE_OUTCOMES = [
+    GATE_PROCEED_WITH_ANALYSIS, GATE_PROCEED_WITH_LIMITATIONS, GATE_ADDITIONAL_IMAGE_REQUIRED,
+    GATE_BASELINE_REVIEW_REQUIRED, GATE_SUPERVISOR_REVIEW_REQUIRED, GATE_EVIDENCE_CONFLICT, GATE_ANALYSIS_BLOCKED,
+]
+
+# ── Section 15: Training dataset statuses ────────────────────────────────────
+DATASET_CANDIDATE = "candidate"
+DATASET_PENDING_VALIDATION = "pending_validation"
+DATASET_APPROVED_FOR_TRAINING = "approved_for_training"
+DATASET_EXCLUDED = "excluded"
+DATASET_QUARANTINED = "quarantined"
+DATASET_STATUSES = [DATASET_CANDIDATE, DATASET_PENDING_VALIDATION, DATASET_APPROVED_FOR_TRAINING, DATASET_EXCLUDED, DATASET_QUARANTINED]
+
+# ── Section 17 feedback actions (includes the Section 10 gate override) ─────
+FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE = "override_evidence_gate"
+
+VERITAS_AGENT_VERSION = "1.0.0"
+
+DISCLAIMER = (
+    "Veritas evaluates whether an inspection has sufficient, reliable, and governed evidence to "
+    "support an AI recommendation. Veritas does not independently approve an instrument -- it "
+    "determines whether the evidence is trustworthy enough for the inspection workflow to proceed "
+    "and identifies what additional evidence is required. Every evidence decision remains versioned, "
+    "explainable, auditable, tenant-isolated, and human-governed."
+)
+
+
+class VeritasBaselineResolution(Base):
+    """One point-in-time baseline resolution (Section 2) -- a persisted audit
+    row every time resolution runs, built on top of the real
+    `baseline_comparison_scoring_service.resolve_baseline`, never a
+    silent substitution of an unapproved baseline."""
+
+    __tablename__ = "veritas_baseline_resolutions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    instrument_identity: Mapped[str] = mapped_column(String(300), default="", nullable=False, index=True)
+    instrument_type: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+
+    resolution_status: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    baseline_source_type: Mapped[str] = mapped_column(String(30), default="", nullable=False)
+    baseline_source_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    baseline_tier: Mapped[str] = mapped_column(String(40), default=BASELINE_TIER_NONE, nullable=False, index=True)
+    baseline_version: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    approval_status: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    manufacturer: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    model: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    image_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    reviewer: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    resolution_reason: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    message: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+
+class VeritasBaselineGovernanceAction(Base):
+    """An append-only governance action on a real baseline (Section 3, 13).
+    The baseline's effective canonical status is the status of the latest
+    action for its (source_type, source_id) -- this table is never mutated
+    or deleted, so every action is its own audit event."""
+
+    __tablename__ = "veritas_baseline_governance_actions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    baseline_source_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    baseline_source_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    action: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    resulting_status: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+
+    owner: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    review_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    known_limitations: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    usage_rights: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    performed_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    performed_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+
+class VeritasEvidenceProvenanceRecord(Base):
+    """One evidence-object provenance record (Section 7) -- references
+    existing evidence (RetainedImage/baseline/etc.) by ID, never a
+    duplicate of the underlying bytes or table."""
+
+    __tablename__ = "veritas_evidence_provenance_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    evidence_type: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    source: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    organization: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    facility: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    creator: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+
+    instrument_id: Mapped[str] = mapped_column(String(300), default="", nullable=False, index=True)
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    baseline_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    file_hash: Mapped[str] = mapped_column(String(64), default="", nullable=False, index=True)
+    storage_location: Mapped[str] = mapped_column(String(500), default="", nullable=False)
+    approval_status: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    reviewer: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    version: Mapped[str] = mapped_column(String(40), default="1.0.0", nullable=False)
+    modification_history_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    usage_scope: Mapped[str] = mapped_column(String(100), default="internal", nullable=False)
+
+
+class VeritasEvidenceReadinessAssessment(Base):
+    """The central Veritas assessment (Sections 1, 8, 10, 12) -- one row per
+    evidence-assurance run for an inspection. Mirrors
+    `VulcanReliabilityAssessment`'s role for Vulcan. `recommended_gate` is
+    Veritas's own advisory output; `final_disposition`/override fields are
+    only ever set via a supervisor-gated `VeritasFeedback` action."""
+
+    __tablename__ = "veritas_evidence_readiness_assessments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    inspection_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    instrument_identity: Mapped[str] = mapped_column(String(300), default="", nullable=False, index=True)
+    baseline_resolution_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+
+    match_classification: Mapped[str] = mapped_column(String(20), default=MATCH_UNAVAILABLE, nullable=False, index=True)
+    image_quality_status: Mapped[str] = mapped_column(String(20), default=IMAGE_QUALITY_INSUFFICIENT, nullable=False, index=True)
+    coverage_status: Mapped[str] = mapped_column(String(20), default=COVERAGE_NOT_ASSESSED, nullable=False, index=True)
+    coverage_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
+    missing_zones_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    readiness_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    readiness_category: Mapped[str] = mapped_column(String(30), default=READINESS_INSUFFICIENT, nullable=False, index=True)
+    score_breakdown_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    limitations_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+
+    recommended_gate: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    next_action: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    reasoning_narrative: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+
+    model_version: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    dataset_version: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    agent_version: Mapped[str] = mapped_column(String(20), default=VERITAS_AGENT_VERSION, nullable=False)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    final_gate_override: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    overridden_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    overridden_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)
+
+
+class VeritasEvidenceConflict(Base):
+    """One detected conflict (Section 9), linked to the assessment it was
+    found under."""
+
+    __tablename__ = "veritas_evidence_conflicts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    assessment_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    conflict_type: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    severity: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+    affected_evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    recommended_resolution: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    responsible_reviewer_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    resolved: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+
+class VeritasTrainingDatasetEntry(Base):
+    """Training Dataset Assurance (Section 15) -- gates a real
+    `RetainedImage`/`ImageLabel` pair into a training-dataset status.
+    Mirrors Sage's `SageEducationImageEntry` reference-by-ID pattern."""
+
+    __tablename__ = "veritas_training_dataset_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    retained_image_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    image_label_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    finding_category: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+    severity: Mapped[str] = mapped_column(String(30), default="", nullable=False)
+
+    supervisor_validated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    image_quality_threshold_met: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    usage_rights: Mapped[str] = mapped_column(String(100), default="", nullable=False)
+    dataset_version: Mapped[str] = mapped_column(String(20), default="1.0.0", nullable=False)
+    phi_review_status: Mapped[str] = mapped_column(String(20), default="pending", nullable=False, index=True)
+    is_duplicate: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    provenance_complete: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    dataset_status: Mapped[str] = mapped_column(String(30), default=DATASET_CANDIDATE, nullable=False, index=True)
+    status_reason: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+
+class VeritasFeedback(Base):
+    """Supervisor/reviewer feedback on Veritas findings (Section 17) --
+    also the ONLY place an evidence-gate override is recorded (action
+    `override_evidence_gate`, `override_reason` required)."""
+
+    __tablename__ = "veritas_feedback"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    assessment_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    action: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+
+    baseline_match_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    image_quality_assessment_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    anatomy_zone_tag_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    coverage_determination_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    evidence_conflict_valid: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
+    corrected_baseline: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    corrected_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False)
+    final_evidence_status: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    reviewer_rationale: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    override_reason: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    limitations_acknowledged: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    final_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+
+    submitted_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    submitted_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/models/vulcan_reliability.py
+++ b/backend/app/models/vulcan_reliability.py
@@ -1,0 +1,347 @@
+"""LumenAI AI Specialist — Project Vulcan: Instrument Reliability, Failure
+Analysis & Repair Intelligence.
+
+## Naming disambiguation (read this first)
+
+Vulcan composes existing, real data rather than inventing a parallel
+instrument-history store:
+
+  * **Finding history (Sections 3, 4)** — `InspectionFinding`
+    (`app/models/inspection_finding.py`, v1.5) already logs one row per
+    actionable finding (`finding_type`, `zone`, `severity_index`,
+    `created_at`) per real inspection -- this *is* the progression
+    history Vulcan analyzes. Vulcan never re-derives or duplicates it.
+  * **Repair history (Section 5)** — `RepairRequest`
+    (`app/models/or_connect.py`) already tracks `inspection_id`,
+    `vendor_name`, `repair_type`, `status`, `expected_return_date`/
+    `actual_return_date`, and a coarse `failure_category` (7 values:
+    corrosion/mechanical_wear/electrical_fault/insulation_defect/
+    misuse_damage/manufacturing_defect/other). Vulcan's granular
+    taxonomy (Section 2, below) maps onto that coarse category where
+    relevant for repair-effectiveness correlation -- never a second
+    repair-request table.
+  * **Instrument identity/anatomy (Sections 1, 4)** — `instrument_knowledge.py`
+    (manufacturer/model/instrument_family/anatomy_zones/high_risk_zones/
+    known_failure_modes) and `Inspection.instrument_udi`/
+    `instrument_barcode` (the real cross-inspection identity key) are
+    reused directly.
+  * **Digital Twin / baseline versions (Section 15 audit)** —
+    `digital_twin_engine`'s twin state and `BaselineLibraryEntry.baseline_version`
+    are referenced by version string only, never copied.
+  * **Supervisor feedback pattern** — `SupervisorReview`
+    (`app/models/supervisor_review.py`) already captures AI-agreement
+    feedback for the inspection pipeline; `VulcanFeedback` (below) is
+    deliberately a separate, Vulcan-specific table because Section 13
+    needs fields `SupervisorReview` was never built for (repair-vendor
+    response, manufacturer response, progression/repair-effectiveness/
+    probable-cause correctness) -- not a duplicate of the same concept.
+  * **Aegis (Section 12)** — no "Aegis" agent or process-variation
+    engine exists anywhere in this codebase yet. Rather than fabricate
+    one, `vulcan_aegis_integration_service.py` builds a real, honestly
+    minimal process-variation signal from actual `Inspection.technician`/
+    `vendor_name` concentration patterns -- a genuine analysis, not a
+    placeholder. `VulcanReliabilityAssessment.aegis_conclusion_json` is
+    populated only when that signal is composed in, and is never merged
+    into or overwritten by Vulcan's own conclusion fields -- "no agent
+    may overwrite the other's conclusion."
+
+## What is genuinely new in this file
+
+Three tables: `VulcanReliabilityAssessment`, `VulcanRepairEffectivenessAssessment`,
+`VulcanFeedback`.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+# ── Section 2: Instrument Failure Taxonomy ───────────────────────────────────
+# Cleaning-related
+FAIL_RETAINED_BLOOD = "retained_blood"
+FAIL_RETAINED_BONE = "retained_bone"
+FAIL_TISSUE = "tissue"
+FAIL_ORGANIC_RESIDUE = "organic_residue"
+FAIL_DEBRIS = "debris"
+FAIL_OBSTRUCTION = "obstruction"
+# Condition-related
+FAIL_RUST = "rust"
+FAIL_CORROSION = "corrosion"
+FAIL_PITTING = "pitting"
+FAIL_DISCOLORATION = "discoloration"
+FAIL_SURFACE_DEGRADATION = "surface_degradation"
+FAIL_STAINING = "staining"
+# Mechanical
+FAIL_CRACK = "crack"
+FAIL_MISALIGNMENT = "misalignment"
+FAIL_LOOSE_JOINT = "loose_joint"
+FAIL_DAMAGED_HINGE = "damaged_hinge"
+FAIL_DAMAGED_RATCHET = "damaged_ratchet"
+FAIL_DAMAGED_SERRATION = "damaged_serration"
+FAIL_WORN_CUTTING_EDGE = "worn_cutting_edge"
+FAIL_BENT_COMPONENT = "bent_component"
+FAIL_MISSING_COMPONENT = "missing_component"
+# Scope-specific
+FAIL_DAMAGED_O_RING = "damaged_o_ring"
+FAIL_DAMAGED_SEAL = "damaged_seal"
+FAIL_LENS_DAMAGE = "lens_damage"
+FAIL_LIGHT_POST_DAMAGE = "light_post_damage"
+FAIL_SHEATH_DAMAGE = "sheath_damage"
+FAIL_PORT_DAMAGE = "port_damage"
+FAIL_CHANNEL_DAMAGE = "channel_damage"
+# Powered/orthopedic
+FAIL_DAMAGED_DRILL_FLUTE = "damaged_drill_flute"
+FAIL_DAMAGED_THREAD = "damaged_thread"
+FAIL_WORN_CUTTING_TIP = "worn_cutting_tip"
+FAIL_DAMAGED_HUB = "damaged_hub"
+FAIL_METAL_DEFORMATION = "metal_deformation"
+# Insulation-related
+FAIL_INSULATION_BREACH = "insulation_breach"
+FAIL_PEELING_INSULATION = "peeling_insulation"
+FAIL_EXPOSED_CONDUCTOR = "exposed_conductor"
+FAIL_SURFACE_NICK = "surface_nick"
+# Unknown
+FAIL_INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+FAIL_IMAGE_QUALITY_LIMITATION = "image_quality_limitation"
+FAIL_ANATOMY_NOT_RECOGNIZED = "anatomy_not_recognized"
+FAIL_MANUFACTURER_EVALUATION_REQUIRED = "manufacturer_evaluation_required"
+
+TAXONOMY_GROUP_CLEANING = "cleaning_related"
+TAXONOMY_GROUP_CONDITION = "condition_related"
+TAXONOMY_GROUP_MECHANICAL = "mechanical"
+TAXONOMY_GROUP_SCOPE_SPECIFIC = "scope_specific"
+TAXONOMY_GROUP_POWERED_ORTHOPEDIC = "powered_orthopedic"
+TAXONOMY_GROUP_INSULATION = "insulation_related"
+TAXONOMY_GROUP_UNKNOWN = "unknown"
+
+FAILURE_TAXONOMY: dict[str, list[str]] = {
+    TAXONOMY_GROUP_CLEANING: [
+        FAIL_RETAINED_BLOOD, FAIL_RETAINED_BONE, FAIL_TISSUE, FAIL_ORGANIC_RESIDUE, FAIL_DEBRIS, FAIL_OBSTRUCTION,
+    ],
+    TAXONOMY_GROUP_CONDITION: [
+        FAIL_RUST, FAIL_CORROSION, FAIL_PITTING, FAIL_DISCOLORATION, FAIL_SURFACE_DEGRADATION, FAIL_STAINING,
+    ],
+    TAXONOMY_GROUP_MECHANICAL: [
+        FAIL_CRACK, FAIL_MISALIGNMENT, FAIL_LOOSE_JOINT, FAIL_DAMAGED_HINGE, FAIL_DAMAGED_RATCHET,
+        FAIL_DAMAGED_SERRATION, FAIL_WORN_CUTTING_EDGE, FAIL_BENT_COMPONENT, FAIL_MISSING_COMPONENT,
+    ],
+    TAXONOMY_GROUP_SCOPE_SPECIFIC: [
+        FAIL_DAMAGED_O_RING, FAIL_DAMAGED_SEAL, FAIL_LENS_DAMAGE, FAIL_LIGHT_POST_DAMAGE, FAIL_SHEATH_DAMAGE,
+        FAIL_PORT_DAMAGE, FAIL_CHANNEL_DAMAGE,
+    ],
+    TAXONOMY_GROUP_POWERED_ORTHOPEDIC: [
+        FAIL_DAMAGED_DRILL_FLUTE, FAIL_DAMAGED_THREAD, FAIL_WORN_CUTTING_TIP, FAIL_DAMAGED_HUB, FAIL_METAL_DEFORMATION,
+    ],
+    TAXONOMY_GROUP_INSULATION: [
+        FAIL_INSULATION_BREACH, FAIL_PEELING_INSULATION, FAIL_EXPOSED_CONDUCTOR, FAIL_SURFACE_NICK,
+    ],
+    TAXONOMY_GROUP_UNKNOWN: [
+        FAIL_INSUFFICIENT_EVIDENCE, FAIL_IMAGE_QUALITY_LIMITATION, FAIL_ANATOMY_NOT_RECOGNIZED,
+        FAIL_MANUFACTURER_EVALUATION_REQUIRED,
+    ],
+}
+
+# ── Section 3: Failure Progression Model ─────────────────────────────────────
+PROGRESSION_STABLE = "stable"
+PROGRESSION_IMPROVING = "improving"
+PROGRESSION_SLOWLY_WORSENING = "slowly_worsening"
+PROGRESSION_RAPIDLY_WORSENING = "rapidly_worsening"
+PROGRESSION_INTERMITTENT = "intermittent"
+PROGRESSION_UNRESOLVED = "unresolved"
+PROGRESSION_INSUFFICIENT_HISTORY = "insufficient_history"
+PROGRESSION_STATES = [
+    PROGRESSION_STABLE, PROGRESSION_IMPROVING, PROGRESSION_SLOWLY_WORSENING, PROGRESSION_RAPIDLY_WORSENING,
+    PROGRESSION_INTERMITTENT, PROGRESSION_UNRESOLVED, PROGRESSION_INSUFFICIENT_HISTORY,
+]
+
+# ── Section 5: Repair Effectiveness Intelligence ─────────────────────────────
+REPAIR_OUTCOME_EFFECTIVE = "effective"
+REPAIR_OUTCOME_PARTIALLY_EFFECTIVE = "partially_effective"
+REPAIR_OUTCOME_FAILURE_RECURRED = "failure_recurred"
+REPAIR_OUTCOME_NEW_DEFECT_DETECTED = "new_defect_detected"
+REPAIR_OUTCOME_UNABLE_TO_DETERMINE = "unable_to_determine"
+REPAIR_OUTCOMES = [
+    REPAIR_OUTCOME_EFFECTIVE, REPAIR_OUTCOME_PARTIALLY_EFFECTIVE, REPAIR_OUTCOME_FAILURE_RECURRED,
+    REPAIR_OUTCOME_NEW_DEFECT_DETECTED, REPAIR_OUTCOME_UNABLE_TO_DETERMINE,
+]
+
+# ── Section 6: Probable Cause Classification ─────────────────────────────────
+CAUSE_INCOMPLETE_CLEANING = "incomplete_cleaning"
+CAUSE_IMPROPER_BRUSHING = "improper_brushing"
+CAUSE_IMPROPER_FLUSHING = "improper_flushing"
+CAUSE_CHEMICAL_EXPOSURE = "chemical_exposure"
+CAUSE_MOISTURE_EXPOSURE = "moisture_exposure"
+CAUSE_INADEQUATE_DRYING = "inadequate_drying"
+CAUSE_NORMAL_WEAR = "normal_wear"
+CAUSE_HEAVY_USE = "heavy_use"
+CAUSE_HANDLING_DAMAGE = "handling_damage"
+CAUSE_ASSEMBLY_DAMAGE = "assembly_damage"
+CAUSE_REPAIR_RECURRENCE = "repair_recurrence"
+CAUSE_MATERIAL_DEGRADATION = "material_degradation"
+CAUSE_SUSPECTED_MANUFACTURING_DESIGN_ISSUE = "suspected_manufacturing_design_issue"
+CAUSE_UNKNOWN = "unknown"
+PROBABLE_CAUSES = [
+    CAUSE_INCOMPLETE_CLEANING, CAUSE_IMPROPER_BRUSHING, CAUSE_IMPROPER_FLUSHING, CAUSE_CHEMICAL_EXPOSURE,
+    CAUSE_MOISTURE_EXPOSURE, CAUSE_INADEQUATE_DRYING, CAUSE_NORMAL_WEAR, CAUSE_HEAVY_USE, CAUSE_HANDLING_DAMAGE,
+    CAUSE_ASSEMBLY_DAMAGE, CAUSE_REPAIR_RECURRENCE, CAUSE_MATERIAL_DEGRADATION,
+    CAUSE_SUSPECTED_MANUFACTURING_DESIGN_ISSUE, CAUSE_UNKNOWN,
+]
+
+# ── Section 7: Reliability Score bands ────────────────────────────────────────
+RELIABILITY_RELIABLE = "reliable"
+RELIABILITY_MONITOR = "monitor"
+RELIABILITY_ELEVATED_CONCERN = "elevated_concern"
+RELIABILITY_REPAIR_MANUFACTURER_REVIEW = "repair_manufacturer_review"
+RELIABILITY_REMOVE_FROM_SERVICE_CANDIDATE = "remove_from_service_candidate"
+
+
+def reliability_category(score: float) -> str:
+    if score >= 90:
+        return RELIABILITY_RELIABLE
+    if score >= 75:
+        return RELIABILITY_MONITOR
+    if score >= 50:
+        return RELIABILITY_ELEVATED_CONCERN
+    if score >= 25:
+        return RELIABILITY_REPAIR_MANUFACTURER_REVIEW
+    return RELIABILITY_REMOVE_FROM_SERVICE_CANDIDATE
+
+
+# ── Section 8: Recommended Dispositions ───────────────────────────────────────
+DISPOSITION_CONTINUE_ROUTINE_INSPECTION = "continue_routine_inspection"
+DISPOSITION_INCREASE_INSPECTION_FREQUENCY = "increase_inspection_frequency"
+DISPOSITION_RECLEAN_AND_REINSPECT = "reclean_and_reinspect"
+DISPOSITION_SUPERVISOR_REVIEW = "supervisor_review"
+DISPOSITION_REPAIR_EVALUATION = "repair_evaluation"
+DISPOSITION_CLINICAL_ENGINEERING_REVIEW = "clinical_engineering_review"
+DISPOSITION_MANUFACTURER_EVALUATION = "manufacturer_evaluation"
+DISPOSITION_QUARANTINE_PENDING_REVIEW = "quarantine_pending_review"
+DISPOSITION_REMOVE_FROM_SERVICE = "remove_from_service"
+DISPOSITION_RETIREMENT_CANDIDATE = "retirement_candidate"
+RECOMMENDED_DISPOSITIONS = [
+    DISPOSITION_CONTINUE_ROUTINE_INSPECTION, DISPOSITION_INCREASE_INSPECTION_FREQUENCY,
+    DISPOSITION_RECLEAN_AND_REINSPECT, DISPOSITION_SUPERVISOR_REVIEW, DISPOSITION_REPAIR_EVALUATION,
+    DISPOSITION_CLINICAL_ENGINEERING_REVIEW, DISPOSITION_MANUFACTURER_EVALUATION,
+    DISPOSITION_QUARANTINE_PENDING_REVIEW, DISPOSITION_REMOVE_FROM_SERVICE, DISPOSITION_RETIREMENT_CANDIDATE,
+]
+
+VULCAN_AGENT_VERSION = "1.0.0"
+
+DISCLAIMER = (
+    "Vulcan supports pre-sterilization inspection and asset-quality decisions. It does not "
+    "certify instrument safety independently. Every conclusion is evidence-based, "
+    "confidence-scored, and requires human review; supervisor, clinical engineering, repair "
+    "vendor, and manufacturer review remain available where appropriate. Vulcan describes "
+    "potential associations and probable contributors only, never a definitive root cause "
+    "unless confirmed through approved investigation."
+)
+
+
+class VulcanReliabilityAssessment(Base):
+    """One Instrument Reliability assessment (Sections 1, 3, 4, 6, 7, 8,
+    11, 12, 15) -- the durable, auditable record of what Vulcan
+    concluded, from what evidence, with what confidence, and what
+    happened after human review. `final_disposition` is nullable and can
+    only be set via a supervisor-gated action (`vulcan_feedback_service`)
+    -- Vulcan's own compute step never sets it, satisfying "Vulcan
+    cannot independently finalize irreversible disposition."
+    """
+
+    __tablename__ = "vulcan_reliability_assessments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    instrument_identity: Mapped[str] = mapped_column(String(300), nullable=False, index=True)
+    instrument_family: Mapped[str] = mapped_column(String(100), default="", nullable=False, index=True)
+    manufacturer_name: Mapped[str] = mapped_column(String(255), default="", nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+
+    failure_category: Mapped[str] = mapped_column(String(50), default="", nullable=False, index=True)
+    progression: Mapped[str] = mapped_column(String(30), default=PROGRESSION_INSUFFICIENT_HISTORY, nullable=False, index=True)
+    recurrence_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    reliability_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    reliability_category: Mapped[str] = mapped_column(String(40), default=RELIABILITY_ELEVATED_CONCERN, nullable=False, index=True)
+    score_breakdown_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+
+    probable_causes_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    recommended_disposition: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    reasoning_narrative: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    confidence: Mapped[str] = mapped_column(String(20), default="moderate", nullable=False)
+
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    rules_applied_json: Mapped[str] = mapped_column(Text, default="[]", nullable=False)
+    digital_twin_version: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    baseline_version: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    anatomy_profile_version: Mapped[str] = mapped_column(String(40), default="", nullable=False)
+    agent_version: Mapped[str] = mapped_column(String(20), default=VULCAN_AGENT_VERSION, nullable=False)
+
+    aegis_conclusion_json: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    combined_conclusion: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    final_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    finalized_by: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    finalized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    disclaimer: Mapped[str] = mapped_column(Text, default=DISCLAIMER, nullable=False)
+
+
+class VulcanRepairEffectivenessAssessment(Base):
+    """One repair-effectiveness classification (Section 5), linked to a
+    real `RepairRequest` row -- never a duplicate of its fields."""
+
+    __tablename__ = "vulcan_repair_effectiveness_assessments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    repair_request_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    instrument_identity: Mapped[str] = mapped_column(String(300), nullable=False, index=True)
+    anatomy_zone: Mapped[str] = mapped_column(String(60), default="", nullable=False, index=True)
+
+    repair_outcome: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    time_to_recurrence_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}", nullable=False)
+    human_review_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+
+class VulcanFeedback(Base):
+    """Supervisor / repair-vendor / manufacturer feedback on a Vulcan
+    assessment (Section 13) -- stored as a learning signal, distinct
+    from `SupervisorReview` (a different pipeline's AI-agreement
+    label store)."""
+
+    __tablename__ = "vulcan_feedback"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False, index=True,
+    )
+
+    assessment_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    failure_classification_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    anatomy_zone_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    progression_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    repair_effectiveness_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    probable_contributor_correct: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
+    final_disposition: Mapped[str] = mapped_column(String(50), default="", nullable=False)
+    supervisor_rationale: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    repair_vendor_response: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    manufacturer_response: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    submitted_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    submitted_role: Mapped[str] = mapped_column(String(50), default="", nullable=False)

--- a/backend/app/routes/council_leadership.py
+++ b/backend/app/routes/council_leadership.py
@@ -1,0 +1,353 @@
+"""LumenAI AI Leadership Platform — Project Council: Multi-Agent
+Leadership Teams & Governed Consensus Intelligence routes.
+
+Frontend route: /council. API prefix: /api/council.
+
+Uses `tenant_authz.require_tenant_roles` for tenant-scoped access
+(Section 20 -- cross-tenant Council access is always denied, since every
+query below filters by the authenticated user's own `tenant_id`).
+Finalizing a human decision additionally enforces the brief's five-tier
+authority scale via `council_human_decision_service.can_approve` -- a
+`viewer`/`operator` ("technician") can read a Council Case but can never
+finalize its decision.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.orm import Session
+
+from app.deps import get_db
+from app.models.council_leadership import CASE_TYPES
+from app.services import (
+    council_agreement_map_service,
+    council_brief_service,
+    council_decision_journal_service,
+    council_decision_options_service,
+    council_dissent_service,
+    council_human_decision_service,
+    council_meeting_service,
+    council_notification_service,
+    council_orchestration_service,
+    council_outcome_service,
+    council_performance_service,
+    council_reports_service,
+    council_specialist_assessment_service,
+    council_team_registry_service,
+    council_workspace_service,
+)
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/council", tags=["council"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+# ---------------------------------------------------------------------------
+# Sections 2 & 15 — Leadership Team Registry & Governance
+# ---------------------------------------------------------------------------
+
+
+@router.get("/teams")
+def get_teams(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    council_team_registry_service.ensure_default_teams(db, _tenant(current_user))
+    return {"teams": council_team_registry_service.list_teams(db, _tenant(current_user))}
+
+
+@router.post("/teams/{team_key}")
+def post_update_team(
+    team_key: str, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        row = council_team_registry_service.update_team_config(
+            db, _tenant(current_user), team_key,
+            required_specialists=payload.get("required_specialists"), optional_specialists=payload.get("optional_specialists"),
+            decision_scope=payload.get("decision_scope"), escalation_rules=payload.get("escalation_rules"),
+            quorum_requirement=payload.get("quorum_requirement"), evidence_requirements=payload.get("evidence_requirements"),
+            review_frequency=payload.get("review_frequency"), owner=_actor(current_user),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return council_team_registry_service.to_dict(row)
+
+
+@router.get("/teams/{team_key}/history")
+def get_team_history(team_key: str, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"history": council_team_registry_service.team_config_history(db, _tenant(current_user), team_key)}
+
+
+# ---------------------------------------------------------------------------
+# Section 1 & 3 — Council Orchestration Engine + Council Case
+# ---------------------------------------------------------------------------
+
+
+@router.post("/cases", status_code=201)
+def post_open_case(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    case_type = payload.get("case_type", "")
+    if case_type not in CASE_TYPES:
+        raise HTTPException(status_code=422, detail=f"Unknown case_type '{case_type}'")
+    row = council_orchestration_service.open_case(
+        db, _tenant(current_user), case_type=case_type, source_event=payload.get("source_event", ""),
+        inspection_ids=payload.get("inspection_ids"), instrument_ids=payload.get("instrument_ids"),
+        digital_twin_refs=payload.get("digital_twin_refs"), evidence_package=payload.get("evidence_package"),
+        risk_level=payload.get("risk_level", ""), urgency=payload.get("urgency", "routine"),
+        requested_decision=payload.get("requested_decision", ""), facility_id=payload.get("facility_id", ""),
+    )
+    return council_orchestration_service.to_dict(row)
+
+
+@router.post("/cases/{council_case_id}/convene")
+def post_convene(council_case_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        row = council_orchestration_service.convene(db, _tenant(current_user), council_case_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return council_orchestration_service.to_dict(row)
+
+
+@router.get("/cases")
+def get_cases(
+    status: str = Query(""), case_type: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return {"cases": council_orchestration_service.list_cases(db, _tenant(current_user), status=status, case_type=case_type)}
+
+
+@router.get("/cases/{council_case_id}")
+def get_case_detail(council_case_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    case = council_orchestration_service.get_case(db, _tenant(current_user), council_case_id)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Council Case not found")
+    return {
+        "case": council_orchestration_service.to_dict(case),
+        "assessments": council_specialist_assessment_service.assessments_for_case(db, _tenant(current_user), council_case_id),
+        "dissent": council_dissent_service.dissent_for_case(db, _tenant(current_user), council_case_id),
+        "decision_options": council_decision_options_service.options_for_case(db, _tenant(current_user), council_case_id),
+        "human_decisions": council_human_decision_service.decisions_for_case(db, _tenant(current_user), council_case_id),
+        "agreement_map": council_agreement_map_service.build_agreement_map(db, _tenant(current_user), council_case_id),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Independent Specialist Assessments (revision support)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/cases/{council_case_id}/assessments")
+def get_assessments(council_case_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"assessments": council_specialist_assessment_service.assessments_for_case(db, _tenant(current_user), council_case_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 10 — Agreement Map
+# ---------------------------------------------------------------------------
+
+
+@router.get("/cases/{council_case_id}/agreement-map")
+def get_agreement_map(council_case_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return council_agreement_map_service.build_agreement_map(db, _tenant(current_user), council_case_id)
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Human Decision Authority
+# ---------------------------------------------------------------------------
+
+
+@router.post("/cases/{council_case_id}/decisions", status_code=201)
+def post_finalize_decision(
+    council_case_id: int, payload: dict,
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        row = council_human_decision_service.finalize_decision(
+            db, _tenant(current_user), council_case_id, approver=_actor(current_user),
+            approver_role=current_user.get("role", ""), decision=payload.get("decision", ""),
+            rationale=payload.get("rationale", ""), conditions=payload.get("conditions", ""),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    return council_human_decision_service.to_dict(row)
+
+
+@router.get("/cases/{council_case_id}/decisions")
+def get_decisions(council_case_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"decisions": council_human_decision_service.decisions_for_case(db, _tenant(current_user), council_case_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Council Workspace (`/council`)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/workspace")
+def get_workspace(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return council_workspace_service.workspace_summary(db, _tenant(current_user))
+
+
+# ---------------------------------------------------------------------------
+# Section 11 — Council Brief Generator
+# ---------------------------------------------------------------------------
+
+
+@router.get("/cases/{council_case_id}/briefs/{brief_type}")
+def get_brief(
+    council_case_id: int, brief_type: str,
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    resolver = {
+        "supervisor": council_brief_service.supervisor_brief,
+        "manager": council_brief_service.manager_brief,
+        "executive": council_brief_service.executive_brief,
+    }.get(brief_type)
+    if resolver is None:
+        raise HTTPException(status_code=422, detail=f"Unknown brief_type '{brief_type}'")
+    try:
+        return resolver(db, _tenant(current_user), council_case_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Section 12 — Council Meeting Mode
+# ---------------------------------------------------------------------------
+
+
+@router.post("/cases/{council_case_id}/meeting-notes", status_code=201)
+def post_meeting_notes(
+    council_case_id: int, payload: dict,
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        row = council_meeting_service.record_meeting_notes(
+            db, _tenant(current_user), council_case_id, discussion_notes=payload.get("discussion_notes", ""),
+            recorded_by=payload.get("recorded_by") or _actor(current_user), action_items=payload.get("action_items"),
+            owner=payload.get("owner", ""), agenda=payload.get("agenda"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return council_meeting_service.to_dict(row)
+
+
+@router.get("/cases/{council_case_id}/meeting-notes")
+def get_meeting_notes(council_case_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"meeting_notes": council_meeting_service.meeting_notes_for_case(db, _tenant(current_user), council_case_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 13 — Decision Journal Integration
+# ---------------------------------------------------------------------------
+
+
+@router.post("/cases/{council_case_id}/journal", status_code=201)
+def post_journal_entry(
+    council_case_id: int, payload: dict,
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        return council_decision_journal_service.record_council_decision(
+            db, _tenant(current_user), council_case_id, leader_decision=payload.get("leader_decision", ""),
+            decided_by=_actor(current_user), decided_role=current_user.get("role", ""),
+            outcome=payload.get("outcome", ""), lessons_learned=payload.get("lessons_learned", ""),
+            new_status=payload.get("new_status"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Section 14 — Outcome Effectiveness Review
+# ---------------------------------------------------------------------------
+
+
+@router.post("/cases/{council_case_id}/outcome-review", status_code=201)
+def post_outcome_review(
+    council_case_id: int, payload: dict,
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    row = council_outcome_service.record_outcome_review(
+        db, _tenant(current_user), council_case_id,
+        issue_resolved=payload.get("issue_resolved"), recurred=payload.get("recurred"),
+        risk_decreased=payload.get("risk_decreased"), operational_performance_improved=payload.get("operational_performance_improved"),
+        recommendation_followed=payload.get("recommendation_followed"), dissent_valid=payload.get("dissent_valid"),
+        additional_evidence_changed_decision=payload.get("additional_evidence_changed_decision"),
+        unintended_consequence=payload.get("unintended_consequence", False), notes=payload.get("notes", ""),
+    )
+    return council_outcome_service.to_dict(row)
+
+
+@router.get("/cases/{council_case_id}/outcome-review")
+def get_outcome_reviews(council_case_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"outcome_reviews": council_outcome_service.outcome_reviews_for_case(db, _tenant(current_user), council_case_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 17 — Specialist Performance Review
+# ---------------------------------------------------------------------------
+
+
+@router.get("/performance")
+def get_performance(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return council_performance_service.specialist_performance_summary(db, _tenant(current_user))
+
+
+# ---------------------------------------------------------------------------
+# Section 18 — Notifications and Escalations
+# ---------------------------------------------------------------------------
+
+
+@router.get("/notifications")
+def get_notifications(
+    recipient_role: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return {"notifications": council_notification_service.combined_notifications(db, _tenant(current_user), recipient_role=recipient_role)}
+
+
+# ---------------------------------------------------------------------------
+# Section 19 — Reports
+# ---------------------------------------------------------------------------
+
+_MEDIA_TYPES = {"pdf": "application/pdf", "csv": "text/csv", "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}
+
+
+@router.get("/cases/{council_case_id}/reports/{report_type}")
+def get_case_report(
+    council_case_id: int, report_type: str, export_format: str = Query("pdf"),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        data = council_reports_service.export_case_report(db, _tenant(current_user), council_case_id, report_type, export_format)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return Response(content=data, media_type=_MEDIA_TYPES.get(export_format, "application/octet-stream"))
+
+
+@router.get("/reports/governance")
+def get_governance_report(
+    export_format: str = Query("pdf"), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        data = council_reports_service.export_governance_report(db, _tenant(current_user), export_format)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return Response(content=data, media_type=_MEDIA_TYPES.get(export_format, "application/octet-stream"))
+
+
+@router.get("/reports/performance")
+def get_performance_report(
+    export_format: str = Query("pdf"), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        data = council_reports_service.export_performance_report(db, _tenant(current_user), export_format)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return Response(content=data, media_type=_MEDIA_TYPES.get(export_format, "application/octet-stream"))

--- a/backend/app/routes/maestro_orchestration.py
+++ b/backend/app/routes/maestro_orchestration.py
@@ -1,0 +1,228 @@
+"""LumenAI AI Specialist — Project Maestro: Operational Orchestration &
+Decision Intelligence routes.
+
+Frontend route: /maestro. API prefix: /api/maestro.
+
+Maestro is a pure read-and-synthesize leadership layer over every other
+specialist -- see `app/models/maestro_orchestration.py` for the full
+naming disambiguation from Phase 22's `app.agents.orchestrator` and
+Nova's `nova_orchestration_service.py`, neither of which this router
+touches.
+
+Uses `tenant_authz.require_tenant_roles`, consistent with every sprint
+since Athena (v4.8).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.deps import get_db
+from app.models.maestro_orchestration import BRIEF_TYPES
+from app.services import (
+    maestro_capa_integration_service,
+    maestro_daily_brief_service,
+    maestro_decision_journal_service,
+    maestro_orchestration_service,
+    maestro_priority_engine_service,
+    maestro_recommendation_engine_service,
+    maestro_timeline_service,
+)
+from app.services.maestro_health_index_service import compute_operational_health, to_dict as health_to_dict
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/maestro", tags=["maestro"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Operational Orchestrator
+# ---------------------------------------------------------------------------
+
+
+@router.post("/run")
+def post_run_orchestration(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return maestro_orchestration_service.run_daily_orchestration(db, _tenant(current_user))
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Priority Engine
+# ---------------------------------------------------------------------------
+
+
+@router.post("/priorities/run", status_code=201)
+def post_run_priorities(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    rows = maestro_priority_engine_service.compute_priorities(db, _tenant(current_user))
+    return {"priorities": [maestro_priority_engine_service.to_dict(r) for r in rows]}
+
+
+@router.get("/priorities")
+def get_priorities(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"priorities": maestro_priority_engine_service.latest_priorities(db, _tenant(current_user))}
+
+
+# ---------------------------------------------------------------------------
+# Sections 3 & 5 — Leadership Recommendation Engine
+# ---------------------------------------------------------------------------
+
+
+@router.post("/recommendations/run", status_code=201)
+def post_run_recommendations(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    specific = maestro_recommendation_engine_service.generate_recommendations(db, _tenant(current_user))
+    strategic = maestro_recommendation_engine_service.generate_strategic_recommendations(db, _tenant(current_user))
+    return {
+        "recommendations": [
+            maestro_recommendation_engine_service.to_dict(r) for r in (*specific, *strategic)
+        ],
+    }
+
+
+@router.get("/recommendations")
+def get_recommendations(
+    status: str = Query(""), timeline_horizon: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return {
+        "recommendations": maestro_recommendation_engine_service.list_recommendations(
+            db, _tenant(current_user), status=status, timeline_horizon=timeline_horizon,
+        ),
+    }
+
+
+@router.post("/recommendations/{recommendation_id}/status")
+def post_recommendation_status(
+    recommendation_id: int, payload: dict,
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    row = maestro_recommendation_engine_service.update_status(
+        db, _tenant(current_user), recommendation_id, payload.get("status", ""),
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Recommendation not found")
+    return maestro_recommendation_engine_service.to_dict(row)
+
+
+@router.post("/recommendations/{recommendation_id}/create-capa", status_code=201)
+def post_create_capa(
+    recommendation_id: int,
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    capa = maestro_capa_integration_service.create_capa_from_recommendation(
+        db, _tenant(current_user), recommendation_id, owner=_actor(current_user),
+    )
+    if capa is None:
+        raise HTTPException(status_code=404, detail="No matching CAPA-draft recommendation or triggering pattern found")
+    return capa
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Daily Operational Brief
+# ---------------------------------------------------------------------------
+
+
+@router.post("/briefs/{brief_type}/generate", status_code=201)
+def post_generate_brief(
+    brief_type: str, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    if brief_type not in BRIEF_TYPES:
+        raise HTTPException(status_code=422, detail=f"Unknown brief_type '{brief_type}'")
+    row = maestro_daily_brief_service.generate_brief(db, _tenant(current_user), brief_type)
+    return maestro_daily_brief_service.to_dict(row)
+
+
+@router.get("/briefs/{brief_type}/latest")
+def get_latest_brief(
+    brief_type: str, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    result = maestro_daily_brief_service.latest_brief(db, _tenant(current_user), brief_type)
+    if result is None:
+        raise HTTPException(status_code=404, detail="No brief generated yet")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Strategy Timeline
+# ---------------------------------------------------------------------------
+
+
+@router.get("/timeline")
+def get_timeline(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return maestro_timeline_service.strategy_timeline(db, _tenant(current_user))
+
+
+@router.post("/timeline/{recommendation_id}/move")
+def post_move_timeline(
+    recommendation_id: int, payload: dict,
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        row = maestro_timeline_service.move_horizon(
+            db, _tenant(current_user), recommendation_id, payload.get("timeline_horizon", ""),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if row is None:
+        raise HTTPException(status_code=404, detail="Recommendation not found")
+    return maestro_recommendation_engine_service.to_dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Operational Health Index
+# ---------------------------------------------------------------------------
+
+
+@router.post("/health/run", status_code=201)
+def post_run_health(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = compute_operational_health(db, _tenant(current_user))
+    return health_to_dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Decision Journal
+# ---------------------------------------------------------------------------
+
+
+@router.post("/decisions", status_code=201)
+def post_decision(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        row = maestro_decision_journal_service.record_decision(
+            db, _tenant(current_user), payload.get("recommendation_id"),
+            leader_decision=payload.get("leader_decision", ""), decided_by=_actor(current_user),
+            decided_role=current_user.get("role", ""), outcome=payload.get("outcome", ""),
+            lessons_learned=payload.get("lessons_learned", ""), new_status=payload.get("new_status"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return maestro_decision_journal_service.to_dict(row)
+
+
+@router.get("/decisions")
+def get_decisions(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"journal": maestro_decision_journal_service.list_journal(db, _tenant(current_user))}
+
+
+@router.get("/decisions/{recommendation_id}")
+def get_decisions_for_recommendation(
+    recommendation_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    return {"journal": maestro_decision_journal_service.journal_for_recommendation(db, _tenant(current_user), recommendation_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Leadership Workspace (`/maestro`)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/workspace")
+def get_workspace(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return maestro_orchestration_service.leadership_workspace_summary(db, _tenant(current_user))

--- a/backend/app/routes/sage_education.py
+++ b/backend/app/routes/sage_education.py
@@ -1,0 +1,400 @@
+"""LumenAI AI Specialist — Project Sage: SPD Education, Competency &
+Workforce Intelligence routes.
+
+Frontend routes: /sage (leadership/educator workspace), /my-learning
+(technician self-view). API prefix: /api/sage.
+
+Uses `tenant_authz.require_tenant_roles`, consistent with every sprint since
+Athena (v4.8). Individual-level competency/learning data (gaps, learning
+plans, assessments, executive summary) is leadership-only
+(`_LEADERSHIP_ROLES`) per Section 16 -- a viewer/operator may only ever see
+their OWN data, via `/my-learning`, which resolves the learner identity from
+the authenticated user, never from a client-supplied technician parameter.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.deps import get_db
+from app.models.vulcan_reliability import VulcanReliabilityAssessment
+from app.services import (
+    sage_aegis_vulcan_integration_service,
+    sage_assessment_service,
+    sage_athena_apollo_integration_service,
+    sage_competency_taxonomy_service,
+    sage_effectiveness_service,
+    sage_executive_intelligence_service,
+    sage_feedback_service,
+    sage_image_library_service,
+    sage_knowledge_gap_service,
+    sage_learning_plan_service,
+    sage_microlearning_service,
+    sage_my_learning_service,
+    sage_workforce_privacy_service,
+    sage_workspace_service,
+)
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/sage", tags=["sage"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Competency Taxonomy
+# ---------------------------------------------------------------------------
+
+
+@router.get("/taxonomy")
+def get_taxonomy(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES))):
+    return sage_competency_taxonomy_service.taxonomy_tree()
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Competency Gap Detection (leadership-only: individual data)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/gaps/detect/{technician}", status_code=201)
+def post_detect_gaps(
+    technician: str, window_days: int = Query(90),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    tenant_id = _tenant(current_user)
+    sage_workforce_privacy_service.log_individual_access(
+        db, tenant_id, viewer=_actor(current_user), viewer_role=current_user.get("role", ""),
+        subject=technician, resource_type="sage_knowledge_gap",
+    )
+    return {"gaps": sage_knowledge_gap_service.run_gap_detection_for_technician(db, tenant_id, technician, window_days)}
+
+
+@router.get("/gaps")
+def get_gaps(
+    competency_domain: str = Query(""), scope_type: str = Query(""), scope_value: str = Query(""),
+    instrument_family: str = Query(""), anatomy_zone: str = Query(""), status: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    return {
+        "gaps": sage_knowledge_gap_service.list_gaps(
+            db, _tenant(current_user), competency_domain=competency_domain, scope_type=scope_type,
+            scope_value=scope_value, instrument_family=instrument_family, anatomy_zone=anatomy_zone, status=status,
+        )
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Adaptive Learning Plans (leadership-only to create/manage)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/learning-plans", status_code=201)
+def post_learning_plan(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    due_date = payload.get("due_date")
+    row = sage_learning_plan_service.create_learning_plan(
+        db, _tenant(current_user), learner_or_group=payload.get("learner_or_group", ""), created_by=_actor(current_user),
+        knowledge_gap_id=payload.get("knowledge_gap_id"), scope_type=payload.get("scope_type", "individual"),
+        identified_need=payload.get("identified_need", ""), supporting_evidence=payload.get("supporting_evidence"),
+        learning_objective=payload.get("learning_objective", ""), instrument_family=payload.get("instrument_family", ""),
+        anatomy_zone=payload.get("anatomy_zone", ""), finding_category=payload.get("finding_category", ""),
+        education_content=payload.get("education_content", ""), microlearning_module_id=payload.get("microlearning_module_id"),
+        practice_activity=payload.get("practice_activity", ""),
+        return_demonstration_required=bool(payload.get("return_demonstration_required", False)),
+        evaluator=payload.get("evaluator", ""), due_date=datetime.fromisoformat(due_date) if due_date else None,
+        confidence=payload.get("confidence", "moderate"),
+    )
+    return sage_learning_plan_service.to_dict(row)
+
+
+@router.post("/learning-plans/{plan_id}/approve")
+def post_approve_plan(plan_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sage_learning_plan_service.approve_learning_plan(db, _tenant(current_user), plan_id, approved_by=_actor(current_user))
+    if row is None:
+        raise HTTPException(status_code=404, detail="Learning plan not found")
+    return sage_learning_plan_service.to_dict(row)
+
+
+@router.post("/learning-plans/{plan_id}/reject-or-edit")
+def post_reject_or_edit_plan(plan_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        row = sage_learning_plan_service.reject_or_edit_learning_plan(
+            db, _tenant(current_user), plan_id, acted_by=_actor(current_user), action=payload.get("action", "edit"),
+            override_reason=payload.get("override_reason", ""), edits=payload.get("edits"),
+        )
+    except sage_learning_plan_service.OverrideReasonRequiredError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if row is None:
+        raise HTTPException(status_code=404, detail="Learning plan not found")
+    return sage_learning_plan_service.to_dict(row)
+
+
+@router.post("/learning-plans/{plan_id}/complete")
+def post_complete_plan(plan_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sage_learning_plan_service.mark_completed(db, _tenant(current_user), plan_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Learning plan not found")
+    return sage_learning_plan_service.to_dict(row)
+
+
+@router.get("/learning-plans")
+def get_learning_plans(
+    learner_or_group: str = Query(""), completion_status: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    return {"plans": sage_learning_plan_service.list_plans(db, _tenant(current_user), learner_or_group=learner_or_group, completion_status=completion_status)}
+
+
+@router.get("/learning-plans/{plan_id}")
+def get_learning_plan(plan_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sage_learning_plan_service.get_plan(db, _tenant(current_user), plan_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Learning plan not found")
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Microlearning Generator
+# ---------------------------------------------------------------------------
+
+
+@router.post("/microlearning/{finding_type}", status_code=201)
+def post_build_module(
+    finding_type: str, instrument_family: str = Query(""), anatomy_zone: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    row = sage_microlearning_service.build_module_from_finding(
+        db, _tenant(current_user), finding_type, instrument_family=instrument_family, anatomy_zone=anatomy_zone,
+    )
+    if row is None:
+        raise HTTPException(status_code=422, detail=f"'{finding_type}' is not an approved knowledge-library category")
+    return sage_microlearning_service._to_dict(row)
+
+
+@router.post("/microlearning/{module_id}/approve")
+def post_approve_module(module_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sage_microlearning_service.approve_module(db, _tenant(current_user), module_id, approved_by=_actor(current_user))
+    if row is None:
+        raise HTTPException(status_code=404, detail="Microlearning module not found")
+    return sage_microlearning_service._to_dict(row)
+
+
+@router.get("/microlearning")
+def get_modules(approval_status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"modules": sage_microlearning_service.list_modules(db, _tenant(current_user), approval_status=approval_status)}
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Competency Assessment Builder
+# ---------------------------------------------------------------------------
+
+
+@router.post("/assessments", status_code=201)
+def post_assessment(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        row = sage_assessment_service.create_assessment(
+            db, _tenant(current_user), assessment_format=payload.get("assessment_format", ""),
+            target_learner=payload.get("target_learner", ""), competency_domain=payload.get("competency_domain", ""),
+            content=payload.get("content"), learning_plan_id=payload.get("learning_plan_id"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return sage_assessment_service.to_dict(row)
+
+
+@router.post("/assessments/{assessment_id}/result")
+def post_assessment_result(assessment_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sage_assessment_service.record_result(db, _tenant(current_user), assessment_id, result=payload.get("result", {}))
+    if row is None:
+        raise HTTPException(status_code=404, detail="Assessment not found")
+    return sage_assessment_service.to_dict(row)
+
+
+@router.post("/assessments/{assessment_id}/validate")
+def post_validate_assessment(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sage_assessment_service.validate_result(db, _tenant(current_user), assessment_id, validated_by=_actor(current_user))
+    if row is None:
+        raise HTTPException(status_code=404, detail="Assessment not found")
+    return sage_assessment_service.to_dict(row)
+
+
+@router.get("/assessments")
+def get_assessments(target_learner: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"assessments": sage_assessment_service.list_assessments(db, _tenant(current_user), target_learner=target_learner)}
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Image-Based Learning Library
+# ---------------------------------------------------------------------------
+
+
+@router.post("/images/{retained_image_id}/curate", status_code=201)
+def post_curate_image(retained_image_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sage_image_library_service.curate_image_for_education(
+        db, _tenant(current_user), retained_image_id, anatomy_zone=payload.get("anatomy_zone", ""),
+        usage_rights=payload.get("usage_rights", "internal_education_use"), dataset_version=payload.get("dataset_version", "1.0.0"),
+    )
+    if row is None:
+        raise HTTPException(status_code=422, detail="Image is not consented and gold-labeled; cannot curate for education")
+    return sage_image_library_service.to_dict(row)
+
+
+@router.post("/images/{entry_id}/phi-review")
+def post_phi_review(entry_id: int, payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sage_image_library_service.mark_phi_reviewed(db, _tenant(current_user), entry_id, cleared=bool(payload.get("cleared", False)))
+    if row is None:
+        raise HTTPException(status_code=404, detail="Education image entry not found")
+    return sage_image_library_service.to_dict(row)
+
+
+@router.get("/images")
+def get_images(
+    instrument_family: str = Query(""), anatomy_zone: str = Query(""), finding_category: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return {
+        "images": sage_image_library_service.list_education_images(
+            db, _tenant(current_user), instrument_family=instrument_family, anatomy_zone=anatomy_zone,
+            finding_category=finding_category, phi_cleared_only=True,
+        )
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Learning Effectiveness Engine
+# ---------------------------------------------------------------------------
+
+
+@router.post("/learning-plans/{plan_id}/measure-effectiveness", status_code=201)
+def post_measure_effectiveness(
+    plan_id: int, window_days: int = Query(30),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    from app.models.sage_education import SageLearningPlan
+    plan = db.query(SageLearningPlan).filter(SageLearningPlan.id == plan_id, SageLearningPlan.tenant_id == _tenant(current_user)).first()
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Learning plan not found")
+    if plan.completion_status != "completed":
+        raise HTTPException(status_code=422, detail="Effectiveness can only be measured for a completed learning plan")
+    row = sage_effectiveness_service.measure_learning_plan_effectiveness(db, _tenant(current_user), plan, window_days=window_days)
+    plan.effectiveness_assessment_id = row.id
+    db.commit()
+    return sage_effectiveness_service.to_dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Section 10 — Sage Workspace
+# ---------------------------------------------------------------------------
+
+
+@router.get("/workspace")
+def get_workspace(
+    instrument_family: str = Query(""), anatomy_zone: str = Query(""), competency_domain: str = Query(""),
+    learner_or_group: str = Query(""), shift: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    return sage_workspace_service.workspace_summary(
+        db, _tenant(current_user), instrument_family=instrument_family, anatomy_zone=anatomy_zone,
+        competency_domain=competency_domain, learner_or_group=learner_or_group, shift=shift,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 11 — Technician Learning Center (`/my-learning`)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/my-learning")
+def get_my_learning(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    """Always resolves the learner from the AUTHENTICATED identity -- never
+    from a client-supplied parameter, so a technician can never view a
+    peer's learning data through this endpoint."""
+    return sage_my_learning_service.my_learning_center(db, _tenant(current_user), _actor(current_user))
+
+
+# ---------------------------------------------------------------------------
+# Section 12 — Educator and Supervisor Feedback
+# ---------------------------------------------------------------------------
+
+
+@router.post("/feedback", status_code=201)
+def post_feedback(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        row = sage_feedback_service.record_feedback(
+            db, _tenant(current_user), action=payload.get("action", ""), submitted_by=_actor(current_user),
+            submitted_role=current_user.get("role", ""), learning_plan_id=payload.get("learning_plan_id"),
+            knowledge_gap_id=payload.get("knowledge_gap_id"), comment=payload.get("comment", ""),
+            override_reason=payload.get("override_reason", ""),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return sage_feedback_service.to_dict(row)
+
+
+@router.get("/feedback/{plan_id}")
+def get_feedback(plan_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"feedback": sage_feedback_service.feedback_for_plan(db, _tenant(current_user), plan_id)}
+
+
+# ---------------------------------------------------------------------------
+# Sections 13, 14 — Aegis / Vulcan Integration
+# ---------------------------------------------------------------------------
+
+
+@router.get("/aegis-recommendation")
+def get_aegis_recommendation(
+    instrument_identity: str = Query(...), zone: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    return sage_aegis_vulcan_integration_service.sage_recommendation_from_aegis(db, _tenant(current_user), instrument_identity, zone=zone or None)
+
+
+@router.get("/vulcan-recommendation/{assessment_id}")
+def get_vulcan_recommendation(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    assessment = (
+        db.query(VulcanReliabilityAssessment)
+        .filter(VulcanReliabilityAssessment.id == assessment_id, VulcanReliabilityAssessment.tenant_id == _tenant(current_user))
+        .first()
+    )
+    if assessment is None:
+        raise HTTPException(status_code=404, detail="Vulcan reliability assessment not found")
+    return sage_aegis_vulcan_integration_service.sage_recommendation_from_vulcan(assessment)
+
+
+# ---------------------------------------------------------------------------
+# Section 15 — Athena and Apollo Integration
+# ---------------------------------------------------------------------------
+
+
+@router.get("/institutional-content")
+def get_institutional_content(query: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"entries": sage_athena_apollo_integration_service.approved_institutional_content(db, _tenant(current_user), query=query)}
+
+
+@router.get("/department-competency-evidence")
+def get_department_competency_evidence(
+    department: str = Query("unspecified"),
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    result = sage_athena_apollo_integration_service.department_competency_evidence(db, _tenant(current_user), department)
+    return result or {"department": department, "competency_score": None, "education_score": None, "snapshot_created_at": None}
+
+
+# ---------------------------------------------------------------------------
+# Section 18 — Executive Workforce Intelligence
+# ---------------------------------------------------------------------------
+
+
+@router.get("/executive-summary")
+def get_executive_summary(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return sage_executive_intelligence_service.executive_workforce_intelligence(db, _tenant(current_user))

--- a/backend/app/routes/sentinelx_risk.py
+++ b/backend/app/routes/sentinelx_risk.py
@@ -1,0 +1,184 @@
+"""LumenAI AI Specialist — Project Sentinel-X: Clinical Risk Intelligence &
+Patient Safety Agent routes.
+
+Frontend route: /risk. API prefix: /api/sentinelx.
+
+**"Sentinel" already exists** as a different, established system in this
+codebase (`/api/sentinel`, `/sentinel`) -- this router deliberately uses a
+distinct `/api/sentinelx` prefix to avoid any collision or confusion; see
+`app/models/sentinelx_risk.py` for the full naming disambiguation.
+
+Uses `tenant_authz.require_tenant_roles`, consistent with every sprint
+since Athena (v4.8).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.deps import get_db
+from app.models.sentinelx_risk import SentinelXRiskAssessment
+from app.services import (
+    sentinelx_dashboard_service,
+    sentinelx_heatmap_service,
+    sentinelx_override_service,
+    sentinelx_patient_safety_watch_service,
+    sentinelx_predictive_service,
+    sentinelx_risk_agent_service,
+    sentinelx_supervisor_workspace_service,
+    sentinelx_timeline_service,
+)
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/sentinelx", tags=["sentinelx"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Risk Intelligence Agent
+# ---------------------------------------------------------------------------
+
+
+@router.post("/assess", status_code=201)
+def post_assess(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    instrument_identity = payload.get("instrument_identity", "")
+    if not instrument_identity:
+        raise HTTPException(status_code=422, detail="instrument_identity is required")
+    row = sentinelx_risk_agent_service.run_risk_assessment(
+        db, _tenant(current_user), instrument_identity,
+        instrument_type=payload.get("instrument_type", ""), inspection_id=payload.get("inspection_id"),
+    )
+    return sentinelx_risk_agent_service.to_dict(row)
+
+
+@router.get("/assessments/{assessment_id}")
+def get_assessment(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    row = (
+        db.query(SentinelXRiskAssessment)
+        .filter(SentinelXRiskAssessment.id == assessment_id, SentinelXRiskAssessment.tenant_id == _tenant(current_user))
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Sentinel-X risk assessment not found")
+    return sentinelx_risk_agent_service.to_dict(row)
+
+
+@router.get("/assessments")
+def get_assessments(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    rows = (
+        db.query(SentinelXRiskAssessment)
+        .filter(SentinelXRiskAssessment.tenant_id == _tenant(current_user))
+        .order_by(SentinelXRiskAssessment.created_at.desc())
+        .all()
+    )
+    return {"assessments": [sentinelx_risk_agent_service.to_dict(r) for r in rows]}
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Patient Safety Watch
+# ---------------------------------------------------------------------------
+
+
+@router.post("/alerts/scan", status_code=201)
+def post_scan_alerts(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    fired = sentinelx_patient_safety_watch_service.scan_for_alerts(db, _tenant(current_user))
+    return {"alerts_fired": [sentinelx_patient_safety_watch_service.to_dict(a) for a in fired]}
+
+
+@router.get("/alerts")
+def get_alerts(acknowledged: bool | None = Query(None), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"alerts": sentinelx_patient_safety_watch_service.list_alerts(db, _tenant(current_user), acknowledged=acknowledged)}
+
+
+@router.post("/alerts/{alert_id}/acknowledge")
+def post_acknowledge_alert(alert_id: int, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    row = sentinelx_patient_safety_watch_service.acknowledge_alert(db, _tenant(current_user), alert_id, acknowledged_by=_actor(current_user))
+    if row is None:
+        raise HTTPException(status_code=404, detail="Alert not found")
+    return sentinelx_patient_safety_watch_service.to_dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Enterprise Risk Heatmaps
+# ---------------------------------------------------------------------------
+
+
+@router.get("/heatmaps")
+def get_heatmaps(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return sentinelx_heatmap_service.all_heatmaps(db, _tenant(current_user))
+
+
+@router.get("/heatmaps/{dimension}")
+def get_heatmap(dimension: str, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    result = sentinelx_heatmap_service.risk_heatmap(db, _tenant(current_user), dimension)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Unknown heatmap dimension '{dimension}'")
+    return {"dimension": dimension, "buckets": result}
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Risk Timeline
+# ---------------------------------------------------------------------------
+
+
+@router.get("/timeline/{instrument_identity}")
+def get_timeline(instrument_identity: str, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return sentinelx_timeline_service.build_risk_timeline(db, _tenant(current_user), instrument_identity)
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Predictive Risk
+# ---------------------------------------------------------------------------
+
+
+@router.get("/predictive/{instrument_identity}")
+def get_predictive(instrument_identity: str, instrument_type: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return sentinelx_predictive_service.predictive_risk_summary(db, _tenant(current_user), instrument_identity, instrument_type)
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Risk Dashboard (`/risk`)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/dashboard")
+def get_dashboard(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return sentinelx_dashboard_service.risk_dashboard_summary(db, _tenant(current_user))
+
+
+# ---------------------------------------------------------------------------
+# Section 10 — Supervisor Workspace + auditable overrides
+# ---------------------------------------------------------------------------
+
+
+@router.get("/supervisor-workspace")
+def get_supervisor_workspace(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return sentinelx_supervisor_workspace_service.supervisor_workspace_summary(db, _tenant(current_user))
+
+
+@router.post("/overrides", status_code=201)
+def post_override(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        row = sentinelx_override_service.submit_override(
+            db, _tenant(current_user), payload.get("assessment_id"),
+            overridden_risk_level=payload.get("overridden_risk_level", ""), rationale=payload.get("rationale", ""),
+            submitted_by=_actor(current_user), submitted_role=current_user.get("role", ""),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return sentinelx_override_service.to_dict(row)
+
+
+@router.get("/overrides/{assessment_id}")
+def get_overrides(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"overrides": sentinelx_override_service.overrides_for_assessment(db, _tenant(current_user), assessment_id)}

--- a/backend/app/routes/veritas_evidence.py
+++ b/backend/app/routes/veritas_evidence.py
@@ -1,0 +1,287 @@
+"""LumenAI AI Specialist — Project Veritas: Baseline Governance, Evidence
+Integrity & Clinical Data Quality routes.
+
+Frontend route: /veritas. API prefix: /api/veritas.
+
+Uses `tenant_authz.require_tenant_roles`, consistent with every sprint since
+Athena (v4.8). Per Section 20: viewers may not approve baselines or
+override evidence gates; technicians (`operator` role) may not alter
+baseline governance status. Both are enforced at the route layer via
+`_LEADERSHIP_ROLES` for governance/override endpoints, with an additional
+in-handler check on the shared `/feedback` endpoint since only one of its
+several actions (`override_evidence_gate`) requires leadership.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.orm import Session
+
+from app.deps import get_db
+from app.models.veritas_evidence import FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE, VeritasEvidenceReadinessAssessment
+from app.services import (
+    veritas_baseline_governance_service,
+    veritas_data_quality_service,
+    veritas_evidence_agent_service,
+    veritas_feedback_service,
+    veritas_provenance_service,
+    veritas_reports_service,
+    veritas_specialist_collaboration_service,
+    veritas_training_dataset_service,
+    veritas_watchlist_service,
+    veritas_workspace_service,
+)
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/veritas", tags=["veritas"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+# ---------------------------------------------------------------------------
+# Sections 1, 10, 12 — Evidence Assurance Agent + Evidence Gate + Panel data
+# ---------------------------------------------------------------------------
+
+
+@router.post("/assess/{inspection_id}", status_code=201)
+def post_assess(inspection_id: int, payload: dict | None = None, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    payload = payload or {}
+    try:
+        row = veritas_evidence_agent_service.run_evidence_assessment(
+            db, _tenant(current_user), inspection_id,
+            model_version=payload.get("model_version", ""), dataset_version=payload.get("dataset_version", ""),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return veritas_evidence_agent_service.to_dict(row)
+
+
+@router.get("/assessments/{assessment_id}")
+def get_assessment(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    row = (
+        db.query(VeritasEvidenceReadinessAssessment)
+        .filter(VeritasEvidenceReadinessAssessment.id == assessment_id, VeritasEvidenceReadinessAssessment.tenant_id == _tenant(current_user))
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Veritas assessment not found")
+    return veritas_evidence_agent_service.to_dict(row)
+
+
+@router.get("/assessments")
+def get_assessments(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    rows = (
+        db.query(VeritasEvidenceReadinessAssessment)
+        .filter(VeritasEvidenceReadinessAssessment.tenant_id == _tenant(current_user))
+        .order_by(VeritasEvidenceReadinessAssessment.created_at.desc())
+        .all()
+    )
+    return {"assessments": [veritas_evidence_agent_service.to_dict(r) for r in rows]}
+
+
+# ---------------------------------------------------------------------------
+# Sections 3, 13 — Baseline Governance + Review Workspace
+# ---------------------------------------------------------------------------
+
+
+@router.post("/baselines/{source_type}/{source_id}/governance-action", status_code=201)
+def post_governance_action(
+    source_type: str, source_id: int, payload: dict,
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        row = veritas_baseline_governance_service.record_governance_action(
+            db, _tenant(current_user), baseline_source_type=source_type, baseline_source_id=source_id,
+            action=payload.get("action", ""), performed_by=_actor(current_user), performed_role=current_user.get("role", ""),
+            owner=payload.get("owner", ""), review_date=payload.get("review_date"),
+            known_limitations=payload.get("known_limitations", ""), usage_rights=payload.get("usage_rights", ""),
+            rationale=payload.get("rationale", ""),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return veritas_baseline_governance_service._to_dict(row)
+
+
+@router.get("/baselines/{source_type}/{source_id}/governance-history")
+def get_governance_history(source_type: str, source_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {
+        "history": veritas_baseline_governance_service.governance_history(db, _tenant(current_user), source_type, source_id),
+        "effective_status": veritas_baseline_governance_service.effective_status(db, _tenant(current_user), source_type, source_id),
+    }
+
+
+@router.post("/baselines/compare")
+def post_compare_baselines(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    candidates = [(c["source_type"], c["source_id"]) for c in payload.get("candidates", [])]
+    return {"comparison": veritas_baseline_governance_service.compare_candidates(db, _tenant(current_user), candidates)}
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Evidence Provenance Ledger
+# ---------------------------------------------------------------------------
+
+
+@router.post("/provenance", status_code=201)
+def post_provenance(payload: dict, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    try:
+        row = veritas_provenance_service.record_provenance(db, _tenant(current_user), **payload)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return veritas_provenance_service.to_dict(row)
+
+
+@router.get("/provenance")
+def get_provenance(inspection_id: int = Query(None), evidence_type: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"records": veritas_provenance_service.list_provenance(db, _tenant(current_user), inspection_id=inspection_id, evidence_type=evidence_type)}
+
+
+# ---------------------------------------------------------------------------
+# Section 15 — Training Dataset Assurance
+# ---------------------------------------------------------------------------
+
+
+@router.post("/training-dataset/{retained_image_id}/evaluate", status_code=201)
+def post_evaluate_training(retained_image_id: int, payload: dict | None = None, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    payload = payload or {}
+    try:
+        row = veritas_training_dataset_service.evaluate_for_training(
+            db, _tenant(current_user), retained_image_id,
+            instrument_family=payload.get("instrument_family", ""), anatomy_zone=payload.get("anatomy_zone", ""),
+            usage_rights=payload.get("usage_rights", ""), image_quality_threshold_met=bool(payload.get("image_quality_threshold_met", False)),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return veritas_training_dataset_service.to_dict(row)
+
+
+@router.get("/training-dataset")
+def get_training_dataset(dataset_status: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return {"entries": veritas_training_dataset_service.list_dataset_entries(db, _tenant(current_user), dataset_status=dataset_status)}
+
+
+# ---------------------------------------------------------------------------
+# Section 17 — Supervisor Feedback (+ Section 10 gate override)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/feedback", status_code=201)
+def post_feedback(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    action = payload.get("action", "")
+    if action == FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE and current_user.get("role") not in _LEADERSHIP_ROLES:
+        raise HTTPException(status_code=403, detail="Only an authorized supervisor/manager may override an evidence gate")
+    try:
+        row = veritas_feedback_service.submit_feedback(
+            db, _tenant(current_user), action=action, submitted_by=_actor(current_user),
+            submitted_role=current_user.get("role", ""), assessment_id=payload.get("assessment_id"),
+            baseline_match_correct=payload.get("baseline_match_correct"),
+            image_quality_assessment_correct=payload.get("image_quality_assessment_correct"),
+            anatomy_zone_tag_correct=payload.get("anatomy_zone_tag_correct"),
+            coverage_determination_correct=payload.get("coverage_determination_correct"),
+            evidence_conflict_valid=payload.get("evidence_conflict_valid"),
+            corrected_baseline=payload.get("corrected_baseline", ""), corrected_zone=payload.get("corrected_zone", ""),
+            final_evidence_status=payload.get("final_evidence_status", ""), reviewer_rationale=payload.get("reviewer_rationale", ""),
+            override_reason=payload.get("override_reason", ""), limitations_acknowledged=payload.get("limitations_acknowledged", ""),
+            final_disposition=payload.get("final_disposition", ""),
+        )
+    except veritas_feedback_service.OverrideReasonRequiredError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return veritas_feedback_service.to_dict(row)
+
+
+@router.get("/feedback/{assessment_id}")
+def get_feedback(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"feedback": veritas_feedback_service.feedback_for_assessment(db, _tenant(current_user), assessment_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 11 — Veritas Workspace
+# ---------------------------------------------------------------------------
+
+
+@router.get("/workspace")
+def get_workspace(instrument_family: str = Query(""), anatomy_zone: str = Query(""), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return veritas_workspace_service.workspace_summary(db, _tenant(current_user), instrument_family=instrument_family, anatomy_zone=anatomy_zone)
+
+
+# ---------------------------------------------------------------------------
+# Section 14 — Data Quality Monitoring
+# ---------------------------------------------------------------------------
+
+
+@router.get("/data-quality")
+def get_data_quality(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    return veritas_data_quality_service.data_quality_summary(db, _tenant(current_user))
+
+
+# ---------------------------------------------------------------------------
+# Section 18 — Alerts and Watchlists
+# ---------------------------------------------------------------------------
+
+
+@router.get("/watchlists")
+def get_watchlists(current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {name: fn(db, tenant_id) for name, fn in veritas_watchlist_service.WATCHLISTS.items()}
+
+
+@router.get("/watchlists/{name}")
+def get_watchlist(name: str, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    result = veritas_watchlist_service.run_watchlist(db, _tenant(current_user), name)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Unknown watchlist '{name}'")
+    return {"watchlist": name, "entries": result}
+
+
+# ---------------------------------------------------------------------------
+# Section 19 — Evidence Assurance Reports
+# ---------------------------------------------------------------------------
+
+
+@router.get("/reports/{name}")
+def get_report(name: str, current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    report = veritas_reports_service.build_named_report(db, _tenant(current_user), name)
+    if report is None:
+        raise HTTPException(status_code=404, detail=f"Unknown report '{name}'")
+    return report
+
+
+@router.get("/reports/{name}/export")
+def get_report_export(name: str, format: str = Query("csv"), current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db)):
+    report = veritas_reports_service.build_named_report(db, _tenant(current_user), name)
+    if report is None:
+        raise HTTPException(status_code=404, detail=f"Unknown report '{name}'")
+    if format == "pdf":
+        data = veritas_reports_service.build_report_pdf_bytes(report["title"], report["content"])
+        media_type = "application/pdf"
+    elif format == "xlsx":
+        data = veritas_reports_service.build_report_xlsx_bytes(report["title"], report["content"])
+        media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    else:
+        data = veritas_reports_service.build_report_csv_bytes(report["content"])
+        media_type = "text/csv"
+    return Response(content=data, media_type=media_type)
+
+
+# ---------------------------------------------------------------------------
+# Section 16 — Collaboration With Other Agents
+# ---------------------------------------------------------------------------
+
+
+@router.get("/collaboration/clinical-reasoning/{assessment_id}")
+def get_clinical_reasoning_support(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    row = (
+        db.query(VeritasEvidenceReadinessAssessment)
+        .filter(VeritasEvidenceReadinessAssessment.id == assessment_id, VeritasEvidenceReadinessAssessment.tenant_id == _tenant(current_user))
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Veritas assessment not found")
+    return veritas_specialist_collaboration_service.evidence_support_for_clinical_reasoning(veritas_evidence_agent_service.to_dict(row))

--- a/backend/app/routes/vulcan_reliability.py
+++ b/backend/app/routes/vulcan_reliability.py
@@ -1,0 +1,224 @@
+"""LumenAI AI Specialist — Project Vulcan: Instrument Reliability, Failure
+Analysis & Repair Intelligence routes.
+
+Frontend route: /instrument-forensics. API prefix: /api/vulcan.
+
+Uses `tenant_authz.require_tenant_roles` (real `TenantMembership`
+verification), consistent with Athena/Phoenix/Infinity/Olympus/GuardianX/
+Genesis AI/Nova.
+
+  * POST /assess, GET /assessments/{id}                                — Sections 1, 7, 8, 15
+  * GET  /taxonomy                                                     — Section 2
+  * GET  /progression, GET /anatomy-zones                              — Sections 3, 4
+  * GET  /repair-effectiveness                                         — Section 5
+  * GET  /forensics/{instrument_identity}, GET /forensics/search        — Section 9
+  * GET  /watchlists, GET /watchlists/{name}                            — Section 10
+  * POST /feedback/{assessment_id}, GET /feedback/{assessment_id}       — Section 13
+  * GET  /executive-summary                                            — Section 14
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.deps import get_db
+from app.models.vulcan_reliability import VulcanReliabilityAssessment
+from app.services import (
+    vulcan_anatomy_zone_service,
+    vulcan_executive_analytics_service,
+    vulcan_failure_taxonomy_service,
+    vulcan_feedback_service,
+    vulcan_forensics_service,
+    vulcan_progression_service,
+    vulcan_reliability_agent_service,
+    vulcan_repair_effectiveness_service,
+    vulcan_watchlist_service,
+)
+from app.tenant_authz import require_tenant_roles
+
+router = APIRouter(prefix="/api/vulcan", tags=["vulcan"])
+
+_ALL_ROLES = ("admin", "spd_manager", "operator", "viewer")
+_LEADERSHIP_ROLES = ("admin", "spd_manager")
+
+
+def _tenant(current_user: dict) -> str:
+    return current_user["tenant_id"]
+
+
+def _actor(current_user: dict) -> str:
+    return current_user["user_email"]
+
+
+# ---------------------------------------------------------------------------
+# Sections 1, 7, 8, 15 — Reliability Agent orchestrator + audit trail
+# ---------------------------------------------------------------------------
+
+
+@router.post("/assess", status_code=201)
+def post_assess(payload: dict, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    instrument_identity = payload.get("instrument_identity", "")
+    if not instrument_identity:
+        raise HTTPException(status_code=422, detail="instrument_identity is required")
+    row = vulcan_reliability_agent_service.run_reliability_assessment(
+        db, tenant_id, instrument_identity,
+        instrument_type=payload.get("instrument_type", ""),
+        supervisor_concern=bool(payload.get("supervisor_concern", False)),
+        digital_twin_version=payload.get("digital_twin_version", ""),
+        baseline_version=payload.get("baseline_version", ""),
+        anatomy_profile_version=payload.get("anatomy_profile_version", ""),
+    )
+    return vulcan_reliability_agent_service.to_dict(row)
+
+
+@router.get("/assessments/{assessment_id}")
+def get_assessment(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    row = (
+        db.query(VulcanReliabilityAssessment)
+        .filter(VulcanReliabilityAssessment.id == assessment_id, VulcanReliabilityAssessment.tenant_id == _tenant(current_user))
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Vulcan assessment not found")
+    return vulcan_reliability_agent_service.to_dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Instrument Failure Taxonomy
+# ---------------------------------------------------------------------------
+
+
+@router.get("/taxonomy")
+def get_taxonomy(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES))):
+    return vulcan_failure_taxonomy_service.taxonomy_tree()
+
+
+# ---------------------------------------------------------------------------
+# Sections 3, 4 — Failure Progression Model + Anatomy-Zone Reliability
+# ---------------------------------------------------------------------------
+
+
+@router.get("/progression")
+def get_progression(
+    instrument_identity: str = Query(...), zone: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return vulcan_progression_service.compute_progression(db, _tenant(current_user), instrument_identity, zone=zone or None)
+
+
+@router.get("/anatomy-zones")
+def get_anatomy_zones(
+    instrument_identity: str = Query(...), instrument_type: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return vulcan_anatomy_zone_service.zone_reliability_analysis(db, _tenant(current_user), instrument_identity, instrument_type)
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Repair Effectiveness Intelligence
+# ---------------------------------------------------------------------------
+
+
+@router.get("/repair-effectiveness")
+def get_repair_effectiveness(
+    instrument_identity: str = Query(...),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return {"repairs": vulcan_repair_effectiveness_service.repair_history_for_instrument(db, _tenant(current_user), instrument_identity)}
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Instrument Forensics Workspace
+# ---------------------------------------------------------------------------
+
+
+@router.get("/forensics/search")
+def get_forensics_search(
+    manufacturer: str = Query(""), instrument_family: str = Query(""), anatomy_zone: str = Query(""),
+    failure_category: str = Query(""), repair_vendor: str = Query(""), facility: str = Query(""),
+    date_from: str = Query(""), date_to: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return {
+        "results": vulcan_forensics_service.search_forensics(
+            db, _tenant(current_user), manufacturer=manufacturer, instrument_family=instrument_family,
+            anatomy_zone=anatomy_zone, failure_category=failure_category, repair_vendor=repair_vendor,
+            facility=facility,
+            date_from=datetime.fromisoformat(date_from) if date_from else None,
+            date_to=datetime.fromisoformat(date_to) if date_to else None,
+        )
+    }
+
+
+@router.get("/forensics/{instrument_identity}")
+def get_forensics_record(
+    instrument_identity: str, instrument_type: str = Query(""),
+    current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db),
+):
+    return vulcan_forensics_service.instrument_forensics_record(db, _tenant(current_user), instrument_identity, instrument_type)
+
+
+# ---------------------------------------------------------------------------
+# Section 10 — Reliability Watchlists
+# ---------------------------------------------------------------------------
+
+
+@router.get("/watchlists")
+def get_watchlists(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    tenant_id = _tenant(current_user)
+    return {name: fn(db, tenant_id) for name, fn in vulcan_watchlist_service.WATCHLISTS.items()}
+
+
+@router.get("/watchlists/{name}")
+def get_watchlist(name: str, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    result = vulcan_watchlist_service.run_watchlist(db, _tenant(current_user), name)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Unknown watchlist '{name}'")
+    return {"watchlist": name, "entries": result}
+
+
+# ---------------------------------------------------------------------------
+# Section 13 — Supervisor and Repair Feedback
+# ---------------------------------------------------------------------------
+
+
+@router.post("/feedback/{assessment_id}", status_code=201)
+def post_feedback(
+    assessment_id: int, payload: dict,
+    current_user: dict = Depends(require_tenant_roles(*_LEADERSHIP_ROLES)), db: Session = Depends(get_db),
+):
+    try:
+        feedback = vulcan_feedback_service.submit_feedback(
+            db, _tenant(current_user), assessment_id,
+            submitted_by=_actor(current_user), submitted_role=payload.get("submitted_role", ""),
+            failure_classification_correct=payload.get("failure_classification_correct"),
+            anatomy_zone_correct=payload.get("anatomy_zone_correct"),
+            progression_correct=payload.get("progression_correct"),
+            repair_effectiveness_correct=payload.get("repair_effectiveness_correct"),
+            probable_contributor_correct=payload.get("probable_contributor_correct"),
+            final_disposition=payload.get("final_disposition", ""),
+            supervisor_rationale=payload.get("supervisor_rationale", ""),
+            repair_vendor_response=payload.get("repair_vendor_response", ""),
+            manufacturer_response=payload.get("manufacturer_response", ""),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return vulcan_feedback_service._feedback_to_dict(feedback)
+
+
+@router.get("/feedback/{assessment_id}")
+def get_feedback(assessment_id: int, current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return {"feedback": vulcan_feedback_service.feedback_for_assessment(db, _tenant(current_user), assessment_id)}
+
+
+# ---------------------------------------------------------------------------
+# Section 14 — Executive Reliability Analytics
+# ---------------------------------------------------------------------------
+
+
+@router.get("/executive-summary")
+def get_executive_summary(current_user: dict = Depends(require_tenant_roles(*_ALL_ROLES)), db: Session = Depends(get_db)):
+    return vulcan_executive_analytics_service.executive_summary(db, _tenant(current_user))

--- a/backend/app/services/council_agreement_map_service.py
+++ b/backend/app/services/council_agreement_map_service.py
@@ -1,0 +1,52 @@
+"""Project Council, Section 10: Agreement Map.
+
+Builds the visual agreement matrix -- rows are specialists, columns are
+distinct recommended actions, cells mark which specialist recommended
+which option -- plus confidence/evidence strength per position.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.services.council_specialist_assessment_service import latest_assessments_for_case
+
+
+def _normalize_action(text: str) -> str:
+    return " ".join((text or "").strip().lower().split()) or "no_action_recommended"
+
+
+def build_agreement_map(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    assessments = latest_assessments_for_case(db, tenant_id, council_case_id)
+    if not assessments:
+        return {"specialists": [], "positions": [], "matrix": {}, "consensus_position": "", "dissenting_specialists": []}
+
+    positions: dict[str, list[str]] = defaultdict(list)
+    original_titles: dict[str, str] = {}
+    for a in assessments:
+        key = _normalize_action(a["recommended_action"])
+        positions[key].append(a["specialist_key"])
+        original_titles.setdefault(key, a["recommended_action"] or "No action recommended")
+
+    consensus_key, consensus_members = max(positions.items(), key=lambda kv: len(kv[1]))
+    dissenting_specialists = [
+        a["specialist_key"] for a in assessments if a["specialist_key"] not in consensus_members
+    ]
+
+    matrix = {
+        a["specialist_key"]: {
+            "position": original_titles[_normalize_action(a["recommended_action"])],
+            "confidence": a["confidence"],
+            "evidence_strength": "high" if a["confidence"] == "high" else "moderate" if a["confidence"] == "moderate" else "low",
+        }
+        for a in assessments
+    }
+
+    return {
+        "specialists": [a["specialist_key"] for a in assessments],
+        "positions": [original_titles[k] for k in positions],
+        "matrix": matrix,
+        "consensus_position": original_titles[consensus_key],
+        "dissenting_specialists": dissenting_specialists,
+    }

--- a/backend/app/services/council_brief_service.py
+++ b/backend/app/services/council_brief_service.py
@@ -1,0 +1,60 @@
+"""Project Council, Section 11: Council Brief Generator.
+
+Role-specific briefs, all grounded in the same Council Case -- never a
+separate narrative that could drift from what the Council actually found.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services import council_orchestration_service
+from app.services.council_dissent_service import dissent_for_case
+from app.services.council_specialist_assessment_service import latest_assessments_for_case
+
+
+def _case_or_raise(db: Session, tenant_id: str, council_case_id: int):
+    case = council_orchestration_service.get_case(db, tenant_id, council_case_id)
+    if case is None:
+        raise ValueError(f"Council Case {council_case_id} not found for this tenant")
+    return case
+
+
+def supervisor_brief(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    case = _case_or_raise(db, tenant_id, council_case_id)
+    dissent = dissent_for_case(db, tenant_id, council_case_id)
+    return {
+        "council_case_id": council_case_id,
+        "brief_type": "supervisor",
+        "immediate_issue": case.source_event or case.case_type,
+        "evidence": council_orchestration_service.to_dict(case)["evidence_package"],
+        "specialist_recommendation": case.recommended_action,
+        "dissent": dissent,
+        "required_next_action": case.recommended_action or "Await additional evidence before proceeding.",
+    }
+
+
+def manager_brief(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    case = _case_or_raise(db, tenant_id, council_case_id)
+    assessments = latest_assessments_for_case(db, tenant_id, council_case_id)
+    return {
+        "council_case_id": council_case_id,
+        "brief_type": "manager",
+        "operational_impact": next((a["significance"] for a in assessments if a["specialist_key"] in ("maestro", "pulse", "aegis")), ""),
+        "staffing_workflow_considerations": next((a["conclusion"] for a in assessments if a["specialist_key"] == "pulse"), ""),
+        "quality_implications": next((a["conclusion"] for a in assessments if a["specialist_key"] == "apollo"), ""),
+        "recommended_owner": case.required_human_approver,
+    }
+
+
+def executive_brief(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    case = _case_or_raise(db, tenant_id, council_case_id)
+    assessments = latest_assessments_for_case(db, tenant_id, council_case_id)
+    return {
+        "council_case_id": council_case_id,
+        "brief_type": "executive",
+        "enterprise_significance": next((a["significance"] for a in assessments if a["specialist_key"] in ("phoenix", "maestro")), ""),
+        "risk": case.risk_level or next((a["conclusion"] for a in assessments if a["specialist_key"] == "sentinelx"), ""),
+        "trend": next((a["conclusion"] for a in assessments if a["specialist_key"] == "aegis"), ""),
+        "resource_impact": next((a["conclusion"] for a in assessments if a["specialist_key"] == "pulse"), ""),
+        "recommended_strategic_action": case.recommended_action,
+    }

--- a/backend/app/services/council_consensus_service.py
+++ b/backend/app/services/council_consensus_service.py
@@ -1,0 +1,108 @@
+"""Project Council, Section 5: Consensus Engine.
+
+Classifies Council outcomes from the latest independent assessment per
+required specialist. A simple majority never overrides unresolved safety
+dissent (Section 16): if any safety/evidence specialist
+(`SAFETY_VETO_SPECIALISTS` -- Sentinel-X, Veritas) dissents from the
+majority position with urgent significance, the outcome is always
+SAFETY_DISSENT regardless of how large the majority is. Consensus itself
+is never treated as evidence -- classification only ever describes
+agreement, not correctness.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from app.models.council_leadership import (
+    CONSENSUS_CONDITIONAL,
+    CONSENSUS_INSUFFICIENT_EVIDENCE,
+    CONSENSUS_SAFETY_DISSENT,
+    CONSENSUS_SPLIT,
+    CONSENSUS_STRONG,
+    CONSENSUS_UNANIMOUS,
+    SAFETY_VETO_SPECIALISTS,
+)
+
+
+def _normalize_action(text: str) -> str:
+    return " ".join((text or "").strip().lower().split()) or "no_action_recommended"
+
+
+def classify_consensus(assessments: list[dict], required_specialists: list[str]) -> dict:
+    """Returns `{"status", "reason", "majority_position", "dissenting_specialists"}`.
+
+    `assessments` must be the latest (post-revision) assessment per
+    specialist -- see `council_specialist_assessment_service.
+    latest_assessments_for_case`.
+    """
+    submitted = {a["specialist_key"] for a in assessments}
+    missing_required = sorted(set(required_specialists) - submitted)
+    if missing_required:
+        return {
+            "status": CONSENSUS_INSUFFICIENT_EVIDENCE,
+            "reason": f"Missing required specialist assessment(s): {', '.join(missing_required)}.",
+            "majority_position": "",
+            "dissenting_specialists": [],
+        }
+
+    blocking = [
+        a for a in assessments
+        if a["confidence"] == "low" and not a["recommended_action"].strip() and a["evidence_limitations"].strip()
+    ]
+    if blocking:
+        return {
+            "status": CONSENSUS_INSUFFICIENT_EVIDENCE,
+            "reason": "One or more specialists could not reach a supported conclusion due to evidence limitations.",
+            "majority_position": "",
+            "dissenting_specialists": [b["specialist_key"] for b in blocking],
+        }
+
+    positions: dict[str, list[str]] = defaultdict(list)
+    for a in assessments:
+        positions[_normalize_action(a["recommended_action"])].append(a["specialist_key"])
+
+    if len(positions) == 1:
+        return {
+            "status": CONSENSUS_UNANIMOUS,
+            "reason": "All required specialists recommend the same action.",
+            "majority_position": next(iter(positions)),
+            "dissenting_specialists": [],
+        }
+
+    majority_position, majority_members = max(positions.items(), key=lambda kv: len(kv[1]))
+    majority_pct = len(majority_members) / len(assessments)
+    dissenters = [a for a in assessments if a["specialist_key"] not in majority_members]
+
+    safety_dissenters = [
+        d for d in dissenters if d["specialist_key"] in SAFETY_VETO_SPECIALISTS and d["urgency"] == "urgent"
+    ]
+    if safety_dissenters:
+        return {
+            "status": CONSENSUS_SAFETY_DISSENT,
+            "reason": "A safety or evidence specialist identifies an unresolved high-risk concern; a simple majority cannot override it.",
+            "majority_position": majority_position,
+            "dissenting_specialists": [d["specialist_key"] for d in safety_dissenters],
+        }
+
+    if majority_pct >= 0.8:
+        return {
+            "status": CONSENSUS_STRONG,
+            "reason": "Most specialists agree and no safety-critical dissent exists.",
+            "majority_position": majority_position,
+            "dissenting_specialists": [d["specialist_key"] for d in dissenters],
+        }
+
+    if majority_pct < 0.6:
+        return {
+            "status": CONSENSUS_SPLIT,
+            "reason": "Material disagreement remains among specialists.",
+            "majority_position": majority_position,
+            "dissenting_specialists": [d["specialist_key"] for d in dissenters],
+        }
+
+    return {
+        "status": CONSENSUS_CONDITIONAL,
+        "reason": "Agreement exists only if stated conditions are met.",
+        "majority_position": majority_position,
+        "dissenting_specialists": [d["specialist_key"] for d in dissenters],
+    }

--- a/backend/app/services/council_decision_journal_service.py
+++ b/backend/app/services/council_decision_journal_service.py
@@ -1,0 +1,84 @@
+"""Project Council, Section 13: Decision Journal Integration.
+
+Rather than building a second, parallel decision-journal schema, Council
+composes a real `MaestroRecommendation` row (Maestro already owns the
+leadership decision journal) representing the Council's synthesized
+recommendation, then records the human decision through Maestro's own
+`maestro_decision_journal_service.record_decision` -- the same leadership
+learning dataset Maestro's Leadership Workspace already reads from.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import (
+    CASE_CAPA_ESCALATION,
+    CASE_EDUCATION_NEED,
+    CASE_HIGH_RISK_INSPECTION,
+    CASE_REPAIR_RECURRENCE,
+    CASE_WORKFLOW_BOTTLENECK,
+)
+from app.models.maestro_orchestration import (
+    RECOMMENDATION_ESCALATE_REPAIR_BACKLOG,
+    RECOMMENDATION_GENERATE_CAPA_DRAFT,
+    RECOMMENDATION_INSPECTION_PRIORITIES,
+    RECOMMENDATION_QUALITY_INITIATIVES,
+    RECOMMENDATION_SCHEDULE_COMPETENCY,
+    MaestroRecommendation,
+)
+from app.services import council_dissent_service, council_orchestration_service, maestro_decision_journal_service
+from app.services.council_specialist_assessment_service import latest_assessments_for_case
+
+_CASE_TYPE_TO_MAESTRO_RECOMMENDATION_TYPE = {
+    CASE_HIGH_RISK_INSPECTION: RECOMMENDATION_INSPECTION_PRIORITIES,
+    CASE_WORKFLOW_BOTTLENECK: RECOMMENDATION_INSPECTION_PRIORITIES,
+    CASE_EDUCATION_NEED: RECOMMENDATION_SCHEDULE_COMPETENCY,
+    CASE_REPAIR_RECURRENCE: RECOMMENDATION_ESCALATE_REPAIR_BACKLOG,
+    CASE_CAPA_ESCALATION: RECOMMENDATION_GENERATE_CAPA_DRAFT,
+}
+
+
+def _ensure_maestro_recommendation(db: Session, tenant_id: str, council_case_id: int) -> MaestroRecommendation:
+    case = council_orchestration_service.get_case(db, tenant_id, council_case_id)
+    if case is None:
+        raise ValueError(f"Council Case {council_case_id} not found for this tenant")
+    assessments = latest_assessments_for_case(db, tenant_id, council_case_id)
+    dissent = council_dissent_service.dissent_for_case(db, tenant_id, council_case_id)
+
+    row = MaestroRecommendation(
+        tenant_id=tenant_id,
+        recommendation_type=_CASE_TYPE_TO_MAESTRO_RECOMMENDATION_TYPE.get(case.case_type, RECOMMENDATION_QUALITY_INITIATIVES),
+        subject=f"Council Case #{council_case_id}: {case.recommended_action or case.case_type}"[:300],
+        rationale=(
+            f"{case.consensus_status}. Participating specialists: {', '.join(json.loads(case.participating_specialists_json))}. "
+            f"Dissent: {'; '.join(d['dissenting_specialist'] for d in dissent) or 'none'}."
+        ),
+        confidence="high" if case.consensus_status == "UNANIMOUS" else "moderate",
+        specialists_consulted_json=json.dumps([a["specialist_key"] for a in assessments]),
+        evidence_json=json.dumps({"council_case_id": council_case_id, "consensus_status": case.consensus_status}),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def record_council_decision(
+    db: Session, tenant_id: str, council_case_id: int, *, leader_decision: str, decided_by: str,
+    decided_role: str = "", outcome: str = "", lessons_learned: str = "", new_status: str | None = None,
+) -> dict:
+    """Section 13: writes one Decision Journal entry that ties the
+    Council Case, its specialist agreement/dissent, the human decision,
+    and lessons learned into Maestro's existing leadership learning
+    dataset."""
+    recommendation = _ensure_maestro_recommendation(db, tenant_id, council_case_id)
+    entry = maestro_decision_journal_service.record_decision(
+        db, tenant_id, recommendation.id, leader_decision=leader_decision, decided_by=decided_by,
+        decided_role=decided_role, outcome=outcome, lessons_learned=lessons_learned, new_status=new_status,
+    )
+    result = maestro_decision_journal_service.to_dict(entry)
+    result["council_case_id"] = council_case_id
+    result["maestro_recommendation_id"] = recommendation.id
+    return result

--- a/backend/app/services/council_decision_options_service.py
+++ b/backend/app/services/council_decision_options_service.py
@@ -1,0 +1,115 @@
+"""Project Council, Section 7: Decision Options and Tradeoff Analysis.
+
+Builds one `CouncilDecisionOption` per distinct recommended action across
+the Council's assessments -- each option's evidence and tradeoffs trace
+back to the specific specialists who proposed it. `financial_impact` is
+only ever populated from a real figure elsewhere in the platform; since no
+such figure exists for these options today, it is always left blank
+rather than fabricated (per the brief's explicit instruction).
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import APPROVAL_TIER_BY_ROLE_NAME, APPROVER_SUPERVISOR, CouncilDecisionOption
+
+_OPTION_LABELS = [chr(ord("A") + i) for i in range(26)]
+
+_CONFIDENCE_RANK = {"low": 0, "moderate": 1, "high": 2}
+_URGENT_TO_RISK = {"urgent": "high", "routine": "moderate"}
+
+
+def _to_dict(row: CouncilDecisionOption) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "council_case_id": row.council_case_id,
+        "option_label": row.option_label,
+        "option_title": row.option_title,
+        "benefits": row.benefits,
+        "risks": row.risks,
+        "clinical_risk": row.clinical_risk,
+        "operational_impact": row.operational_impact,
+        "financial_impact": row.financial_impact,
+        "evidence_strength": row.evidence_strength,
+        "reversibility": row.reversibility,
+        "required_authority": row.required_authority,
+        "expected_time_to_resolution": row.expected_time_to_resolution,
+    }
+
+
+def _reversibility_for(option_title: str) -> str:
+    lowered = option_title.lower()
+    if "remove" in lowered or "discard" in lowered or "retire" in lowered:
+        return "irreversible"
+    return "reversible"
+
+
+def _time_to_resolution_for(option_title: str) -> str:
+    lowered = option_title.lower()
+    if "manufacturer" in lowered:
+        return "1-2 weeks (external turnaround)"
+    if "repair" in lowered or "hold" in lowered:
+        return "Several days"
+    return "Same day"
+
+
+def generate_decision_options(db: Session, tenant_id: str, council_case_id: int, assessments: list[dict]) -> list[CouncilDecisionOption]:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for a in assessments:
+        action = a.get("recommended_action", "").strip()
+        if action:
+            grouped[action].append(a)
+
+    if not grouped:
+        return []
+
+    rows = []
+    for index, (option_title, supporters) in enumerate(grouped.items()):
+        benefits = "; ".join(sorted({s["significance"] for s in supporters if s["significance"]})) or "Addresses the concern raised by the recommending specialist(s)."
+        risks = "; ".join(sorted({s["evidence_limitations"] for s in supporters if s["evidence_limitations"]})) or "Does not address concerns raised by dissenting specialist(s), if any."
+
+        urgencies = [s["urgency"] for s in supporters]
+        clinical_risk = _URGENT_TO_RISK["urgent"] if "urgent" in urgencies else "low"
+
+        confidences = [_CONFIDENCE_RANK.get(s["confidence"], 1) for s in supporters]
+        avg_confidence = sum(confidences) / len(confidences)
+        evidence_strength = "high" if avg_confidence >= 1.5 else "moderate" if avg_confidence >= 0.75 else "low"
+
+        max_tier = max(APPROVAL_TIER_BY_ROLE_NAME.get(s["human_role_required"], 1) for s in supporters)
+        required_authority = next((k for k, v in APPROVAL_TIER_BY_ROLE_NAME.items() if v == max_tier), APPROVER_SUPERVISOR)
+
+        row = CouncilDecisionOption(
+            tenant_id=tenant_id,
+            council_case_id=council_case_id,
+            option_label=_OPTION_LABELS[index] if index < len(_OPTION_LABELS) else str(index),
+            option_title=option_title,
+            benefits=benefits,
+            risks=risks,
+            clinical_risk=clinical_risk,
+            operational_impact=f"Proposed by: {', '.join(s['specialist_key'] for s in supporters)}.",
+            financial_impact="",
+            evidence_strength=evidence_strength,
+            reversibility=_reversibility_for(option_title),
+            required_authority=required_authority,
+            expected_time_to_resolution=_time_to_resolution_for(option_title),
+        )
+        db.add(row)
+        rows.append(row)
+
+    db.commit()
+    for row in rows:
+        db.refresh(row)
+    return rows
+
+
+def options_for_case(db: Session, tenant_id: str, council_case_id: int) -> list[dict]:
+    rows = (
+        db.query(CouncilDecisionOption)
+        .filter(CouncilDecisionOption.tenant_id == tenant_id, CouncilDecisionOption.council_case_id == council_case_id)
+        .order_by(CouncilDecisionOption.option_label.asc())
+        .all()
+    )
+    return [_to_dict(r) for r in rows]

--- a/backend/app/services/council_dissent_service.py
+++ b/backend/app/services/council_dissent_service.py
@@ -1,0 +1,80 @@
+"""Project Council, Section 6: Dissent Registry.
+
+Every specialist not in the consensus majority gets a dissent record --
+dissent is always preserved and displayed prominently, never hidden from
+the final report (Sections 6, 16).
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import SAFETY_VETO_SPECIALISTS, CouncilDissentRecord
+
+
+def _to_dict(row: CouncilDissentRecord) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "council_case_id": row.council_case_id,
+        "dissenting_specialist": row.dissenting_specialist,
+        "disputed_conclusion": row.disputed_conclusion,
+        "evidence_supporting_dissent": row.evidence_supporting_dissent,
+        "risk_if_ignored": row.risk_if_ignored,
+        "additional_evidence_required": row.additional_evidence_required,
+        "proposed_alternative_action": row.proposed_alternative_action,
+        "escalation_level": row.escalation_level,
+    }
+
+
+def record_dissent(
+    db: Session, tenant_id: str, council_case_id: int, *, dissenting_assessment: dict, majority_position: str,
+) -> CouncilDissentRecord:
+    specialist_key = dissenting_assessment["specialist_key"]
+    escalation_level = (
+        "safety_critical"
+        if specialist_key in SAFETY_VETO_SPECIALISTS and dissenting_assessment["urgency"] == "urgent"
+        else "standard"
+    )
+    row = CouncilDissentRecord(
+        tenant_id=tenant_id,
+        council_case_id=council_case_id,
+        dissenting_specialist=specialist_key,
+        disputed_conclusion=majority_position,
+        evidence_supporting_dissent=json.dumps(dissenting_assessment.get("evidence_used", {})),
+        risk_if_ignored=dissenting_assessment.get("significance", ""),
+        additional_evidence_required=dissenting_assessment.get("evidence_limitations", ""),
+        proposed_alternative_action=dissenting_assessment.get("recommended_action", ""),
+        escalation_level=escalation_level,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def record_dissent_records(
+    db: Session, tenant_id: str, council_case_id: int, *, assessments: list[dict], consensus_result: dict,
+) -> list[CouncilDissentRecord]:
+    dissenting_keys = set(consensus_result.get("dissenting_specialists", []))
+    if not dissenting_keys:
+        return []
+    majority_position = consensus_result.get("majority_position", "")
+    rows = []
+    for assessment in assessments:
+        if assessment["specialist_key"] in dissenting_keys:
+            rows.append(record_dissent(
+                db, tenant_id, council_case_id, dissenting_assessment=assessment, majority_position=majority_position,
+            ))
+    return rows
+
+
+def dissent_for_case(db: Session, tenant_id: str, council_case_id: int) -> list[dict]:
+    rows = (
+        db.query(CouncilDissentRecord)
+        .filter(CouncilDissentRecord.tenant_id == tenant_id, CouncilDissentRecord.council_case_id == council_case_id)
+        .order_by(CouncilDissentRecord.created_at.asc())
+        .all()
+    )
+    return [_to_dict(r) for r in rows]

--- a/backend/app/services/council_human_decision_service.py
+++ b/backend/app/services/council_human_decision_service.py
@@ -1,0 +1,78 @@
+"""Project Council, Section 8: Human Decision Authority.
+
+Enforces the brief's five-tier approval scale (technician / supervisor /
+spd_manager / director / clinical_quality_governance) on top of
+LumenAI's actual four-role RBAC, via `ROLE_AUTHORITY_TIER`. A technician
+(mapped from `viewer`/`operator`) can view a Council recommendation but
+can never finalize a decision -- `finalize_decision` raises
+`PermissionError` if the deciding user's role tier is below the case's
+`required_approval_tier`.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import CASE_STATUS_RESOLVED, ROLE_AUTHORITY_TIER, CouncilCase, CouncilHumanDecision
+
+
+def can_approve(role: str, required_tier: int) -> bool:
+    return ROLE_AUTHORITY_TIER.get(role, 0) >= required_tier
+
+
+def to_dict(row: CouncilHumanDecision) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "council_case_id": row.council_case_id,
+        "approver": row.approver,
+        "approver_role": row.approver_role,
+        "decision": row.decision,
+        "rationale": row.rationale,
+        "conditions": row.conditions,
+        "decided_at": row.decided_at.isoformat() if row.decided_at else None,
+    }
+
+
+def finalize_decision(
+    db: Session, tenant_id: str, council_case_id: int, *, approver: str, approver_role: str, decision: str,
+    rationale: str = "", conditions: str = "",
+) -> CouncilHumanDecision:
+    case = (
+        db.query(CouncilCase)
+        .filter(CouncilCase.tenant_id == tenant_id, CouncilCase.id == council_case_id)
+        .first()
+    )
+    if case is None:
+        raise ValueError(f"Council Case {council_case_id} not found for this tenant")
+    if not decision.strip():
+        raise ValueError("decision is required for an auditable Council decision")
+    if not can_approve(approver_role, case.required_approval_tier):
+        raise PermissionError(
+            f"Role '{approver_role}' does not have sufficient authority to finalize this Council Case "
+            f"(requires '{case.required_human_approver}' or higher).",
+        )
+
+    row = CouncilHumanDecision(
+        tenant_id=tenant_id,
+        council_case_id=council_case_id,
+        approver=approver,
+        approver_role=approver_role,
+        decision=decision,
+        rationale=rationale,
+        conditions=conditions,
+    )
+    db.add(row)
+    case.status = CASE_STATUS_RESOLVED
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def decisions_for_case(db: Session, tenant_id: str, council_case_id: int) -> list[dict]:
+    rows = (
+        db.query(CouncilHumanDecision)
+        .filter(CouncilHumanDecision.tenant_id == tenant_id, CouncilHumanDecision.council_case_id == council_case_id)
+        .order_by(CouncilHumanDecision.decided_at.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/council_meeting_service.py
+++ b/backend/app/services/council_meeting_service.py
@@ -1,0 +1,69 @@
+"""Project Council, Section 12: Council Meeting Mode.
+
+Structured review agenda (case introduction, evidence review, specialist
+assessments, dissent review, option comparison, human discussion notes,
+decision, owner assignment, review date). `discussion_notes` and
+`recorded_by` are always human-authored -- Council never presents its own
+generated text as human meeting content, so `recorded_by` is required.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import CouncilMeetingNotes
+
+AGENDA_TEMPLATE = [
+    "case_introduction", "evidence_review", "specialist_assessments", "dissent_review",
+    "option_comparison", "human_discussion_notes", "decision", "owner_assignment", "review_date",
+]
+
+
+def to_dict(row: CouncilMeetingNotes) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "council_case_id": row.council_case_id,
+        "agenda": json.loads(row.agenda_json or "[]"),
+        "discussion_notes": row.discussion_notes,
+        "action_items": json.loads(row.action_items_json or "[]"),
+        "owner": row.owner,
+        "review_date": row.review_date.isoformat() if row.review_date else None,
+        "recorded_by": row.recorded_by,
+    }
+
+
+def record_meeting_notes(
+    db: Session, tenant_id: str, council_case_id: int, *, discussion_notes: str, recorded_by: str,
+    action_items: list[str] | None = None, owner: str = "", review_date: datetime | None = None,
+    agenda: list[str] | None = None,
+) -> CouncilMeetingNotes:
+    if not recorded_by.strip():
+        raise ValueError("recorded_by is required -- Council meeting notes must be human-authored and attributed")
+
+    row = CouncilMeetingNotes(
+        tenant_id=tenant_id,
+        council_case_id=council_case_id,
+        agenda_json=json.dumps(agenda or AGENDA_TEMPLATE),
+        discussion_notes=discussion_notes,
+        action_items_json=json.dumps(action_items or []),
+        owner=owner,
+        review_date=review_date,
+        recorded_by=recorded_by,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def meeting_notes_for_case(db: Session, tenant_id: str, council_case_id: int) -> list[dict]:
+    rows = (
+        db.query(CouncilMeetingNotes)
+        .filter(CouncilMeetingNotes.tenant_id == tenant_id, CouncilMeetingNotes.council_case_id == council_case_id)
+        .order_by(CouncilMeetingNotes.created_at.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/council_notification_service.py
+++ b/backend/app/services/council_notification_service.py
@@ -1,0 +1,85 @@
+"""Project Council, Section 18: Notifications and Escalations.
+
+Surfaces Council-specific notification-worthy conditions (safety dissent,
+insufficient evidence, urgent cases, overdue human decisions, unresolved
+split decisions, missing required specialists, outcome reviews due,
+Council configuration changes) in the same normalized shape as the
+existing platform notification feed (`platform_notification_service.
+unified_notifications`), and merges the two -- reusing the existing
+notification channel rather than inventing a parallel one. Council items
+are computed live from its own tables, never persisted as a fourth
+notification store.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import (
+    CASE_STATUS_AWAITING_DECISION,
+    CASE_STATUS_RESOLVED,
+    CONSENSUS_INSUFFICIENT_EVIDENCE,
+    CONSENSUS_SAFETY_DISSENT,
+    CONSENSUS_SPLIT,
+    CouncilCase,
+    CouncilOutcomeReview,
+    CouncilTeamConfig,
+)
+from app.services.platform_notification_service import unified_notifications
+
+_OVERDUE_DECISION_HOURS = 48
+_OUTCOME_REVIEW_DUE_DAYS = 14
+
+
+def _normalize(*, id_: int, created_at, message: str, recipient_role: str = "") -> dict:
+    return {
+        "source": "council",
+        "id": id_,
+        "created_at": created_at.isoformat() if hasattr(created_at, "isoformat") else created_at,
+        "message": message,
+        "read": False,
+        "recipient_role": recipient_role,
+    }
+
+
+def council_notification_items(db: Session, tenant_id: str) -> list[dict]:
+    now = datetime.now(timezone.utc)
+    items: list[dict] = []
+
+    cases = db.query(CouncilCase).filter(CouncilCase.tenant_id == tenant_id).all()
+    for case in cases:
+        if case.consensus_status == CONSENSUS_SAFETY_DISSENT:
+            items.append(_normalize(id_=case.id, created_at=case.created_at, message=f"Council Case #{case.id}: unresolved safety dissent requires review.", recipient_role="spd_manager"))
+        if case.consensus_status == CONSENSUS_INSUFFICIENT_EVIDENCE:
+            items.append(_normalize(id_=case.id, created_at=case.created_at, message=f"Council Case #{case.id}: insufficient evidence to reach a recommendation.", recipient_role="spd_manager"))
+        if case.urgency == "urgent" and case.status != CASE_STATUS_RESOLVED:
+            items.append(_normalize(id_=case.id, created_at=case.created_at, message=f"Council Case #{case.id}: urgent case still open.", recipient_role="spd_manager"))
+        if case.consensus_status == CONSENSUS_SPLIT:
+            items.append(_normalize(id_=case.id, created_at=case.created_at, message=f"Council Case #{case.id}: unresolved split decision.", recipient_role="spd_manager"))
+        if case.status == CASE_STATUS_AWAITING_DECISION:
+            created_at = case.created_at if case.created_at.tzinfo else case.created_at.replace(tzinfo=timezone.utc)
+            if now - created_at > timedelta(hours=_OVERDUE_DECISION_HOURS):
+                items.append(_normalize(id_=case.id, created_at=case.created_at, message=f"Council Case #{case.id}: human decision overdue.", recipient_role="spd_manager"))
+
+    reviewed_case_ids = {o.council_case_id for o in db.query(CouncilOutcomeReview).filter(CouncilOutcomeReview.tenant_id == tenant_id).all()}
+    for case in cases:
+        if case.status == CASE_STATUS_RESOLVED and case.id not in reviewed_case_ids:
+            created_at = case.created_at if case.created_at.tzinfo else case.created_at.replace(tzinfo=timezone.utc)
+            if now - created_at > timedelta(days=_OUTCOME_REVIEW_DUE_DAYS):
+                items.append(_normalize(id_=case.id, created_at=case.created_at, message=f"Council Case #{case.id}: outcome effectiveness review is due.", recipient_role="spd_manager"))
+
+    for config in db.query(CouncilTeamConfig).filter(CouncilTeamConfig.tenant_id == tenant_id, CouncilTeamConfig.approval_status == "pending_review").all():
+        items.append(_normalize(id_=config.id, created_at=config.created_at, message=f"Council team '{config.team_key}' configuration change (v{config.version}) is pending review.", recipient_role="admin"))
+
+    return items
+
+
+def combined_notifications(db: Session, tenant_id: str, *, recipient_role: str = "", limit: int = 50) -> list[dict]:
+    items = unified_notifications(db, tenant_id, recipient_role=recipient_role, limit=limit)
+    council_items = council_notification_items(db, tenant_id)
+    if recipient_role:
+        council_items = [i for i in council_items if i["recipient_role"] == recipient_role]
+    items.extend(council_items)
+    items.sort(key=lambda i: i["created_at"] or "", reverse=True)
+    return items[:limit]

--- a/backend/app/services/council_orchestration_service.py
+++ b/backend/app/services/council_orchestration_service.py
@@ -1,0 +1,157 @@
+"""Project Council, Section 1: Council Orchestration Engine.
+
+Selects the appropriate leadership team for an issue, distributes a
+shared evidence package, collects independent specialist assessments,
+compares conclusions, classifies consensus, records dissent, generates
+decision options, and routes the recommendation to the correct human
+authority. Everything here composes the other Council services rather
+than reimplementing them.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import (
+    APPROVAL_TIER_BY_ROLE_NAME,
+    APPROVER_SUPERVISOR,
+    CASE_STATUS_AWAITING_DECISION,
+    CASE_STATUS_AWAITING_EVIDENCE,
+    CASE_STATUS_OPEN,
+    CASE_TYPE_DEFAULT_TEAM,
+    CONSENSUS_INSUFFICIENT_EVIDENCE,
+    CONSENSUS_SAFETY_DISSENT,
+    CouncilCase,
+)
+from app.services import (
+    council_consensus_service,
+    council_decision_options_service,
+    council_dissent_service,
+    council_specialist_assessment_service,
+    council_team_registry_service,
+)
+
+
+def select_specialists_for_case(db: Session, tenant_id: str, case_type: str) -> tuple[str, list[str]]:
+    """Section 1: pick the appropriate leadership team + its required
+    specialists for a case type."""
+    council_team_registry_service.ensure_default_teams(db, tenant_id)
+    team_key = CASE_TYPE_DEFAULT_TEAM.get(case_type)
+    if team_key is None:
+        raise ValueError(f"Unknown Council case type: {case_type}")
+    team_config = council_team_registry_service.get_team_config(db, tenant_id, team_key)
+    required = json.loads(team_config.required_specialists_json)
+    return team_key, required
+
+
+def open_case(
+    db: Session, tenant_id: str, *, case_type: str, source_event: str = "", inspection_ids: list[int] | None = None,
+    instrument_ids: list[str] | None = None, digital_twin_refs: list[str] | None = None,
+    evidence_package: dict | None = None, risk_level: str = "", urgency: str = "routine",
+    requested_decision: str = "", facility_id: str = "",
+) -> CouncilCase:
+    """Section 3: creates the typed Council Case and assigns its
+    leadership team -- agents have not yet assessed anything at this
+    point (independence is preserved)."""
+    team_key, required_specialists = select_specialists_for_case(db, tenant_id, case_type)
+
+    row = CouncilCase(
+        tenant_id=tenant_id,
+        facility_id=facility_id,
+        case_type=case_type,
+        source_event=source_event,
+        inspection_ids_json=json.dumps(inspection_ids or []),
+        instrument_ids_json=json.dumps(instrument_ids or []),
+        digital_twin_refs_json=json.dumps(digital_twin_refs or []),
+        evidence_package_json=json.dumps(evidence_package or {}),
+        risk_level=risk_level,
+        urgency=urgency,
+        requested_decision=requested_decision,
+        team_key=team_key,
+        participating_specialists_json=json.dumps(required_specialists),
+        status=CASE_STATUS_OPEN,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def convene(db: Session, tenant_id: str, council_case_id: int) -> CouncilCase:
+    """Runs the full Council cycle for a case: independent assessments,
+    consensus classification, dissent recording, and decision-option
+    generation. Safe to call more than once -- each call runs a fresh
+    round of independent assessments (specialists never see each other's
+    prior-round conclusions when forming a new one)."""
+    case = db.query(CouncilCase).filter(CouncilCase.tenant_id == tenant_id, CouncilCase.id == council_case_id).first()
+    if case is None:
+        raise ValueError(f"Council Case {council_case_id} not found for this tenant")
+
+    required_specialists = json.loads(case.participating_specialists_json)
+    council_specialist_assessment_service.run_independent_assessments(db, tenant_id, case, required_specialists)
+    assessments = council_specialist_assessment_service.latest_assessments_for_case(db, tenant_id, council_case_id)
+
+    consensus_result = council_consensus_service.classify_consensus(assessments, required_specialists)
+    council_dissent_service.record_dissent_records(
+        db, tenant_id, council_case_id, assessments=assessments, consensus_result=consensus_result,
+    )
+    council_decision_options_service.generate_decision_options(db, tenant_id, council_case_id, assessments)
+
+    max_tier = max(
+        (APPROVAL_TIER_BY_ROLE_NAME.get(a["human_role_required"], 1) for a in assessments), default=1,
+    )
+    required_approver = next((k for k, v in APPROVAL_TIER_BY_ROLE_NAME.items() if v == max_tier), APPROVER_SUPERVISOR)
+
+    case.consensus_status = consensus_result["status"]
+    case.recommended_action = consensus_result["majority_position"] or ""
+    case.required_human_approver = required_approver
+    case.required_approval_tier = max_tier
+    case.status = (
+        CASE_STATUS_AWAITING_EVIDENCE
+        if consensus_result["status"] in (CONSENSUS_INSUFFICIENT_EVIDENCE, CONSENSUS_SAFETY_DISSENT)
+        else CASE_STATUS_AWAITING_DECISION
+    )
+    db.commit()
+    db.refresh(case)
+    return case
+
+
+def to_dict(row: CouncilCase) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "facility_id": row.facility_id,
+        "case_type": row.case_type,
+        "source_event": row.source_event,
+        "inspection_ids": json.loads(row.inspection_ids_json or "[]"),
+        "instrument_ids": json.loads(row.instrument_ids_json or "[]"),
+        "digital_twin_refs": json.loads(row.digital_twin_refs_json or "[]"),
+        "evidence_package": json.loads(row.evidence_package_json or "{}"),
+        "risk_level": row.risk_level,
+        "urgency": row.urgency,
+        "requested_decision": row.requested_decision,
+        "team_key": row.team_key,
+        "participating_specialists": json.loads(row.participating_specialists_json or "[]"),
+        "consensus_status": row.consensus_status,
+        "recommended_action": row.recommended_action,
+        "required_human_approver": row.required_human_approver,
+        "required_approval_tier": row.required_approval_tier,
+        "status": row.status,
+        "human_review_required": row.human_review_required,
+        "agent_version": row.agent_version,
+        "disclaimer": row.disclaimer,
+    }
+
+
+def get_case(db: Session, tenant_id: str, council_case_id: int) -> CouncilCase | None:
+    return db.query(CouncilCase).filter(CouncilCase.tenant_id == tenant_id, CouncilCase.id == council_case_id).first()
+
+
+def list_cases(db: Session, tenant_id: str, *, status: str = "", case_type: str = "") -> list[dict]:
+    q = db.query(CouncilCase).filter(CouncilCase.tenant_id == tenant_id)
+    if status:
+        q = q.filter(CouncilCase.status == status)
+    if case_type:
+        q = q.filter(CouncilCase.case_type == case_type)
+    return [to_dict(r) for r in q.order_by(CouncilCase.created_at.desc()).all()]

--- a/backend/app/services/council_outcome_service.py
+++ b/backend/app/services/council_outcome_service.py
@@ -1,0 +1,99 @@
+"""Project Council, Section 14: Outcome Effectiveness Review.
+
+Closes the learning loop by linking back to the original Council Case and
+its recommendation. Council learns from outcomes (`knowledge_update_
+recommended` is a signal, nothing more) but never automatically rewrites
+a clinical rule -- that always remains a separate, human-triggered change
+elsewhere in the platform.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import (
+    OUTCOME_EFFECTIVE,
+    OUTCOME_INEFFECTIVE,
+    OUTCOME_INSUFFICIENT_FOLLOW_UP,
+    OUTCOME_PARTIALLY_EFFECTIVE,
+    OUTCOME_UNINTENDED_CONSEQUENCE,
+    CouncilOutcomeReview,
+)
+
+
+def classify_outcome(
+    *, issue_resolved: bool | None, recurred: bool | None = None, risk_decreased: bool | None = None,
+    operational_performance_improved: bool | None = None, unintended_consequence: bool = False,
+) -> str:
+    if issue_resolved is None:
+        return OUTCOME_INSUFFICIENT_FOLLOW_UP
+    if unintended_consequence:
+        return OUTCOME_UNINTENDED_CONSEQUENCE
+    if issue_resolved and not recurred:
+        return OUTCOME_EFFECTIVE
+    if issue_resolved and recurred:
+        return OUTCOME_PARTIALLY_EFFECTIVE
+    if not issue_resolved and (risk_decreased or operational_performance_improved):
+        return OUTCOME_PARTIALLY_EFFECTIVE
+    return OUTCOME_INEFFECTIVE
+
+
+def to_dict(row: CouncilOutcomeReview) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "council_case_id": row.council_case_id,
+        "issue_resolved": row.issue_resolved,
+        "recurred": row.recurred,
+        "risk_decreased": row.risk_decreased,
+        "operational_performance_improved": row.operational_performance_improved,
+        "recommendation_followed": row.recommendation_followed,
+        "dissent_valid": row.dissent_valid,
+        "additional_evidence_changed_decision": row.additional_evidence_changed_decision,
+        "knowledge_update_recommended": row.knowledge_update_recommended,
+        "classification": row.classification,
+        "notes": row.notes,
+    }
+
+
+def record_outcome_review(
+    db: Session, tenant_id: str, council_case_id: int, *, issue_resolved: bool | None = None,
+    recurred: bool | None = None, risk_decreased: bool | None = None,
+    operational_performance_improved: bool | None = None, recommendation_followed: bool | None = None,
+    dissent_valid: bool | None = None, additional_evidence_changed_decision: bool | None = None,
+    unintended_consequence: bool = False, notes: str = "",
+) -> CouncilOutcomeReview:
+    classification = classify_outcome(
+        issue_resolved=issue_resolved, recurred=recurred, risk_decreased=risk_decreased,
+        operational_performance_improved=operational_performance_improved,
+        unintended_consequence=unintended_consequence,
+    )
+    knowledge_update_recommended = classification in (OUTCOME_INEFFECTIVE, OUTCOME_UNINTENDED_CONSEQUENCE) or bool(dissent_valid)
+
+    row = CouncilOutcomeReview(
+        tenant_id=tenant_id,
+        council_case_id=council_case_id,
+        issue_resolved=issue_resolved,
+        recurred=recurred,
+        risk_decreased=risk_decreased,
+        operational_performance_improved=operational_performance_improved,
+        recommendation_followed=recommendation_followed,
+        dissent_valid=dissent_valid,
+        additional_evidence_changed_decision=additional_evidence_changed_decision,
+        knowledge_update_recommended=knowledge_update_recommended,
+        classification=classification,
+        notes=notes,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def outcome_reviews_for_case(db: Session, tenant_id: str, council_case_id: int) -> list[dict]:
+    rows = (
+        db.query(CouncilOutcomeReview)
+        .filter(CouncilOutcomeReview.tenant_id == tenant_id, CouncilOutcomeReview.council_case_id == council_case_id)
+        .order_by(CouncilOutcomeReview.created_at.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/council_performance_service.py
+++ b/backend/app/services/council_performance_service.py
@@ -1,0 +1,91 @@
+"""Project Council, Section 17: Specialist Performance Review.
+
+Aggregate, non-punitive performance signal computed entirely on the fly
+from `CouncilSpecialistAssessment` + `CouncilDissentRecord` +
+`CouncilOutcomeReview` -- never a separate, independently-drifting
+scoreboard table. This data is read-only reporting: nothing in this
+module feeds back into `council_consensus_service.classify_consensus`,
+so a specialist's historical performance can never automatically
+suppress a valid current safety dissent (Section 16).
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import (
+    CouncilCase,
+    CouncilDissentRecord,
+    CouncilOutcomeReview,
+    CouncilSpecialistAssessment,
+)
+
+
+def _normalize(text: str) -> str:
+    return " ".join((text or "").strip().lower().split())
+
+
+def specialist_performance_summary(db: Session, tenant_id: str) -> dict:
+    assessments = (
+        db.query(CouncilSpecialistAssessment)
+        .filter(CouncilSpecialistAssessment.tenant_id == tenant_id)
+        .all()
+    )
+    dissents = db.query(CouncilDissentRecord).filter(CouncilDissentRecord.tenant_id == tenant_id).all()
+    cases_by_id = {c.id: c for c in db.query(CouncilCase).filter(CouncilCase.tenant_id == tenant_id).all()}
+    outcomes_by_case: dict[int, list[bool | None]] = defaultdict(list)
+    for o in db.query(CouncilOutcomeReview).filter(CouncilOutcomeReview.tenant_id == tenant_id).all():
+        outcomes_by_case[o.council_case_id].append(o.dissent_valid)
+
+    by_specialist: dict[str, dict] = {}
+
+    def bucket(specialist_key: str) -> dict:
+        return by_specialist.setdefault(specialist_key, {
+            "total_assessments": 0,
+            "confidence_distribution": {"low": 0, "moderate": 0, "high": 0},
+            "abstention_count": 0,
+            "agreement_with_final_recommendation": 0,
+            "resolved_case_count": 0,
+            "dissent_count": 0,
+            "dissent_validated_count": 0,
+            "dissent_evaluated_count": 0,
+        })
+
+    for a in assessments:
+        b = bucket(a.specialist_key)
+        b["total_assessments"] += 1
+        b["confidence_distribution"][a.confidence] = b["confidence_distribution"].get(a.confidence, 0) + 1
+        if a.conclusion.startswith("insufficient_data"):
+            b["abstention_count"] += 1
+
+        case = cases_by_id.get(a.council_case_id)
+        if case is not None and case.recommended_action:
+            b["resolved_case_count"] += 1
+            if _normalize(a.recommended_action) == _normalize(case.recommended_action):
+                b["agreement_with_final_recommendation"] += 1
+
+    for d in dissents:
+        b = bucket(d.dissenting_specialist)
+        b["dissent_count"] += 1
+        for dissent_valid in outcomes_by_case.get(d.council_case_id, []):
+            if dissent_valid is not None:
+                b["dissent_evaluated_count"] += 1
+                if dissent_valid:
+                    b["dissent_validated_count"] += 1
+
+    for specialist_key, b in by_specialist.items():
+        b["agreement_rate"] = (
+            round(b["agreement_with_final_recommendation"] / b["resolved_case_count"], 2) if b["resolved_case_count"] else None
+        )
+        b["dissent_accuracy"] = (
+            round(b["dissent_validated_count"] / b["dissent_evaluated_count"], 2) if b["dissent_evaluated_count"] else None
+        )
+
+    return {
+        "by_specialist": by_specialist,
+        "note": (
+            "Performance is aggregate and non-punitive; it is never used to automatically suppress a "
+            "specialist's current safety or evidence dissent."
+        ),
+    }

--- a/backend/app/services/council_reports_service.py
+++ b/backend/app/services/council_reports_service.py
@@ -1,0 +1,100 @@
+"""Project Council, Section 19: Reports.
+
+Reuses Veritas's already-generic export helpers
+(`veritas_reports_service.build_report_pdf_bytes` / `build_report_csv_bytes`
+/ `build_report_xlsx_bytes`) rather than introducing a second PDF/CSV/Excel
+implementation -- every report here is just `{title, content}` fed through
+that shared renderer.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services import (
+    council_brief_service,
+    council_decision_options_service,
+    council_dissent_service,
+    council_orchestration_service,
+    council_performance_service,
+    council_team_registry_service,
+)
+from app.services.council_outcome_service import outcome_reviews_for_case
+from app.services.council_specialist_assessment_service import assessments_for_case
+from app.services.veritas_reports_service import build_report_csv_bytes, build_report_pdf_bytes, build_report_xlsx_bytes
+
+
+def council_decision_report(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    case = council_orchestration_service.get_case(db, tenant_id, council_case_id)
+    content = council_orchestration_service.to_dict(case) if case else {}
+    content["decision_options"] = council_decision_options_service.options_for_case(db, tenant_id, council_case_id)
+    return {"title": "Council Decision Report", "content": content}
+
+
+def specialist_assessment_package(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    return {"title": "Specialist Assessment Package", "content": {"assessments": assessments_for_case(db, tenant_id, council_case_id)}}
+
+
+def dissent_report(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    return {"title": "Dissent Report", "content": {"dissent": council_dissent_service.dissent_for_case(db, tenant_id, council_case_id)}}
+
+
+def decision_options_analysis(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    return {"title": "Decision Options Analysis", "content": {"options": council_decision_options_service.options_for_case(db, tenant_id, council_case_id)}}
+
+
+def leadership_brief_report(db: Session, tenant_id: str, council_case_id: int, brief_type: str) -> dict:
+    resolver = {
+        "supervisor": council_brief_service.supervisor_brief,
+        "manager": council_brief_service.manager_brief,
+        "executive": council_brief_service.executive_brief,
+    }.get(brief_type)
+    if resolver is None:
+        raise ValueError(f"Unknown brief_type '{brief_type}'")
+    return {"title": f"Leadership Brief ({brief_type.title()})", "content": resolver(db, tenant_id, council_case_id)}
+
+
+def outcome_effectiveness_report(db: Session, tenant_id: str, council_case_id: int) -> dict:
+    return {"title": "Outcome Effectiveness Report", "content": {"outcome_reviews": outcome_reviews_for_case(db, tenant_id, council_case_id)}}
+
+
+def council_governance_report(db: Session, tenant_id: str) -> dict:
+    return {"title": "Council Governance Report", "content": {"teams": council_team_registry_service.list_teams(db, tenant_id)}}
+
+
+def ai_leadership_performance_report(db: Session, tenant_id: str) -> dict:
+    return {"title": "AI Leadership Performance Report", "content": council_performance_service.specialist_performance_summary(db, tenant_id)}
+
+
+_REPORT_BUILDERS = {
+    "decision": council_decision_report,
+    "assessments": specialist_assessment_package,
+    "dissent": dissent_report,
+    "options": decision_options_analysis,
+    "outcome": outcome_effectiveness_report,
+}
+
+
+def export_case_report(db: Session, tenant_id: str, council_case_id: int, report_type: str, export_format: str) -> bytes:
+    builder = _REPORT_BUILDERS.get(report_type)
+    if builder is None:
+        raise ValueError(f"Unknown report_type '{report_type}'")
+    doc = builder(db, tenant_id, council_case_id)
+    return _render(doc, export_format)
+
+
+def export_governance_report(db: Session, tenant_id: str, export_format: str) -> bytes:
+    return _render(council_governance_report(db, tenant_id), export_format)
+
+
+def export_performance_report(db: Session, tenant_id: str, export_format: str) -> bytes:
+    return _render(ai_leadership_performance_report(db, tenant_id), export_format)
+
+
+def _render(doc: dict, export_format: str) -> bytes:
+    if export_format == "pdf":
+        return build_report_pdf_bytes(doc["title"], doc["content"])
+    if export_format == "csv":
+        return build_report_csv_bytes(doc["content"])
+    if export_format == "xlsx":
+        return build_report_xlsx_bytes(doc["title"], doc["content"])
+    raise ValueError(f"Unsupported export format '{export_format}'")

--- a/backend/app/services/council_specialist_assessment_service.py
+++ b/backend/app/services/council_specialist_assessment_service.py
@@ -1,0 +1,401 @@
+"""Project Council, Section 4: Independent Specialist Assessments.
+
+Each resolver below derives one specialist's Council-shaped assessment
+directly from that specialist's own, already-built real service -- Council
+never re-runs clinical or operational analysis itself. A resolver that has
+no relevant real data for the case returns an honest "insufficient data"
+conclusion rather than fabricating one.
+
+Independence (Section 1's "agents must first assess independently before
+seeing other agents' conclusions") is structural: every resolver reads
+only the case's evidence package and that one specialist's own store --
+never another specialist's `CouncilSpecialistAssessment` row. Submitted
+assessments are immutable; a specialist that revises its conclusion after
+seeing the rest of the Council gets a new row with `is_revision=True`
+pointing back at the original via `supersedes_assessment_id`, and the
+original is never edited or deleted.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import (
+    APPROVER_CLINICAL_QUALITY_GOVERNANCE,
+    APPROVER_DIRECTOR,
+    APPROVER_SPD_MANAGER,
+    APPROVER_SUPERVISOR,
+    SPECIALIST_AEGIS,
+    SPECIALIST_APOLLO,
+    SPECIALIST_ATHENA,
+    SPECIALIST_MAESTRO,
+    SPECIALIST_PHOENIX,
+    SPECIALIST_PULSE,
+    SPECIALIST_RESEARCH_AGENT,
+    SPECIALIST_SAGE,
+    SPECIALIST_SENTINELX,
+    SPECIALIST_VERITAS,
+    SPECIALIST_VULCAN,
+    CouncilCase,
+    CouncilSpecialistAssessment,
+)
+
+_INSUFFICIENT_DATA = "insufficient_data"
+
+
+def _first(items_json: str) -> str | int | None:
+    try:
+        items = json.loads(items_json or "[]")
+    except (TypeError, ValueError):
+        return None
+    return items[0] if items else None
+
+
+def _base(conclusion: str, *, confidence="moderate", evidence_used=None, evidence_limitations="", significance="",
+          recommended_action="", alternative_explanation="", urgency="routine",
+          human_role_required=APPROVER_SUPERVISOR) -> dict:
+    return {
+        "conclusion": conclusion,
+        "confidence": confidence,
+        "evidence_used": evidence_used or {},
+        "evidence_limitations": evidence_limitations,
+        "significance": significance,
+        "recommended_action": recommended_action,
+        "alternative_explanation": alternative_explanation,
+        "urgency": urgency,
+        "human_role_required": human_role_required,
+    }
+
+
+def _assess_veritas(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.veritas_evidence_agent_service import run_evidence_assessment, to_dict
+
+    inspection_id = _first(case.inspection_ids_json)
+    if inspection_id is None:
+        return _base(
+            _INSUFFICIENT_DATA, confidence="low",
+            evidence_limitations="No inspection is attached to this Council Case for Veritas to evaluate.",
+        )
+    try:
+        row = run_evidence_assessment(db, tenant_id, int(inspection_id))
+    except ValueError as exc:
+        return _base(_INSUFFICIENT_DATA, confidence="low", evidence_limitations=str(exc))
+    result = to_dict(row)
+    return _base(
+        f"Evidence readiness: {result['readiness_category']} ({result['readiness_score']}/100).",
+        confidence="high" if result["readiness_score"] >= 70 else "moderate",
+        evidence_used={"readiness_score": result["readiness_score"], "coverage_status": result["coverage_status"], "image_quality_status": result["image_quality_status"]},
+        evidence_limitations="; ".join(result.get("limitations", []) if isinstance(result.get("limitations"), list) else []),
+        significance=f"Match classification: {result['match_classification']}.",
+        recommended_action=f"Recommended gate: {result['recommended_gate']}.",
+        urgency="urgent" if result["readiness_category"] in ("insufficient", "poor") else "routine",
+        human_role_required=APPROVER_SUPERVISOR,
+    )
+
+
+def _assess_aegis(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.vulcan_aegis_integration_service import compute_process_variation_signal
+
+    instrument_identity = _first(case.instrument_ids_json)
+    if instrument_identity is None:
+        return _base(
+            _INSUFFICIENT_DATA, confidence="low",
+            evidence_limitations="No instrument is attached to this Council Case for Aegis's process-variation check.",
+        )
+    signal = compute_process_variation_signal(db, tenant_id, str(instrument_identity))
+    return _base(
+        signal["narrative"] or "No strong process pattern detected.",
+        confidence="moderate" if signal["sample_size"] >= 5 else "low",
+        evidence_used=signal,
+        significance="Process variation detected." if signal["process_variation_detected"] else "No enterprise process pattern found.",
+        recommended_action="Review technician-specific technique." if signal["process_variation_detected"] else "No process-focused action indicated.",
+        urgency="routine",
+    )
+
+
+def _assess_vulcan(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.vulcan_reliability_agent_service import run_reliability_assessment, to_dict
+
+    instrument_identity = _first(case.instrument_ids_json)
+    if instrument_identity is None:
+        return _base(
+            _INSUFFICIENT_DATA, confidence="low",
+            evidence_limitations="No instrument is attached to this Council Case for Vulcan to assess.",
+        )
+    row = run_reliability_assessment(db, tenant_id, str(instrument_identity))
+    result = to_dict(row)
+    return _base(
+        f"Reliability: {result.get('reliability_category')} ({result.get('reliability_score')}/100), progression: {result.get('progression')}.",
+        confidence=result.get("confidence", "moderate"),
+        evidence_used={"score_breakdown": result.get("score_breakdown"), "recurrence_count": result.get("recurrence_count")},
+        significance=result.get("combined_conclusion", ""),
+        recommended_action=result.get("recommended_disposition", ""),
+        alternative_explanation="; ".join(
+            c.get("probable_cause", "") for c in result.get("probable_causes", []) if isinstance(c, dict)
+        ),
+        urgency="urgent" if result.get("progression") == "worsening" else "routine",
+        human_role_required=APPROVER_SPD_MANAGER,
+    )
+
+
+def _assess_sage(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.sage_knowledge_gap_service import list_gaps
+
+    gaps = list_gaps(db, tenant_id, status="open")
+    if not gaps:
+        return _base(
+            "No open competency gaps identified.", confidence="moderate",
+            recommended_action="No education action indicated at this time.",
+        )
+    top = max(gaps, key=lambda g: g["occurrence_count"])
+    return _base(
+        top["narrative"] or f"Recurring knowledge gap in {top['competency_domain']}.",
+        confidence=top.get("confidence", "moderate"),
+        evidence_used={"occurrence_count": top["occurrence_count"], "competency_domain": top["competency_domain"]},
+        significance=f"Scope: {top['scope_type']} / {top['scope_value']}.",
+        recommended_action=top.get("recommended_education", "Schedule targeted competency review."),
+        urgency="routine",
+        human_role_required=APPROVER_SUPERVISOR,
+    )
+
+
+def _assess_sentinelx(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.sentinelx_risk_agent_service import run_risk_assessment, to_dict
+
+    instrument_identity = _first(case.instrument_ids_json)
+    if instrument_identity is None:
+        return _base(
+            _INSUFFICIENT_DATA, confidence="low",
+            evidence_limitations="No instrument is attached to this Council Case for Sentinel-X to risk-score.",
+        )
+    inspection_id = _first(case.inspection_ids_json)
+    row = run_risk_assessment(
+        db, tenant_id, str(instrument_identity),
+        inspection_id=int(inspection_id) if inspection_id is not None else None,
+    )
+    result = to_dict(row)
+    return _base(
+        f"Clinical risk: {result['risk_level']} ({result['risk_score']}/100).",
+        confidence="high" if result["risk_score"] >= 70 or result["risk_score"] <= 20 else "moderate",
+        evidence_used={"risk_categories": result.get("risk_categories"), "score_breakdown": result.get("score_breakdown")},
+        significance=result.get("reasoning_narrative", ""),
+        recommended_action="Escalate for supervisor review." if result["risk_level"] in ("high", "critical") else "Continue standard monitoring.",
+        urgency="urgent" if result["risk_level"] in ("high", "critical") else "routine",
+        human_role_required=APPROVER_SPD_MANAGER if result["risk_level"] in ("high", "critical") else APPROVER_SUPERVISOR,
+    )
+
+
+def _assess_apollo(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.apollo_capa_engine_service import capa_engine_summary
+
+    summary = capa_engine_summary(db, tenant_id)
+    return _base(
+        f"{summary['total_open_or_active']} open/active CAPA(s); {summary['pending_suggestion_count']} pending suggestion(s).",
+        confidence="moderate",
+        evidence_used={"lifecycle_counts": summary["lifecycle_counts"], "open_complaint_count": summary["open_complaint_count"]},
+        significance="Quality/CAPA backlog may be relevant to this case." if summary["total_open_or_active"] else "No open CAPA backlog pressure identified.",
+        recommended_action="Consider a CAPA draft if this case reflects a recurring pattern." if summary["pending_suggestion_count"] else "No new CAPA indicated.",
+        urgency="routine",
+    )
+
+
+def _assess_athena(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.athena_search_service import organizational_search
+
+    query = case.source_event or str(_first(case.instrument_ids_json) or case.case_type)
+    result = organizational_search(db, tenant_id, query)
+    knowledge_hits = len(result.get("knowledge_articles", []))
+    playbook_hits = len(result.get("playbooks", []))
+    return _base(
+        f"Institutional knowledge search found {knowledge_hits} related article(s) and {playbook_hits} related playbook(s).",
+        confidence="moderate" if (knowledge_hits or playbook_hits) else "low",
+        evidence_used={"query": query, "knowledge_articles": result.get("knowledge_articles", [])[:5], "playbooks": result.get("playbooks", [])[:5]},
+        significance="Prior institutional guidance may apply." if (knowledge_hits or playbook_hits) else "No directly related institutional guidance found.",
+        recommended_action="Review linked institutional knowledge before finalizing disposition." if knowledge_hits else "",
+        urgency="routine",
+    )
+
+
+def _assess_pulse(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.pulse_command_center_service import pulse_command_center
+
+    summary = pulse_command_center(db, tenant_id)
+    supervisor_backlog = summary["supervisor_queue"]["backlog"]
+    repair_open = summary["repair_queue"]["open"]
+    return _base(
+        f"Live operations: supervisor backlog {supervisor_backlog}, open repairs {repair_open}.",
+        confidence="moderate",
+        evidence_used={"supervisor_queue": summary["supervisor_queue"], "repair_queue": summary["repair_queue"], "inspection_queue": summary["inspection_queue"]},
+        significance="Elevated operational load may affect response time." if supervisor_backlog > 5 else "Operational load is within normal range.",
+        recommended_action="Consider staffing/workflow adjustment." if supervisor_backlog > 5 else "",
+        urgency="urgent" if supervisor_backlog > 10 else "routine",
+        human_role_required=APPROVER_SPD_MANAGER,
+    )
+
+
+def _assess_phoenix(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.phoenix_maturity_index_service import compute_platform_maturity_index
+
+    maturity = compute_platform_maturity_index(db, tenant_id)
+    return _base(
+        f"Platform maturity overall score: {maturity['overall_score']}.",
+        confidence="moderate",
+        evidence_used={"scores": maturity["scores"]},
+        significance="Reflects enterprise-wide improvement trajectory, not this case specifically.",
+        recommended_action="",
+        urgency="routine",
+        human_role_required=APPROVER_DIRECTOR,
+    )
+
+
+def _assess_maestro(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.maestro_priority_engine_service import latest_priorities
+
+    priorities = latest_priorities(db, tenant_id)
+    instrument_identity = _first(case.instrument_ids_json)
+    match = next((p for p in priorities if instrument_identity and str(instrument_identity) in p["subject"]), None)
+    top = match or (priorities[0] if priorities else None)
+    if top is None:
+        return _base("No current operational priority ranking available.", confidence="low")
+    return _base(
+        f"Ranked priority: {top['subject']} (#{top['rank']}, category {top['category']}).",
+        confidence="moderate",
+        evidence_used={"priority_score": top["priority_score"], "category": top["category"]},
+        significance=top["rationale"],
+        recommended_action="Coordinate with the operational priority already identified for this issue." if match else "",
+        urgency="routine",
+        human_role_required=APPROVER_SPD_MANAGER,
+    )
+
+
+def _assess_research_agent(db: Session, tenant_id: str, case: CouncilCase) -> dict:
+    from app.services.horizon_research_portal_service import research_portal_summary
+
+    summary = research_portal_summary(db)
+    study_count = len(summary.get("research_studies", []))
+    return _base(
+        f"{study_count} active/published network research study(ies) available for reference.",
+        confidence="low",
+        evidence_used={"research_study_count": study_count, "published_knowledge_count": len(summary.get("published_knowledge", []))},
+        significance="Network research context is read-only reference; it does not constitute site-specific evidence for this case.",
+        recommended_action="Consider a research/pilot proposal if this case reveals a novel pattern." if case.case_type == "innovation_proposal" else "",
+        urgency="routine",
+        human_role_required=APPROVER_CLINICAL_QUALITY_GOVERNANCE,
+    )
+
+
+_ASSESSORS = {
+    SPECIALIST_VERITAS: _assess_veritas,
+    SPECIALIST_AEGIS: _assess_aegis,
+    SPECIALIST_VULCAN: _assess_vulcan,
+    SPECIALIST_SAGE: _assess_sage,
+    SPECIALIST_SENTINELX: _assess_sentinelx,
+    SPECIALIST_APOLLO: _assess_apollo,
+    SPECIALIST_ATHENA: _assess_athena,
+    SPECIALIST_PULSE: _assess_pulse,
+    SPECIALIST_PHOENIX: _assess_phoenix,
+    SPECIALIST_MAESTRO: _assess_maestro,
+    SPECIALIST_RESEARCH_AGENT: _assess_research_agent,
+}
+
+
+def _to_dict(row: CouncilSpecialistAssessment) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "council_case_id": row.council_case_id,
+        "specialist_key": row.specialist_key,
+        "conclusion": row.conclusion,
+        "confidence": row.confidence,
+        "evidence_used": json.loads(row.evidence_used_json or "{}"),
+        "evidence_limitations": row.evidence_limitations,
+        "significance": row.significance,
+        "recommended_action": row.recommended_action,
+        "alternative_explanation": row.alternative_explanation,
+        "urgency": row.urgency,
+        "human_role_required": row.human_role_required,
+        "is_revision": row.is_revision,
+        "supersedes_assessment_id": row.supersedes_assessment_id,
+    }
+
+
+def submit_assessment(
+    db: Session, tenant_id: str, council_case_id: int, specialist_key: str, fields: dict, *, is_revision: bool = False,
+) -> CouncilSpecialistAssessment:
+    """Persists one specialist assessment. Never updates a prior row --
+    assessments are immutable once submitted."""
+    supersedes_id = None
+    if is_revision:
+        prior = (
+            db.query(CouncilSpecialistAssessment)
+            .filter(
+                CouncilSpecialistAssessment.tenant_id == tenant_id,
+                CouncilSpecialistAssessment.council_case_id == council_case_id,
+                CouncilSpecialistAssessment.specialist_key == specialist_key,
+            )
+            .order_by(CouncilSpecialistAssessment.created_at.desc())
+            .first()
+        )
+        supersedes_id = prior.id if prior else None
+
+    row = CouncilSpecialistAssessment(
+        tenant_id=tenant_id,
+        council_case_id=council_case_id,
+        specialist_key=specialist_key,
+        conclusion=fields["conclusion"],
+        confidence=fields.get("confidence", "moderate"),
+        evidence_used_json=json.dumps(fields.get("evidence_used", {})),
+        evidence_limitations=fields.get("evidence_limitations", ""),
+        significance=fields.get("significance", ""),
+        recommended_action=fields.get("recommended_action", ""),
+        alternative_explanation=fields.get("alternative_explanation", ""),
+        urgency=fields.get("urgency", "routine"),
+        human_role_required=fields.get("human_role_required", APPROVER_SUPERVISOR),
+        is_revision=is_revision,
+        supersedes_assessment_id=supersedes_id,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def run_independent_assessments(db: Session, tenant_id: str, case: CouncilCase, specialists: list[str]) -> list[CouncilSpecialistAssessment]:
+    """Runs each named specialist's resolver against its own real store
+    and submits one fresh, independent assessment per specialist --
+    resolvers never see each other's Council conclusions."""
+    rows = []
+    for specialist_key in specialists:
+        resolver = _ASSESSORS.get(specialist_key)
+        if resolver is None:
+            continue
+        fields = resolver(db, tenant_id, case)
+        rows.append(submit_assessment(db, tenant_id, case.id, specialist_key, fields))
+    return rows
+
+
+def submit_revision(db: Session, tenant_id: str, case: CouncilCase, specialist_key: str, fields: dict) -> CouncilSpecialistAssessment:
+    """A specialist revising its conclusion after seeing the rest of the
+    Council -- the original assessment is preserved, never overwritten."""
+    return submit_assessment(db, tenant_id, case.id, specialist_key, fields, is_revision=True)
+
+
+def assessments_for_case(db: Session, tenant_id: str, council_case_id: int) -> list[dict]:
+    rows = (
+        db.query(CouncilSpecialistAssessment)
+        .filter(CouncilSpecialistAssessment.tenant_id == tenant_id, CouncilSpecialistAssessment.council_case_id == council_case_id)
+        .order_by(CouncilSpecialistAssessment.created_at.asc())
+        .all()
+    )
+    return [_to_dict(r) for r in rows]
+
+
+def latest_assessments_for_case(db: Session, tenant_id: str, council_case_id: int) -> list[dict]:
+    """One assessment per specialist -- the most recent (post-revision if
+    any), for consensus/dissent/agreement-map computation."""
+    all_rows = assessments_for_case(db, tenant_id, council_case_id)
+    latest: dict[str, dict] = {}
+    for row in all_rows:
+        latest[row["specialist_key"]] = row
+    return list(latest.values())

--- a/backend/app/services/council_team_registry_service.py
+++ b/backend/app/services/council_team_registry_service.py
@@ -1,0 +1,155 @@
+"""Project Council, Sections 2 & 15: Leadership Team Registry & Governance.
+
+Provisions the six default AI leadership teams for a tenant on first use,
+and supports organization-level configuration changes -- always
+append-only/versioned (mirrors Veritas's baseline governance action
+pattern) so every configuration change is itself auditable. Organizations
+may reconfigure membership but the safety-veto specialists
+(`SAFETY_VETO_SPECIALISTS`) can never be dropped from a required list --
+mandatory safety/evidence review can't be configured away.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import (
+    COUNCIL_TEAM_KEYS,
+    DEFAULT_TEAM_DEFINITIONS,
+    SAFETY_VETO_SPECIALISTS,
+    CouncilTeamConfig,
+)
+
+
+def to_dict(row: CouncilTeamConfig) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "team_key": row.team_key,
+        "team_name": row.team_name,
+        "required_specialists": json.loads(row.required_specialists_json or "[]"),
+        "optional_specialists": json.loads(row.optional_specialists_json or "[]"),
+        "decision_scope": row.decision_scope,
+        "escalation_rules": row.escalation_rules,
+        "quorum_requirement": row.quorum_requirement,
+        "safety_veto_enabled": row.safety_veto_enabled,
+        "evidence_requirements": row.evidence_requirements,
+        "review_frequency": row.review_frequency,
+        "version": row.version,
+        "approval_status": row.approval_status,
+        "owner": row.owner,
+        "is_current": row.is_current,
+    }
+
+
+def ensure_default_teams(db: Session, tenant_id: str) -> list[CouncilTeamConfig]:
+    """Provisions the six default teams for a tenant the first time
+    Council is used there. Idempotent -- does nothing if any current team
+    config already exists for the tenant."""
+    existing = (
+        db.query(CouncilTeamConfig)
+        .filter(CouncilTeamConfig.tenant_id == tenant_id, CouncilTeamConfig.is_current.is_(True))
+        .count()
+    )
+    if existing:
+        return list_teams(db, tenant_id, as_rows=True)
+
+    rows = []
+    for team_key in COUNCIL_TEAM_KEYS:
+        definition = DEFAULT_TEAM_DEFINITIONS[team_key]
+        row = CouncilTeamConfig(
+            tenant_id=tenant_id,
+            team_key=team_key,
+            team_name=definition["team_name"],
+            required_specialists_json=json.dumps(definition["required_specialists"]),
+            optional_specialists_json=json.dumps(definition["optional_specialists"]),
+            decision_scope=definition["decision_scope"],
+            quorum_requirement=max(2, len(definition["required_specialists"]) - 1),
+            evidence_requirements="Each required specialist must submit an independent assessment before consensus is classified.",
+            owner="SPD Leadership",
+        )
+        db.add(row)
+        rows.append(row)
+    db.commit()
+    for row in rows:
+        db.refresh(row)
+    return rows
+
+
+def list_teams(db: Session, tenant_id: str, *, as_rows: bool = False):
+    rows = (
+        db.query(CouncilTeamConfig)
+        .filter(CouncilTeamConfig.tenant_id == tenant_id, CouncilTeamConfig.is_current.is_(True))
+        .order_by(CouncilTeamConfig.team_key.asc())
+        .all()
+    )
+    return rows if as_rows else [to_dict(r) for r in rows]
+
+
+def get_team_config(db: Session, tenant_id: str, team_key: str) -> CouncilTeamConfig | None:
+    return (
+        db.query(CouncilTeamConfig)
+        .filter(
+            CouncilTeamConfig.tenant_id == tenant_id, CouncilTeamConfig.team_key == team_key,
+            CouncilTeamConfig.is_current.is_(True),
+        )
+        .first()
+    )
+
+
+def update_team_config(
+    db: Session, tenant_id: str, team_key: str, *, required_specialists: list[str] | None = None,
+    optional_specialists: list[str] | None = None, decision_scope: str | None = None,
+    escalation_rules: str | None = None, quorum_requirement: int | None = None,
+    evidence_requirements: str | None = None, review_frequency: str | None = None, owner: str = "",
+) -> CouncilTeamConfig:
+    """Inserts a new, incremented-version row rather than mutating the
+    current one -- the full configuration history stays queryable."""
+    current = get_team_config(db, tenant_id, team_key)
+    if current is None:
+        raise ValueError(f"Unknown Council team '{team_key}' for this tenant")
+
+    new_required = required_specialists if required_specialists is not None else json.loads(current.required_specialists_json)
+    missing_safety = SAFETY_VETO_SPECIALISTS - set(new_required) if any(
+        s in json.loads(current.required_specialists_json) for s in SAFETY_VETO_SPECIALISTS
+    ) else set()
+    if missing_safety:
+        raise ValueError(
+            f"Cannot remove mandatory safety/evidence specialist(s) {sorted(missing_safety)} from a required Council review",
+        )
+
+    current.is_current = False
+    db.add(current)
+
+    new_row = CouncilTeamConfig(
+        tenant_id=tenant_id,
+        team_key=team_key,
+        team_name=current.team_name,
+        required_specialists_json=json.dumps(new_required),
+        optional_specialists_json=json.dumps(optional_specialists if optional_specialists is not None else json.loads(current.optional_specialists_json)),
+        decision_scope=decision_scope if decision_scope is not None else current.decision_scope,
+        escalation_rules=escalation_rules if escalation_rules is not None else current.escalation_rules,
+        quorum_requirement=quorum_requirement if quorum_requirement is not None else current.quorum_requirement,
+        safety_veto_enabled=current.safety_veto_enabled,
+        evidence_requirements=evidence_requirements if evidence_requirements is not None else current.evidence_requirements,
+        review_frequency=review_frequency if review_frequency is not None else current.review_frequency,
+        version=current.version + 1,
+        approval_status="pending_review",
+        owner=owner or current.owner,
+        is_current=True,
+    )
+    db.add(new_row)
+    db.commit()
+    db.refresh(new_row)
+    return new_row
+
+
+def team_config_history(db: Session, tenant_id: str, team_key: str) -> list[dict]:
+    rows = (
+        db.query(CouncilTeamConfig)
+        .filter(CouncilTeamConfig.tenant_id == tenant_id, CouncilTeamConfig.team_key == team_key)
+        .order_by(CouncilTeamConfig.version.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/council_workspace_service.py
+++ b/backend/app/services/council_workspace_service.py
@@ -1,0 +1,60 @@
+"""Project Council, Section 9: Council Workspace (`/council`).
+
+Composes the workspace dashboard entirely from already-persisted Council
+tables -- active cases, urgent cases, cases awaiting evidence, cases
+awaiting a human decision, safety dissent, split decisions, recently
+resolved cases, outcome effectiveness, specialist participation, and
+recurring decision themes.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+from sqlalchemy.orm import Session
+
+from app.models.council_leadership import (
+    CASE_STATUS_AWAITING_DECISION,
+    CASE_STATUS_AWAITING_EVIDENCE,
+    CASE_STATUS_RESOLVED,
+    CONSENSUS_SAFETY_DISSENT,
+    CONSENSUS_SPLIT,
+    CouncilCase,
+    CouncilOutcomeReview,
+    CouncilSpecialistAssessment,
+)
+from app.services.council_orchestration_service import to_dict as case_to_dict
+
+
+def workspace_summary(db: Session, tenant_id: str) -> dict:
+    cases = db.query(CouncilCase).filter(CouncilCase.tenant_id == tenant_id).order_by(CouncilCase.created_at.desc()).all()
+
+    active_cases = [c for c in cases if c.status != CASE_STATUS_RESOLVED]
+    urgent_cases = [c for c in active_cases if c.urgency == "urgent"]
+    awaiting_evidence = [c for c in active_cases if c.status == CASE_STATUS_AWAITING_EVIDENCE]
+    awaiting_decision = [c for c in active_cases if c.status == CASE_STATUS_AWAITING_DECISION]
+    safety_dissent_cases = [c for c in active_cases if c.consensus_status == CONSENSUS_SAFETY_DISSENT]
+    split_decision_cases = [c for c in active_cases if c.consensus_status == CONSENSUS_SPLIT]
+    recently_resolved = [c for c in cases if c.status == CASE_STATUS_RESOLVED][:10]
+
+    outcomes = db.query(CouncilOutcomeReview).filter(CouncilOutcomeReview.tenant_id == tenant_id).all()
+    outcome_effectiveness = dict(Counter(o.classification for o in outcomes))
+
+    assessment_rows = db.query(CouncilSpecialistAssessment).filter(CouncilSpecialistAssessment.tenant_id == tenant_id).all()
+    specialist_participation = dict(Counter(a.specialist_key for a in assessment_rows))
+
+    recurring_decision_themes = dict(Counter(c.case_type for c in cases).most_common(10))
+
+    return {
+        "active_case_count": len(active_cases),
+        "active_cases": [case_to_dict(c) for c in active_cases],
+        "urgent_cases": [case_to_dict(c) for c in urgent_cases],
+        "awaiting_evidence": [case_to_dict(c) for c in awaiting_evidence],
+        "awaiting_decision": [case_to_dict(c) for c in awaiting_decision],
+        "safety_dissent_cases": [case_to_dict(c) for c in safety_dissent_cases],
+        "split_decision_cases": [case_to_dict(c) for c in split_decision_cases],
+        "recently_resolved": [case_to_dict(c) for c in recently_resolved],
+        "outcome_effectiveness": outcome_effectiveness,
+        "specialist_participation": specialist_participation,
+        "recurring_decision_themes": recurring_decision_themes,
+        "human_review_required": True,
+    }

--- a/backend/app/services/maestro_capa_integration_service.py
+++ b/backend/app/services/maestro_capa_integration_service.py
@@ -1,0 +1,44 @@
+"""Project Maestro: materializing a "Generate CAPA draft" recommendation.
+
+Thin wrapper over the pre-existing `capa_suggestion_service` -- Maestro
+never invents its own CAPA-detection logic. This is the explicit,
+human-triggered action a leader takes after approving a
+`generate_capa_draft` recommendation in the Decision Journal; nothing here
+runs automatically.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.maestro_orchestration import RECOMMENDATION_GENERATE_CAPA_DRAFT, MaestroRecommendation
+from app.services.capa_suggestion_service import create_capa_from_suggestion, generate_capa_suggestions
+
+
+def create_capa_from_recommendation(
+    db: Session, tenant_id: str, recommendation_id: int, *, owner: str = "Quality / Operations",
+) -> dict | None:
+    """Re-derives the live CAPA suggestion matching the recommendation's
+    recorded subject and materializes it. Returns `None` if the
+    recommendation is not a CAPA-draft recommendation, or if the
+    triggering pattern is no longer present (e.g. already remediated)."""
+    recommendation = (
+        db.query(MaestroRecommendation)
+        .filter(MaestroRecommendation.tenant_id == tenant_id, MaestroRecommendation.id == recommendation_id)
+        .first()
+    )
+    if recommendation is None or recommendation.recommendation_type != RECOMMENDATION_GENERATE_CAPA_DRAFT:
+        return None
+
+    import json
+
+    evidence = json.loads(recommendation.evidence_json or "{}")
+    suggested_title = evidence.get("suggested_title")
+
+    suggestions = generate_capa_suggestions(db, tenant_id)
+    match = next((s for s in suggestions if s["suggested_title"] == suggested_title), None)
+    if match is None and suggestions:
+        match = suggestions[0]
+    if match is None:
+        return None
+
+    return create_capa_from_suggestion(match, owner=owner)

--- a/backend/app/services/maestro_daily_brief_service.py
+++ b/backend/app/services/maestro_daily_brief_service.py
@@ -1,0 +1,101 @@
+"""Project Maestro, Section 4: Daily Operational Brief.
+
+Five brief types (morning/afternoon/end-of-day/weekend-readiness/shift-
+handoff) all compose the same real underlying signals -- current
+priorities, pending recommendations, operational health, and open patient
+safety alerts -- varying only in emphasis and narrative framing per the
+moment in the day they're read.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.maestro_orchestration import (
+    BRIEF_AFTERNOON,
+    BRIEF_END_OF_DAY,
+    BRIEF_MORNING,
+    BRIEF_SHIFT_HANDOFF,
+    BRIEF_WEEKEND_READINESS,
+    DECISION_STATUS_PENDING,
+    MaestroDailyBrief,
+)
+from app.services import maestro_priority_engine_service, maestro_recommendation_engine_service
+from app.services.maestro_health_index_service import compute_operational_health, to_dict as health_to_dict
+from app.services.sentinelx_patient_safety_watch_service import list_alerts
+
+
+def _compose_content(db: Session, tenant_id: str) -> dict:
+    priorities = maestro_priority_engine_service.latest_priorities(db, tenant_id)
+    if not priorities:
+        priorities = [
+            maestro_priority_engine_service.to_dict(r)
+            for r in maestro_priority_engine_service.compute_priorities(db, tenant_id)
+        ]
+
+    pending_recommendations = maestro_recommendation_engine_service.list_recommendations(
+        db, tenant_id, status=DECISION_STATUS_PENDING,
+    )
+    health = health_to_dict(compute_operational_health(db, tenant_id))
+    open_alerts = list_alerts(db, tenant_id, acknowledged=False)
+
+    return {
+        "top_priorities": priorities[:5],
+        "pending_recommendations": pending_recommendations[:10],
+        "operational_health": health,
+        "open_patient_safety_alerts": open_alerts,
+    }
+
+
+def _narrative(brief_type: str, content: dict) -> str:
+    top = content["top_priorities"][0] if content["top_priorities"] else None
+    lead = f"Top priority: {top['subject']} ({top['category']})." if top else "No active priorities to report."
+    alerts = len(content["open_patient_safety_alerts"])
+    overall = content["operational_health"].get("overall_score")
+    health_line = f"Operational health index: {overall}." if overall is not None else "Operational health index: insufficient data."
+
+    if brief_type == BRIEF_MORNING:
+        return f"Morning Brief -- {lead} {health_line} {alerts} open patient safety alert(s) require attention today."
+    if brief_type == BRIEF_AFTERNOON:
+        return f"Afternoon Update -- {lead} {alerts} open patient safety alert(s) remain outstanding."
+    if brief_type == BRIEF_END_OF_DAY:
+        return f"End-of-Day Summary -- {lead} {health_line} {len(content['pending_recommendations'])} recommendation(s) still pending leadership decision."
+    if brief_type == BRIEF_WEEKEND_READINESS:
+        return f"Weekend Readiness -- {lead} {alerts} open patient safety alert(s); confirm on-call coverage before the weekend."
+    if brief_type == BRIEF_SHIFT_HANDOFF:
+        return f"Shift Handoff -- {lead} {alerts} open patient safety alert(s) and {len(content['pending_recommendations'])} pending recommendation(s) carry into the next shift."
+    return lead
+
+
+def generate_brief(db: Session, tenant_id: str, brief_type: str) -> MaestroDailyBrief:
+    content = _compose_content(db, tenant_id)
+    narrative = _narrative(brief_type, content)
+
+    row = MaestroDailyBrief(
+        tenant_id=tenant_id, brief_type=brief_type, content_json=json.dumps(content), narrative=narrative,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: MaestroDailyBrief) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "brief_type": row.brief_type,
+        "content": json.loads(row.content_json or "{}"),
+        "narrative": row.narrative,
+    }
+
+
+def latest_brief(db: Session, tenant_id: str, brief_type: str) -> dict | None:
+    row = (
+        db.query(MaestroDailyBrief)
+        .filter(MaestroDailyBrief.tenant_id == tenant_id, MaestroDailyBrief.brief_type == brief_type)
+        .order_by(MaestroDailyBrief.created_at.desc())
+        .first()
+    )
+    return to_dict(row) if row else None

--- a/backend/app/services/maestro_decision_journal_service.py
+++ b/backend/app/services/maestro_decision_journal_service.py
@@ -1,0 +1,92 @@
+"""Project Maestro, Section 8: Decision Journal.
+
+The leadership knowledge base: for every recommendation a leader acts on,
+records the evidence it was based on, which specialists were consulted,
+Maestro's confidence, what the leader actually decided, the outcome, and
+lessons learned. Recording a journal entry also advances the linked
+recommendation's `status` -- this is the only place a recommendation
+moves out of `pending`.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.maestro_orchestration import MaestroDecisionJournalEntry, MaestroRecommendation
+
+
+def record_decision(
+    db: Session, tenant_id: str, recommendation_id: int, *, leader_decision: str, decided_by: str,
+    decided_role: str = "", outcome: str = "", lessons_learned: str = "", new_status: str | None = None,
+) -> MaestroDecisionJournalEntry:
+    recommendation = (
+        db.query(MaestroRecommendation)
+        .filter(MaestroRecommendation.tenant_id == tenant_id, MaestroRecommendation.id == recommendation_id)
+        .first()
+    )
+    if recommendation is None:
+        raise ValueError(f"Recommendation {recommendation_id} not found for this tenant")
+    if not leader_decision:
+        raise ValueError("leader_decision is required for an auditable journal entry")
+
+    entry = MaestroDecisionJournalEntry(
+        tenant_id=tenant_id,
+        recommendation_id=recommendation_id,
+        evidence_json=recommendation.evidence_json,
+        specialists_consulted_json=recommendation.specialists_consulted_json,
+        confidence=recommendation.confidence,
+        leader_decision=leader_decision,
+        outcome=outcome,
+        lessons_learned=lessons_learned,
+        decided_by=decided_by,
+        decided_role=decided_role,
+    )
+    db.add(entry)
+
+    if new_status:
+        recommendation.status = new_status
+
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+def to_dict(row: MaestroDecisionJournalEntry) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "recommendation_id": row.recommendation_id,
+        "evidence": json.loads(row.evidence_json or "{}"),
+        "specialists_consulted": json.loads(row.specialists_consulted_json or "[]"),
+        "confidence": row.confidence,
+        "leader_decision": row.leader_decision,
+        "outcome": row.outcome,
+        "lessons_learned": row.lessons_learned,
+        "decided_by": row.decided_by,
+        "decided_role": row.decided_role,
+    }
+
+
+def journal_for_recommendation(db: Session, tenant_id: str, recommendation_id: int) -> list[dict]:
+    rows = (
+        db.query(MaestroDecisionJournalEntry)
+        .filter(
+            MaestroDecisionJournalEntry.tenant_id == tenant_id,
+            MaestroDecisionJournalEntry.recommendation_id == recommendation_id,
+        )
+        .order_by(MaestroDecisionJournalEntry.created_at.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]
+
+
+def list_journal(db: Session, tenant_id: str, *, limit: int = 50) -> list[dict]:
+    rows = (
+        db.query(MaestroDecisionJournalEntry)
+        .filter(MaestroDecisionJournalEntry.tenant_id == tenant_id)
+        .order_by(MaestroDecisionJournalEntry.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/maestro_health_index_service.py
+++ b/backend/app/services/maestro_health_index_service.py
@@ -1,0 +1,85 @@
+"""Project Maestro, Section 7: Operational Health Index.
+
+Reuses Phoenix's already-computed platform maturity dimensions
+(`phoenix_maturity_index_service.compute_platform_maturity_index`) directly
+for Quality/Workflow/Education/Digital-Twins/Knowledge -- never re-derived.
+"Enterprise" reuses Phoenix's executive-intelligence (audit-readiness)
+dimension, the closest existing leadership-facing composite. "Equipment" is
+genuinely new here: the average Vulcan Instrument Reliability Score across
+recent assessments, a real measure of fleet condition Phoenix does not
+track.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.maestro_orchestration import MaestroOperationalHealthSnapshot
+from app.models.vulcan_reliability import VulcanReliabilityAssessment
+from app.services.phoenix_maturity_index_service import compute_platform_maturity_index
+
+
+def _equipment_score(db: Session, tenant_id: str) -> float | None:
+    rows = (
+        db.query(VulcanReliabilityAssessment)
+        .filter(VulcanReliabilityAssessment.tenant_id == tenant_id)
+        .order_by(VulcanReliabilityAssessment.created_at.desc())
+        .limit(200)
+        .all()
+    )
+    if not rows:
+        return None
+    return round(sum(r.reliability_score for r in rows) / len(rows), 1)
+
+
+def compute_operational_health(db: Session, tenant_id: str) -> MaestroOperationalHealthSnapshot:
+    maturity = compute_platform_maturity_index(db, tenant_id)
+    scores = maturity["scores"]
+
+    quality_score = scores.get("quality_score")
+    workflow_score = scores.get("workflow_score")
+    education_score = scores.get("education_score")
+    digital_twin_score = scores.get("digital_twins_score")
+    knowledge_score = scores.get("knowledge_score")
+    enterprise_score = scores.get("executive_intelligence_score")
+    equipment_score = _equipment_score(db, tenant_id)
+
+    dimension_scores = {
+        "quality_score": quality_score, "workflow_score": workflow_score, "education_score": education_score,
+        "equipment_score": equipment_score, "digital_twin_score": digital_twin_score,
+        "knowledge_score": knowledge_score, "enterprise_score": enterprise_score,
+    }
+    present = [v for v in dimension_scores.values() if v is not None]
+    overall_score = round(sum(present) / len(present), 1) if present else None
+
+    row = MaestroOperationalHealthSnapshot(
+        tenant_id=tenant_id, quality_score=quality_score, workflow_score=workflow_score,
+        education_score=education_score, equipment_score=equipment_score, digital_twin_score=digital_twin_score,
+        knowledge_score=knowledge_score, enterprise_score=enterprise_score, overall_score=overall_score,
+        breakdown_json=json.dumps({
+            "source_phoenix_maturity_snapshot_id": maturity["id"], "dimension_scores": dimension_scores,
+            "phoenix_factors": maturity["factors"],
+        }),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: MaestroOperationalHealthSnapshot) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "quality_score": row.quality_score,
+        "workflow_score": row.workflow_score,
+        "education_score": row.education_score,
+        "equipment_score": row.equipment_score,
+        "digital_twin_score": row.digital_twin_score,
+        "knowledge_score": row.knowledge_score,
+        "enterprise_score": row.enterprise_score,
+        "overall_score": row.overall_score,
+        "breakdown": json.loads(row.breakdown_json or "{}"),
+        "human_review_required": row.human_review_required,
+    }

--- a/backend/app/services/maestro_orchestration_service.py
+++ b/backend/app/services/maestro_orchestration_service.py
@@ -1,0 +1,96 @@
+"""Project Maestro, Sections 1 & 9: Operational Orchestrator & Leadership
+Workspace.
+
+This is the single top-level entry point that composes every other
+Maestro service (priority engine, recommendation engine, health index,
+timeline) plus a handful of specialists' own summaries (Sentinel-X,
+Pulse) into the one leadership view the brief calls for: "What should I do
+first today, and why?" Nothing here is computed fresh -- it is a pure
+read-and-synthesize layer, exactly like every other Maestro module.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.maestro_orchestration import BRIEF_MORNING, DECISION_STATUS_PENDING, DISCLAIMER, TIMELINE_TODAY
+from app.services import (
+    maestro_daily_brief_service,
+    maestro_priority_engine_service,
+    maestro_recommendation_engine_service,
+)
+from app.services.maestro_health_index_service import compute_operational_health, to_dict as health_to_dict
+from app.services.sentinelx_dashboard_service import risk_dashboard_summary
+from app.services.sentinelx_patient_safety_watch_service import list_alerts
+from app.services.sentinelx_supervisor_workspace_service import supervisor_workspace_summary
+
+
+def run_daily_orchestration(db: Session, tenant_id: str) -> dict:
+    """Section 1: the Operational Orchestrator's main run -- ranks
+    priorities, derives leadership recommendations (both specific and
+    strategic), refreshes the Operational Health Index, and generates the
+    morning brief. Intended to be triggered once per day (or on demand)
+    per tenant; every downstream artifact this produces is independently
+    queryable afterward."""
+    priority_items = maestro_priority_engine_service.compute_priorities(db, tenant_id)
+    specific_recommendations = maestro_recommendation_engine_service.generate_recommendations(db, tenant_id)
+    strategic_recommendations = maestro_recommendation_engine_service.generate_strategic_recommendations(db, tenant_id)
+    health = compute_operational_health(db, tenant_id)
+    brief = maestro_daily_brief_service.generate_brief(db, tenant_id, BRIEF_MORNING)
+
+    return {
+        "priority_item_count": len(priority_items),
+        "recommendation_count": len(specific_recommendations) + len(strategic_recommendations),
+        "operational_health": health_to_dict(health),
+        "daily_brief": maestro_daily_brief_service.to_dict(brief),
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def leadership_workspace_summary(db: Session, tenant_id: str) -> dict:
+    """Section 9: the `/maestro` Leadership Workspace payload -- Top
+    Priorities, Operational Health, Open Risks, Today's Recommendations,
+    Pending Executive Decisions, Shift Readiness, and Enterprise Status."""
+    top_priorities = maestro_priority_engine_service.latest_priorities(db, tenant_id)
+
+    health = health_to_dict(compute_operational_health(db, tenant_id))
+
+    dashboard = risk_dashboard_summary(db, tenant_id)
+    open_risks = {
+        "enterprise_risk": dashboard["enterprise_risk"],
+        "top_facility_risk": (dashboard["facility_risk"][:3]),
+        "top_anatomy_risk": (dashboard["anatomy_risk"][:3]),
+    }
+
+    todays_recommendations = maestro_recommendation_engine_service.list_recommendations(
+        db, tenant_id, status=DECISION_STATUS_PENDING, timeline_horizon=TIMELINE_TODAY,
+    )
+    pending_executive_decisions = maestro_recommendation_engine_service.list_recommendations(
+        db, tenant_id, status=DECISION_STATUS_PENDING,
+    )
+
+    workspace = supervisor_workspace_summary(db, tenant_id, limit=10)
+    open_alerts = list_alerts(db, tenant_id, acknowledged=False)
+    shift_readiness = {
+        "pending_reviews": len(workspace["pending_reviews"]),
+        "open_patient_safety_alerts": len(open_alerts),
+        "escalating_trends": workspace["escalating_trends"],
+    }
+
+    enterprise_status = {
+        "overall_operational_health": health.get("overall_score"),
+        "average_risk_score": dashboard["enterprise_risk"].get("average_risk_score"),
+        "high_or_critical_risk_pct": dashboard["enterprise_risk"].get("high_or_critical_pct"),
+    }
+
+    return {
+        "top_priorities": top_priorities[:9],
+        "operational_health": health,
+        "open_risks": open_risks,
+        "todays_recommendations": todays_recommendations,
+        "pending_executive_decisions": pending_executive_decisions[:20],
+        "shift_readiness": shift_readiness,
+        "enterprise_status": enterprise_status,
+        "human_review_required": True,
+        "disclaimer": DISCLAIMER,
+    }

--- a/backend/app/services/maestro_priority_engine_service.py
+++ b/backend/app/services/maestro_priority_engine_service.py
@@ -1,0 +1,269 @@
+"""Project Maestro, Section 2: Priority Engine.
+
+Ranks the 9 named priority categories from real, already-computed
+specialist signals -- Maestro never invents its own risk math. Each
+category resolver is a thin read of one specialist's existing output;
+Maestro's only original work is comparing across categories and ranking
+them into one ordered leadership list.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.maestro_orchestration import (
+    PRIORITY_HIGHEST_PRIORITY_CAPA,
+    PRIORITY_HIGHEST_PRIORITY_EXECUTIVE_ISSUE,
+    PRIORITY_HIGHEST_PRIORITY_INSPECTION,
+    PRIORITY_HIGHEST_PRIORITY_REPAIR,
+    PRIORITY_HIGHEST_RISK_EQUIPMENT,
+    PRIORITY_HIGHEST_RISK_FACILITY,
+    PRIORITY_HIGHEST_RISK_INSTRUMENT,
+    PRIORITY_HIGHEST_RISK_TECHNICIAN_EDUCATION_NEED,
+    PRIORITY_HIGHEST_RISK_WORKFLOW,
+    MaestroPriorityItem,
+)
+from app.models.or_connect import REPAIR_PENDING, RepairRequest
+from app.models.patient_safety import ExecutiveRiskSignal
+from app.models.vulcan_reliability import VulcanReliabilityAssessment
+from app.services.capa_suggestion_service import generate_capa_suggestions
+from app.services.sage_knowledge_gap_service import list_gaps
+from app.services.sentinelx_dashboard_service import risk_dashboard_summary
+from app.services.sentinelx_supervisor_workspace_service import supervisor_workspace_summary
+
+
+def _highest_risk_instrument(db: Session, tenant_id: str) -> dict | None:
+    top = supervisor_workspace_summary(db, tenant_id, limit=1)["highest_risk_instruments"][:1]
+    if not top:
+        return None
+    item = top[0]
+    return {
+        "subject": item["instrument_identity"],
+        "priority_score": item["average_risk_score"],
+        "source_specialist": "sentinelx",
+        "rationale": f"Highest average risk score ({item['average_risk_score']}) across {item['assessment_count']} Sentinel-X assessments.",
+        "evidence": item,
+    }
+
+
+def _highest_risk_workflow(db: Session, tenant_id: str) -> dict | None:
+    workflow = risk_dashboard_summary(db, tenant_id)["workflow_risk"]
+    count = workflow.get("process_variation_flagged_count") or 0
+    if count <= 0:
+        return None
+    return {
+        "subject": "process_variation",
+        "priority_score": float(count),
+        "source_specialist": "sentinelx",
+        "rationale": f"{count} risk assessments flag technician process-variation as a contributing factor.",
+        "evidence": workflow,
+    }
+
+
+def _highest_risk_facility(db: Session, tenant_id: str) -> dict | None:
+    facilities = risk_dashboard_summary(db, tenant_id)["facility_risk"]
+    if not facilities:
+        return None
+    top = facilities[0]
+    return {
+        "subject": top["key"],
+        "priority_score": top["average_risk_score"],
+        "source_specialist": "sentinelx",
+        "rationale": f"Highest average risk score ({top['average_risk_score']}) across {top['count']} assessments at this facility.",
+        "evidence": top,
+    }
+
+
+def _highest_risk_technician_education_need(db: Session, tenant_id: str) -> dict | None:
+    gaps = list_gaps(db, tenant_id, status="open")
+    if not gaps:
+        return None
+    top = max(gaps, key=lambda g: g["occurrence_count"])
+    return {
+        "subject": f"{top['competency_domain']} / {top['scope_value']}",
+        "priority_score": float(top["occurrence_count"]),
+        "source_specialist": "sage",
+        "rationale": top["narrative"] or f"Recurring knowledge gap ({top['occurrence_count']} occurrences) in {top['competency_domain']}.",
+        "evidence": top,
+    }
+
+
+def _highest_risk_equipment(db: Session, tenant_id: str) -> dict | None:
+    rows = (
+        db.query(VulcanReliabilityAssessment)
+        .filter(VulcanReliabilityAssessment.tenant_id == tenant_id)
+        .order_by(VulcanReliabilityAssessment.created_at.desc())
+        .limit(200)
+        .all()
+    )
+    if not rows:
+        return None
+    worst = min(rows, key=lambda r: r.reliability_score)
+    return {
+        "subject": worst.instrument_identity,
+        "priority_score": round(100.0 - worst.reliability_score, 1),
+        "source_specialist": "vulcan",
+        "rationale": f"Lowest reliability score ({worst.reliability_score}) of any recently tracked instrument, category '{worst.reliability_category}'.",
+        "evidence": {
+            "reliability_score": worst.reliability_score,
+            "reliability_category": worst.reliability_category,
+            "instrument_family": worst.instrument_family,
+        },
+    }
+
+
+def _highest_priority_capa(db: Session, tenant_id: str) -> dict | None:
+    suggestions = generate_capa_suggestions(db, tenant_id)
+    if not suggestions:
+        return None
+    top = max(suggestions, key=lambda s: s["occurrences"])
+    return {
+        "subject": top["suggested_title"],
+        "priority_score": float(top["occurrences"]),
+        "source_specialist": "capa_suggestion_service",
+        "rationale": top["recommendation"],
+        "evidence": top,
+    }
+
+
+def _highest_priority_inspection(db: Session, tenant_id: str) -> dict | None:
+    top = supervisor_workspace_summary(db, tenant_id, limit=1)["highest_risk_inspections"][:1]
+    if not top:
+        return None
+    item = top[0]
+    return {
+        "subject": f"inspection:{item['inspection_id']}",
+        "priority_score": item["risk_score"],
+        "source_specialist": "sentinelx",
+        "rationale": item.get("reasoning_narrative") or f"Highest risk score ({item['risk_score']}) among open inspections.",
+        "evidence": item,
+    }
+
+
+def _highest_priority_repair(db: Session, tenant_id: str) -> dict | None:
+    rows = (
+        db.query(RepairRequest)
+        .filter(RepairRequest.tenant_id == tenant_id, RepairRequest.status == REPAIR_PENDING)
+        .order_by(RepairRequest.created_at.asc())
+        .all()
+    )
+    if not rows:
+        return None
+    top = rows[0]
+    created_at = top.created_at if top.created_at.tzinfo else top.created_at.replace(tzinfo=timezone.utc)
+    age_days = (datetime.now(timezone.utc) - created_at).days
+    return {
+        "subject": top.instrument_identity or f"repair:{top.id}",
+        "priority_score": float(age_days),
+        "source_specialist": "or_connect",
+        "rationale": f"Oldest pending repair request ({age_days} days open), vendor {top.vendor_name or 'unassigned'}.",
+        "evidence": {
+            "repair_id": top.id, "status": top.status, "repair_type": top.repair_type, "vendor_name": top.vendor_name,
+        },
+    }
+
+
+_RISK_TIER_RANK = {"critical": 3, "high": 2, "medium": 1, "low": 0}
+
+
+def _highest_priority_executive_issue(db: Session, tenant_id: str) -> dict | None:
+    rows = (
+        db.query(ExecutiveRiskSignal)
+        .filter(ExecutiveRiskSignal.tenant_id == tenant_id, ExecutiveRiskSignal.human_review_status == "pending")
+        .all()
+    )
+    if not rows:
+        return None
+    top = max(rows, key=lambda r: (_RISK_TIER_RANK.get(r.risk_tier, 0), r.confidence_score or 0.0))
+    score = round(_RISK_TIER_RANK.get(top.risk_tier, 0) * 25.0 + (top.confidence_score or 0.0) * 10.0, 1)
+    return {
+        "subject": top.event_type,
+        "priority_score": score,
+        "source_specialist": "executive_risk_signal",
+        "rationale": top.association_reason or f"Unreviewed {top.risk_tier} executive risk signal ({top.event_type}).",
+        "evidence": {
+            "risk_tier": top.risk_tier, "event_type": top.event_type,
+            "estimated_financial_exposure": top.estimated_financial_exposure,
+        },
+    }
+
+
+_CATEGORY_RESOLVERS = {
+    PRIORITY_HIGHEST_RISK_INSTRUMENT: _highest_risk_instrument,
+    PRIORITY_HIGHEST_RISK_WORKFLOW: _highest_risk_workflow,
+    PRIORITY_HIGHEST_RISK_FACILITY: _highest_risk_facility,
+    PRIORITY_HIGHEST_RISK_TECHNICIAN_EDUCATION_NEED: _highest_risk_technician_education_need,
+    PRIORITY_HIGHEST_RISK_EQUIPMENT: _highest_risk_equipment,
+    PRIORITY_HIGHEST_PRIORITY_CAPA: _highest_priority_capa,
+    PRIORITY_HIGHEST_PRIORITY_INSPECTION: _highest_priority_inspection,
+    PRIORITY_HIGHEST_PRIORITY_REPAIR: _highest_priority_repair,
+    PRIORITY_HIGHEST_PRIORITY_EXECUTIVE_ISSUE: _highest_priority_executive_issue,
+}
+
+
+def compute_priorities(db: Session, tenant_id: str) -> list[MaestroPriorityItem]:
+    """Runs every category resolver, persists one `MaestroPriorityItem` per
+    category that has real data (categories with nothing to report are
+    skipped, never fabricated), and ranks the result across categories by
+    `priority_score`."""
+    candidates = []
+    for category, resolver in _CATEGORY_RESOLVERS.items():
+        result = resolver(db, tenant_id)
+        if result is not None:
+            candidates.append((category, result))
+
+    candidates.sort(key=lambda c: c[1]["priority_score"], reverse=True)
+
+    rows = []
+    for rank, (category, result) in enumerate(candidates, start=1):
+        row = MaestroPriorityItem(
+            tenant_id=tenant_id,
+            category=category,
+            subject=result["subject"][:300],
+            priority_score=result["priority_score"],
+            rank=rank,
+            source_specialist=result["source_specialist"],
+            rationale=result["rationale"],
+            evidence_json=json.dumps(result["evidence"]),
+        )
+        db.add(row)
+        rows.append(row)
+    db.commit()
+    for row in rows:
+        db.refresh(row)
+    return rows
+
+
+def to_dict(row: MaestroPriorityItem) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "category": row.category,
+        "subject": row.subject,
+        "priority_score": row.priority_score,
+        "rank": row.rank,
+        "source_specialist": row.source_specialist,
+        "rationale": row.rationale,
+        "evidence": json.loads(row.evidence_json or "{}"),
+    }
+
+
+def latest_priorities(db: Session, tenant_id: str) -> list[dict]:
+    """Returns the most recent priority-engine run's items, ranked."""
+    latest = (
+        db.query(MaestroPriorityItem)
+        .filter(MaestroPriorityItem.tenant_id == tenant_id)
+        .order_by(MaestroPriorityItem.created_at.desc())
+        .first()
+    )
+    if latest is None:
+        return []
+    rows = (
+        db.query(MaestroPriorityItem)
+        .filter(MaestroPriorityItem.tenant_id == tenant_id, MaestroPriorityItem.created_at == latest.created_at)
+        .order_by(MaestroPriorityItem.rank.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/maestro_recommendation_engine_service.py
+++ b/backend/app/services/maestro_recommendation_engine_service.py
@@ -1,0 +1,292 @@
+"""Project Maestro, Sections 3 & 5: Leadership Recommendation Engine.
+
+Section 3 ("specific") recommendations are generated one-per-priority-item,
+directly citing the `MaestroPriorityItem` that triggered them (e.g. "Move
+supervisor to review <facility>.", "Schedule <domain> competency for
+<scope>.", "Generate CAPA draft: <title>."). Section 5 ("strategic")
+recommendations are a periodic, higher-level digest derived from the
+Operational Health Index and the full priority list rather than any single
+item. Every recommendation is advisory only -- `human_review_required` is
+always `True`, and nothing here calls `capa_suggestion_service.
+create_capa_from_suggestion` or `forge_approval_service` directly; those
+remain explicit, separate human-triggered actions.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.maestro_orchestration import (
+    PRIORITY_HIGHEST_PRIORITY_CAPA,
+    PRIORITY_HIGHEST_PRIORITY_EXECUTIVE_ISSUE,
+    PRIORITY_HIGHEST_PRIORITY_INSPECTION,
+    PRIORITY_HIGHEST_PRIORITY_REPAIR,
+    PRIORITY_HIGHEST_RISK_EQUIPMENT,
+    PRIORITY_HIGHEST_RISK_FACILITY,
+    PRIORITY_HIGHEST_RISK_INSTRUMENT,
+    PRIORITY_HIGHEST_RISK_TECHNICIAN_EDUCATION_NEED,
+    PRIORITY_HIGHEST_RISK_WORKFLOW,
+    RECOMMENDATION_EDUCATION_PRIORITIES,
+    RECOMMENDATION_ESCALATE_REPAIR_BACKLOG,
+    RECOMMENDATION_EQUIPMENT_UTILIZATION,
+    RECOMMENDATION_GENERATE_CAPA_DRAFT,
+    RECOMMENDATION_INSPECTION_PRIORITIES,
+    RECOMMENDATION_MOVE_SUPERVISOR,
+    RECOMMENDATION_PUBLISH_BASELINE,
+    RECOMMENDATION_QUALITY_INITIATIVES,
+    RECOMMENDATION_RESOURCE_ALLOCATION,
+    RECOMMENDATION_REVIEW_CORROSION_TREND,
+    RECOMMENDATION_SCHEDULE_COMPETENCY,
+    RECOMMENDATION_STAFFING_CHANGES,
+    TIMELINE_QUARTER,
+    TIMELINE_THIS_WEEK,
+    TIMELINE_TODAY,
+    MaestroRecommendation,
+)
+from app.models.veritas_evidence import VeritasEvidenceConflict
+from app.services import maestro_priority_engine_service
+from app.services.sage_knowledge_gap_service import list_gaps
+
+_CORROSION_FAILURE_CATEGORIES = {"corrosion", "rust", "pitting"}
+
+# Baseline-governance-relevant conflict types (Veritas Section 9) that a
+# supervisor resolves by publishing an updated baseline.
+_BASELINE_CONFLICT_TYPES = {
+    "multiple_active_approved_baselines",
+    "baseline_superseded_after_inspection",
+}
+
+
+def _to_dict(row: MaestroRecommendation) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "priority_item_id": row.priority_item_id,
+        "recommendation_type": row.recommendation_type,
+        "subject": row.subject,
+        "rationale": row.rationale,
+        "confidence": row.confidence,
+        "specialists_consulted": json.loads(row.specialists_consulted_json or "[]"),
+        "evidence": json.loads(row.evidence_json or "{}"),
+        "timeline_horizon": row.timeline_horizon,
+        "status": row.status,
+        "human_review_required": row.human_review_required,
+        "agent_version": row.agent_version,
+    }
+
+
+def _persist(
+    db: Session, tenant_id: str, *, priority_item_id: int | None, recommendation_type: str, subject: str,
+    rationale: str, specialists: list[str], evidence: dict, timeline_horizon: str = TIMELINE_TODAY,
+    confidence: str = "moderate",
+) -> MaestroRecommendation:
+    row = MaestroRecommendation(
+        tenant_id=tenant_id, priority_item_id=priority_item_id, recommendation_type=recommendation_type,
+        subject=subject[:300], rationale=rationale, confidence=confidence,
+        specialists_consulted_json=json.dumps(specialists), evidence_json=json.dumps(evidence),
+        timeline_horizon=timeline_horizon,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+_SPECIALIST_BY_SOURCE = {
+    "sentinelx": ["sentinelx"],
+    "sage": ["sage"],
+    "vulcan": ["vulcan"],
+    "capa_suggestion_service": ["capa_suggestion_service"],
+    "or_connect": ["or_connect"],
+    "executive_risk_signal": ["executive_risk_signal"],
+}
+
+
+def _specific_recommendation_for_item(db: Session, tenant_id: str, item) -> MaestroRecommendation | None:
+    evidence = json.loads(item.evidence_json or "{}")
+    specialists = _SPECIALIST_BY_SOURCE.get(item.source_specialist, [item.source_specialist])
+
+    if item.category == PRIORITY_HIGHEST_RISK_FACILITY:
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_MOVE_SUPERVISOR,
+            subject=f"Move supervisor to {item.subject}.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    if item.category == PRIORITY_HIGHEST_RISK_INSTRUMENT:
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_MOVE_SUPERVISOR,
+            subject=f"Move supervisor to review {item.subject}.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    if item.category == PRIORITY_HIGHEST_RISK_WORKFLOW:
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_INSPECTION_PRIORITIES,
+            subject="Review process-variation workflow controls.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    if item.category == PRIORITY_HIGHEST_RISK_TECHNICIAN_EDUCATION_NEED:
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_SCHEDULE_COMPETENCY,
+            subject=f"Schedule {item.subject} competency.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    if item.category == PRIORITY_HIGHEST_RISK_EQUIPMENT:
+        failure_category = (evidence.get("reliability_category") or "").lower()
+        if any(term in failure_category for term in _CORROSION_FAILURE_CATEGORIES):
+            return _persist(
+                db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_REVIEW_CORROSION_TREND,
+                subject=f"Review {item.subject} corrosion trend.",
+                rationale=item.rationale, specialists=specialists, evidence=evidence,
+            )
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_EQUIPMENT_UTILIZATION,
+            subject=f"Review utilization for {item.subject}.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    if item.category == PRIORITY_HIGHEST_PRIORITY_CAPA:
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_GENERATE_CAPA_DRAFT,
+            subject="Generate CAPA draft.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    if item.category == PRIORITY_HIGHEST_PRIORITY_INSPECTION:
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_INSPECTION_PRIORITIES,
+            subject=f"Prioritize {item.subject}.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    if item.category == PRIORITY_HIGHEST_PRIORITY_REPAIR:
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_ESCALATE_REPAIR_BACKLOG,
+            subject="Escalate repair backlog.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    if item.category == PRIORITY_HIGHEST_PRIORITY_EXECUTIVE_ISSUE:
+        return _persist(
+            db, tenant_id, priority_item_id=item.id, recommendation_type=RECOMMENDATION_QUALITY_INITIATIVES,
+            subject=f"Address executive risk: {item.subject}.",
+            rationale=item.rationale, specialists=specialists, evidence=evidence,
+        )
+    return None
+
+
+def _publish_baseline_recommendation(db: Session, tenant_id: str) -> MaestroRecommendation | None:
+    conflict = (
+        db.query(VeritasEvidenceConflict)
+        .filter(
+            VeritasEvidenceConflict.tenant_id == tenant_id,
+            VeritasEvidenceConflict.conflict_type.in_(_BASELINE_CONFLICT_TYPES),
+            VeritasEvidenceConflict.resolved.is_(False),
+        )
+        .order_by(VeritasEvidenceConflict.created_at.desc())
+        .first()
+    )
+    if conflict is None:
+        return None
+    return _persist(
+        db, tenant_id, priority_item_id=None, recommendation_type=RECOMMENDATION_PUBLISH_BASELINE,
+        subject="Publish updated baseline.",
+        rationale=conflict.recommended_resolution or f"Unresolved baseline conflict: {conflict.conflict_type}.",
+        specialists=["veritas"],
+        evidence={"conflict_type": conflict.conflict_type, "severity": conflict.severity, "conflict_id": conflict.id},
+    )
+
+
+def generate_recommendations(db: Session, tenant_id: str) -> list[MaestroRecommendation]:
+    """Section 3: runs the Priority Engine, then converts each real
+    priority item (plus any pending Veritas baseline conflict) into one
+    specific, evidence-linked leadership recommendation."""
+    priority_items = maestro_priority_engine_service.compute_priorities(db, tenant_id)
+
+    recommendations: list[MaestroRecommendation] = []
+    for item in priority_items:
+        rec = _specific_recommendation_for_item(db, tenant_id, item)
+        if rec is not None:
+            recommendations.append(rec)
+
+    baseline_rec = _publish_baseline_recommendation(db, tenant_id)
+    if baseline_rec is not None:
+        recommendations.append(baseline_rec)
+
+    return recommendations
+
+
+def generate_strategic_recommendations(db: Session, tenant_id: str) -> list[MaestroRecommendation]:
+    """Section 5: a periodic, higher-level digest across the six strategic
+    categories, derived from the Operational Health Index and the current
+    priority list rather than any single item."""
+    from app.services.maestro_health_index_service import compute_operational_health
+
+    health = compute_operational_health(db, tenant_id)
+    priority_items = maestro_priority_engine_service.latest_priorities(db, tenant_id) or [
+        maestro_priority_engine_service.to_dict(r) for r in maestro_priority_engine_service.compute_priorities(db, tenant_id)
+    ]
+
+    recommendations: list[MaestroRecommendation] = []
+
+    if health.equipment_score is not None and health.equipment_score < 70:
+        recommendations.append(_persist(
+            db, tenant_id, priority_item_id=None, recommendation_type=RECOMMENDATION_RESOURCE_ALLOCATION,
+            subject="Reallocate maintenance resources toward declining equipment reliability.",
+            rationale=f"Equipment health score is {health.equipment_score}, below the 70 review threshold.",
+            specialists=["vulcan", "phoenix"], evidence={"equipment_score": health.equipment_score},
+            timeline_horizon=TIMELINE_THIS_WEEK,
+        ))
+
+    repair_items = [p for p in priority_items if p["category"] == "highest_priority_repair"]
+    if repair_items:
+        recommendations.append(_persist(
+            db, tenant_id, priority_item_id=repair_items[0]["id"], recommendation_type=RECOMMENDATION_STAFFING_CHANGES,
+            subject="Review repair-vendor staffing capacity.",
+            rationale=repair_items[0]["rationale"], specialists=["or_connect"],
+            evidence=repair_items[0]["evidence"], timeline_horizon=TIMELINE_THIS_WEEK,
+        ))
+
+    open_gaps = list_gaps(db, tenant_id, status="open")
+    if open_gaps:
+        recommendations.append(_persist(
+            db, tenant_id, priority_item_id=None, recommendation_type=RECOMMENDATION_EDUCATION_PRIORITIES,
+            subject=f"Prioritize education plans for {len(open_gaps)} open competency gap(s).",
+            rationale="Aggregated across all currently open Sage knowledge gaps for this tenant.",
+            specialists=["sage"], evidence={"open_gap_count": len(open_gaps)}, timeline_horizon=TIMELINE_QUARTER,
+        ))
+
+    if health.quality_score is not None and health.quality_score < 70:
+        recommendations.append(_persist(
+            db, tenant_id, priority_item_id=None, recommendation_type=RECOMMENDATION_QUALITY_INITIATIVES,
+            subject="Launch a quality improvement initiative.",
+            rationale=f"Quality health score is {health.quality_score}, below the 70 review threshold.",
+            specialists=["phoenix"], evidence={"quality_score": health.quality_score}, timeline_horizon=TIMELINE_QUARTER,
+        ))
+
+    return recommendations
+
+
+def to_dict(row: MaestroRecommendation) -> dict:
+    return _to_dict(row)
+
+
+def list_recommendations(
+    db: Session, tenant_id: str, *, status: str = "", timeline_horizon: str = "",
+) -> list[dict]:
+    q = db.query(MaestroRecommendation).filter(MaestroRecommendation.tenant_id == tenant_id)
+    if status:
+        q = q.filter(MaestroRecommendation.status == status)
+    if timeline_horizon:
+        q = q.filter(MaestroRecommendation.timeline_horizon == timeline_horizon)
+    return [_to_dict(r) for r in q.order_by(MaestroRecommendation.created_at.desc()).all()]
+
+
+def update_status(db: Session, tenant_id: str, recommendation_id: int, status: str) -> MaestroRecommendation | None:
+    row = (
+        db.query(MaestroRecommendation)
+        .filter(MaestroRecommendation.tenant_id == tenant_id, MaestroRecommendation.id == recommendation_id)
+        .first()
+    )
+    if row is None:
+        return None
+    row.status = status
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/services/maestro_timeline_service.py
+++ b/backend/app/services/maestro_timeline_service.py
@@ -1,0 +1,48 @@
+"""Project Maestro, Section 6: Strategy Timeline.
+
+A pure query over `MaestroRecommendation` -- there is no separate timeline
+table. Recommendations are grouped by `timeline_horizon` and, within each
+horizon, by `status`, so leadership can see what's due today versus this
+quarter, and what's still pending versus already actioned.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.maestro_orchestration import TIMELINE_HORIZONS, MaestroRecommendation
+from app.services.maestro_recommendation_engine_service import to_dict
+
+
+def strategy_timeline(db: Session, tenant_id: str) -> dict:
+    rows = (
+        db.query(MaestroRecommendation)
+        .filter(MaestroRecommendation.tenant_id == tenant_id)
+        .order_by(MaestroRecommendation.created_at.desc())
+        .all()
+    )
+
+    by_horizon: dict[str, list[dict]] = {horizon: [] for horizon in TIMELINE_HORIZONS}
+    for row in rows:
+        by_horizon.setdefault(row.timeline_horizon, []).append(to_dict(row))
+
+    return {
+        "horizons": by_horizon,
+        "total_recommendations": len(rows),
+        "human_review_required": True,
+    }
+
+
+def move_horizon(db: Session, tenant_id: str, recommendation_id: int, timeline_horizon: str) -> MaestroRecommendation | None:
+    if timeline_horizon not in TIMELINE_HORIZONS:
+        raise ValueError(f"Unknown timeline horizon: {timeline_horizon}")
+    row = (
+        db.query(MaestroRecommendation)
+        .filter(MaestroRecommendation.tenant_id == tenant_id, MaestroRecommendation.id == recommendation_id)
+        .first()
+    )
+    if row is None:
+        return None
+    row.timeline_horizon = timeline_horizon
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/services/sage_aegis_vulcan_integration_service.py
+++ b/backend/app/services/sage_aegis_vulcan_integration_service.py
@@ -1,0 +1,74 @@
+"""Project Sage, Sections 13 & 14: Integration With Aegis and Vulcan.
+
+Aegis remains responsible for process analysis; Vulcan remains responsible
+for instrument reliability; Sage remains responsible only for education and
+competency support. Each integration point *reads* the other agent's real
+conclusion (`vulcan_aegis_integration_service.compute_process_variation_signal`,
+`VulcanReliabilityAssessment`) and returns a Sage-specific recommendation --
+it never mutates or overwrites the source conclusion, and the two remain
+separately traceable via `source_vulcan_assessment_id`/`source_aegis_signal`
+in the returned evidence, never merged into a single blended field.
+"""
+from __future__ import annotations
+
+from app.models.vulcan_reliability import VulcanReliabilityAssessment
+from app.services.vulcan_aegis_integration_service import compute_process_variation_signal
+
+# Vulcan failure leaves easily confused with a benign cosmetic finding --
+# Sage should recommend differentiation education specifically for these.
+_AMBIGUOUS_CONDITION_PAIRS = {
+    "corrosion": "cosmetic discoloration",
+    "rust": "cosmetic discoloration",
+    "pitting": "cosmetic surface wear",
+}
+
+
+def sage_recommendation_from_aegis(db, tenant_id: str, instrument_identity: str, zone: str | None = None) -> dict:
+    """Section 13 example: Aegis finds a process-concentration pattern;
+    Sage recommends focused brushing/inspection education for the affected
+    anatomy -- Aegis's own signal is included by reference, never edited."""
+    aegis_signal = compute_process_variation_signal(db, tenant_id, instrument_identity, zone=zone)
+    if not aegis_signal["process_variation_detected"]:
+        return {
+            "has_recommendation": False,
+            "source_aegis_signal": aegis_signal,
+            "recommendation": "",
+        }
+    zone_text = f" for {zone}" if zone else ""
+    return {
+        "has_recommendation": True,
+        "source_aegis_signal": aegis_signal,
+        "recommendation": (
+            f"Aegis evidence shows a process-concentration pattern ({aegis_signal['narrative']}). "
+            f"Recommend focused brushing and inspection education{zone_text} for the affected workflow."
+        ),
+    }
+
+
+def sage_recommendation_from_vulcan(assessment: VulcanReliabilityAssessment) -> dict:
+    """Section 14 example: Vulcan finds repeated corrosion at an anatomy
+    zone; Sage recommends differentiation education (corrosion vs cosmetic
+    discoloration) plus focused inspection of that zone. Vulcan's own
+    `reasoning_narrative`/`recommended_disposition` are referenced by ID,
+    never copied into or overwritten by Sage's recommendation."""
+    confusable_with = _AMBIGUOUS_CONDITION_PAIRS.get(assessment.failure_category)
+    zone_text = assessment.anatomy_zone.replace("_", " ") if assessment.anatomy_zone else "the affected anatomy zone"
+
+    if confusable_with:
+        recommendation = (
+            f"Vulcan evidence shows recurring {assessment.failure_category} at {zone_text}. "
+            f"Recommend education on differentiating {assessment.failure_category} from {confusable_with} "
+            f"and focused {zone_text} inspection."
+        )
+    else:
+        recommendation = (
+            f"Vulcan evidence shows a reliability pattern ({assessment.failure_category or 'unspecified'}) "
+            f"at {zone_text}. Recommend focused inspection education for {zone_text}."
+        )
+
+    return {
+        "has_recommendation": True,
+        "source_vulcan_assessment_id": assessment.id,
+        "source_vulcan_reliability_category": assessment.reliability_category,
+        "recommendation": recommendation,
+    }

--- a/backend/app/services/sage_assessment_service.py
+++ b/backend/app/services/sage_assessment_service.py
@@ -1,0 +1,77 @@
+"""Project Sage, Section 7: Competency Assessment Builder.
+
+Results remain advisory (`result_status = "advisory"`) until an authorized
+evaluator validates them -- mirrors Vulcan's `recommended_disposition` vs
+`final_disposition` split: Sage's own scoring is never treated as a final
+competency determination.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.sage_education import ASSESSMENT_FORMATS, SageAssessment
+
+
+def create_assessment(
+    db: Session, tenant_id: str, *, assessment_format: str, target_learner: str,
+    competency_domain: str = "", content: dict | None = None, learning_plan_id: int | None = None,
+) -> SageAssessment:
+    if assessment_format not in ASSESSMENT_FORMATS:
+        raise ValueError(f"Unknown assessment_format '{assessment_format}'")
+    row = SageAssessment(
+        tenant_id=tenant_id, learning_plan_id=learning_plan_id, assessment_format=assessment_format,
+        target_learner=target_learner, competency_domain=competency_domain, content_json=json.dumps(content or {}),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def record_result(db: Session, tenant_id: str, assessment_id: int, *, result: dict) -> SageAssessment | None:
+    row = db.query(SageAssessment).filter(SageAssessment.id == assessment_id, SageAssessment.tenant_id == tenant_id).first()
+    if row is None:
+        return None
+    row.result_json = json.dumps(result)
+    row.result_status = "advisory"
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def validate_result(db: Session, tenant_id: str, assessment_id: int, *, validated_by: str) -> SageAssessment | None:
+    row = db.query(SageAssessment).filter(SageAssessment.id == assessment_id, SageAssessment.tenant_id == tenant_id).first()
+    if row is None:
+        return None
+    row.result_status = "validated"
+    row.validated_by = validated_by
+    row.validated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: SageAssessment) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "learning_plan_id": row.learning_plan_id,
+        "assessment_format": row.assessment_format,
+        "target_learner": row.target_learner,
+        "competency_domain": row.competency_domain,
+        "content": json.loads(row.content_json or "{}"),
+        "result": json.loads(row.result_json or "{}"),
+        "result_status": row.result_status,
+        "validated_by": row.validated_by,
+        "validated_at": row.validated_at.isoformat() if row.validated_at else None,
+    }
+
+
+def list_assessments(db: Session, tenant_id: str, *, target_learner: str = "") -> list[dict]:
+    q = db.query(SageAssessment).filter(SageAssessment.tenant_id == tenant_id)
+    if target_learner:
+        q = q.filter(SageAssessment.target_learner == target_learner)
+    return [to_dict(r) for r in q.order_by(SageAssessment.created_at.desc()).all()]

--- a/backend/app/services/sage_athena_apollo_integration_service.py
+++ b/backend/app/services/sage_athena_apollo_integration_service.py
@@ -1,0 +1,42 @@
+"""Project Sage, Section 15: Integration With Athena and Apollo.
+
+Athena provides institutional knowledge / approved lessons learned /
+clinical cases / playbooks -- via `athena_memory_service.list_memory_entries`,
+called through rather than re-querying `KnowledgeArticle`/`ClinicalCase`/CAPA/
+root-cause tables directly. Apollo provides competency/CAPA/audit/policy
+evidence -- via the real `QualityTwinSnapshot` (`competency_score`/
+`education_score`), read-only. Sage returns learning recommendations,
+education completion, competency evidence, and effectiveness results built
+from this input -- it never writes back to either Athena's or Apollo's
+tables.
+"""
+from __future__ import annotations
+
+from app.services.apollo_quality_twin_service import twin_history
+from app.services.athena_memory_service import list_memory_entries
+
+
+def approved_institutional_content(db, tenant_id: str, *, query: str = "") -> list[dict]:
+    """Athena's approved lessons-learned/clinical-cases/playbooks content
+    Sage may cite as a source for education (never authored by Sage)."""
+    entries = list_memory_entries(db, tenant_id)
+    if query:
+        needle = query.lower()
+        entries = [e for e in entries if needle in str(e).lower()]
+    return entries
+
+
+def department_competency_evidence(db, tenant_id: str, department: str = "unspecified") -> dict | None:
+    """Apollo's most recent department-level competency/education scores --
+    read-only supplementary evidence for Sage's executive workforce view."""
+    history = twin_history(db, tenant_id, department, limit=1)
+    if not history:
+        return None
+    latest = history[0]
+    scores = latest.get("scores", {})
+    return {
+        "department": department,
+        "competency_score": scores.get("competency_score"),
+        "education_score": scores.get("education_score"),
+        "snapshot_created_at": latest.get("created_at"),
+    }

--- a/backend/app/services/sage_competency_taxonomy_service.py
+++ b/backend/app/services/sage_competency_taxonomy_service.py
@@ -1,0 +1,67 @@
+"""Project Sage, Section 2: Competency Taxonomy.
+
+Thin accessor over `app.models.sage_education.COMPETENCY_TAXONOMY` plus a
+mapping from real, already-recognized signal (finding_type strings,
+SupervisorReview correction fields) onto the taxonomy leaf it evidences --
+mirrors `vulcan_failure_taxonomy_service`'s classify-don't-fabricate pattern.
+"""
+from __future__ import annotations
+
+from app.models.sage_education import (
+    COMPETENCY_ANATOMY_ZONE_LABELING_DOC,
+    COMPETENCY_BLOOD,
+    COMPETENCY_BONE,
+    COMPETENCY_CORROSION,
+    COMPETENCY_DEBRIS,
+    COMPETENCY_DISCOLORATION,
+    COMPETENCY_INSPECTION_COVERAGE,
+    COMPETENCY_INSTRUMENT_FAMILY_RECOGNITION,
+    COMPETENCY_MISSING_COMPONENTS,
+    COMPETENCY_ORGANIC_RESIDUE,
+    COMPETENCY_RUST,
+    COMPETENCY_TAXONOMY,
+    COMPETENCY_TISSUE,
+)
+
+# Real finding_type strings (the CV pipeline's actual vocabulary, see
+# baseline_comparison_scoring_service.KPI_LABELS) mapped onto the contamination/
+# condition competency leaf they evidence.
+_FINDING_TYPE_TO_COMPETENCY: dict[str, str] = {
+    "blood": COMPETENCY_BLOOD,
+    "bone": COMPETENCY_BONE,
+    "tissue": COMPETENCY_TISSUE,
+    "other_organic_residue": COMPETENCY_ORGANIC_RESIDUE,
+    "debris": COMPETENCY_DEBRIS,
+    "rust": COMPETENCY_RUST,
+    "discoloration": COMPETENCY_DISCOLORATION,
+    "corrosion": COMPETENCY_CORROSION,
+    "missing_component": COMPETENCY_MISSING_COMPONENTS,
+}
+
+# SupervisorReview boolean-correction fields mapped onto the competency
+# domain a `False` value (a supervisor correction) evidences.
+_SUPERVISOR_FIELD_TO_COMPETENCY: dict[str, str] = {
+    "zone_correct": COMPETENCY_ANATOMY_ZONE_LABELING_DOC,
+    "instrument_family_correct": COMPETENCY_INSTRUMENT_FAMILY_RECOGNITION,
+    "image_view_correct": COMPETENCY_INSPECTION_COVERAGE,
+}
+
+_LEAF_TO_DOMAIN: dict[str, str] = {
+    leaf: domain for domain, leaves in COMPETENCY_TAXONOMY.items() for leaf in leaves
+}
+
+
+def taxonomy_tree() -> dict:
+    return {"domains": COMPETENCY_TAXONOMY}
+
+
+def domain_for_leaf(leaf: str) -> str:
+    return _LEAF_TO_DOMAIN.get(leaf, "")
+
+
+def competency_for_finding_type(finding_type: str) -> str | None:
+    return _FINDING_TYPE_TO_COMPETENCY.get((finding_type or "").strip().lower())
+
+
+def competency_for_supervisor_field(field_name: str) -> str | None:
+    return _SUPERVISOR_FIELD_TO_COMPETENCY.get(field_name)

--- a/backend/app/services/sage_effectiveness_service.py
+++ b/backend/app/services/sage_effectiveness_service.py
@@ -1,0 +1,161 @@
+"""Project Sage, Section 9: Learning Effectiveness Engine.
+
+Compares real before/after metrics for one learner across a completed
+learning plan's before-window (plan creation) and after-window (plan
+completion) -- inspection coverage (`Inspection.coverage_pct`), supervisor
+correction rate (`SupervisorReview.agreement`), image quality proxy
+(`Inspection.ai_confidence` -- this codebase does not separately measure
+image quality, so AI confidence on image-based inspections is the closest
+real signal), finding accuracy (`SupervisorReview.finding_correct`), anatomy
+accuracy (`SupervisorReview.zone_correct`), and workflow compliance
+(`SupervisorReview.image_view_correct` + `missing_zone_correct`). Never
+claims causation -- only classifies the pattern the numbers show.
+"""
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.sage_education import (
+    EFFECTIVENESS_DECLINED,
+    EFFECTIVENESS_IMPROVED,
+    EFFECTIVENESS_INSUFFICIENT_EVIDENCE,
+    EFFECTIVENESS_PARTIALLY_IMPROVED,
+    EFFECTIVENESS_UNCHANGED,
+    SageEffectivenessAssessment,
+)
+from app.models.supervisor_review import SupervisorReview
+
+_CHANGE_THRESHOLD_PCT = 5.0
+
+# metric_name -> True if higher is better
+_METRIC_DIRECTION = {
+    "avg_coverage_pct": True,
+    "avg_ai_confidence_pct": True,
+    "finding_accuracy_pct": True,
+    "anatomy_accuracy_pct": True,
+    "workflow_compliance_pct": True,
+    "supervisor_correction_rate_pct": False,
+}
+
+
+def _window_metrics(db: Session, tenant_id: str, technician: str, start, end) -> dict:
+    inspections = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id, models.Inspection.technician == technician,
+            models.Inspection.created_at >= start, models.Inspection.created_at < end,
+        )
+        .all()
+    )
+    coverage = [i.coverage_pct for i in inspections if i.coverage_pct is not None]
+    confidences = [i.ai_confidence for i in inspections if i.has_image and i.ai_confidence is not None]
+
+    insp_ids = [i.id for i in inspections]
+    reviews = (
+        db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id, SupervisorReview.inspection_id.in_(insp_ids)).all()
+    ) if insp_ids else []
+
+    metrics: dict[str, float | None] = {
+        "avg_coverage_pct": round(sum(coverage) / len(coverage), 1) if coverage else None,
+        "avg_ai_confidence_pct": round(100 * sum(confidences) / len(confidences), 1) if confidences else None,
+        "supervisor_correction_rate_pct": (
+            round(100 * sum(1 for r in reviews if r.agreement != "agree") / len(reviews), 1) if reviews else None
+        ),
+        "finding_accuracy_pct": (
+            round(100 * sum(1 for r in reviews if r.finding_correct) / sum(1 for r in reviews if r.finding_correct is not None), 1)
+            if any(r.finding_correct is not None for r in reviews) else None
+        ),
+        "anatomy_accuracy_pct": (
+            round(100 * sum(1 for r in reviews if r.zone_correct) / sum(1 for r in reviews if r.zone_correct is not None), 1)
+            if any(r.zone_correct is not None for r in reviews) else None
+        ),
+        "workflow_compliance_pct": (
+            round(
+                100 * sum(1 for r in reviews if r.image_view_correct and r.missing_zone_correct)
+                / sum(1 for r in reviews if r.image_view_correct is not None and r.missing_zone_correct is not None), 1
+            )
+            if any(r.image_view_correct is not None and r.missing_zone_correct is not None for r in reviews) else None
+        ),
+        "sample_size": len(inspections),
+    }
+    return metrics
+
+
+def classify_effectiveness(before: dict, after: dict) -> str:
+    tracked = [m for m in _METRIC_DIRECTION if before.get(m) is not None and after.get(m) is not None]
+    if not tracked:
+        return EFFECTIVENESS_INSUFFICIENT_EVIDENCE
+
+    improved = declined = 0
+    for metric in tracked:
+        delta = after[metric] - before[metric]
+        higher_is_better = _METRIC_DIRECTION[metric]
+        signed_delta = delta if higher_is_better else -delta
+        if signed_delta >= _CHANGE_THRESHOLD_PCT:
+            improved += 1
+        elif signed_delta <= -_CHANGE_THRESHOLD_PCT:
+            declined += 1
+
+    if improved == len(tracked):
+        return EFFECTIVENESS_IMPROVED
+    if declined == len(tracked):
+        return EFFECTIVENESS_DECLINED
+    if improved > declined:
+        return EFFECTIVENESS_PARTIALLY_IMPROVED
+    if declined > improved:
+        return EFFECTIVENESS_DECLINED
+    return EFFECTIVENESS_UNCHANGED
+
+
+def measure_learning_plan_effectiveness(
+    db: Session, tenant_id: str, learning_plan, *, window_days: int = 30,
+) -> SageEffectivenessAssessment:
+    """`learning_plan` must be a completed `SageLearningPlan` row (has
+    `completed_at`)."""
+    technician = learning_plan.learner_or_group
+    before_start = learning_plan.created_at - timedelta(days=window_days)
+    before = _window_metrics(db, tenant_id, technician, before_start, learning_plan.created_at)
+
+    after_end = (learning_plan.completed_at or learning_plan.created_at) + timedelta(days=window_days)
+    after = _window_metrics(db, tenant_id, technician, learning_plan.completed_at or learning_plan.created_at, after_end)
+
+    effectiveness = classify_effectiveness(before, after)
+    if effectiveness == EFFECTIVENESS_INSUFFICIENT_EVIDENCE:
+        narrative = (
+            f"Insufficient inspection/review activity in the before or after window to assess whether "
+            f"education for {technician} improved outcomes."
+        )
+    else:
+        narrative = (
+            f"Comparing the {window_days} days before and after this learning plan's completion, "
+            f"the recorded metrics for {technician} are classified as '{effectiveness.replace('_', ' ')}'. "
+            "This reflects an observed pattern, not a confirmed causal effect of the education itself."
+        )
+
+    row = SageEffectivenessAssessment(
+        tenant_id=tenant_id, learning_plan_id=learning_plan.id, learner_or_group=technician,
+        before_metrics_json=json.dumps(before), after_metrics_json=json.dumps(after),
+        effectiveness=effectiveness, narrative=narrative,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: SageEffectivenessAssessment) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "learning_plan_id": row.learning_plan_id,
+        "learner_or_group": row.learner_or_group,
+        "before_metrics": json.loads(row.before_metrics_json or "{}"),
+        "after_metrics": json.loads(row.after_metrics_json or "{}"),
+        "effectiveness": row.effectiveness,
+        "narrative": row.narrative,
+        "human_review_required": row.human_review_required,
+    }

--- a/backend/app/services/sage_executive_intelligence_service.py
+++ b/backend/app/services/sage_executive_intelligence_service.py
@@ -1,0 +1,58 @@
+"""Project Sage, Section 18: Executive Workforce Intelligence.
+
+Aggregate-only analytics for authorized leadership -- every number here is a
+count or rate grouped by domain/instrument-family/anatomy-zone, never a
+per-individual ranking list. No technician name appears in this summary.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+from sqlalchemy.orm import Session
+
+from app.models.sage_education import (
+    EFFECTIVENESS_IMPROVED,
+    EFFECTIVENESS_PARTIALLY_IMPROVED,
+    PLAN_STATUS_COMPLETED,
+    PLAN_STATUS_OVERDUE,
+    SageEffectivenessAssessment,
+    SageKnowledgeGap,
+    SageLearningPlan,
+)
+
+
+def executive_workforce_intelligence(db: Session, tenant_id: str) -> dict:
+    plans = db.query(SageLearningPlan).filter(SageLearningPlan.tenant_id == tenant_id).all()
+    gaps = db.query(SageKnowledgeGap).filter(SageKnowledgeGap.tenant_id == tenant_id).all()
+    effectiveness_rows = db.query(SageEffectivenessAssessment).filter(SageEffectivenessAssessment.tenant_id == tenant_id).all()
+
+    total_plans = len(plans)
+    completed_plans = sum(1 for p in plans if p.completion_status == PLAN_STATUS_COMPLETED)
+    overdue_plans = sum(1 for p in plans if p.completion_status == PLAN_STATUS_OVERDUE)
+    learners_with_plans = {p.learner_or_group for p in plans}
+    learners_with_completed = {p.learner_or_group for p in plans if p.completion_status == PLAN_STATUS_COMPLETED}
+
+    high_priority_gaps = [g for g in gaps if g.confidence == "high"]
+    anatomy_zone_counts = Counter(g.anatomy_zone for g in gaps if g.anatomy_zone)
+    instrument_family_counts = Counter(g.instrument_family for g in gaps if g.instrument_family)
+
+    effectiveness_counts = Counter(r.effectiveness for r in effectiveness_rows)
+    improved_count = effectiveness_counts.get(EFFECTIVENESS_IMPROVED, 0) + effectiveness_counts.get(EFFECTIVENESS_PARTIALLY_IMPROVED, 0)
+
+    return {
+        "competency_completion_pct": round(100 * completed_plans / total_plans, 1) if total_plans else None,
+        "education_coverage_pct": (
+            round(100 * len(learners_with_completed) / len(learners_with_plans), 1) if learners_with_plans else None
+        ),
+        "high_priority_knowledge_gap_count": len(high_priority_gaps),
+        "anatomy_zone_training_needs": dict(anatomy_zone_counts),
+        "instrument_family_training_needs": dict(instrument_family_counts),
+        "improvement_after_education_pct": (
+            round(100 * improved_count / len(effectiveness_rows), 1) if effectiveness_rows else None
+        ),
+        "overdue_competency_count": overdue_plans,
+        "learning_effectiveness_breakdown": dict(effectiveness_counts),
+        "total_learning_plans": total_plans,
+        "human_review_required": True,
+        "note": "Aggregate counts only -- no individual technician is ranked or named in this summary.",
+    }

--- a/backend/app/services/sage_feedback_service.py
+++ b/backend/app/services/sage_feedback_service.py
@@ -1,0 +1,62 @@
+"""Project Sage, Section 12: Educator and Supervisor Workspace actions.
+
+Logs every educator/supervisor action (review/approve/reject/edit/assign/
+document observation/validate return demonstration/close competency item/
+review effectiveness/add comment) as a `SageFeedback` row -- the audit
+record Section 17 requires. `override_reason` is required by the caller
+(enforced in `sage_learning_plan_service`) for reject/edit actions on a
+high-confidence recommendation; this service just persists whatever reason
+was supplied.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.sage_education import SageFeedback
+
+VALID_ACTIONS = (
+    "review", "approve", "reject", "edit_objective", "assign", "document_observation",
+    "validate_return_demonstration", "close_competency_item", "review_effectiveness", "add_comment",
+)
+
+
+def record_feedback(
+    db: Session, tenant_id: str, *, action: str, submitted_by: str, submitted_role: str = "",
+    learning_plan_id: int | None = None, knowledge_gap_id: int | None = None,
+    comment: str = "", override_reason: str = "",
+) -> SageFeedback:
+    if action not in VALID_ACTIONS:
+        raise ValueError(f"Unknown Sage feedback action '{action}'")
+    row = SageFeedback(
+        tenant_id=tenant_id, learning_plan_id=learning_plan_id, knowledge_gap_id=knowledge_gap_id,
+        action=action, comment=comment, override_reason=override_reason,
+        submitted_by=submitted_by, submitted_role=submitted_role,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: SageFeedback) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "learning_plan_id": row.learning_plan_id,
+        "knowledge_gap_id": row.knowledge_gap_id,
+        "action": row.action,
+        "comment": row.comment,
+        "override_reason": row.override_reason,
+        "submitted_by": row.submitted_by,
+        "submitted_role": row.submitted_role,
+    }
+
+
+def feedback_for_plan(db: Session, tenant_id: str, learning_plan_id: int) -> list[dict]:
+    rows = (
+        db.query(SageFeedback)
+        .filter(SageFeedback.tenant_id == tenant_id, SageFeedback.learning_plan_id == learning_plan_id)
+        .order_by(SageFeedback.created_at.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/sage_gap_detection_service.py
+++ b/backend/app/services/sage_gap_detection_service.py
@@ -1,0 +1,221 @@
+"""Project Sage, Section 3: Competency Gap Detection.
+
+Identifies possible competency gaps from real, already-validated patterns --
+`SupervisorReview` corrections (the ML ground-truth label store, joined to
+`Inspection.technician`), `CompetencyEvent` repeated-error counts, and
+`Inspection.coverage_pct`. A single isolated correction never creates a gap
+(`_MIN_OCCURRENCES = 2`) -- only a repeated pattern does. Every narrative uses
+non-punitive language ("targeted education may be beneficial," "competency
+verification is recommended," "additional observation may be appropriate")
+and never concludes that an individual is incompetent.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.sage_education import (
+    COMPETENCY_ANATOMY_ZONE_LABELING_DOC,
+    COMPETENCY_DOMAIN_CLINICAL_DECISION,
+    COMPETENCY_IMAGE_CAPTURE,
+    COMPETENCY_INSPECTION_COVERAGE,
+    COMPETENCY_RIGID_VS_FLEXIBLE_SCOPE,
+    SCOPE_INDIVIDUAL,
+)
+from app.models.supervisor_review import SupervisorReview
+from app.services.sage_competency_taxonomy_service import competency_for_finding_type
+
+_MIN_OCCURRENCES = 2
+_LOW_COVERAGE_THRESHOLD_PCT = 70
+_CONFUSION_PAIRS = [("blood", "rust"), ("rust", "corrosion"), ("rust", "discoloration")]
+
+_NARRATIVE_TEMPLATES = {
+    "low": "Additional observation may be appropriate.",
+    "moderate": "Targeted education may be beneficial.",
+    "high": "Competency verification is recommended.",
+}
+
+
+def _confidence_for_count(count: int) -> str:
+    if count >= 5:
+        return "high"
+    if count >= 3:
+        return "moderate"
+    return "low"
+
+
+def _reviews_for_technician(db: Session, tenant_id: str, technician: str, window_days: int) -> list[SupervisorReview]:
+    since = datetime.now(timezone.utc) - timedelta(days=window_days)
+    inspection_ids = [
+        row.id for row in db.query(models.Inspection).filter(
+            models.Inspection.tenant_id == tenant_id, models.Inspection.technician == technician,
+            models.Inspection.created_at >= since,
+        )
+    ]
+    if not inspection_ids:
+        return []
+    return (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.tenant_id == tenant_id, SupervisorReview.inspection_id.in_(inspection_ids))
+        .all()
+    )
+
+
+def _make_gap(*, competency_domain, scope_value, instrument_family="", anatomy_zone="", finding_category="",
+              occurrence_count, evidence, recommended_education) -> dict:
+    confidence = _confidence_for_count(occurrence_count)
+    return {
+        "competency_domain": competency_domain,
+        "scope_type": SCOPE_INDIVIDUAL,
+        "scope_value": scope_value,
+        "instrument_family": instrument_family,
+        "anatomy_zone": anatomy_zone,
+        "finding_category": finding_category,
+        "occurrence_count": occurrence_count,
+        "confidence": confidence,
+        "evidence": evidence,
+        "narrative": _NARRATIVE_TEMPLATES[confidence],
+        "recommended_education": recommended_education,
+    }
+
+
+def detect_missed_anatomy_zones(db: Session, tenant_id: str, technician: str, window_days: int = 90) -> list[dict]:
+    """'repeated missed serration images' / 'missing O-ring images' / drill-bit
+    flute omissions -- from real `missing_zone_correct == False` corrections."""
+    reviews = _reviews_for_technician(db, tenant_id, technician, window_days)
+    by_zone: dict[str, list[SupervisorReview]] = defaultdict(list)
+    for r in reviews:
+        if r.missing_zone_correct is False and r.corrected_missing_zone:
+            by_zone[r.corrected_missing_zone].append(r)
+
+    gaps = []
+    for zone, rows in by_zone.items():
+        if len(rows) < _MIN_OCCURRENCES:
+            continue
+        families = sorted({r.instrument_family for r in rows if r.instrument_family})
+        gaps.append(_make_gap(
+            competency_domain=COMPETENCY_ANATOMY_ZONE_LABELING_DOC,
+            scope_value=technician, anatomy_zone=zone,
+            instrument_family=families[0] if families else "",
+            occurrence_count=len(rows),
+            evidence={"supervisor_review_ids": [r.id for r in rows], "corrected_missing_zone": zone},
+            recommended_education=f"Provide focused review of {zone} inspection and image-capture practice.",
+        ))
+    return gaps
+
+
+def detect_anatomy_label_errors(db: Session, tenant_id: str, technician: str, window_days: int = 90) -> list[dict]:
+    """Incorrect anatomy-zone labels, grouped by instrument family so rigid-
+    scope and flexible-endoscope gaps remain distinct (never merged)."""
+    reviews = _reviews_for_technician(db, tenant_id, technician, window_days)
+    by_family: dict[str, list[SupervisorReview]] = defaultdict(list)
+    for r in reviews:
+        if r.zone_correct is False and r.instrument_family:
+            by_family[r.instrument_family].append(r)
+
+    gaps = []
+    for family, rows in by_family.items():
+        if len(rows) < _MIN_OCCURRENCES:
+            continue
+        domain = (
+            COMPETENCY_RIGID_VS_FLEXIBLE_SCOPE
+            if family in ("rigid_scope", "flexible_endoscope")
+            else COMPETENCY_ANATOMY_ZONE_LABELING_DOC
+        )
+        gaps.append(_make_gap(
+            competency_domain=domain, scope_value=technician, instrument_family=family,
+            occurrence_count=len(rows),
+            evidence={"supervisor_review_ids": [r.id for r in rows], "instrument_family": family},
+            recommended_education=f"Provide focused anatomy-zone review for {family.replace('_', ' ')}.",
+        ))
+    return gaps
+
+
+def detect_finding_confusion(db: Session, tenant_id: str, technician: str, window_days: int = 90) -> list[dict]:
+    """'frequent confusion between rust and discoloration' / 'blood-versus-
+    rust confusion' -- both members of a known confusable pair are each
+    individually corrected for the same technician."""
+    reviews = _reviews_for_technician(db, tenant_id, technician, window_days)
+    incorrect_by_type: dict[str, list[SupervisorReview]] = defaultdict(list)
+    for r in reviews:
+        if r.finding_correct is False and r.finding_type:
+            incorrect_by_type[r.finding_type].append(r)
+
+    gaps = []
+    for type_a, type_b in _CONFUSION_PAIRS:
+        rows_a, rows_b = incorrect_by_type.get(type_a, []), incorrect_by_type.get(type_b, [])
+        combined = rows_a + rows_b
+        if len(combined) < _MIN_OCCURRENCES or not rows_a or not rows_b:
+            continue
+        leaf = competency_for_finding_type(type_a) or type_a
+        gaps.append(_make_gap(
+            competency_domain=leaf, scope_value=technician, finding_category=f"{type_a}_vs_{type_b}",
+            occurrence_count=len(combined),
+            evidence={"supervisor_review_ids": [r.id for r in combined], "confusable_pair": [type_a, type_b]},
+            recommended_education=f"Provide targeted education distinguishing {type_a} from {type_b}.",
+        ))
+    return gaps
+
+
+def detect_low_inspection_coverage(db: Session, tenant_id: str, technician: str, window_days: int = 90) -> list[dict]:
+    since = datetime.now(timezone.utc) - timedelta(days=window_days)
+    rows = (
+        db.query(models.Inspection)
+        .filter(
+            models.Inspection.tenant_id == tenant_id, models.Inspection.technician == technician,
+            models.Inspection.created_at >= since, models.Inspection.coverage_pct.isnot(None),
+        )
+        .all()
+    )
+    low = [r for r in rows if r.coverage_pct < _LOW_COVERAGE_THRESHOLD_PCT]
+    if len(low) < _MIN_OCCURRENCES:
+        return []
+    return [_make_gap(
+        competency_domain=COMPETENCY_INSPECTION_COVERAGE, scope_value=technician,
+        occurrence_count=len(low),
+        evidence={"inspection_ids": [r.id for r in low], "avg_coverage_pct": round(sum(r.coverage_pct for r in low) / len(low), 1)},
+        recommended_education="Provide focused review of inspection coverage requirements and image-capture workflow.",
+    )]
+
+
+def detect_image_capture_issues(db: Session, tenant_id: str, technician: str, window_days: int = 90) -> list[dict]:
+    """Poor image focus/lighting/angle: this codebase only measures the
+    aggregate `image_view_correct` signal, not focus/lighting/angle
+    separately -- never fabricated beyond what is actually tracked."""
+    reviews = _reviews_for_technician(db, tenant_id, technician, window_days)
+    bad_views = [r for r in reviews if r.image_view_correct is False]
+    if len(bad_views) < _MIN_OCCURRENCES:
+        return []
+    return [_make_gap(
+        competency_domain=COMPETENCY_IMAGE_CAPTURE, scope_value=technician,
+        occurrence_count=len(bad_views),
+        evidence={"supervisor_review_ids": [r.id for r in bad_views]},
+        recommended_education="Provide image-capture practice covering lighting, focus, and angle selection.",
+    )]
+
+
+def detect_disposition_errors(db: Session, tenant_id: str, technician: str, window_days: int = 90) -> list[dict]:
+    reviews = _reviews_for_technician(db, tenant_id, technician, window_days)
+    overridden = [r for r in reviews if r.override_action]
+    if len(overridden) < _MIN_OCCURRENCES:
+        return []
+    return [_make_gap(
+        competency_domain=COMPETENCY_DOMAIN_CLINICAL_DECISION, scope_value=technician,
+        occurrence_count=len(overridden),
+        evidence={"supervisor_review_ids": [r.id for r in overridden]},
+        recommended_education="Provide case review of clinical decision support options (reclean/repair/manufacturer evaluation/remove from service).",
+    )]
+
+
+def detect_all_gaps_for_technician(db: Session, tenant_id: str, technician: str, window_days: int = 90) -> list[dict]:
+    return (
+        detect_missed_anatomy_zones(db, tenant_id, technician, window_days)
+        + detect_anatomy_label_errors(db, tenant_id, technician, window_days)
+        + detect_finding_confusion(db, tenant_id, technician, window_days)
+        + detect_low_inspection_coverage(db, tenant_id, technician, window_days)
+        + detect_image_capture_issues(db, tenant_id, technician, window_days)
+        + detect_disposition_errors(db, tenant_id, technician, window_days)
+    )

--- a/backend/app/services/sage_image_library_service.py
+++ b/backend/app/services/sage_image_library_service.py
@@ -1,0 +1,90 @@
+"""Project Sage, Section 8: Image-Based Learning Library.
+
+Curates real, already-governed `RetainedImage`/`ImageLabel` rows
+(`app/models/retained_image.py` -- EXIF-stripped, consent-gated, gold-label
+lifecycle) into education-ready entries. Never duplicates image bytes or the
+ML-training label lifecycle; only adds the education-specific curation
+fields those tables don't carry.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.retained_image import ImageLabel, RetainedImage
+from app.models.sage_education import SageEducationImageEntry
+
+
+def curate_image_for_education(
+    db: Session, tenant_id: str, retained_image_id: int, *, anatomy_zone: str = "",
+    usage_rights: str = "internal_education_use", dataset_version: str = "1.0.0",
+) -> SageEducationImageEntry | None:
+    """Curate one `RetainedImage` (with its best gold `ImageLabel`, if any)
+    into the education library. Requires the image to already be gold-
+    labeled and consent-recorded -- Sage never surfaces an unvalidated or
+    non-consented image for education use."""
+    image = db.query(RetainedImage).filter(RetainedImage.id == retained_image_id, RetainedImage.tenant_id == tenant_id).first()
+    if image is None or not image.consent_recorded:
+        return None
+
+    label = (
+        db.query(ImageLabel)
+        .filter(ImageLabel.image_id == retained_image_id, ImageLabel.tenant_id == tenant_id, ImageLabel.is_gold.is_(True))
+        .first()
+    )
+    if label is None:
+        return None
+
+    row = SageEducationImageEntry(
+        tenant_id=tenant_id, retained_image_id=retained_image_id, image_label_id=label.id,
+        instrument_family=image.instrument_type, anatomy_zone=anatomy_zone,
+        finding_category=label.finding_type, severity=label.severity,
+        supervisor_validated=bool(label.reviewer), usage_rights=usage_rights, dataset_version=dataset_version,
+        phi_review_status="pending",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def mark_phi_reviewed(db: Session, tenant_id: str, entry_id: int, *, cleared: bool) -> SageEducationImageEntry | None:
+    row = db.query(SageEducationImageEntry).filter(SageEducationImageEntry.id == entry_id, SageEducationImageEntry.tenant_id == tenant_id).first()
+    if row is None:
+        return None
+    row.phi_review_status = "cleared" if cleared else "flagged"
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: SageEducationImageEntry) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "retained_image_id": row.retained_image_id,
+        "image_label_id": row.image_label_id,
+        "instrument_family": row.instrument_family,
+        "anatomy_zone": row.anatomy_zone,
+        "finding_category": row.finding_category,
+        "severity": row.severity,
+        "supervisor_validated": row.supervisor_validated,
+        "usage_rights": row.usage_rights,
+        "dataset_version": row.dataset_version,
+        "phi_review_status": row.phi_review_status,
+    }
+
+
+def list_education_images(
+    db: Session, tenant_id: str, *, instrument_family: str = "", anatomy_zone: str = "",
+    finding_category: str = "", phi_cleared_only: bool = True,
+) -> list[dict]:
+    q = db.query(SageEducationImageEntry).filter(SageEducationImageEntry.tenant_id == tenant_id)
+    if instrument_family:
+        q = q.filter(SageEducationImageEntry.instrument_family == instrument_family)
+    if anatomy_zone:
+        q = q.filter(SageEducationImageEntry.anatomy_zone == anatomy_zone)
+    if finding_category:
+        q = q.filter(SageEducationImageEntry.finding_category == finding_category)
+    if phi_cleared_only:
+        q = q.filter(SageEducationImageEntry.phi_review_status == "cleared")
+    return [to_dict(r) for r in q.order_by(SageEducationImageEntry.created_at.desc()).all()]

--- a/backend/app/services/sage_knowledge_gap_service.py
+++ b/backend/app/services/sage_knowledge_gap_service.py
@@ -1,0 +1,90 @@
+"""Project Sage: persistence + retrieval for detected knowledge gaps
+(Section 3), separate from the pure-detection logic in
+`sage_gap_detection_service.py` so gaps can be re-listed/filtered without
+re-scanning source data every time.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.sage_education import SageKnowledgeGap
+from app.services.sage_gap_detection_service import detect_all_gaps_for_technician
+
+
+def _to_dict(row: SageKnowledgeGap) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "tenant_id": row.tenant_id,
+        "competency_domain": row.competency_domain,
+        "scope_type": row.scope_type,
+        "scope_value": row.scope_value,
+        "instrument_family": row.instrument_family,
+        "anatomy_zone": row.anatomy_zone,
+        "finding_category": row.finding_category,
+        "occurrence_count": row.occurrence_count,
+        "confidence": row.confidence,
+        "evidence": json.loads(row.evidence_json or "{}"),
+        "narrative": row.narrative,
+        "recommended_education": row.recommended_education,
+        "status": row.status,
+        "human_review_required": row.human_review_required,
+        "agent_version": row.agent_version,
+        "disclaimer": row.disclaimer,
+    }
+
+
+def run_gap_detection_for_technician(db: Session, tenant_id: str, technician: str, window_days: int = 90) -> list[dict]:
+    """Detect and persist gaps for one technician. Idempotent-ish: re-running
+    creates a fresh snapshot row per call (each is a point-in-time detection,
+    same pattern as Vulcan's assessments)."""
+    detected = detect_all_gaps_for_technician(db, tenant_id, technician, window_days)
+    rows = []
+    for gap in detected:
+        row = SageKnowledgeGap(
+            tenant_id=tenant_id,
+            competency_domain=gap["competency_domain"],
+            scope_type=gap["scope_type"],
+            scope_value=gap["scope_value"],
+            instrument_family=gap.get("instrument_family", ""),
+            anatomy_zone=gap.get("anatomy_zone", ""),
+            finding_category=gap.get("finding_category", ""),
+            occurrence_count=gap["occurrence_count"],
+            confidence=gap["confidence"],
+            evidence_json=json.dumps(gap["evidence"]),
+            narrative=gap["narrative"],
+            recommended_education=gap["recommended_education"],
+        )
+        db.add(row)
+        rows.append(row)
+    db.commit()
+    for row in rows:
+        db.refresh(row)
+    return [_to_dict(row) for row in rows]
+
+
+def list_gaps(
+    db: Session, tenant_id: str, *, competency_domain: str = "", scope_type: str = "", scope_value: str = "",
+    instrument_family: str = "", anatomy_zone: str = "", status: str = "",
+) -> list[dict]:
+    q = db.query(SageKnowledgeGap).filter(SageKnowledgeGap.tenant_id == tenant_id)
+    if competency_domain:
+        q = q.filter(SageKnowledgeGap.competency_domain == competency_domain)
+    if scope_type:
+        q = q.filter(SageKnowledgeGap.scope_type == scope_type)
+    if scope_value:
+        q = q.filter(SageKnowledgeGap.scope_value == scope_value)
+    if instrument_family:
+        q = q.filter(SageKnowledgeGap.instrument_family == instrument_family)
+    if anatomy_zone:
+        q = q.filter(SageKnowledgeGap.anatomy_zone == anatomy_zone)
+    if status:
+        q = q.filter(SageKnowledgeGap.status == status)
+    return [_to_dict(r) for r in q.order_by(SageKnowledgeGap.created_at.desc()).all()]
+
+
+def get_gap(db: Session, tenant_id: str, gap_id: int) -> dict | None:
+    row = db.query(SageKnowledgeGap).filter(SageKnowledgeGap.id == gap_id, SageKnowledgeGap.tenant_id == tenant_id).first()
+    return _to_dict(row) if row else None

--- a/backend/app/services/sage_learning_plan_service.py
+++ b/backend/app/services/sage_learning_plan_service.py
@@ -1,0 +1,156 @@
+"""Project Sage, Section 5: Adaptive Learning Plans.
+
+A plan is only "assigned" in the sense a technician can see it once an
+authorized educator/supervisor/manager has approved it (`approved_by` set) --
+`create_learning_plan` never sets `approved_by` itself. Editing or rejecting
+a *high-confidence* recommendation requires `override_reason` (Section 12);
+this is enforced here, not just documented.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.sage_education import PLAN_STATUS_CANCELLED, SCOPE_INDIVIDUAL, SageLearningPlan
+
+
+class OverrideReasonRequiredError(ValueError):
+    pass
+
+
+def create_learning_plan(
+    db: Session, tenant_id: str, *, learner_or_group: str, created_by: str,
+    knowledge_gap_id: int | None = None, scope_type: str = SCOPE_INDIVIDUAL,
+    identified_need: str = "", supporting_evidence: dict | None = None, learning_objective: str = "",
+    instrument_family: str = "", anatomy_zone: str = "", finding_category: str = "",
+    education_content: str = "", microlearning_module_id: int | None = None, practice_activity: str = "",
+    return_demonstration_required: bool = False, evaluator: str = "", due_date: datetime | None = None,
+    confidence: str = "moderate",
+) -> SageLearningPlan:
+    row = SageLearningPlan(
+        tenant_id=tenant_id, knowledge_gap_id=knowledge_gap_id, learner_or_group=learner_or_group,
+        scope_type=scope_type, identified_need=identified_need,
+        supporting_evidence_json=json.dumps(supporting_evidence or {}), learning_objective=learning_objective,
+        instrument_family=instrument_family, anatomy_zone=anatomy_zone, finding_category=finding_category,
+        education_content=education_content, microlearning_module_id=microlearning_module_id,
+        practice_activity=practice_activity, return_demonstration_required=return_demonstration_required,
+        evaluator=evaluator, due_date=due_date, confidence=confidence, created_by=created_by,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def approve_learning_plan(db: Session, tenant_id: str, plan_id: int, *, approved_by: str) -> SageLearningPlan | None:
+    """Assignment requires this call -- a plan is not visible to its
+    learner via `list_plans_for_learner` until `approved_by` is set."""
+    row = db.query(SageLearningPlan).filter(SageLearningPlan.id == plan_id, SageLearningPlan.tenant_id == tenant_id).first()
+    if row is None:
+        return None
+    row.approved_by = approved_by
+    row.approved_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def reject_or_edit_learning_plan(
+    db: Session, tenant_id: str, plan_id: int, *, acted_by: str, action: str,
+    override_reason: str = "", edits: dict | None = None,
+) -> SageLearningPlan | None:
+    """`action` is 'reject' or 'edit'. If the plan's own confidence is
+    'high', `override_reason` is required -- raises otherwise."""
+    row = db.query(SageLearningPlan).filter(SageLearningPlan.id == plan_id, SageLearningPlan.tenant_id == tenant_id).first()
+    if row is None:
+        return None
+    if row.confidence == "high" and not override_reason.strip():
+        raise OverrideReasonRequiredError(
+            "override_reason is required to reject or edit a high-confidence Sage recommendation"
+        )
+    row.override_reason = override_reason
+    if action == "reject":
+        row.completion_status = PLAN_STATUS_CANCELLED
+    elif action == "edit" and edits:
+        for field in ("learning_objective", "practice_activity", "instrument_family", "anatomy_zone", "evaluator"):
+            if field in edits:
+                setattr(row, field, edits[field])
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def mark_completed(db: Session, tenant_id: str, plan_id: int) -> SageLearningPlan | None:
+    row = db.query(SageLearningPlan).filter(SageLearningPlan.id == plan_id, SageLearningPlan.tenant_id == tenant_id).first()
+    if row is None:
+        return None
+    row.completion_status = "completed"
+    row.completed_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: SageLearningPlan) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "tenant_id": row.tenant_id,
+        "knowledge_gap_id": row.knowledge_gap_id,
+        "learner_or_group": row.learner_or_group,
+        "scope_type": row.scope_type,
+        "identified_need": row.identified_need,
+        "supporting_evidence": json.loads(row.supporting_evidence_json or "{}"),
+        "learning_objective": row.learning_objective,
+        "instrument_family": row.instrument_family,
+        "anatomy_zone": row.anatomy_zone,
+        "finding_category": row.finding_category,
+        "education_content": row.education_content,
+        "microlearning_module_id": row.microlearning_module_id,
+        "practice_activity": row.practice_activity,
+        "return_demonstration_required": row.return_demonstration_required,
+        "return_demonstration_validated": row.return_demonstration_validated,
+        "evaluator": row.evaluator,
+        "due_date": row.due_date.isoformat() if row.due_date else None,
+        "completion_status": row.completion_status,
+        "completed_at": row.completed_at.isoformat() if row.completed_at else None,
+        "effectiveness_assessment_id": row.effectiveness_assessment_id,
+        "confidence": row.confidence,
+        "approved_by": row.approved_by,
+        "approved_at": row.approved_at.isoformat() if row.approved_at else None,
+        "override_reason": row.override_reason,
+        "created_by": row.created_by,
+        "human_review_required": row.human_review_required,
+        "agent_version": row.agent_version,
+    }
+
+
+def get_plan(db: Session, tenant_id: str, plan_id: int) -> dict | None:
+    row = db.query(SageLearningPlan).filter(SageLearningPlan.id == plan_id, SageLearningPlan.tenant_id == tenant_id).first()
+    return to_dict(row) if row else None
+
+
+def list_plans(db: Session, tenant_id: str, *, learner_or_group: str = "", completion_status: str = "") -> list[dict]:
+    q = db.query(SageLearningPlan).filter(SageLearningPlan.tenant_id == tenant_id)
+    if learner_or_group:
+        q = q.filter(SageLearningPlan.learner_or_group == learner_or_group)
+    if completion_status:
+        q = q.filter(SageLearningPlan.completion_status == completion_status)
+    return [to_dict(r) for r in q.order_by(SageLearningPlan.created_at.desc()).all()]
+
+
+def list_plans_for_learner(db: Session, tenant_id: str, learner: str) -> list[dict]:
+    """Section 11 -- only this learner's own APPROVED (assigned) plans,
+    never a peer's."""
+    rows = (
+        db.query(SageLearningPlan)
+        .filter(
+            SageLearningPlan.tenant_id == tenant_id, SageLearningPlan.learner_or_group == learner,
+            SageLearningPlan.approved_by != "",
+        )
+        .order_by(SageLearningPlan.created_at.desc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/sage_microlearning_service.py
+++ b/backend/app/services/sage_microlearning_service.py
@@ -1,0 +1,105 @@
+"""Project Sage, Section 6: Microlearning Generator.
+
+Generates short educational modules *only* from the platform's one approved
+knowledge source -- `education_library.get_article` (itself built from
+`clinical_mentor.FINDING_EDUCATION` + `instrument_anatomy.py` + the IFU
+reference note). A `finding_type` outside that approved 12-category library
+is refused (returns `None`) rather than have Sage author unsupported
+clinical guidance -- satisfies "unapproved guidance is excluded."
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.sage_education import SageMicrolearningModule
+from app.services.education_library import CATEGORIES, get_article
+
+
+def _knowledge_check(article: dict) -> list[dict]:
+    return [{
+        "question": f"What is the clinical significance of {article['finding'].lower()}?",
+        "answer": article["clinical_importance"],
+    }, {
+        "question": f"Which anatomy zones most commonly retain {article['finding'].lower()}?",
+        "answer": ", ".join(article["typical_anatomy_locations"]) or "Not yet established for this finding.",
+    }]
+
+
+def build_module_from_finding(db: Session, tenant_id: str, finding_type: str, *, instrument_family: str = "", anatomy_zone: str = "") -> SageMicrolearningModule | None:
+    """Refuses to build a module for any finding_type outside the approved
+    knowledge library -- returns None, never fabricates content."""
+    article = get_article(finding_type)
+    if article is None:
+        return None
+
+    title = f"Recognizing {article['finding'].capitalize()}" if finding_type != "insulation_damage" else "Recognizing Insulation Damage"
+    row = SageMicrolearningModule(
+        tenant_id=tenant_id,
+        title=title,
+        learning_objective=f"Correctly identify and document {article['finding'].lower()} during inspection.",
+        why_it_matters=article["clinical_importance"],
+        anatomy_overview=", ".join(article["typical_anatomy_locations"]) or "General inspection zones.",
+        common_findings_json=json.dumps([article["finding"]]),
+        inspection_steps_json=json.dumps(article["inspection_tips"]),
+        corrective_actions_json=json.dumps(article["corrective_actions"]),
+        knowledge_check_json=json.dumps(_knowledge_check(article)),
+        source_refs_json=json.dumps([article["reference"], "clinical_mentor.FINDING_EDUCATION", "education_library"]),
+        instrument_family=instrument_family,
+        anatomy_zone=anatomy_zone,
+        competency_domain=finding_type,
+        approval_status="draft",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def approve_module(db: Session, tenant_id: str, module_id: int, *, approved_by: str) -> SageMicrolearningModule | None:
+    row = db.query(SageMicrolearningModule).filter(SageMicrolearningModule.id == module_id, SageMicrolearningModule.tenant_id == tenant_id).first()
+    if row is None:
+        return None
+    row.approval_status = "approved"
+    row.approved_by = approved_by
+    from datetime import datetime, timezone
+    row.approved_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _to_dict(row: SageMicrolearningModule) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "title": row.title,
+        "learning_objective": row.learning_objective,
+        "why_it_matters": row.why_it_matters,
+        "anatomy_overview": row.anatomy_overview,
+        "common_findings": json.loads(row.common_findings_json or "[]"),
+        "inspection_steps": json.loads(row.inspection_steps_json or "[]"),
+        "corrective_actions": json.loads(row.corrective_actions_json or "[]"),
+        "knowledge_check": json.loads(row.knowledge_check_json or "[]"),
+        "source_refs": json.loads(row.source_refs_json or "[]"),
+        "instrument_family": row.instrument_family,
+        "anatomy_zone": row.anatomy_zone,
+        "competency_domain": row.competency_domain,
+        "approval_status": row.approval_status,
+        "approved_by": row.approved_by,
+        "approved_at": row.approved_at.isoformat() if row.approved_at else None,
+        "version": row.version,
+    }
+
+
+def list_modules(db: Session, tenant_id: str, *, approval_status: str = "") -> list[dict]:
+    q = db.query(SageMicrolearningModule).filter(SageMicrolearningModule.tenant_id == tenant_id)
+    if approval_status:
+        q = q.filter(SageMicrolearningModule.approval_status == approval_status)
+    return [_to_dict(r) for r in q.order_by(SageMicrolearningModule.created_at.desc()).all()]
+
+
+def available_categories() -> list[str]:
+    """The only finding_types Sage may generate approved modules for."""
+    return list(CATEGORIES)

--- a/backend/app/services/sage_my_learning_service.py
+++ b/backend/app/services/sage_my_learning_service.py
@@ -1,0 +1,32 @@
+"""Project Sage, Section 11: Technician Learning Center (`/my-learning`).
+
+Returns only the authenticated user's own authorized learning information --
+never a peer's. The route layer is responsible for passing the actual
+authenticated identity as `learner`; this service never accepts an arbitrary
+"which technician" parameter from the request body, only the resolved
+identity, so there is no way to request someone else's data through this
+function's signature.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services.competency_service import competency_summary
+from app.services.sage_assessment_service import list_assessments
+from app.services.sage_learning_plan_service import list_plans_for_learner
+
+
+def my_learning_center(db: Session, tenant_id: str, learner: str) -> dict:
+    plans = list_plans_for_learner(db, tenant_id, learner)
+    assessments = list_assessments(db, tenant_id, target_learner=learner)
+    competency = competency_summary(db, learner)
+
+    return {
+        "learner": learner,
+        "assigned_modules": [p for p in plans if p["completion_status"] in ("assigned", "in_progress")],
+        "completed_education": [p for p in plans if p["completion_status"] == "completed"],
+        "due_dates": [{"learning_plan_id": p["id"], "due_date": p["due_date"]} for p in plans if p["due_date"]],
+        "competency_status": competency,
+        "assessments": assessments,
+        "supervisor_feedback": [p["override_reason"] for p in plans if p["override_reason"]],
+    }

--- a/backend/app/services/sage_workforce_privacy_service.py
+++ b/backend/app/services/sage_workforce_privacy_service.py
@@ -1,0 +1,57 @@
+"""Project Sage, Section 16: Workforce Privacy and Fairness.
+
+Sage must not: rank employees publicly, assign disciplinary action, infer
+protected characteristics, use unvalidated AI findings for performance
+action, expose individual performance to unauthorized users, or make
+employment decisions. This module provides the access-control predicate
+routes call before returning individual-level data, plus an access-log
+helper that reuses the platform's existing hash-chained, tamper-evident
+audit trail (`enterprise_audit_service.record_enterprise_audit_event`)
+rather than a new, weaker log table.
+"""
+from __future__ import annotations
+
+from app.services.enterprise_audit_service import record_enterprise_audit_event
+
+# Roles authorized to view any individual technician's competency/learning
+# data (educators/supervisors/admins) -- "operator" and "viewer" may only
+# ever see their own data (enforced by identity match below), never a peer's.
+_INDIVIDUAL_DATA_ROLES = ("admin", "spd_manager")
+
+PROHIBITED_ACTIONS = (
+    "public_employee_ranking",
+    "disciplinary_action",
+    "protected_characteristic_inference",
+    "unvalidated_ai_performance_action",
+    "unauthorized_individual_exposure",
+    "employment_decision",
+)
+
+
+class UnauthorizedIndividualAccessError(PermissionError):
+    pass
+
+
+def can_view_individual_competency(role: str, viewer_identity: str, subject_identity: str) -> bool:
+    """True if `viewer_identity` may see `subject_identity`'s individual
+    competency/learning data -- either they are the same person (self-view,
+    Section 11) or the viewer holds an authorized leadership/educator role."""
+    if viewer_identity == subject_identity:
+        return True
+    return role in _INDIVIDUAL_DATA_ROLES
+
+
+def assert_can_view_individual(role: str, viewer_identity: str, subject_identity: str) -> None:
+    if not can_view_individual_competency(role, viewer_identity, subject_identity):
+        raise UnauthorizedIndividualAccessError(
+            f"'{viewer_identity}' (role={role}) is not authorized to view {subject_identity}'s individual competency data"
+        )
+
+
+def log_individual_access(db, tenant_id: str, *, viewer: str, viewer_role: str, subject: str, resource_type: str) -> None:
+    """Section 16/17 access log -- routed through the platform's existing
+    tamper-evident audit trail rather than a separate, weaker log."""
+    record_enterprise_audit_event(
+        db, action_type="sage_individual_competency_access", resource_type=resource_type,
+        resource_id=subject, actor=viewer, actor_role=viewer_role, tenant_id=tenant_id,
+    )

--- a/backend/app/services/sage_workspace_service.py
+++ b/backend/app/services/sage_workspace_service.py
@@ -1,0 +1,41 @@
+"""Project Sage, Section 10: Sage Workspace (`/sage`).
+
+Aggregates learning plans, gaps, microlearning, and assessments with the
+filters the brief names -- facility/department/shift/role/instrument
+family/anatomy zone/finding/competency/date range. `shift` is honestly
+reported as not tracked (this codebase already treats `shift` as an
+`UNTRACKED_TARGET` -- see `app/models/quality_guardian.py`) rather than
+deriving a fabricated time-of-day bucket.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services.sage_knowledge_gap_service import list_gaps
+from app.services.sage_learning_plan_service import list_plans
+from app.services.sage_microlearning_service import list_modules
+
+SHIFT_NOT_TRACKED_NOTE = "Shift-level attribution is not tracked in this codebase; reported honestly as unavailable rather than derived."
+
+
+def workspace_summary(
+    db: Session, tenant_id: str, *, instrument_family: str = "", anatomy_zone: str = "",
+    competency_domain: str = "", learner_or_group: str = "", shift: str = "",
+) -> dict:
+    if shift:
+        return {"available": False, "note": SHIFT_NOT_TRACKED_NOTE}
+
+    gaps = list_gaps(db, tenant_id, competency_domain=competency_domain, instrument_family=instrument_family, anatomy_zone=anatomy_zone)
+    plans = list_plans(db, tenant_id, learner_or_group=learner_or_group)
+    overdue = [p for p in plans if p["completion_status"] == "overdue"]
+    modules = list_modules(db, tenant_id, approval_status="approved")
+
+    return {
+        "recommended_learning_plans": [p for p in plans if not p["approved_by"]],
+        "overdue_competencies": overdue,
+        "recurring_knowledge_gaps": gaps,
+        "instrument_family_education_needs": sorted({g["instrument_family"] for g in gaps if g["instrument_family"]}),
+        "anatomy_zone_education_needs": sorted({g["anatomy_zone"] for g in gaps if g["anatomy_zone"]}),
+        "approved_microlearning_modules": modules,
+        "human_review_required": True,
+    }

--- a/backend/app/services/sentinelx_dashboard_service.py
+++ b/backend/app/services/sentinelx_dashboard_service.py
@@ -1,0 +1,63 @@
+"""Project Sentinel-X, Section 9: Risk Dashboard (`/risk`).
+
+Aggregates every dimension the brief names from already-persisted
+Sentinel-X assessments plus the real Knowledge Graph confidence signal --
+no new tables, no fabricated distributions.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+from sqlalchemy.orm import Session
+
+from app.models.sentinelx_risk import RISK_LEVEL_CRITICAL, RISK_LEVEL_HIGH, SentinelXRiskAssessment
+from app.services.knowledge_graph_service import learning_confidence
+from app.services.sage_knowledge_gap_service import list_gaps
+from app.services.sentinelx_heatmap_service import all_heatmaps
+
+
+def risk_dashboard_summary(db: Session, tenant_id: str) -> dict:
+    assessments = db.query(SentinelXRiskAssessment).filter(SentinelXRiskAssessment.tenant_id == tenant_id).all()
+    total = len(assessments)
+
+    level_counts = Counter(a.risk_level for a in assessments)
+    enterprise_risk = {
+        "total_assessments": total,
+        "average_risk_score": round(sum(a.risk_score for a in assessments) / total, 1) if total else None,
+        "risk_level_distribution": dict(level_counts),
+        "high_or_critical_pct": round(100 * sum(1 for a in assessments if a.risk_level in (RISK_LEVEL_HIGH, RISK_LEVEL_CRITICAL)) / total, 1) if total else None,
+    }
+
+    heatmaps = all_heatmaps(db, tenant_id)
+
+    workflow_risk = {
+        "process_variation_flagged_count": sum(1 for a in assessments if "process_variation" in a.evidence_json),
+    }
+
+    declining_count = sum(1 for a in assessments if a.digital_twin_condition_trend == "declining")
+    digital_twin_risk = {
+        "declining_assessment_count": declining_count,
+        "declining_pct": round(100 * declining_count / total, 1) if total else None,
+    }
+
+    knowledge = learning_confidence(db, tenant_id)
+    knowledge_risk = {
+        "knowledge_confidence": knowledge.get("knowledge_confidence"),
+        "clinical_recommendation_confidence": knowledge.get("clinical_recommendation_confidence"),
+        "sample_sizes": knowledge.get("sample_sizes"),
+    }
+
+    open_gaps = list_gaps(db, tenant_id, status="open")
+    education_risk = {"open_knowledge_gap_count": len(open_gaps)}
+
+    return {
+        "enterprise_risk": enterprise_risk,
+        "facility_risk": heatmaps["facility"],
+        "instrument_risk": heatmaps["instrument_family"],
+        "anatomy_risk": heatmaps["anatomy"],
+        "workflow_risk": workflow_risk,
+        "education_risk": education_risk,
+        "knowledge_risk": knowledge_risk,
+        "digital_twin_risk": digital_twin_risk,
+        "human_review_required": True,
+    }

--- a/backend/app/services/sentinelx_heatmap_service.py
+++ b/backend/app/services/sentinelx_heatmap_service.py
@@ -1,0 +1,45 @@
+"""Project Sentinel-X, Section 6: Enterprise Risk Heatmaps.
+
+Pure aggregation over already-persisted `SentinelXRiskAssessment` rows --
+zero new tables, no fabricated distribution.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.sentinelx_risk import SentinelXRiskAssessment
+
+_DIMENSIONS = {
+    "facility": "facility_name",
+    "department": "department",
+    "instrument_family": "instrument_family",
+    "anatomy": "anatomy_zone",
+    "manufacturer": "manufacturer_name",
+    "service_line": "service_line",
+}
+
+
+def _bucket(rows: list[SentinelXRiskAssessment], attr: str) -> list[dict]:
+    grouped: dict[str, list[float]] = defaultdict(list)
+    for r in rows:
+        key = getattr(r, attr) or "unspecified"
+        grouped[key].append(r.risk_score)
+    return sorted(
+        ({"key": k, "count": len(v), "average_risk_score": round(sum(v) / len(v), 1)} for k, v in grouped.items()),
+        key=lambda x: x["average_risk_score"], reverse=True,
+    )
+
+
+def risk_heatmap(db: Session, tenant_id: str, dimension: str) -> list[dict] | None:
+    attr = _DIMENSIONS.get(dimension)
+    if attr is None:
+        return None
+    rows = db.query(SentinelXRiskAssessment).filter(SentinelXRiskAssessment.tenant_id == tenant_id).all()
+    return _bucket(rows, attr)
+
+
+def all_heatmaps(db: Session, tenant_id: str) -> dict:
+    rows = db.query(SentinelXRiskAssessment).filter(SentinelXRiskAssessment.tenant_id == tenant_id).all()
+    return {dimension: _bucket(rows, attr) for dimension, attr in _DIMENSIONS.items()}

--- a/backend/app/services/sentinelx_override_service.py
+++ b/backend/app/services/sentinelx_override_service.py
@@ -1,0 +1,60 @@
+"""Project Sentinel-X, Sections 10 & 13: auditable supervisor override.
+
+Sentinel-X's own risk level is always advisory. A supervisor may override
+it, but the override is itself an append-only, auditable record -- never a
+silent mutation of the original assessment's `risk_level`/`risk_score`.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.sentinelx_risk import SentinelXRiskAssessment, SentinelXSupervisorOverride
+
+
+def submit_override(
+    db: Session, tenant_id: str, assessment_id: int, *, overridden_risk_level: str, rationale: str,
+    submitted_by: str, submitted_role: str = "",
+) -> SentinelXSupervisorOverride:
+    if not rationale.strip():
+        raise ValueError("rationale is required to override a Sentinel-X risk assessment")
+
+    assessment = (
+        db.query(SentinelXRiskAssessment)
+        .filter(SentinelXRiskAssessment.id == assessment_id, SentinelXRiskAssessment.tenant_id == tenant_id)
+        .first()
+    )
+    if assessment is None:
+        raise ValueError("Sentinel-X risk assessment not found for this tenant")
+
+    row = SentinelXSupervisorOverride(
+        tenant_id=tenant_id, assessment_id=assessment_id, original_risk_level=assessment.risk_level,
+        overridden_risk_level=overridden_risk_level, rationale=rationale, submitted_by=submitted_by,
+        submitted_role=submitted_role,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: SentinelXSupervisorOverride) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "assessment_id": row.assessment_id,
+        "original_risk_level": row.original_risk_level,
+        "overridden_risk_level": row.overridden_risk_level,
+        "rationale": row.rationale,
+        "submitted_by": row.submitted_by,
+        "submitted_role": row.submitted_role,
+    }
+
+
+def overrides_for_assessment(db: Session, tenant_id: str, assessment_id: int) -> list[dict]:
+    rows = (
+        db.query(SentinelXSupervisorOverride)
+        .filter(SentinelXSupervisorOverride.tenant_id == tenant_id, SentinelXSupervisorOverride.assessment_id == assessment_id)
+        .order_by(SentinelXSupervisorOverride.created_at.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/sentinelx_patient_safety_watch_service.py
+++ b/backend/app/services/sentinelx_patient_safety_watch_service.py
@@ -1,0 +1,135 @@
+"""Project Sentinel-X, Section 5: Patient Safety Watch.
+
+Proactive alerts fired from real, repeated patterns across already-
+persisted `SentinelXRiskAssessment` rows -- never a single event, and
+never the pre-existing `SentinelAlert` table (Project Sentinel v3.0, a
+different system).
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.sentinelx_risk import RISK_LEVEL_CRITICAL, RISK_LEVEL_HIGH, SentinelXPatientSafetyAlert, SentinelXRiskAssessment
+
+_MIN_REPEAT = 2
+_CONTAMINATION_FINDINGS = {"blood", "bone", "tissue", "other_organic_residue", "debris"}
+
+
+def _create_alert(db: Session, tenant_id: str, *, alert_type: str, instrument_identity: str, severity: str, narrative: str, evidence: dict) -> SentinelXPatientSafetyAlert:
+    row = SentinelXPatientSafetyAlert(
+        tenant_id=tenant_id, alert_type=alert_type, instrument_identity=instrument_identity,
+        severity=severity, narrative=narrative, evidence_json=json.dumps(evidence),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def scan_for_alerts(db: Session, tenant_id: str) -> list[SentinelXPatientSafetyAlert]:
+    """Section 5: scan real assessment history and fire (persist) any newly
+    qualifying proactive alert. Idempotent-ish per call -- callers should
+    run this periodically, not on every read."""
+    assessments = db.query(SentinelXRiskAssessment).filter(SentinelXRiskAssessment.tenant_id == tenant_id).all()
+
+    by_instrument_finding: dict[tuple, int] = defaultdict(int)
+    by_instrument: dict[str, list[SentinelXRiskAssessment]] = defaultdict(list)
+    for a in assessments:
+        by_instrument_finding[(a.instrument_identity, a.finding_type)] += 1
+        by_instrument[a.instrument_identity].append(a)
+
+    fired: list[SentinelXPatientSafetyAlert] = []
+
+    for (instrument, finding_type), count in by_instrument_finding.items():
+        if count < _MIN_REPEAT or not finding_type:
+            continue
+        if finding_type in _CONTAMINATION_FINDINGS:
+            fired.append(_create_alert(
+                db, tenant_id, alert_type="repeat_contamination", instrument_identity=instrument, severity="high",
+                narrative=f"Repeated {finding_type} findings ({count}) detected for this instrument.",
+                evidence={"finding_type": finding_type, "occurrence_count": count},
+            ))
+        elif finding_type in ("corrosion", "rust"):
+            fired.append(_create_alert(
+                db, tenant_id, alert_type="repeat_corrosion", instrument_identity=instrument, severity="high",
+                narrative=f"Repeated {finding_type} findings ({count}) detected for this instrument.",
+                evidence={"finding_type": finding_type, "occurrence_count": count},
+            ))
+
+    for instrument, rows in by_instrument.items():
+        anatomy_zones = {r.anatomy_zone for r in rows if r.anatomy_zone}
+        for zone in anatomy_zones:
+            zone_count = sum(1 for r in rows if r.anatomy_zone == zone)
+            if zone_count >= _MIN_REPEAT:
+                fired.append(_create_alert(
+                    db, tenant_id, alert_type="repeat_anatomy_failure", instrument_identity=instrument, severity="moderate",
+                    narrative=f"Repeated findings ({zone_count}) at anatomy zone '{zone}' for this instrument.",
+                    evidence={"anatomy_zone": zone, "occurrence_count": zone_count},
+                ))
+
+        high_risk_count = sum(1 for r in rows if r.risk_level in (RISK_LEVEL_HIGH, RISK_LEVEL_CRITICAL))
+        if high_risk_count >= _MIN_REPEAT:
+            fired.append(_create_alert(
+                db, tenant_id, alert_type="high_risk_instrument", instrument_identity=instrument, severity="critical",
+                narrative=f"This instrument has been assessed as high or critical risk {high_risk_count} times.",
+                evidence={"high_risk_assessment_count": high_risk_count},
+            ))
+
+        declining = [r for r in rows if r.digital_twin_condition_trend == "declining"]
+        if len(declining) >= _MIN_REPEAT:
+            fired.append(_create_alert(
+                db, tenant_id, alert_type="escalating_digital_twin", instrument_identity=instrument, severity="high",
+                narrative="This instrument's Digital Twin has shown a declining condition trend across multiple assessments.",
+                evidence={"declining_assessment_count": len(declining)},
+            ))
+
+    repair_recurrence_instruments = [
+        a.instrument_identity for a in assessments if "repair_recurrence" in json.loads(a.score_breakdown_json or "{}")
+    ]
+    for instrument, count in {i: repair_recurrence_instruments.count(i) for i in set(repair_recurrence_instruments)}.items():
+        if count >= _MIN_REPEAT:
+            fired.append(_create_alert(
+                db, tenant_id, alert_type="repeat_repair", instrument_identity=instrument, severity="high",
+                narrative=f"Repair recurrence contributed to risk scoring {count} times for this instrument.",
+                evidence={"occurrence_count": count},
+            ))
+
+    return fired
+
+
+def to_dict(row: SentinelXPatientSafetyAlert) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "alert_type": row.alert_type,
+        "instrument_identity": row.instrument_identity,
+        "severity": row.severity,
+        "narrative": row.narrative,
+        "evidence": json.loads(row.evidence_json or "{}"),
+        "acknowledged": row.acknowledged,
+        "acknowledged_by": row.acknowledged_by,
+        "acknowledged_at": row.acknowledged_at.isoformat() if row.acknowledged_at else None,
+    }
+
+
+def list_alerts(db: Session, tenant_id: str, *, acknowledged: bool | None = None) -> list[dict]:
+    q = db.query(SentinelXPatientSafetyAlert).filter(SentinelXPatientSafetyAlert.tenant_id == tenant_id)
+    if acknowledged is not None:
+        q = q.filter(SentinelXPatientSafetyAlert.acknowledged == acknowledged)
+    return [to_dict(r) for r in q.order_by(SentinelXPatientSafetyAlert.created_at.desc()).all()]
+
+
+def acknowledge_alert(db: Session, tenant_id: str, alert_id: int, *, acknowledged_by: str) -> SentinelXPatientSafetyAlert | None:
+    row = db.query(SentinelXPatientSafetyAlert).filter(SentinelXPatientSafetyAlert.id == alert_id, SentinelXPatientSafetyAlert.tenant_id == tenant_id).first()
+    if row is None:
+        return None
+    row.acknowledged = True
+    row.acknowledged_by = acknowledged_by
+    from datetime import datetime, timezone
+    row.acknowledged_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/services/sentinelx_predictive_service.py
+++ b/backend/app/services/sentinelx_predictive_service.py
@@ -1,0 +1,86 @@
+"""Project Sentinel-X, Section 8: Predictive Risk.
+
+Deterministic trend extrapolation over real, already-computed signal --
+never a trained forecasting model. Every forecast states its confidence
+and the assumptions behind it explicitly, so it is never mistaken for a
+statistically validated prediction.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.sentinelx_risk import RISK_LEVEL_CRITICAL, RISK_LEVEL_HIGH, SentinelXRiskAssessment
+from app.services.vulcan_anatomy_zone_service import zone_reliability_analysis
+from app.services.vulcan_progression_service import compute_progression, findings_timeline
+
+
+def forecast_escalating_corrosion(db: Session, tenant_id: str, instrument_identity: str) -> dict:
+    progression = compute_progression(db, tenant_id, instrument_identity)
+    timeline = findings_timeline(db, tenant_id, instrument_identity)
+    corrosion_events = [e for e in timeline if e["finding_type"] in ("corrosion", "rust", "pitting")]
+    escalating = progression["progression"] in ("rapidly_worsening", "slowly_worsening") and len(corrosion_events) >= 2
+    return {
+        "forecast": "escalating_corrosion_likely" if escalating else "no_clear_escalation_pattern",
+        "confidence": progression["confidence"] if corrosion_events else "low",
+        "assumptions": "Based on the real severity trend across prior corrosion/rust/pitting findings; does not account for any future intervention.",
+        "supporting_evidence": {"progression": progression["progression"], "corrosion_event_count": len(corrosion_events)},
+    }
+
+
+def forecast_repeat_blood_findings(db: Session, tenant_id: str, instrument_identity: str) -> dict:
+    timeline = findings_timeline(db, tenant_id, instrument_identity)
+    blood_events = [e for e in timeline if e["finding_type"] == "blood"]
+    likely = len(blood_events) >= 2
+    return {
+        "forecast": "repeat_blood_finding_risk_elevated" if likely else "no_repeat_pattern_established",
+        "confidence": "moderate" if len(blood_events) >= 3 else "low",
+        "assumptions": "Based on the count of real prior blood findings for this instrument; cleaning process itself is not directly observed.",
+        "supporting_evidence": {"blood_event_count": len(blood_events)},
+    }
+
+
+def forecast_inspection_backlog_risk(db: Session, tenant_id: str) -> dict:
+    queued = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id, models.Inspection.status == "queued").count()
+    total = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).count()
+    backlog_pct = round(100 * queued / total, 1) if total else 0.0
+    return {
+        "forecast": "elevated_backlog_risk" if backlog_pct >= 20 else "backlog_within_normal_range",
+        "confidence": "moderate" if total >= 10 else "low",
+        "assumptions": "Based on the real proportion of inspections still queued; does not model future inspection throughput.",
+        "supporting_evidence": {"queued_count": queued, "total_inspections": total, "backlog_pct": backlog_pct},
+    }
+
+
+def forecast_high_risk_workflows(db: Session, tenant_id: str) -> dict:
+    assessments = db.query(SentinelXRiskAssessment).filter(SentinelXRiskAssessment.tenant_id == tenant_id).order_by(SentinelXRiskAssessment.created_at.desc()).limit(50).all()
+    high_risk = sum(1 for a in assessments if a.risk_level in (RISK_LEVEL_HIGH, RISK_LEVEL_CRITICAL))
+    pct = round(100 * high_risk / len(assessments), 1) if assessments else 0.0
+    return {
+        "forecast": "elevated_high_risk_workflow_share" if pct >= 25 else "high_risk_share_within_normal_range",
+        "confidence": "moderate" if len(assessments) >= 10 else "low",
+        "assumptions": "Based on the most recent 50 real risk assessments; not a prediction of any specific future inspection.",
+        "supporting_evidence": {"high_or_critical_count": high_risk, "sample_size": len(assessments), "pct": pct},
+    }
+
+
+def forecast_recurring_anatomy_failures(db: Session, tenant_id: str, instrument_identity: str, instrument_type: str) -> dict:
+    analysis = zone_reliability_analysis(db, tenant_id, instrument_identity, instrument_type)
+    recurring_zones = [z for z in analysis["zones"] if z["recurrence_count"] >= 2]
+    return {
+        "forecast": "recurring_anatomy_failure_pattern" if recurring_zones else "no_recurring_zone_pattern",
+        "confidence": "moderate" if recurring_zones else "low",
+        "assumptions": "Based on real per-zone finding recurrence counts for this instrument.",
+        "supporting_evidence": {"recurring_zones": [z["anatomy_zone"] for z in recurring_zones]},
+    }
+
+
+def predictive_risk_summary(db: Session, tenant_id: str, instrument_identity: str, instrument_type: str = "") -> dict:
+    return {
+        "escalating_corrosion": forecast_escalating_corrosion(db, tenant_id, instrument_identity),
+        "repeat_blood_findings": forecast_repeat_blood_findings(db, tenant_id, instrument_identity),
+        "inspection_backlog_risk": forecast_inspection_backlog_risk(db, tenant_id),
+        "high_risk_workflows": forecast_high_risk_workflows(db, tenant_id),
+        "recurring_anatomy_failures": forecast_recurring_anatomy_failures(db, tenant_id, instrument_identity, instrument_type),
+        "human_review_required": True,
+    }

--- a/backend/app/services/sentinelx_risk_agent_service.py
+++ b/backend/app/services/sentinelx_risk_agent_service.py
@@ -1,0 +1,202 @@
+"""Project Sentinel-X, Section 1: Risk Intelligence Agent orchestrator.
+
+Composes real, already-built specialist outputs -- Vulcan (instrument
+reliability + progression), Aegis (process variation), Veritas (evidence
+readiness), the Knowledge Graph (confidence), and the real per-instrument
+Digital Twin condition trend (`instrument_condition_service`) -- into one
+explainable, persisted `SentinelXRiskAssessment`. Never replaces human
+clinical judgment; `human_review_required` is always True and there is no
+supervisor-override path except through `sentinelx_override_service`.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.sentinelx_risk import SentinelXRiskAssessment
+from app.models.supervisor_review import SupervisorReview
+from app.services.instrument_anatomy import get_anatomy
+from app.services.instrument_condition_service import instrument_condition_history
+from app.services.knowledge_graph_service import learning_confidence
+from app.services.sentinelx_risk_scoring_service import compute_risk_score
+from app.services.sentinelx_risk_taxonomy_service import classify_categories
+from app.services.vulcan_aegis_integration_service import compute_process_variation_signal
+from app.services.vulcan_progression_service import _inspections_for_identity, findings_timeline
+from app.services.vulcan_reliability_agent_service import run_reliability_assessment
+from app.services.vulcan_repair_effectiveness_service import repair_history_for_instrument
+from app.services.veritas_evidence_agent_service import run_evidence_assessment
+
+_SEVERITY_LABELS = {0: "none", 1: "minor", 2: "moderate", 3: "severe"}
+
+
+def _recent_supervisor_concern(db: Session, tenant_id: str, instrument_identity: str) -> bool:
+    inspections = _inspections_for_identity(db, tenant_id, instrument_identity)
+    ids = [i.id for i in inspections]
+    if not ids:
+        return False
+    return (
+        db.query(SupervisorReview)
+        .filter(SupervisorReview.tenant_id == tenant_id, SupervisorReview.inspection_id.in_(ids), SupervisorReview.agreement == "disagree")
+        .first()
+        is not None
+    )
+
+
+def _build_narrative(*, severity_label: str, finding_type: str, anatomy_zone: str, instrument_family: str,
+                      recurrence_count: int, evidence_readiness_score: float | None, digital_twin_condition_trend: str,
+                      repair_recurrence: bool, risk_level_value: str) -> str:
+    if not finding_type:
+        return (
+            "Insufficient inspection evidence is available for this instrument to produce a clinical risk "
+            "narrative. Supervisor review is recommended before the instrument proceeds further in the "
+            "pre-sterilization workflow."
+        )
+
+    zone_text = anatomy_zone.replace("_", " ") if anatomy_zone else "an unspecified anatomy zone"
+    family_text = instrument_family.replace("_", " ") if instrument_family else "this instrument"
+    subject = f"{severity_label.capitalize()} {finding_type.replace('_', ' ')}"
+
+    recurrence_clause = (
+        f" The instrument has demonstrated recurring {finding_type.replace('_', ' ')} over {recurrence_count} inspections."
+        if recurrence_count >= 2 else ""
+    )
+    evidence_clause = (
+        f" Evidence quality is {'high' if evidence_readiness_score is not None and evidence_readiness_score >= 75 else 'limited'}."
+        if evidence_readiness_score is not None else " Evidence readiness has not been separately assessed for this inspection."
+    )
+    twin_clause = (
+        " The Digital Twin shows declining reliability."
+        if digital_twin_condition_trend == "declining" else
+        f" The Digital Twin trend is {digital_twin_condition_trend.replace('_', ' ')}."
+    )
+    repair_clause = " Similar instruments have required repair for this issue." if repair_recurrence else ""
+
+    return (
+        f"{subject} has been identified on the {zone_text}, a monitored anatomy zone for {family_text}."
+        f"{recurrence_clause}{evidence_clause}{twin_clause}{repair_clause} "
+        f"Clinical risk is {risk_level_value.replace('_', ' ').upper()}. Supervisor review is recommended "
+        "before the instrument proceeds further in the pre-sterilization workflow."
+    )
+
+
+def run_risk_assessment(
+    db: Session, tenant_id: str, instrument_identity: str, *, instrument_type: str = "", inspection_id: int | None = None,
+) -> SentinelXRiskAssessment:
+    """Section 1: run the full Sentinel-X risk pipeline and persist one
+    assessment."""
+    vulcan_row = run_reliability_assessment(db, tenant_id, instrument_identity, instrument_type=instrument_type)
+
+    timeline = findings_timeline(db, tenant_id, instrument_identity, zone=vulcan_row.anatomy_zone or None)
+    latest = timeline[-1] if timeline else None
+    finding_type = latest["finding_type"] if latest else ""
+    severity_index = latest["severity_index"] if latest else 0
+    severity_label = _SEVERITY_LABELS.get(max(0, min(3, severity_index)), "none")
+
+    anatomy = get_anatomy(instrument_type) if instrument_type else {"high_risk_zones": []}
+    anatomy_zone_high_risk = vulcan_row.anatomy_zone in anatomy.get("high_risk_zones", [])
+
+    aegis_signal = compute_process_variation_signal(db, tenant_id, instrument_identity, zone=vulcan_row.anatomy_zone or None)
+
+    veritas_row = None
+    if inspection_id is not None:
+        veritas_row = run_evidence_assessment(db, tenant_id, inspection_id)
+
+    condition = instrument_condition_history(db, tenant_id, instrument_identity)
+    digital_twin_condition_trend = condition["condition_trend"] if condition else "insufficient_data"
+
+    repairs = repair_history_for_instrument(db, tenant_id, instrument_identity)
+    repair_recurrence = any(r["repair_outcome"] == "failure_recurred" for r in repairs)
+
+    confidence_signals = learning_confidence(db, tenant_id)
+    knowledge_confidence = confidence_signals.get("clinical_recommendation_confidence")
+
+    supervisor_concern = _recent_supervisor_concern(db, tenant_id, instrument_identity)
+
+    score_result = compute_risk_score(
+        finding_type=finding_type, severity_index=severity_index, anatomy_zone_high_risk=anatomy_zone_high_risk,
+        recurrence_count=vulcan_row.recurrence_count, digital_twin_condition_trend=digital_twin_condition_trend,
+        evidence_readiness_score=veritas_row.readiness_score if veritas_row else None,
+        repair_recurrence=repair_recurrence, supervisor_concern=supervisor_concern,
+        knowledge_confidence=knowledge_confidence, process_variation_detected=aegis_signal["process_variation_detected"],
+    )
+
+    categories = classify_categories(
+        finding_type=finding_type, evidence_readiness_score=veritas_row.readiness_score if veritas_row else None,
+        digital_twin_condition_trend=digital_twin_condition_trend, recurrence_count=vulcan_row.recurrence_count,
+        repair_recurrence=repair_recurrence, process_variation_detected=aegis_signal["process_variation_detected"],
+        knowledge_confidence=knowledge_confidence,
+    )
+
+    narrative = _build_narrative(
+        severity_label=severity_label, finding_type=finding_type, anatomy_zone=vulcan_row.anatomy_zone,
+        instrument_family=vulcan_row.instrument_family, recurrence_count=vulcan_row.recurrence_count,
+        evidence_readiness_score=veritas_row.readiness_score if veritas_row else None,
+        digital_twin_condition_trend=digital_twin_condition_trend, repair_recurrence=repair_recurrence,
+        risk_level_value=score_result["risk_level"],
+    )
+
+    facility_name, department, service_line = "", "", ""
+    if inspection_id is not None:
+        inspection = db.query(models.Inspection).filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id).first()
+        if inspection is not None:
+            facility_name = inspection.facility_name or ""
+            department = inspection.department or ""
+            if inspection.case_id is not None:
+                from app.models.or_connect import SurgicalCase
+                case = db.query(SurgicalCase).filter(SurgicalCase.id == inspection.case_id, SurgicalCase.tenant_id == tenant_id).first()
+                service_line = case.service_line if case else ""
+
+    row = SentinelXRiskAssessment(
+        tenant_id=tenant_id, inspection_id=inspection_id, instrument_identity=instrument_identity,
+        instrument_family=vulcan_row.instrument_family, manufacturer_name=vulcan_row.manufacturer_name,
+        anatomy_zone=vulcan_row.anatomy_zone, facility_name=facility_name, department=department, service_line=service_line,
+        risk_categories_json=json.dumps(categories), risk_score=score_result["risk_score"], risk_level=score_result["risk_level"],
+        score_breakdown_json=json.dumps(score_result["score_breakdown"]),
+        contamination_severity=severity_label, finding_type=finding_type, recurrence_count=vulcan_row.recurrence_count,
+        digital_twin_condition_trend=digital_twin_condition_trend,
+        vulcan_assessment_id=vulcan_row.id, veritas_assessment_id=veritas_row.id if veritas_row else None,
+        reasoning_narrative=narrative, confidence="high" if knowledge_confidence and knowledge_confidence >= 0.75 else "moderate",
+        evidence_json=json.dumps({
+            "aegis_signal": aegis_signal, "repair_history_count": len(repairs),
+            "confidence_signals": confidence_signals, "supervisor_concern": supervisor_concern,
+        }),
+        human_review_required=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: SentinelXRiskAssessment) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "tenant_id": row.tenant_id,
+        "inspection_id": row.inspection_id,
+        "instrument_identity": row.instrument_identity,
+        "instrument_family": row.instrument_family,
+        "manufacturer_name": row.manufacturer_name,
+        "anatomy_zone": row.anatomy_zone,
+        "facility_name": row.facility_name,
+        "department": row.department,
+        "service_line": row.service_line,
+        "risk_categories": json.loads(row.risk_categories_json or "[]"),
+        "risk_score": row.risk_score,
+        "risk_level": row.risk_level,
+        "score_breakdown": json.loads(row.score_breakdown_json or "{}"),
+        "contamination_severity": row.contamination_severity,
+        "finding_type": row.finding_type,
+        "recurrence_count": row.recurrence_count,
+        "digital_twin_condition_trend": row.digital_twin_condition_trend,
+        "vulcan_assessment_id": row.vulcan_assessment_id,
+        "veritas_assessment_id": row.veritas_assessment_id,
+        "reasoning_narrative": row.reasoning_narrative,
+        "confidence": row.confidence,
+        "evidence": json.loads(row.evidence_json or "{}"),
+        "human_review_required": row.human_review_required,
+        "agent_version": row.agent_version,
+        "disclaimer": row.disclaimer,
+    }

--- a/backend/app/services/sentinelx_risk_scoring_service.py
+++ b/backend/app/services/sentinelx_risk_scoring_service.py
@@ -1,0 +1,76 @@
+"""Project Sentinel-X, Sections 3 & 4: SPD Risk Matrix + Dynamic Risk Scoring.
+
+0-100 composite where **higher = more risk** (the inverse convention of
+Vulcan's reliability score / Veritas's readiness score, both "higher is
+better") -- deliberately so a caller can never mistake one score type for
+another. Every factor is real, already-computed signal from another
+specialist; nothing here is a fabricated probability.
+"""
+from __future__ import annotations
+
+from app.models.sentinelx_risk import risk_level, spd_risk_weight_value
+
+_SEVERITY_WEIGHT_MULTIPLIER = 6
+_ANATOMY_ZONE_HIGH_RISK_POINTS = 10
+_RECURRENCE_POINTS_PER_OCCURRENCE = 5
+_RECURRENCE_POINTS_CAP = 25
+_DIGITAL_TWIN_TREND_POINTS = {"declining": 20, "insufficient_data": 5, "stable": 0, "improving": -5}
+_REPAIR_RECURRENCE_POINTS = 15
+_SUPERVISOR_CONCERN_POINTS = 10
+_PROCESS_VARIATION_POINTS = 8
+_LOW_KNOWLEDGE_CONFIDENCE_POINTS = 10
+_UNKNOWN_KNOWLEDGE_CONFIDENCE_POINTS = 5
+_LOW_KNOWLEDGE_CONFIDENCE_THRESHOLD = 0.5
+
+
+def compute_risk_score(
+    *, finding_type: str = "", severity_index: int = 0, anatomy_zone_high_risk: bool = False,
+    recurrence_count: int = 0, digital_twin_condition_trend: str = "insufficient_data",
+    evidence_readiness_score: float | None = None, repair_recurrence: bool = False,
+    supervisor_concern: bool = False, knowledge_confidence: float | None = None,
+    process_variation_detected: bool = False,
+) -> dict:
+    """Section 4: composite clinical risk score with a transparent, itemized
+    breakdown -- explain every score, per the brief."""
+    breakdown: dict[str, float] = {}
+
+    weight_value = spd_risk_weight_value(finding_type) if finding_type else 0
+    severity_points = weight_value * max(0, severity_index) * _SEVERITY_WEIGHT_MULTIPLIER
+    if severity_points:
+        breakdown["finding_severity_and_spd_weight"] = severity_points
+
+    if anatomy_zone_high_risk:
+        breakdown["anatomy_zone_risk"] = _ANATOMY_ZONE_HIGH_RISK_POINTS
+
+    recurrence_points = min(_RECURRENCE_POINTS_CAP, recurrence_count * _RECURRENCE_POINTS_PER_OCCURRENCE)
+    if recurrence_points:
+        breakdown["recurrence"] = recurrence_points
+
+    twin_points = _DIGITAL_TWIN_TREND_POINTS.get(digital_twin_condition_trend, 5)
+    if twin_points:
+        breakdown["digital_twin_condition"] = twin_points
+
+    if evidence_readiness_score is not None:
+        evidence_points = round((100 - evidence_readiness_score) * 0.15, 1)
+        if evidence_points:
+            breakdown["evidence_readiness_gap"] = evidence_points
+    else:
+        breakdown["evidence_readiness_gap"] = 10  # no evidence assessment on record is itself a risk factor
+
+    if repair_recurrence:
+        breakdown["repair_recurrence"] = _REPAIR_RECURRENCE_POINTS
+
+    if supervisor_concern:
+        breakdown["supervisor_concern"] = _SUPERVISOR_CONCERN_POINTS
+
+    if process_variation_detected:
+        breakdown["process_variation"] = _PROCESS_VARIATION_POINTS
+
+    if knowledge_confidence is None:
+        breakdown["knowledge_confidence"] = _UNKNOWN_KNOWLEDGE_CONFIDENCE_POINTS
+    elif knowledge_confidence < _LOW_KNOWLEDGE_CONFIDENCE_THRESHOLD:
+        breakdown["knowledge_confidence"] = _LOW_KNOWLEDGE_CONFIDENCE_POINTS
+
+    score = max(0.0, min(100.0, sum(breakdown.values())))
+
+    return {"risk_score": score, "risk_level": risk_level(score), "score_breakdown": breakdown}

--- a/backend/app/services/sentinelx_risk_taxonomy_service.py
+++ b/backend/app/services/sentinelx_risk_taxonomy_service.py
@@ -1,0 +1,64 @@
+"""Project Sentinel-X, Section 2: Risk Taxonomy.
+
+A finding may belong to multiple categories at once -- this returns a list,
+never a single enum. Each category is assigned only when a real, already-
+computed signal supports it; nothing here is a guess.
+"""
+from __future__ import annotations
+
+from app.models.sentinelx_risk import (
+    RISK_CATEGORY_CLINICAL_QUALITY,
+    RISK_CATEGORY_COMPLIANCE,
+    RISK_CATEGORY_EDUCATION,
+    RISK_CATEGORY_ENTERPRISE,
+    RISK_CATEGORY_INSPECTION_QUALITY,
+    RISK_CATEGORY_INSTRUMENT_INTEGRITY,
+    RISK_CATEGORY_OPERATIONAL,
+    RISK_CATEGORY_PATIENT_SAFETY,
+    RISK_CATEGORY_WORKFLOW,
+    RISK_WEIGHT_HIGHEST,
+    spd_risk_weight,
+)
+
+_INSTRUMENT_INTEGRITY_FINDINGS = {
+    "corrosion", "rust", "crack", "pitting", "missing_component", "damaged_o_ring",
+    "insulation_damage", "insulation_breach", "wear", "worn_cutting_edge",
+    "loose_joint", "damaged_hinge", "damaged_ratchet",
+}
+
+
+def classify_categories(
+    *, finding_type: str = "", evidence_readiness_score: float | None = None,
+    digital_twin_condition_trend: str = "insufficient_data", recurrence_count: int = 0,
+    repair_recurrence: bool = False, process_variation_detected: bool = False,
+    knowledge_confidence: float | None = None,
+) -> list[str]:
+    categories: set[str] = set()
+
+    if finding_type:
+        categories.add(RISK_CATEGORY_CLINICAL_QUALITY)
+        if spd_risk_weight(finding_type) == RISK_WEIGHT_HIGHEST:
+            categories.add(RISK_CATEGORY_PATIENT_SAFETY)
+        if finding_type in _INSTRUMENT_INTEGRITY_FINDINGS:
+            categories.add(RISK_CATEGORY_INSTRUMENT_INTEGRITY)
+
+    if digital_twin_condition_trend == "declining":
+        categories.add(RISK_CATEGORY_INSTRUMENT_INTEGRITY)
+
+    if evidence_readiness_score is not None and evidence_readiness_score < 75:
+        categories.add(RISK_CATEGORY_INSPECTION_QUALITY)
+        categories.add(RISK_CATEGORY_COMPLIANCE)
+
+    if process_variation_detected:
+        categories.add(RISK_CATEGORY_WORKFLOW)
+
+    if recurrence_count > 0 or repair_recurrence:
+        categories.add(RISK_CATEGORY_OPERATIONAL)
+
+    if knowledge_confidence is not None and knowledge_confidence < 0.5:
+        categories.add(RISK_CATEGORY_EDUCATION)
+
+    if recurrence_count >= 3:
+        categories.add(RISK_CATEGORY_ENTERPRISE)
+
+    return sorted(categories)

--- a/backend/app/services/sentinelx_supervisor_workspace_service.py
+++ b/backend/app/services/sentinelx_supervisor_workspace_service.py
@@ -1,0 +1,56 @@
+"""Project Sentinel-X, Section 10: Supervisor Workspace."""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.sentinelx_risk import RISK_LEVEL_CRITICAL, RISK_LEVEL_HIGH, SentinelXRiskAssessment
+from app.services.sentinelx_risk_agent_service import to_dict
+
+
+def supervisor_workspace_summary(db: Session, tenant_id: str, *, limit: int = 20) -> dict:
+    rows = (
+        db.query(SentinelXRiskAssessment)
+        .filter(SentinelXRiskAssessment.tenant_id == tenant_id)
+        .order_by(SentinelXRiskAssessment.created_at.desc())
+        .all()
+    )
+
+    highest_risk_inspections = sorted(
+        [r for r in rows if r.inspection_id is not None], key=lambda r: r.risk_score, reverse=True,
+    )[:limit]
+
+    by_instrument: dict[str, list[SentinelXRiskAssessment]] = defaultdict(list)
+    for r in rows:
+        by_instrument[r.instrument_identity].append(r)
+    highest_risk_instruments = sorted(
+        ({"instrument_identity": k, "average_risk_score": round(sum(x.risk_score for x in v) / len(v), 1), "assessment_count": len(v)} for k, v in by_instrument.items()),
+        key=lambda x: x["average_risk_score"], reverse=True,
+    )[:limit]
+
+    pending_reviews = [r for r in rows if r.risk_level in (RISK_LEVEL_HIGH, RISK_LEVEL_CRITICAL) and r.human_review_required]
+
+    critical_anatomy = defaultdict(int)
+    for r in rows:
+        if r.risk_level == RISK_LEVEL_CRITICAL and r.anatomy_zone:
+            critical_anatomy[r.anatomy_zone] += 1
+
+    escalating_trends = [
+        {"instrument_identity": k, "declining_count": sum(1 for x in v if x.digital_twin_condition_trend == "declining")}
+        for k, v in by_instrument.items() if sum(1 for x in v if x.digital_twin_condition_trend == "declining") >= 2
+    ]
+
+    recommended_priorities = [
+        {"instrument_identity": r.instrument_identity, "risk_level": r.risk_level, "reasoning_narrative": r.reasoning_narrative}
+        for r in sorted(rows, key=lambda r: r.risk_score, reverse=True)[:5]
+    ]
+
+    return {
+        "highest_risk_inspections": [to_dict(r) for r in highest_risk_inspections],
+        "highest_risk_instruments": highest_risk_instruments,
+        "pending_reviews": [to_dict(r) for r in pending_reviews[:limit]],
+        "critical_anatomy": dict(critical_anatomy),
+        "escalating_trends": escalating_trends,
+        "recommended_priorities": recommended_priorities,
+    }

--- a/backend/app/services/sentinelx_timeline_service.py
+++ b/backend/app/services/sentinelx_timeline_service.py
@@ -1,0 +1,66 @@
+"""Project Sentinel-X, Section 7: Risk Timeline.
+
+A chronological, real-data timeline for one instrument -- findings,
+supervisor reviews, and repairs (each with a real timestamp), followed by
+the current Digital Twin condition trend and the most recent risk
+assessment. Never a fabricated "Education" stage when no instrument-
+specific education record exists -- omitted rather than invented.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.sentinelx_risk import SentinelXRiskAssessment
+from app.models.supervisor_review import SupervisorReview
+from app.services.instrument_condition_service import instrument_condition_history
+from app.services.vulcan_progression_service import _inspections_for_identity, findings_timeline
+from app.services.vulcan_repair_effectiveness_service import repair_history_for_instrument
+
+
+def build_risk_timeline(db: Session, tenant_id: str, instrument_identity: str) -> dict:
+    events: list[dict] = []
+
+    for row in findings_timeline(db, tenant_id, instrument_identity):
+        events.append({
+            "stage": "finding", "at": row["created_at"].isoformat() if row["created_at"] else None,
+            "detail": f"{row['finding_type']} at {row['zone']} (severity {row['severity_index']})",
+        })
+
+    inspections = _inspections_for_identity(db, tenant_id, instrument_identity)
+    insp_ids = [i.id for i in inspections]
+    if insp_ids:
+        reviews = db.query(SupervisorReview).filter(SupervisorReview.tenant_id == tenant_id, SupervisorReview.inspection_id.in_(insp_ids)).all()
+        for r in reviews:
+            events.append({
+                "stage": "supervisor", "at": r.created_at.isoformat() if r.created_at else None,
+                "detail": f"Supervisor {r.agreement} (finding_correct={r.finding_correct}, zone_correct={r.zone_correct})",
+            })
+
+    for repair in repair_history_for_instrument(db, tenant_id, instrument_identity):
+        events.append({
+            "stage": "repair", "at": None,
+            "detail": f"Repair outcome: {repair['repair_outcome']} (vendor: {repair['evidence'].get('vendor_name', '')})",
+        })
+
+    events = [e for e in events if e["at"] is not None]
+    events.sort(key=lambda e: e["at"])
+
+    condition = instrument_condition_history(db, tenant_id, instrument_identity)
+    current_twin_trend = condition["condition_trend"] if condition else "insufficient_data"
+
+    latest_risk = (
+        db.query(SentinelXRiskAssessment)
+        .filter(SentinelXRiskAssessment.tenant_id == tenant_id, SentinelXRiskAssessment.instrument_identity == instrument_identity)
+        .order_by(SentinelXRiskAssessment.created_at.desc())
+        .first()
+    )
+
+    return {
+        "instrument_identity": instrument_identity,
+        "events": events,
+        "current_digital_twin_trend": current_twin_trend,
+        "current_risk": {
+            "risk_score": latest_risk.risk_score, "risk_level": latest_risk.risk_level,
+            "assessed_at": latest_risk.created_at.isoformat() if latest_risk.created_at else None,
+        } if latest_risk else None,
+    }

--- a/backend/app/services/veritas_baseline_governance_service.py
+++ b/backend/app/services/veritas_baseline_governance_service.py
@@ -1,0 +1,101 @@
+"""Project Veritas, Sections 3 & 13: Baseline Governance Rules + Baseline
+Review Workspace.
+
+`VeritasBaselineGovernanceAction` is append-only -- a baseline's effective
+canonical status is the `resulting_status` of its latest action row, never a
+mutation of the real `BaselineLibraryEntry`/`EnterpriseVendorBaselineSubscription`
+tables those actions govern. Every action IS its own audit event by
+construction (a new row, never edited or deleted).
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.veritas_evidence import (
+    BASELINE_STATUS_PENDING_REVIEW,
+    BASELINE_STATUSES_USABLE_FOR_SCORING,
+    GOVERNANCE_ACTIONS,
+    VeritasBaselineGovernanceAction,
+    status_for_action,
+)
+
+
+def record_governance_action(
+    db: Session, tenant_id: str, *, baseline_source_type: str, baseline_source_id: int, action: str,
+    performed_by: str, performed_role: str = "", owner: str = "", review_date=None,
+    known_limitations: str = "", usage_rights: str = "", rationale: str = "",
+) -> VeritasBaselineGovernanceAction:
+    if action not in GOVERNANCE_ACTIONS:
+        raise ValueError(f"Unknown governance action '{action}'")
+    row = VeritasBaselineGovernanceAction(
+        tenant_id=tenant_id, baseline_source_type=baseline_source_type, baseline_source_id=baseline_source_id,
+        action=action, resulting_status=status_for_action(action), owner=owner, review_date=review_date,
+        known_limitations=known_limitations, usage_rights=usage_rights, rationale=rationale,
+        performed_by=performed_by, performed_role=performed_role,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _to_dict(row: VeritasBaselineGovernanceAction) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "baseline_source_type": row.baseline_source_type,
+        "baseline_source_id": row.baseline_source_id,
+        "action": row.action,
+        "resulting_status": row.resulting_status,
+        "owner": row.owner,
+        "review_date": row.review_date.isoformat() if row.review_date else None,
+        "known_limitations": row.known_limitations,
+        "usage_rights": row.usage_rights,
+        "rationale": row.rationale,
+        "performed_by": row.performed_by,
+        "performed_role": row.performed_role,
+    }
+
+
+def governance_history(db: Session, tenant_id: str, baseline_source_type: str, baseline_source_id: int) -> list[dict]:
+    rows = (
+        db.query(VeritasBaselineGovernanceAction)
+        .filter(
+            VeritasBaselineGovernanceAction.tenant_id == tenant_id,
+            VeritasBaselineGovernanceAction.baseline_source_type == baseline_source_type,
+            VeritasBaselineGovernanceAction.baseline_source_id == baseline_source_id,
+        )
+        .order_by(VeritasBaselineGovernanceAction.created_at.asc())
+        .all()
+    )
+    return [_to_dict(r) for r in rows]
+
+
+def effective_status(db: Session, tenant_id: str, baseline_source_type: str, baseline_source_id: int) -> str:
+    """The canonical Veritas status for a real baseline -- the latest
+    status-changing action, or `pending_review` if none has been recorded
+    yet (Section 3's default lifecycle entry point)."""
+    history = governance_history(db, tenant_id, baseline_source_type, baseline_source_id)
+    for entry in reversed(history):
+        if entry["resulting_status"]:
+            return entry["resulting_status"]
+    return BASELINE_STATUS_PENDING_REVIEW
+
+
+def is_usable_for_scoring(status: str) -> bool:
+    """Section 3: only approved or conditionally approved baselines may
+    influence a clinical recommendation."""
+    return status in BASELINE_STATUSES_USABLE_FOR_SCORING
+
+
+def compare_candidates(db: Session, tenant_id: str, candidates: list[tuple[str, int]]) -> list[dict]:
+    """Section 13: compare baseline candidates side by side, each identified
+    by (baseline_source_type, baseline_source_id)."""
+    return [
+        {
+            "baseline_source_type": source_type, "baseline_source_id": source_id,
+            "effective_status": effective_status(db, tenant_id, source_type, source_id),
+            "governance_history": governance_history(db, tenant_id, source_type, source_id),
+        }
+        for source_type, source_id in candidates
+    ]

--- a/backend/app/services/veritas_baseline_matching_service.py
+++ b/backend/app/services/veritas_baseline_matching_service.py
@@ -1,0 +1,71 @@
+"""Project Veritas, Section 4: Instrument-to-Baseline Matching.
+
+Neither real baseline table (`BaselineLibraryEntry`,
+`EnterpriseVendorBaselineSubscription`) tracks anatomy zone or a resolved
+anatomy family directly -- only a free-text `instrument_category`/
+`instrument_name` and manufacturer/model. Matching therefore compares real,
+already-resolved anatomy families (`instrument_anatomy.resolve_family`)
+rather than a fabricated zone-level comparison the underlying data can't
+support. A rigid-scope image is never compared against a flexible-endoscope
+baseline (different families) -- exactly the brief's example.
+"""
+from __future__ import annotations
+
+from app.models.veritas_evidence import (
+    MATCH_COMPATIBLE,
+    MATCH_EXACT,
+    MATCH_MISMATCH,
+    MATCH_PARTIAL,
+    MATCH_UNAVAILABLE,
+    MATCH_UNCERTAIN,
+)
+from app.services.instrument_anatomy import resolve_family
+
+
+def classify_match(
+    *, instrument_type: str, baseline_instrument_category: str = "", baseline_manufacturer: str = "",
+    instrument_manufacturer: str = "", baseline_model: str = "", instrument_model: str = "",
+) -> dict:
+    """Section 4: classify baseline compatibility from real, resolved
+    anatomy families -- never a fabricated per-zone comparison."""
+    if not baseline_instrument_category:
+        return {
+            "match_classification": MATCH_UNAVAILABLE,
+            "reason": "No baseline instrument category available to compare against.",
+        }
+
+    instrument_family = resolve_family(instrument_type)
+    baseline_family = resolve_family(baseline_instrument_category)
+
+    if instrument_family == "unknown" or baseline_family == "unknown":
+        return {
+            "match_classification": MATCH_UNCERTAIN,
+            "reason": "Instrument or baseline family could not be confidently resolved.",
+        }
+
+    if instrument_family != baseline_family:
+        return {
+            "match_classification": MATCH_MISMATCH,
+            "reason": (
+                f"Instrument family '{instrument_family}' does not match baseline family '{baseline_family}' -- "
+                "these anatomy profiles must not be compared."
+            ),
+        }
+
+    manufacturer_match = (
+        bool(instrument_manufacturer) and bool(baseline_manufacturer)
+        and instrument_manufacturer.strip().lower() == baseline_manufacturer.strip().lower()
+    )
+    model_match = (
+        bool(instrument_model) and bool(baseline_model)
+        and instrument_model.strip().lower() == baseline_model.strip().lower()
+    )
+
+    if manufacturer_match and (model_match or not (instrument_model and baseline_model)):
+        return {"match_classification": MATCH_EXACT, "reason": "Family and manufacturer/model match."}
+    if manufacturer_match or not (instrument_manufacturer or baseline_manufacturer):
+        return {"match_classification": MATCH_COMPATIBLE, "reason": "Same anatomy family; manufacturer/model not fully confirmed."}
+    return {
+        "match_classification": MATCH_PARTIAL,
+        "reason": "Same anatomy family, but manufacturer differs -- compatible profile, reduced confidence.",
+    }

--- a/backend/app/services/veritas_baseline_resolution_service.py
+++ b/backend/app/services/veritas_baseline_resolution_service.py
@@ -1,0 +1,140 @@
+"""Project Veritas, Section 2: Baseline Resolution Hierarchy.
+
+Wraps the real, already-built `baseline_comparison_scoring_service.
+resolve_baseline` (manufacturer -> vendor -> hospital priority across
+`BaselineLibraryEntry` and `EnterpriseVendorBaselineSubscription`) rather
+than re-implementing resolution. Neither real baseline table tracks
+anatomy_zone -- `anatomy_zone` here is the caller's requested zone, carried
+through for display/audit only, never used as a fabricated filter the real
+tables can't actually support.
+
+Never silently substitutes an unapproved baseline: `resolve_baseline`
+already only returns approved entries; when nothing approved is found this
+returns `SUPERVISOR_REVIEW_REQUIRED` with the brief's exact message.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.veritas_evidence import (
+    BASELINE_TIER_MANUFACTURER,
+    BASELINE_TIER_NONE,
+    BASELINE_TIER_ORGANIZATION,
+    BASELINE_TIER_VENDOR,
+    NO_APPROVED_BASELINE_MESSAGE,
+    RESOLUTION_STATUS_RESOLVED,
+    RESOLUTION_STATUS_SUPERVISOR_REVIEW_REQUIRED,
+    VeritasBaselineResolution,
+)
+from app.services.baseline_comparison_scoring_service import _resolve_from_library, _resolve_from_uploaded
+from app.services.instrument_anatomy import resolve_family
+
+_SOURCE_TO_TIER = {
+    "manufacturer": BASELINE_TIER_MANUFACTURER,
+    "vendor": BASELINE_TIER_VENDOR,
+    "hospital": BASELINE_TIER_ORGANIZATION,
+}
+
+
+def _enrich_from_library(db: Session, entry_id: int) -> dict:
+    from app.models.baseline_library import BaselineLibraryEntry
+    row = db.query(BaselineLibraryEntry).filter(BaselineLibraryEntry.id == entry_id).first()
+    if row is None:
+        return {}
+    return {
+        "manufacturer": row.manufacturer_name or "", "model": row.model_name or "",
+        "approval_status": row.approval_status or "", "reviewer": row.approved_by or "",
+        "image_count": row.contributing_facilities or 0,
+    }
+
+
+def _enrich_from_uploaded(db: Session, entry_id: int) -> dict:
+    from app.models.enterprise_quality import EnterpriseVendorBaselineSubscription as Sub
+    row = db.query(Sub).filter(Sub.id == entry_id).first()
+    if row is None:
+        return {}
+    return {
+        "manufacturer": row.vendor_name or "", "model": row.model_number or "",
+        "approval_status": row.approval_status or row.baseline_status or "", "reviewer": row.approved_by or "",
+        "image_count": 0,
+    }
+
+
+def resolve_governed_baseline(
+    db: Session, tenant_id: str, instrument_type: str, *, instrument_identity: str = "", anatomy_zone: str = "",
+) -> VeritasBaselineResolution:
+    """Section 2: resolve, enrich, and persist an audit row for one baseline
+    resolution. Tries the network library first, then uploaded/approved
+    vendor subscriptions -- mirrors `resolve_baseline`'s own order, but keeps
+    track of *which* real table matched (that function doesn't expose it)."""
+    instrument_family = resolve_family(instrument_type) if instrument_type else ""
+
+    library_hit = _resolve_from_library(db, instrument_type) if instrument_type else None
+    if library_hit is not None:
+        enrichment = _enrich_from_library(db, library_hit["baseline_entry_id"])
+        source_type = "baseline_library"
+        hit = library_hit
+    else:
+        uploaded_hit = _resolve_from_uploaded(db, instrument_type) if instrument_type else None
+        if uploaded_hit is not None:
+            enrichment = _enrich_from_uploaded(db, uploaded_hit["baseline_entry_id"])
+            source_type = "enterprise_vendor_subscription"
+            hit = uploaded_hit
+        else:
+            hit = None
+            enrichment = {}
+            source_type = ""
+
+    if hit is None:
+        row = VeritasBaselineResolution(
+            tenant_id=tenant_id, instrument_identity=instrument_identity, instrument_type=instrument_type,
+            instrument_family=instrument_family, anatomy_zone=anatomy_zone,
+            resolution_status=RESOLUTION_STATUS_SUPERVISOR_REVIEW_REQUIRED,
+            baseline_tier=BASELINE_TIER_NONE, confidence="low",
+            resolution_reason="No approved baseline matched this instrument type in either real baseline source.",
+            message=NO_APPROVED_BASELINE_MESSAGE,
+        )
+    else:
+        tier = _SOURCE_TO_TIER.get(hit["baseline_source"], BASELINE_TIER_NONE)
+        row = VeritasBaselineResolution(
+            tenant_id=tenant_id, instrument_identity=instrument_identity, instrument_type=instrument_type,
+            instrument_family=instrument_family, anatomy_zone=anatomy_zone,
+            resolution_status=RESOLUTION_STATUS_RESOLVED,
+            baseline_source_type=source_type, baseline_source_id=hit["baseline_entry_id"], baseline_tier=tier,
+            baseline_version=hit.get("baseline_version") or "", approval_status=enrichment.get("approval_status", ""),
+            manufacturer=enrichment.get("manufacturer", ""), model=enrichment.get("model", ""),
+            image_count=enrichment.get("image_count", 0), reviewer=enrichment.get("reviewer", ""),
+            confidence="high" if tier == BASELINE_TIER_MANUFACTURER else "moderate",
+            resolution_reason=f"Resolved from {source_type} at tier '{tier}'.",
+            message="",
+        )
+
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: VeritasBaselineResolution) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "instrument_identity": row.instrument_identity,
+        "instrument_type": row.instrument_type,
+        "instrument_family": row.instrument_family,
+        "anatomy_zone": row.anatomy_zone,
+        "resolution_status": row.resolution_status,
+        "baseline_source_type": row.baseline_source_type,
+        "baseline_source_id": row.baseline_source_id,
+        "baseline_tier": row.baseline_tier,
+        "baseline_version": row.baseline_version,
+        "approval_status": row.approval_status,
+        "manufacturer": row.manufacturer,
+        "model": row.model,
+        "image_count": row.image_count,
+        "reviewer": row.reviewer,
+        "confidence": row.confidence,
+        "resolution_reason": row.resolution_reason,
+        "message": row.message,
+        "human_review_required": row.human_review_required,
+    }

--- a/backend/app/services/veritas_conflict_detection_service.py
+++ b/backend/app/services/veritas_conflict_detection_service.py
@@ -1,0 +1,112 @@
+"""Project Veritas, Section 9: Conflict Detection.
+
+Each detector is a small, deterministic comparison over real inputs already
+computed by the other Veritas services (match classification, coverage,
+governance status) or supplied by the caller (supervisor/AI labels,
+timestamps) -- never a fabricated inference.
+"""
+from __future__ import annotations
+
+from app.models.veritas_evidence import (
+    CONFLICT_BASELINE_SUPERSEDED_AFTER_INSPECTION,
+    CONFLICT_DUPLICATE_IMAGE_DIFFERENT_ZONES,
+    CONFLICT_EVIDENCE_TIMESTAMP_INCONSISTENCY,
+    CONFLICT_IMAGE_TAG_DIFFERS,
+    CONFLICT_INSTRUMENT_FAMILY_DIFFERS,
+    CONFLICT_MANUFACTURER_DIFFERS,
+    CONFLICT_MODEL_NOT_APPROVED,
+    CONFLICT_MULTIPLE_ACTIVE_BASELINES,
+    CONFLICT_SUPERVISOR_LABEL_CONFLICT,
+    MATCH_MISMATCH,
+)
+
+
+def _conflict(conflict_type: str, *, severity: str, affected_evidence: dict, recommended_resolution: str, responsible_reviewer_role: str) -> dict:
+    return {
+        "conflict_type": conflict_type, "severity": severity, "affected_evidence": affected_evidence,
+        "recommended_resolution": recommended_resolution, "responsible_reviewer_role": responsible_reviewer_role,
+    }
+
+
+def detect_conflicts(
+    *, match_classification: str = "", instrument_manufacturer: str = "", baseline_manufacturer: str = "",
+    ai_zone: str = "", tagged_zone: str = "", supervisor_label: str = "", ai_label: str = "",
+    model_approved_for_family: bool = True, baseline_superseded_after_inspection: bool = False,
+    duplicate_image_zones: list[str] | None = None, timestamp_inconsistent: bool = False,
+    multiple_active_baselines: bool = False,
+) -> list[dict]:
+    conflicts: list[dict] = []
+
+    if match_classification == MATCH_MISMATCH:
+        conflicts.append(_conflict(
+            CONFLICT_INSTRUMENT_FAMILY_DIFFERS, severity="high",
+            affected_evidence={"match_classification": match_classification},
+            recommended_resolution="Resolve a baseline matching this instrument's actual anatomy family before scoring.",
+            responsible_reviewer_role="baseline_reviewer",
+        ))
+
+    if ai_zone and tagged_zone and ai_zone != tagged_zone:
+        conflicts.append(_conflict(
+            CONFLICT_IMAGE_TAG_DIFFERS, severity="moderate",
+            affected_evidence={"ai_zone": ai_zone, "tagged_zone": tagged_zone},
+            recommended_resolution="Supervisor to confirm the correct anatomy zone for this image.",
+            responsible_reviewer_role="supervisor",
+        ))
+
+    if instrument_manufacturer and baseline_manufacturer and instrument_manufacturer.strip().lower() != baseline_manufacturer.strip().lower():
+        conflicts.append(_conflict(
+            CONFLICT_MANUFACTURER_DIFFERS, severity="high",
+            affected_evidence={"instrument_manufacturer": instrument_manufacturer, "baseline_manufacturer": baseline_manufacturer},
+            recommended_resolution="Confirm instrument manufacturer/model before using this baseline.",
+            responsible_reviewer_role="baseline_reviewer",
+        ))
+
+    if multiple_active_baselines:
+        conflicts.append(_conflict(
+            CONFLICT_MULTIPLE_ACTIVE_BASELINES, severity="high",
+            affected_evidence={},
+            recommended_resolution="Baseline governance review required to determine the single active baseline.",
+            responsible_reviewer_role="baseline_reviewer",
+        ))
+
+    if supervisor_label and ai_label and supervisor_label != ai_label:
+        conflicts.append(_conflict(
+            CONFLICT_SUPERVISOR_LABEL_CONFLICT, severity="moderate",
+            affected_evidence={"supervisor_label": supervisor_label, "ai_label": ai_label},
+            recommended_resolution="Supervisor review to reconcile the AI and supervisor labels.",
+            responsible_reviewer_role="supervisor",
+        ))
+
+    if not model_approved_for_family:
+        conflicts.append(_conflict(
+            CONFLICT_MODEL_NOT_APPROVED, severity="high",
+            affected_evidence={},
+            recommended_resolution="Do not use this model's output for this instrument family until approved.",
+            responsible_reviewer_role="model_governance_reviewer",
+        ))
+
+    if baseline_superseded_after_inspection:
+        conflicts.append(_conflict(
+            CONFLICT_BASELINE_SUPERSEDED_AFTER_INSPECTION, severity="moderate",
+            affected_evidence={},
+            recommended_resolution="Re-run evidence assessment against the current baseline version.",
+            responsible_reviewer_role="baseline_reviewer",
+        ))
+
+    if duplicate_image_zones and len(set(duplicate_image_zones)) > 1:
+        conflicts.append(_conflict(
+            CONFLICT_DUPLICATE_IMAGE_DIFFERENT_ZONES, severity="low",
+            affected_evidence={"zones": duplicate_image_zones},
+            recommended_resolution="Confirm which zone this image actually depicts.",
+            responsible_reviewer_role="supervisor",
+        ))
+
+    if timestamp_inconsistent:
+        conflicts.append(_conflict(
+            CONFLICT_EVIDENCE_TIMESTAMP_INCONSISTENCY, severity="low",
+            affected_evidence={},
+            recommended_resolution="Investigate evidence timestamp ordering before finalizing.",
+            responsible_reviewer_role="baseline_reviewer",
+        ))
+
+    return conflicts

--- a/backend/app/services/veritas_coverage_service.py
+++ b/backend/app/services/veritas_coverage_service.py
@@ -1,0 +1,48 @@
+"""Project Veritas, Section 6: Inspection Coverage Assurance.
+
+Wraps the real `inspection_coverage.compute_coverage` (required/inspected/
+missing zones + a quality band that already maps almost 1:1 onto this
+brief's coverage statuses) rather than re-deriving coverage. Adds only the
+brief's explicit "identify high-risk zones captured" and duplicate-view
+detection on top of the real engine's output.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+from app.models.veritas_evidence import COVERAGE_NOT_ASSESSED
+from app.services.instrument_anatomy import get_anatomy
+from app.services.inspection_coverage import compute_coverage
+
+_QUALITY_TO_COVERAGE_STATUS = {
+    "not_assessed": COVERAGE_NOT_ASSESSED,
+    "complete": "complete",
+    "acceptable": "acceptable",
+    "incomplete": "incomplete",
+    "insufficient": "insufficient",
+}
+
+
+def assess_coverage(instrument_type: str, inspected_zones: list[str] | None) -> dict:
+    """Section 6: coverage assurance, built on the real coverage engine."""
+    result = compute_coverage(instrument_type, inspected_zones)
+    anatomy = get_anatomy(instrument_type)
+    high_risk_zones = set(anatomy.get("high_risk_zones", []))
+
+    inspected_norm = [z for z in (inspected_zones or [])]
+    duplicate_views = [zone for zone, count in Counter(inspected_norm).items() if count > 1]
+    high_risk_captured = sorted({z for z in result.get("inspected", []) if z in high_risk_zones})
+    high_risk_missing = sorted({z for z in result.get("missing", []) if z in high_risk_zones})
+
+    return {
+        "assessed": result["assessed"],
+        "coverage_pct": result["overall_coverage"],
+        "coverage_status": _QUALITY_TO_COVERAGE_STATUS.get(result["quality"], COVERAGE_NOT_ASSESSED),
+        "required_zones": result["required_zones"],
+        "captured_zones": result["inspected"],
+        "missing_zones": result["missing"],
+        "high_risk_zones_captured": high_risk_captured,
+        "high_risk_zones_missing": high_risk_missing,
+        "duplicate_views": duplicate_views,
+        "message": result["message"],
+    }

--- a/backend/app/services/veritas_data_quality_service.py
+++ b/backend/app/services/veritas_data_quality_service.py
@@ -1,0 +1,72 @@
+"""Project Veritas, Section 14: Data Quality Monitoring.
+
+Every rate below is computed from real, already-persisted Veritas rows --
+no fabricated trend lines. A rate is `None` (not 0%) when there is no
+denominator activity yet.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.veritas_evidence import (
+    BASELINE_STATUS_SUPERSEDED,
+    CONFLICT_DUPLICATE_IMAGE_DIFFERENT_ZONES,
+    CONFLICT_IMAGE_TAG_DIFFERS,
+    COVERAGE_INCOMPLETE,
+    COVERAGE_INSUFFICIENT,
+    DATASET_APPROVED_FOR_TRAINING,
+    FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE,
+    IMAGE_QUALITY_INSUFFICIENT,
+    MATCH_MISMATCH,
+    VeritasBaselineGovernanceAction,
+    VeritasEvidenceConflict,
+    VeritasEvidenceProvenanceRecord,
+    VeritasEvidenceReadinessAssessment,
+    VeritasFeedback,
+    VeritasTrainingDatasetEntry,
+)
+
+
+def _rate(numerator: int, denominator: int) -> float | None:
+    return round(100 * numerator / denominator, 1) if denominator else None
+
+
+def data_quality_summary(db: Session, tenant_id: str) -> dict:
+    assessments = db.query(VeritasEvidenceReadinessAssessment).filter(VeritasEvidenceReadinessAssessment.tenant_id == tenant_id).all()
+    total = len(assessments)
+
+    conflicts = db.query(VeritasEvidenceConflict).filter(VeritasEvidenceConflict.tenant_id == tenant_id).all()
+    duplicate_conflicts = sum(1 for c in conflicts if c.conflict_type == CONFLICT_DUPLICATE_IMAGE_DIFFERENT_ZONES)
+    tag_conflicts = sum(1 for c in conflicts if c.conflict_type == CONFLICT_IMAGE_TAG_DIFFERS)
+
+    overrides = (
+        db.query(VeritasFeedback)
+        .filter(VeritasFeedback.tenant_id == tenant_id, VeritasFeedback.action == FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE)
+        .count()
+    )
+
+    governance_actions = db.query(VeritasBaselineGovernanceAction).filter(VeritasBaselineGovernanceAction.tenant_id == tenant_id).all()
+    baseline_keys = {(a.baseline_source_type, a.baseline_source_id) for a in governance_actions}
+    latest_by_baseline = {}
+    for action in sorted(governance_actions, key=lambda a: a.created_at):
+        latest_by_baseline[(action.baseline_source_type, action.baseline_source_id)] = action
+    superseded = sum(1 for a in latest_by_baseline.values() if a.resulting_status == BASELINE_STATUS_SUPERSEDED)
+
+    provenance = db.query(VeritasEvidenceProvenanceRecord).filter(VeritasEvidenceProvenanceRecord.tenant_id == tenant_id).all()
+    provenance_complete = sum(1 for p in provenance if p.file_hash and p.storage_location)
+
+    dataset_entries = db.query(VeritasTrainingDatasetEntry).filter(VeritasTrainingDatasetEntry.tenant_id == tenant_id).all()
+    approved_for_training = sum(1 for e in dataset_entries if e.dataset_status == DATASET_APPROVED_FOR_TRAINING)
+
+    return {
+        "duplicate_image_rate_pct": _rate(duplicate_conflicts, total),
+        "incorrect_anatomy_tag_rate_pct": _rate(tag_conflicts, total),
+        "baseline_mismatch_rate_pct": _rate(sum(1 for a in assessments if a.match_classification == MATCH_MISMATCH), total),
+        "incomplete_coverage_rate_pct": _rate(sum(1 for a in assessments if a.coverage_status in (COVERAGE_INCOMPLETE, COVERAGE_INSUFFICIENT)), total),
+        "insufficient_image_quality_rate_pct": _rate(sum(1 for a in assessments if a.image_quality_status == IMAGE_QUALITY_INSUFFICIENT), total),
+        "supervisor_override_rate_pct": _rate(overrides, total),
+        "stale_baseline_rate_pct": _rate(superseded, len(baseline_keys)),
+        "provenance_completeness_pct": _rate(provenance_complete, len(provenance)),
+        "dataset_readiness_pct": _rate(approved_for_training, len(dataset_entries)),
+        "total_assessments": total,
+    }

--- a/backend/app/services/veritas_evidence_agent_service.py
+++ b/backend/app/services/veritas_evidence_agent_service.py
@@ -1,0 +1,230 @@
+"""Project Veritas, Sections 1, 10 & 12: Evidence Assurance Agent
+orchestrator + Evidence Gate + Inspection Evidence Panel data.
+
+Composes baseline resolution, matching, image quality, coverage, and
+conflict detection into one persisted `VeritasEvidenceReadinessAssessment` +
+a recommended (never self-finalized) evidence gate. Veritas does not
+independently approve an instrument -- `recommended_gate` is always
+advisory; only a supervisor-gated `VeritasFeedback` action
+(`override_evidence_gate`) can set `final_gate_override`.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.veritas_evidence import (
+    BASELINE_STATUS_APPROVED,
+    BASELINE_STATUS_DRAFT,
+    BASELINE_STATUS_PENDING_REVIEW,
+    COVERAGE_INSUFFICIENT,
+    GATE_ADDITIONAL_IMAGE_REQUIRED,
+    GATE_ANALYSIS_BLOCKED,
+    GATE_BASELINE_REVIEW_REQUIRED,
+    GATE_EVIDENCE_CONFLICT,
+    GATE_PROCEED_WITH_ANALYSIS,
+    GATE_PROCEED_WITH_LIMITATIONS,
+    GATE_SUPERVISOR_REVIEW_REQUIRED,
+    IMAGE_QUALITY_INSUFFICIENT,
+    READINESS_INSUFFICIENT,
+    READINESS_LIMITED,
+    READINESS_MODERATE,
+    RESOLUTION_STATUS_SUPERVISOR_REVIEW_REQUIRED,
+    VeritasEvidenceConflict,
+    VeritasEvidenceReadinessAssessment,
+)
+from app.services.veritas_baseline_governance_service import effective_status
+from app.services.veritas_baseline_matching_service import classify_match
+from app.services.veritas_baseline_resolution_service import resolve_governed_baseline
+from app.services.veritas_conflict_detection_service import detect_conflicts
+from app.services.veritas_coverage_service import assess_coverage
+from app.services.veritas_image_quality_service import assess_image_quality
+from app.services.veritas_readiness_score_service import compute_evidence_readiness_score
+
+
+def _recommend_gate(*, has_conflicts: bool, baseline_resolution_status: str, baseline_governance_status: str,
+                     image_quality_status: str, coverage_status: str, readiness_category_value: str) -> str:
+    if has_conflicts:
+        return GATE_EVIDENCE_CONFLICT
+    if baseline_resolution_status == RESOLUTION_STATUS_SUPERVISOR_REVIEW_REQUIRED:
+        return GATE_SUPERVISOR_REVIEW_REQUIRED
+    if baseline_governance_status in (BASELINE_STATUS_DRAFT, BASELINE_STATUS_PENDING_REVIEW):
+        return GATE_BASELINE_REVIEW_REQUIRED
+    if image_quality_status == IMAGE_QUALITY_INSUFFICIENT or coverage_status == COVERAGE_INSUFFICIENT:
+        return GATE_ADDITIONAL_IMAGE_REQUIRED
+    if readiness_category_value == READINESS_INSUFFICIENT:
+        return GATE_ANALYSIS_BLOCKED
+    if readiness_category_value in (READINESS_LIMITED, READINESS_MODERATE):
+        return GATE_PROCEED_WITH_LIMITATIONS
+    return GATE_PROCEED_WITH_ANALYSIS
+
+
+_NEXT_ACTION = {
+    GATE_PROCEED_WITH_ANALYSIS: "No additional evidence required; proceed with analysis.",
+    GATE_PROCEED_WITH_LIMITATIONS: "Proceed, but address the documented limitation before final disposition if possible.",
+    GATE_ADDITIONAL_IMAGE_REQUIRED: "Capture the missing anatomy zone image(s) before final disposition.",
+    GATE_BASELINE_REVIEW_REQUIRED: "Route this baseline for governance review before it can support a final score.",
+    GATE_SUPERVISOR_REVIEW_REQUIRED: "No approved baseline is available -- request supervisor review before final disposition.",
+    GATE_EVIDENCE_CONFLICT: "Resolve the detected evidence conflict(s) before final disposition.",
+    GATE_ANALYSIS_BLOCKED: "Evidence is insufficient -- do not issue a final AI conclusion from this inspection as-is.",
+}
+
+
+def run_evidence_assessment(
+    db: Session, tenant_id: str, inspection_id: int, *, model_version: str = "", dataset_version: str = "",
+) -> VeritasEvidenceReadinessAssessment:
+    """Section 1: run the full Veritas pipeline and persist one assessment."""
+    inspection = db.query(models.Inspection).filter(models.Inspection.id == inspection_id, models.Inspection.tenant_id == tenant_id).first()
+    if inspection is None:
+        raise ValueError(f"Inspection {inspection_id} not found for this tenant")
+
+    instrument_identity = (
+        f"barcode:{inspection.instrument_barcode}" if inspection.instrument_barcode
+        else f"udi:{inspection.instrument_udi}" if inspection.instrument_udi
+        else f"untracked:{inspection.instrument_type}:{inspection.id}"
+    )
+
+    baseline_resolution = resolve_governed_baseline(
+        db, tenant_id, inspection.instrument_type, instrument_identity=instrument_identity,
+    )
+
+    if baseline_resolution.baseline_source_id is not None:
+        baseline_governance_status = effective_status(
+            db, tenant_id, baseline_resolution.baseline_source_type, baseline_resolution.baseline_source_id,
+        )
+        # A freshly-resolved approved baseline with no explicit Veritas governance
+        # history yet is treated as approved (it already passed the real
+        # resolve_baseline() approval filter) rather than defaulting to
+        # pending_review, which would understate a genuinely approved baseline.
+        if baseline_governance_status == BASELINE_STATUS_PENDING_REVIEW and baseline_resolution.approval_status.lower() in (
+            "approved", "active", "vendor_approved", "hospital_approved",
+        ):
+            baseline_governance_status = BASELINE_STATUS_APPROVED
+        match = classify_match(
+            instrument_type=inspection.instrument_type, baseline_instrument_category=inspection.instrument_type,
+            baseline_manufacturer=baseline_resolution.manufacturer, instrument_manufacturer=baseline_resolution.manufacturer,
+        )
+    else:
+        baseline_governance_status = ""
+        match = {"match_classification": "unavailable", "reason": baseline_resolution.message}
+
+    image_quality = assess_image_quality(has_image=inspection.has_image, ai_confidence=inspection.ai_confidence)
+
+    inspected_zones = json.loads(inspection.inspected_zones_json) if inspection.inspected_zones_json not in (None, "null") else None
+    coverage = assess_coverage(inspection.instrument_type, inspected_zones)
+
+    conflicts = detect_conflicts(match_classification=match["match_classification"])
+
+    score_result = compute_evidence_readiness_score(
+        match_classification=match["match_classification"],
+        baseline_governance_status=baseline_governance_status or "unresolved",
+        image_quality_status=image_quality["quality_status"],
+        coverage_status=coverage["coverage_status"],
+        instrument_identity_confidence="high" if instrument_identity.startswith(("barcode:", "udi:")) else "low",
+        provenance_complete=True,
+        supervisor_validated=False,
+        model_compatible=True,
+        has_conflicts=bool(conflicts),
+    )
+
+    gate = _recommend_gate(
+        has_conflicts=bool(conflicts), baseline_resolution_status=baseline_resolution.resolution_status,
+        baseline_governance_status=baseline_governance_status, image_quality_status=image_quality["quality_status"],
+        coverage_status=coverage["coverage_status"], readiness_category_value=score_result["readiness_category"],
+    )
+
+    limitations = []
+    if coverage["missing_zones"]:
+        limitations.append(f"Missing zone(s): {', '.join(coverage['missing_zones'])}.")
+    if image_quality["detected_issues"]:
+        limitations.append(f"Image quality issue(s): {', '.join(image_quality['detected_issues'])}.")
+    if baseline_resolution.resolution_status == RESOLUTION_STATUS_SUPERVISOR_REVIEW_REQUIRED:
+        limitations.append(baseline_resolution.message)
+
+    narrative = _build_narrative(
+        baseline_resolution=baseline_resolution, match=match, image_quality=image_quality, coverage=coverage,
+        score_result=score_result, gate=gate,
+    )
+
+    row = VeritasEvidenceReadinessAssessment(
+        tenant_id=tenant_id, inspection_id=inspection_id, instrument_identity=instrument_identity,
+        baseline_resolution_id=baseline_resolution.id,
+        match_classification=match["match_classification"], image_quality_status=image_quality["quality_status"],
+        coverage_status=coverage["coverage_status"], coverage_pct=coverage["coverage_pct"],
+        missing_zones_json=json.dumps(coverage["missing_zones"]),
+        readiness_score=score_result["readiness_score"], readiness_category=score_result["readiness_category"],
+        score_breakdown_json=json.dumps(score_result["score_breakdown"]), limitations_json=json.dumps(limitations),
+        recommended_gate=gate, next_action=_NEXT_ACTION[gate], reasoning_narrative=narrative,
+        confidence=baseline_resolution.confidence, model_version=model_version, dataset_version=dataset_version,
+        human_review_required=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    for conflict in conflicts:
+        db.add(VeritasEvidenceConflict(
+            tenant_id=tenant_id, assessment_id=row.id, conflict_type=conflict["conflict_type"],
+            severity=conflict["severity"], affected_evidence_json=json.dumps(conflict["affected_evidence"]),
+            recommended_resolution=conflict["recommended_resolution"], responsible_reviewer_role=conflict["responsible_reviewer_role"],
+        ))
+    db.commit()
+
+    return row
+
+
+def _build_narrative(*, baseline_resolution, match, image_quality, coverage, score_result, gate) -> str:
+    if baseline_resolution.resolution_status == RESOLUTION_STATUS_SUPERVISOR_REVIEW_REQUIRED:
+        return baseline_resolution.message
+
+    baseline_text = (
+        f"An approved {baseline_resolution.baseline_tier.replace('_', ' ')} baseline (v{baseline_resolution.baseline_version or '?'}) "
+        f"was resolved for this instrument." if baseline_resolution.baseline_source_id else "No baseline was resolved for this instrument."
+    )
+    quality_text = f"Image quality is {image_quality['quality_status']}."
+    coverage_text = (
+        f"Coverage is {coverage['coverage_status']}"
+        + (f" ({coverage['coverage_pct']}%)" if coverage["coverage_pct"] is not None else "")
+        + (f"; missing: {', '.join(coverage['missing_zones'])}." if coverage["missing_zones"] else ".")
+    )
+    readiness_text = (
+        f"Evidence readiness is {score_result['readiness_category'].replace('_', ' ')} at "
+        f"{int(score_result['readiness_score'])}/100."
+    )
+    action_text = _NEXT_ACTION[gate]
+
+    return f"{baseline_text} {quality_text} {coverage_text} {readiness_text} {action_text}"
+
+
+def to_dict(row: VeritasEvidenceReadinessAssessment) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "tenant_id": row.tenant_id,
+        "inspection_id": row.inspection_id,
+        "instrument_identity": row.instrument_identity,
+        "baseline_resolution_id": row.baseline_resolution_id,
+        "match_classification": row.match_classification,
+        "image_quality_status": row.image_quality_status,
+        "coverage_status": row.coverage_status,
+        "coverage_pct": row.coverage_pct,
+        "missing_zones": json.loads(row.missing_zones_json or "[]"),
+        "readiness_score": row.readiness_score,
+        "readiness_category": row.readiness_category,
+        "score_breakdown": json.loads(row.score_breakdown_json or "{}"),
+        "limitations": json.loads(row.limitations_json or "[]"),
+        "recommended_gate": row.recommended_gate,
+        "next_action": row.next_action,
+        "reasoning_narrative": row.reasoning_narrative,
+        "confidence": row.confidence,
+        "model_version": row.model_version,
+        "dataset_version": row.dataset_version,
+        "agent_version": row.agent_version,
+        "human_review_required": row.human_review_required,
+        "final_gate_override": row.final_gate_override,
+        "overridden_by": row.overridden_by,
+        "overridden_at": row.overridden_at.isoformat() if row.overridden_at else None,
+        "disclaimer": row.disclaimer,
+    }

--- a/backend/app/services/veritas_feedback_service.py
+++ b/backend/app/services/veritas_feedback_service.py
@@ -1,0 +1,91 @@
+"""Project Veritas, Section 17: Supervisor Feedback.
+
+Also the ONLY place an evidence-gate override is recorded (action
+`override_evidence_gate`, requires `override_reason`) -- mirrors Vulcan's
+`final_disposition`-via-feedback-only pattern. Veritas's own orchestrator
+never sets `VeritasEvidenceReadinessAssessment.final_gate_override`.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.veritas_evidence import FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE, VeritasEvidenceReadinessAssessment, VeritasFeedback
+
+
+class OverrideReasonRequiredError(ValueError):
+    pass
+
+
+def submit_feedback(
+    db: Session, tenant_id: str, *, action: str, submitted_by: str, submitted_role: str = "",
+    assessment_id: int | None = None, baseline_match_correct: bool | None = None,
+    image_quality_assessment_correct: bool | None = None, anatomy_zone_tag_correct: bool | None = None,
+    coverage_determination_correct: bool | None = None, evidence_conflict_valid: bool | None = None,
+    corrected_baseline: str = "", corrected_zone: str = "", final_evidence_status: str = "",
+    reviewer_rationale: str = "", override_reason: str = "", limitations_acknowledged: str = "",
+    final_disposition: str = "",
+) -> VeritasFeedback:
+    if action == FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE and not override_reason.strip():
+        raise OverrideReasonRequiredError("override_reason is required to override an evidence gate")
+
+    row = VeritasFeedback(
+        tenant_id=tenant_id, assessment_id=assessment_id, action=action,
+        baseline_match_correct=baseline_match_correct, image_quality_assessment_correct=image_quality_assessment_correct,
+        anatomy_zone_tag_correct=anatomy_zone_tag_correct, coverage_determination_correct=coverage_determination_correct,
+        evidence_conflict_valid=evidence_conflict_valid, corrected_baseline=corrected_baseline,
+        corrected_zone=corrected_zone, final_evidence_status=final_evidence_status,
+        reviewer_rationale=reviewer_rationale, override_reason=override_reason,
+        limitations_acknowledged=limitations_acknowledged, final_disposition=final_disposition,
+        submitted_by=submitted_by, submitted_role=submitted_role,
+    )
+    db.add(row)
+
+    if action == FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE and assessment_id is not None:
+        assessment = (
+            db.query(VeritasEvidenceReadinessAssessment)
+            .filter(VeritasEvidenceReadinessAssessment.id == assessment_id, VeritasEvidenceReadinessAssessment.tenant_id == tenant_id)
+            .first()
+        )
+        if assessment is not None:
+            assessment.final_gate_override = final_evidence_status or assessment.recommended_gate
+            assessment.overridden_by = submitted_by
+            assessment.overridden_at = datetime.now(timezone.utc)
+
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: VeritasFeedback) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "assessment_id": row.assessment_id,
+        "action": row.action,
+        "baseline_match_correct": row.baseline_match_correct,
+        "image_quality_assessment_correct": row.image_quality_assessment_correct,
+        "anatomy_zone_tag_correct": row.anatomy_zone_tag_correct,
+        "coverage_determination_correct": row.coverage_determination_correct,
+        "evidence_conflict_valid": row.evidence_conflict_valid,
+        "corrected_baseline": row.corrected_baseline,
+        "corrected_zone": row.corrected_zone,
+        "final_evidence_status": row.final_evidence_status,
+        "reviewer_rationale": row.reviewer_rationale,
+        "override_reason": row.override_reason,
+        "limitations_acknowledged": row.limitations_acknowledged,
+        "final_disposition": row.final_disposition,
+        "submitted_by": row.submitted_by,
+        "submitted_role": row.submitted_role,
+    }
+
+
+def feedback_for_assessment(db: Session, tenant_id: str, assessment_id: int) -> list[dict]:
+    rows = (
+        db.query(VeritasFeedback)
+        .filter(VeritasFeedback.tenant_id == tenant_id, VeritasFeedback.assessment_id == assessment_id)
+        .order_by(VeritasFeedback.created_at.asc())
+        .all()
+    )
+    return [to_dict(r) for r in rows]

--- a/backend/app/services/veritas_image_quality_service.py
+++ b/backend/app/services/veritas_image_quality_service.py
@@ -1,0 +1,81 @@
+"""Project Veritas, Section 5: Image Quality Assessment.
+
+Confirmed via repo-wide search: no real CV-based focus/blur/lighting/glare/
+exposure/obstruction/framing/magnification/orientation/duplication/
+compression-artifact detector exists anywhere in this codebase. Each of
+those signals is honestly reported as unavailable (`"available": false`) --
+the same discipline as Nova's observability summary -- rather than
+fabricated. `quality_status` is derived only from what IS real: image
+presence and, when present, the AI confidence score already computed for
+that inspection (a coarse proxy, not a quality metric, and documented as
+such).
+"""
+from __future__ import annotations
+
+from app.models.veritas_evidence import (
+    IMAGE_QUALITY_ACCEPTABLE,
+    IMAGE_QUALITY_EXCELLENT,
+    IMAGE_QUALITY_INSUFFICIENT,
+    IMAGE_QUALITY_LIMITED,
+)
+
+_UNAVAILABLE_SIGNALS = [
+    "focus", "blur", "lighting", "glare", "exposure", "obstruction", "framing",
+    "magnification", "orientation", "image_duplication", "compression_artifacts",
+]
+
+_NOTE = (
+    "Per-image focus/blur/lighting/glare/exposure/obstruction/framing/magnification/"
+    "orientation/duplication/compression-artifact detection is not implemented in this "
+    "codebase. quality_status below is a coarse proxy derived only from image presence "
+    "and existing AI confidence -- never a fabricated per-signal quality score."
+)
+
+
+def assess_image_quality(*, has_image: bool, ai_confidence: float | None = None) -> dict:
+    """Section 5: honest image quality assessment."""
+    detected_issues: list[str] = []
+    recommended_recapture_steps: list[str] = []
+
+    if not has_image:
+        return {
+            "image_quality_score": 0.0,
+            "quality_status": IMAGE_QUALITY_INSUFFICIENT,
+            "detected_issues": ["no_image_captured"],
+            "recommended_recapture_steps": ["Capture at least one in-focus image of the required anatomy zone."],
+            "signals": {name: {"available": False} for name in _UNAVAILABLE_SIGNALS},
+            "note": _NOTE,
+        }
+
+    if ai_confidence is None:
+        return {
+            "image_quality_score": None,
+            "quality_status": IMAGE_QUALITY_LIMITED,
+            "detected_issues": ["no_confidence_signal_available"],
+            "recommended_recapture_steps": ["Re-run analysis or recapture if the image appears unclear."],
+            "signals": {name: {"available": False} for name in _UNAVAILABLE_SIGNALS},
+            "note": _NOTE,
+        }
+
+    score = round(100 * ai_confidence, 1)
+    if score >= 85:
+        status = IMAGE_QUALITY_EXCELLENT
+    elif score >= 65:
+        status = IMAGE_QUALITY_ACCEPTABLE
+    elif score >= 40:
+        status = IMAGE_QUALITY_LIMITED
+        detected_issues.append("low_confidence_may_indicate_quality_issue")
+        recommended_recapture_steps.append("Consider recapturing with better lighting/focus and re-running analysis.")
+    else:
+        status = IMAGE_QUALITY_INSUFFICIENT
+        detected_issues.append("very_low_confidence")
+        recommended_recapture_steps.append("Recapture this image before relying on it for a final disposition.")
+
+    return {
+        "image_quality_score": score,
+        "quality_status": status,
+        "detected_issues": detected_issues,
+        "recommended_recapture_steps": recommended_recapture_steps,
+        "signals": {name: {"available": False} for name in _UNAVAILABLE_SIGNALS},
+        "note": _NOTE,
+    }

--- a/backend/app/services/veritas_provenance_service.py
+++ b/backend/app/services/veritas_provenance_service.py
@@ -1,0 +1,82 @@
+"""Project Veritas, Section 7: Evidence Provenance Ledger.
+
+Records provenance for an evidence object by reference (never duplicating
+the underlying bytes/table) -- the same reuse pattern Sage's
+`SageEducationImageEntry` established for `RetainedImage`.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.veritas_evidence import EVIDENCE_TYPES, VeritasEvidenceProvenanceRecord
+
+
+def record_provenance(
+    db: Session, tenant_id: str, *, evidence_type: str, source: str = "", organization: str = "",
+    facility: str = "", creator: str = "", instrument_id: str = "", inspection_id: int | None = None,
+    anatomy_zone: str = "", baseline_id: int | None = None, file_hash: str = "", storage_location: str = "",
+    approval_status: str = "", reviewer: str = "", version: str = "1.0.0", usage_scope: str = "internal",
+) -> VeritasEvidenceProvenanceRecord:
+    if evidence_type not in EVIDENCE_TYPES:
+        raise ValueError(f"Unknown evidence_type '{evidence_type}'")
+    row = VeritasEvidenceProvenanceRecord(
+        tenant_id=tenant_id, evidence_type=evidence_type, source=source, organization=organization,
+        facility=facility, creator=creator, instrument_id=instrument_id, inspection_id=inspection_id,
+        anatomy_zone=anatomy_zone, baseline_id=baseline_id, file_hash=file_hash, storage_location=storage_location,
+        approval_status=approval_status, reviewer=reviewer, version=version, usage_scope=usage_scope,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def append_modification(db: Session, tenant_id: str, record_id: int, *, actor: str, change: str) -> VeritasEvidenceProvenanceRecord | None:
+    row = (
+        db.query(VeritasEvidenceProvenanceRecord)
+        .filter(VeritasEvidenceProvenanceRecord.id == record_id, VeritasEvidenceProvenanceRecord.tenant_id == tenant_id)
+        .first()
+    )
+    if row is None:
+        return None
+    history = json.loads(row.modification_history_json or "[]")
+    from datetime import datetime, timezone
+    history.append({"actor": actor, "change": change, "at": datetime.now(timezone.utc).isoformat()})
+    row.modification_history_json = json.dumps(history)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: VeritasEvidenceProvenanceRecord) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "evidence_type": row.evidence_type,
+        "source": row.source,
+        "organization": row.organization,
+        "facility": row.facility,
+        "creator": row.creator,
+        "instrument_id": row.instrument_id,
+        "inspection_id": row.inspection_id,
+        "anatomy_zone": row.anatomy_zone,
+        "baseline_id": row.baseline_id,
+        "file_hash": row.file_hash,
+        "storage_location": row.storage_location,
+        "approval_status": row.approval_status,
+        "reviewer": row.reviewer,
+        "version": row.version,
+        "modification_history": json.loads(row.modification_history_json or "[]"),
+        "usage_scope": row.usage_scope,
+    }
+
+
+def list_provenance(db: Session, tenant_id: str, *, inspection_id: int | None = None, evidence_type: str = "") -> list[dict]:
+    q = db.query(VeritasEvidenceProvenanceRecord).filter(VeritasEvidenceProvenanceRecord.tenant_id == tenant_id)
+    if inspection_id is not None:
+        q = q.filter(VeritasEvidenceProvenanceRecord.inspection_id == inspection_id)
+    if evidence_type:
+        q = q.filter(VeritasEvidenceProvenanceRecord.evidence_type == evidence_type)
+    return [to_dict(r) for r in q.order_by(VeritasEvidenceProvenanceRecord.created_at.desc()).all()]

--- a/backend/app/services/veritas_readiness_score_service.py
+++ b/backend/app/services/veritas_readiness_score_service.py
@@ -1,0 +1,86 @@
+"""Project Veritas, Section 8: Evidence Readiness Score.
+
+0-100 composite with a transparent breakdown -- evaluates evidence quality,
+not instrument cleanliness (a Vulcan reliability score answers a different
+question and is never conflated with this one).
+"""
+from __future__ import annotations
+
+from app.models.veritas_evidence import (
+    BASELINE_STATUS_APPROVED,
+    BASELINE_STATUS_CONDITIONALLY_APPROVED,
+    IMAGE_QUALITY_ACCEPTABLE,
+    IMAGE_QUALITY_EXCELLENT,
+    IMAGE_QUALITY_INSUFFICIENT,
+    IMAGE_QUALITY_LIMITED,
+    MATCH_COMPATIBLE,
+    MATCH_EXACT,
+    MATCH_MISMATCH,
+    MATCH_PARTIAL,
+    MATCH_UNAVAILABLE,
+    MATCH_UNCERTAIN,
+    readiness_category,
+)
+
+_MATCH_PENALTY = {
+    MATCH_EXACT: 0, MATCH_COMPATIBLE: 5, MATCH_PARTIAL: 15, MATCH_UNCERTAIN: 20,
+    MATCH_MISMATCH: 40, MATCH_UNAVAILABLE: 30,
+}
+_IMAGE_QUALITY_PENALTY = {
+    IMAGE_QUALITY_EXCELLENT: 0, IMAGE_QUALITY_ACCEPTABLE: 5, IMAGE_QUALITY_LIMITED: 15, IMAGE_QUALITY_INSUFFICIENT: 30,
+}
+_COVERAGE_PENALTY = {
+    "complete": 0, "acceptable": 5, "incomplete": 15, "insufficient": 30, "not_assessed": 20,
+}
+_IDENTITY_CONFIDENCE_PENALTY = {"high": 0, "moderate": 5, "low": 15}
+
+
+def compute_evidence_readiness_score(
+    *, match_classification: str, baseline_governance_status: str, image_quality_status: str, coverage_status: str,
+    instrument_identity_confidence: str = "moderate", provenance_complete: bool = True,
+    supervisor_validated: bool = False, model_compatible: bool = True, has_conflicts: bool = False,
+) -> dict:
+    breakdown: dict[str, int] = {}
+
+    match_penalty = _MATCH_PENALTY.get(match_classification, 20)
+    if match_penalty:
+        breakdown["baseline_match_quality"] = -match_penalty
+
+    if baseline_governance_status == BASELINE_STATUS_APPROVED:
+        pass
+    elif baseline_governance_status == BASELINE_STATUS_CONDITIONALLY_APPROVED:
+        breakdown["baseline_governance_status"] = -10
+    else:
+        breakdown["baseline_governance_status"] = -25
+
+    image_penalty = _IMAGE_QUALITY_PENALTY.get(image_quality_status, 15)
+    if image_penalty:
+        breakdown["image_quality"] = -image_penalty
+
+    coverage_penalty = _COVERAGE_PENALTY.get(coverage_status, 20)
+    if coverage_penalty:
+        breakdown["anatomy_zone_coverage"] = -coverage_penalty
+
+    identity_penalty = _IDENTITY_CONFIDENCE_PENALTY.get(instrument_identity_confidence, 10)
+    if identity_penalty:
+        breakdown["instrument_identity_confidence"] = -identity_penalty
+
+    if not provenance_complete:
+        breakdown["evidence_provenance_completeness"] = -10
+
+    if not supervisor_validated:
+        breakdown["supervisor_validation_status"] = -5
+
+    if not model_compatible:
+        breakdown["model_compatibility"] = -20
+
+    if has_conflicts:
+        breakdown["conflicting_evidence"] = -15
+
+    score = max(0, min(100, 100 + sum(breakdown.values())))
+
+    return {
+        "readiness_score": float(score),
+        "readiness_category": readiness_category(score),
+        "score_breakdown": breakdown,
+    }

--- a/backend/app/services/veritas_reports_service.py
+++ b/backend/app/services/veritas_reports_service.py
@@ -1,0 +1,130 @@
+"""Project Veritas, Section 19: Evidence Assurance Reports.
+
+Reuses this codebase's existing report-generation libraries (reportlab for
+PDF -- see `report_pdf.py`/`vanguard_board_reporting_service.py` -- and
+openpyxl for Excel) rather than introducing a new export dependency. CSV
+uses the stdlib, the same pattern as `audit_export_service.py`.
+"""
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime, timezone
+from io import BytesIO, StringIO
+
+from openpyxl import Workbook
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+from sqlalchemy.orm import Session
+
+from app.services.veritas_data_quality_service import data_quality_summary
+from app.services.veritas_evidence_agent_service import to_dict as assessment_to_dict
+from app.services.veritas_training_dataset_service import list_dataset_entries
+from app.services.veritas_workspace_service import workspace_summary
+
+
+def _flatten(content: dict) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    for key, value in content.items():
+        if isinstance(value, (dict, list)):
+            rows.append((key, json.dumps(value, default=str)[:300]))
+        else:
+            rows.append((key, str(value)))
+    return rows
+
+
+def build_report_pdf_bytes(title: str, content: dict) -> bytes:
+    bio = BytesIO()
+    c = canvas.Canvas(bio, pagesize=letter)
+    width, height = letter
+    y = height - 50
+
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(50, y, title)
+    y -= 22
+    c.setFont("Helvetica", 9)
+    c.drawString(50, y, f"Generated: {datetime.now(timezone.utc).isoformat()}")
+    y -= 20
+
+    c.setFont("Helvetica", 9)
+    for key, value in _flatten(content):
+        if y < 50:
+            c.showPage()
+            y = height - 50
+        c.drawString(50, y, f"{key}: {value}"[:110])
+        y -= 13
+
+    c.showPage()
+    c.save()
+    return bio.getvalue()
+
+
+def build_report_csv_bytes(content: dict) -> bytes:
+    buf = StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["Key", "Value"])
+    for key, value in _flatten(content):
+        writer.writerow([key, value])
+    return buf.getvalue().encode("utf-8")
+
+
+def build_report_xlsx_bytes(title: str, content: dict) -> bytes:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = title[:31] or "Report"
+    ws.append(["Key", "Value"])
+    for key, value in _flatten(content):
+        ws.append([key, value])
+    bio = BytesIO()
+    wb.save(bio)
+    return bio.getvalue()
+
+
+def inspection_evidence_package(db: Session, tenant_id: str, assessment) -> dict:
+    return {"title": "Inspection Evidence Package", "content": assessment_to_dict(assessment)}
+
+
+def baseline_governance_report(db: Session, tenant_id: str) -> dict:
+    return {"title": "Baseline Governance Report", "content": workspace_summary(db, tenant_id)}
+
+
+def evidence_readiness_report(db: Session, tenant_id: str) -> dict:
+    return {"title": "Evidence Readiness Report", "content": workspace_summary(db, tenant_id)}
+
+
+def training_dataset_assurance_report(db: Session, tenant_id: str) -> dict:
+    entries = list_dataset_entries(db, tenant_id)
+    statuses: dict[str, int] = {}
+    for e in entries:
+        statuses[e["dataset_status"]] = statuses.get(e["dataset_status"], 0) + 1
+    return {"title": "Training Dataset Assurance Report", "content": {"total_entries": len(entries), "by_status": statuses}}
+
+
+def provenance_audit_report(db: Session, tenant_id: str) -> dict:
+    from app.services.veritas_provenance_service import list_provenance
+    entries = list_provenance(db, tenant_id)
+    return {"title": "Provenance Audit Report", "content": {"total_records": len(entries), "records": entries[:50]}}
+
+
+def baseline_review_aging_report(db: Session, tenant_id: str) -> dict:
+    from app.services.veritas_watchlist_service import baseline_review_overdue
+    return {"title": "Baseline Review Aging Report", "content": {"overdue": baseline_review_overdue(db, tenant_id)}}
+
+
+def data_quality_trend_report(db: Session, tenant_id: str) -> dict:
+    return {"title": "Data Quality Trend Report", "content": data_quality_summary(db, tenant_id)}
+
+
+REPORTS = {
+    "baseline_governance": baseline_governance_report,
+    "evidence_readiness": evidence_readiness_report,
+    "training_dataset_assurance": training_dataset_assurance_report,
+    "provenance_audit": provenance_audit_report,
+    "baseline_review_aging": baseline_review_aging_report,
+    "data_quality_trend": data_quality_trend_report,
+}
+
+
+def build_named_report(db: Session, tenant_id: str, name: str) -> dict | None:
+    fn = REPORTS.get(name)
+    return fn(db, tenant_id) if fn else None

--- a/backend/app/services/veritas_specialist_collaboration_service.py
+++ b/backend/app/services/veritas_specialist_collaboration_service.py
@@ -1,0 +1,84 @@
+"""Project Veritas, Section 16: Collaboration With Other Agents.
+
+Every function here reads another specialist's real output by reference and
+returns a Veritas-specific evidence opinion -- it never mutates or
+overwrites the source. No specialist may overwrite Veritas evidence
+findings; the orchestrator preserves separate agent conclusions by
+construction (each function below returns its own dict, never merged).
+"""
+from __future__ import annotations
+
+from app.models.veritas_evidence import (
+    DATASET_APPROVED_FOR_TRAINING,
+    READINESS_INSUFFICIENT,
+    READINESS_LIMITED,
+)
+
+
+def evidence_support_for_aegis(aegis_conclusion: dict, veritas_assessment: dict) -> dict:
+    """Section 16: does Veritas's evidence support Aegis's process
+    conclusion? Aegis's own signal (`aegis_conclusion`) is referenced
+    verbatim, never edited."""
+    supported = veritas_assessment["readiness_category"] not in (READINESS_INSUFFICIENT, READINESS_LIMITED)
+    return {
+        "source_aegis_conclusion": aegis_conclusion,
+        "source_veritas_assessment_id": veritas_assessment["id"],
+        "evidence_supports_conclusion": supported,
+        "opinion": (
+            "Evidence readiness is sufficient to support this process conclusion."
+            if supported else
+            "Evidence readiness is limited or insufficient -- this process conclusion should be treated as provisional "
+            "until additional evidence is captured."
+        ),
+    }
+
+
+def evidence_support_for_vulcan(veritas_assessments: list[dict]) -> dict:
+    """Section 16: confirms Vulcan's progression comparison used comparable
+    images/anatomy zones/baseline versions -- flags if the assessments being
+    compared don't share a baseline version."""
+    baseline_versions = {a.get("baseline_resolution_id") for a in veritas_assessments}
+    zones = {a.get("anatomy_zone", "") for a in veritas_assessments if a.get("anatomy_zone")}
+    comparable = len(baseline_versions) <= 1
+    return {
+        "source_veritas_assessment_ids": [a["id"] for a in veritas_assessments],
+        "images_comparable": comparable,
+        "anatomy_zones_referenced": sorted(zones),
+        "opinion": (
+            "Images used for this progression comparison share a common baseline resolution."
+            if comparable else
+            "Images used for this progression comparison were evaluated against different baseline resolutions -- "
+            "the progression trend should be treated with reduced confidence until re-verified against one baseline."
+        ),
+    }
+
+
+def evidence_support_for_sage(sage_image_entry: dict, veritas_training_entry: dict | None) -> dict:
+    """Section 16: confirms Sage's education content uses approved,
+    correctly labeled, rights-cleared images -- cross-checking Sage's own
+    curation fields against Veritas's independent training-dataset gate."""
+    veritas_approved = bool(veritas_training_entry) and veritas_training_entry["dataset_status"] == DATASET_APPROVED_FOR_TRAINING
+    sage_cleared = sage_image_entry.get("phi_review_status") == "cleared" and sage_image_entry.get("supervisor_validated")
+    return {
+        "source_sage_image_entry_id": sage_image_entry.get("id"),
+        "source_veritas_training_entry_id": veritas_training_entry.get("id") if veritas_training_entry else None,
+        "governed_for_education_use": sage_cleared and (veritas_training_entry is None or veritas_approved),
+        "opinion": (
+            "Image is validated, PHI-cleared, and rights-cleared for education use."
+            if sage_cleared else
+            "Image is missing supervisor validation or PHI clearance -- do not use in education content yet."
+        ),
+    }
+
+
+def evidence_support_for_clinical_reasoning(veritas_assessment: dict) -> dict:
+    """Section 16: evidence limitations and readiness status the Clinical
+    Reasoning Agent must consider before finalizing a recommendation."""
+    return {
+        "source_veritas_assessment_id": veritas_assessment["id"],
+        "readiness_category": veritas_assessment["readiness_category"],
+        "readiness_score": veritas_assessment["readiness_score"],
+        "limitations": veritas_assessment["limitations"],
+        "recommended_gate": veritas_assessment["recommended_gate"],
+        "opinion": veritas_assessment["next_action"],
+    }

--- a/backend/app/services/veritas_training_dataset_service.py
+++ b/backend/app/services/veritas_training_dataset_service.py
@@ -1,0 +1,126 @@
+"""Project Veritas, Section 15: Training Dataset Assurance.
+
+Gates a real `RetainedImage`/`ImageLabel` pair into a training-dataset
+status -- mirrors Sage's `SageEducationImageEntry` reference-by-ID pattern,
+extended with the training-specific checks this section names (confirmed
+finding/severity, image quality threshold, duplicate detection). Never
+allows an unvalidated inspection image into `approved_for_training`.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.retained_image import ImageLabel, RetainedImage
+from app.models.veritas_evidence import (
+    DATASET_APPROVED_FOR_TRAINING,
+    DATASET_EXCLUDED,
+    DATASET_PENDING_VALIDATION,
+    DATASET_QUARANTINED,
+    VeritasTrainingDatasetEntry,
+)
+
+
+def _is_duplicate(db: Session, tenant_id: str, sha256: str, exclude_image_id: int) -> bool:
+    if not sha256:
+        return False
+    return (
+        db.query(RetainedImage)
+        .filter(RetainedImage.tenant_id == tenant_id, RetainedImage.sha256 == sha256, RetainedImage.id != exclude_image_id)
+        .first()
+        is not None
+    )
+
+
+def evaluate_for_training(
+    db: Session, tenant_id: str, retained_image_id: int, *, instrument_family: str = "", anatomy_zone: str = "",
+    usage_rights: str = "", image_quality_threshold_met: bool = False,
+) -> VeritasTrainingDatasetEntry:
+    """Section 15: evaluate one image against every named gate and persist
+    the resulting dataset status + reason."""
+    image = db.query(RetainedImage).filter(RetainedImage.id == retained_image_id, RetainedImage.tenant_id == tenant_id).first()
+    if image is None:
+        raise ValueError("Retained image not found for this tenant")
+
+    label = (
+        db.query(ImageLabel)
+        .filter(ImageLabel.image_id == retained_image_id, ImageLabel.tenant_id == tenant_id)
+        .order_by(ImageLabel.is_gold.desc(), ImageLabel.created_at.desc())
+        .first()
+    )
+
+    is_duplicate = _is_duplicate(db, tenant_id, image.sha256, retained_image_id)
+    supervisor_validated = bool(label and label.is_gold)
+    phi_review_status = "cleared" if image.exif_stripped and image.consent_recorded else "pending"
+    provenance_complete = bool(image.sha256 and image.consent_recorded and image.uploaded_by)
+    finding_confirmed = bool(label and label.finding_type)
+    severity_labeled = bool(label and label.severity)
+
+    reasons = []
+    if is_duplicate:
+        reasons.append("duplicate image detected")
+    if not supervisor_validated:
+        reasons.append("not supervisor-validated (gold label required)")
+    if phi_review_status != "cleared":
+        reasons.append("PHI review not cleared")
+    if not usage_rights:
+        reasons.append("usage rights not declared")
+    if not image_quality_threshold_met:
+        reasons.append("image quality threshold not met")
+    if not finding_confirmed:
+        reasons.append("finding not confirmed")
+    if not severity_labeled:
+        reasons.append("severity not labeled")
+    if not provenance_complete:
+        reasons.append("provenance incomplete")
+
+    if is_duplicate:
+        status = DATASET_QUARANTINED
+    elif not image.consent_recorded:
+        status = DATASET_EXCLUDED
+    elif reasons:
+        status = DATASET_PENDING_VALIDATION
+    else:
+        status = DATASET_APPROVED_FOR_TRAINING
+
+    row = VeritasTrainingDatasetEntry(
+        tenant_id=tenant_id, retained_image_id=retained_image_id, image_label_id=label.id if label else None,
+        instrument_family=instrument_family or image.instrument_type, anatomy_zone=anatomy_zone,
+        finding_category=label.finding_type if label else "", severity=label.severity if label else "",
+        supervisor_validated=supervisor_validated, image_quality_threshold_met=image_quality_threshold_met,
+        usage_rights=usage_rights, phi_review_status=phi_review_status, is_duplicate=is_duplicate,
+        provenance_complete=provenance_complete, dataset_status=status,
+        status_reason="; ".join(reasons) if reasons else "All training-readiness checks passed.",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: VeritasTrainingDatasetEntry) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "retained_image_id": row.retained_image_id,
+        "image_label_id": row.image_label_id,
+        "instrument_family": row.instrument_family,
+        "anatomy_zone": row.anatomy_zone,
+        "finding_category": row.finding_category,
+        "severity": row.severity,
+        "supervisor_validated": row.supervisor_validated,
+        "image_quality_threshold_met": row.image_quality_threshold_met,
+        "usage_rights": row.usage_rights,
+        "dataset_version": row.dataset_version,
+        "phi_review_status": row.phi_review_status,
+        "is_duplicate": row.is_duplicate,
+        "provenance_complete": row.provenance_complete,
+        "dataset_status": row.dataset_status,
+        "status_reason": row.status_reason,
+    }
+
+
+def list_dataset_entries(db: Session, tenant_id: str, *, dataset_status: str = "") -> list[dict]:
+    q = db.query(VeritasTrainingDatasetEntry).filter(VeritasTrainingDatasetEntry.tenant_id == tenant_id)
+    if dataset_status:
+        q = q.filter(VeritasTrainingDatasetEntry.dataset_status == dataset_status)
+    return [to_dict(r) for r in q.order_by(VeritasTrainingDatasetEntry.created_at.desc()).all()]

--- a/backend/app/services/veritas_watchlist_service.py
+++ b/backend/app/services/veritas_watchlist_service.py
@@ -1,0 +1,178 @@
+"""Project Veritas, Section 18: Alerts and Watchlists.
+
+Every watchlist is a live query over already-persisted Veritas rows -- zero
+new tables. Each entry identifies an owner (responsible role) and a
+recommended next action, per the brief's explicit requirement.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.veritas_evidence import (
+    BASELINE_STATUS_DRAFT,
+    BASELINE_STATUS_PENDING_REVIEW,
+    BASELINE_STATUS_SUPERSEDED,
+    COVERAGE_INCOMPLETE,
+    COVERAGE_INSUFFICIENT,
+    DATASET_APPROVED_FOR_TRAINING,
+    FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE,
+    IMAGE_QUALITY_INSUFFICIENT,
+    MATCH_MISMATCH,
+    MATCH_UNAVAILABLE,
+    VeritasBaselineGovernanceAction,
+    VeritasEvidenceConflict,
+    VeritasEvidenceProvenanceRecord,
+    VeritasEvidenceReadinessAssessment,
+    VeritasFeedback,
+    VeritasTrainingDatasetEntry,
+)
+
+_MIN_REPEAT = 2
+
+
+def _entry(item: str, *, owner: str, next_action: str) -> dict:
+    return {"item": item, "owner": owner, "recommended_next_action": next_action}
+
+
+def no_approved_baseline(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(VeritasEvidenceReadinessAssessment)
+        .filter(VeritasEvidenceReadinessAssessment.tenant_id == tenant_id, VeritasEvidenceReadinessAssessment.match_classification == MATCH_UNAVAILABLE)
+        .all()
+    )
+    return [_entry(f"assessment:{r.id} ({r.instrument_identity})", owner="baseline_reviewer", next_action="Submit or approve a baseline for this instrument.") for r in rows]
+
+
+def _latest_governance_by_baseline(db: Session, tenant_id: str) -> dict[tuple, VeritasBaselineGovernanceAction]:
+    actions = db.query(VeritasBaselineGovernanceAction).filter(VeritasBaselineGovernanceAction.tenant_id == tenant_id).all()
+    latest: dict[tuple, VeritasBaselineGovernanceAction] = {}
+    for a in sorted(actions, key=lambda a: a.created_at):
+        latest[(a.baseline_source_type, a.baseline_source_id)] = a
+    return latest
+
+
+def baseline_review_overdue(db: Session, tenant_id: str) -> list[dict]:
+    now = datetime.now(timezone.utc)
+    latest = _latest_governance_by_baseline(db, tenant_id)
+    return [
+        _entry(f"{t}:{sid}", owner="baseline_reviewer", next_action="Complete the overdue baseline review.")
+        for (t, sid), a in latest.items()
+        if a.review_date and a.review_date < now and a.resulting_status in (BASELINE_STATUS_DRAFT, BASELINE_STATUS_PENDING_REVIEW, "")
+    ]
+
+
+def baseline_superseded(db: Session, tenant_id: str) -> list[dict]:
+    latest = _latest_governance_by_baseline(db, tenant_id)
+    return [
+        _entry(f"{t}:{sid}", owner="baseline_reviewer", next_action="Confirm the replacement baseline is in active use.")
+        for (t, sid), a in latest.items() if a.resulting_status == BASELINE_STATUS_SUPERSEDED
+    ]
+
+
+def repeated_poor_image_quality(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(VeritasEvidenceReadinessAssessment)
+        .filter(VeritasEvidenceReadinessAssessment.tenant_id == tenant_id, VeritasEvidenceReadinessAssessment.image_quality_status == IMAGE_QUALITY_INSUFFICIENT)
+        .all()
+    )
+    by_instrument: dict[str, int] = defaultdict(int)
+    for r in rows:
+        by_instrument[r.instrument_identity] += 1
+    return [
+        _entry(instrument, owner="technician", next_action="Recapture images meeting quality requirements.")
+        for instrument, count in by_instrument.items() if count >= _MIN_REPEAT
+    ]
+
+
+def repeated_incomplete_coverage(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(VeritasEvidenceReadinessAssessment)
+        .filter(VeritasEvidenceReadinessAssessment.tenant_id == tenant_id, VeritasEvidenceReadinessAssessment.coverage_status.in_([COVERAGE_INCOMPLETE, COVERAGE_INSUFFICIENT]))
+        .all()
+    )
+    by_instrument: dict[str, int] = defaultdict(int)
+    for r in rows:
+        by_instrument[r.instrument_identity] += 1
+    return [
+        _entry(instrument, owner="technician", next_action="Capture the missing required anatomy zones.")
+        for instrument, count in by_instrument.items() if count >= _MIN_REPEAT
+    ]
+
+
+def high_baseline_mismatch(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(VeritasEvidenceReadinessAssessment)
+        .filter(VeritasEvidenceReadinessAssessment.tenant_id == tenant_id, VeritasEvidenceReadinessAssessment.match_classification == MATCH_MISMATCH)
+        .all()
+    )
+    by_instrument: dict[str, int] = defaultdict(int)
+    for r in rows:
+        by_instrument[r.instrument_identity] += 1
+    return [
+        _entry(instrument, owner="baseline_reviewer", next_action="Resolve a correctly matched baseline for this instrument family.")
+        for instrument, count in by_instrument.items() if count >= _MIN_REPEAT
+    ]
+
+
+def conflicting_evidence(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(VeritasEvidenceConflict)
+        .filter(VeritasEvidenceConflict.tenant_id == tenant_id, VeritasEvidenceConflict.resolved.is_(False))
+        .all()
+    )
+    return [_entry(f"conflict:{c.id} ({c.conflict_type})", owner=c.responsible_reviewer_role or "supervisor", next_action=c.recommended_resolution) for c in rows]
+
+
+def unapproved_training_candidates(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(VeritasTrainingDatasetEntry)
+        .filter(VeritasTrainingDatasetEntry.tenant_id == tenant_id, VeritasTrainingDatasetEntry.dataset_status != DATASET_APPROVED_FOR_TRAINING)
+        .all()
+    )
+    return [_entry(f"training_entry:{e.id}", owner="dataset_reviewer", next_action=e.status_reason) for e in rows]
+
+
+def missing_provenance(db: Session, tenant_id: str) -> list[dict]:
+    rows = (
+        db.query(VeritasEvidenceProvenanceRecord)
+        .filter(VeritasEvidenceProvenanceRecord.tenant_id == tenant_id, VeritasEvidenceProvenanceRecord.file_hash == "")
+        .all()
+    )
+    return [_entry(f"provenance:{p.id} ({p.evidence_type})", owner="evidence_reviewer", next_action="Record the missing file hash/storage location.") for p in rows]
+
+
+def repeated_evidence_gate_override(db: Session, tenant_id: str) -> list[dict]:
+    overrides = (
+        db.query(VeritasFeedback)
+        .filter(VeritasFeedback.tenant_id == tenant_id, VeritasFeedback.action == FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE)
+        .all()
+    )
+    by_submitter: dict[str, int] = defaultdict(int)
+    for o in overrides:
+        by_submitter[o.submitted_by] += 1
+    return [
+        _entry(submitter, owner="quality_leadership", next_action="Review override pattern for this reviewer.")
+        for submitter, count in by_submitter.items() if count >= _MIN_REPEAT
+    ]
+
+
+WATCHLISTS = {
+    "no_approved_baseline": no_approved_baseline,
+    "baseline_review_overdue": baseline_review_overdue,
+    "baseline_superseded": baseline_superseded,
+    "repeated_poor_image_quality": repeated_poor_image_quality,
+    "repeated_incomplete_coverage": repeated_incomplete_coverage,
+    "high_baseline_mismatch": high_baseline_mismatch,
+    "conflicting_evidence": conflicting_evidence,
+    "unapproved_training_candidates": unapproved_training_candidates,
+    "missing_provenance": missing_provenance,
+    "repeated_evidence_gate_override": repeated_evidence_gate_override,
+}
+
+
+def run_watchlist(db: Session, tenant_id: str, name: str) -> list[dict] | None:
+    fn = WATCHLISTS.get(name)
+    return fn(db, tenant_id) if fn else None

--- a/backend/app/services/veritas_workspace_service.py
+++ b/backend/app/services/veritas_workspace_service.py
@@ -1,0 +1,95 @@
+"""Project Veritas, Section 11: Veritas Workspace (`/veritas`)."""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.veritas_evidence import (
+    BASELINE_STATUS_DRAFT,
+    BASELINE_STATUS_PENDING_REVIEW,
+    BASELINE_STATUS_SUPERSEDED,
+    COVERAGE_INCOMPLETE,
+    COVERAGE_INSUFFICIENT,
+    FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE,
+    IMAGE_QUALITY_INSUFFICIENT,
+    MATCH_UNAVAILABLE,
+    VeritasBaselineGovernanceAction,
+    VeritasEvidenceConflict,
+    VeritasEvidenceProvenanceRecord,
+    VeritasEvidenceReadinessAssessment,
+    VeritasFeedback,
+)
+
+
+def workspace_summary(
+    db: Session, tenant_id: str, *, instrument_family: str = "", anatomy_zone: str = "", date_from=None, date_to=None,
+) -> dict:
+    q = db.query(VeritasEvidenceReadinessAssessment).filter(VeritasEvidenceReadinessAssessment.tenant_id == tenant_id)
+    if date_from:
+        q = q.filter(VeritasEvidenceReadinessAssessment.created_at >= date_from)
+    if date_to:
+        q = q.filter(VeritasEvidenceReadinessAssessment.created_at <= date_to)
+    assessments = q.order_by(VeritasEvidenceReadinessAssessment.created_at.desc()).all()
+
+    readiness_overview: dict[str, int] = {}
+    for a in assessments:
+        readiness_overview[a.readiness_category] = readiness_overview.get(a.readiness_category, 0) + 1
+
+    missing_baseline_cases = [a for a in assessments if a.match_classification == MATCH_UNAVAILABLE]
+    insufficient_image_quality_cases = [a for a in assessments if a.image_quality_status == IMAGE_QUALITY_INSUFFICIENT]
+    incomplete_coverage_cases = [a for a in assessments if a.coverage_status in (COVERAGE_INCOMPLETE, COVERAGE_INSUFFICIENT)]
+
+    governance_actions = db.query(VeritasBaselineGovernanceAction).filter(VeritasBaselineGovernanceAction.tenant_id == tenant_id).all()
+    latest_by_baseline: dict[tuple, VeritasBaselineGovernanceAction] = {}
+    for action in sorted(governance_actions, key=lambda a: a.created_at):
+        latest_by_baseline[(action.baseline_source_type, action.baseline_source_id)] = action
+    pending_baseline_reviews = [a for a in latest_by_baseline.values() if a.resulting_status in (BASELINE_STATUS_DRAFT, BASELINE_STATUS_PENDING_REVIEW, "")]
+    superseded_baselines = [a for a in latest_by_baseline.values() if a.resulting_status == BASELINE_STATUS_SUPERSEDED]
+
+    conflicts = (
+        db.query(VeritasEvidenceConflict)
+        .filter(VeritasEvidenceConflict.tenant_id == tenant_id, VeritasEvidenceConflict.resolved.is_(False))
+        .all()
+    )
+
+    provenance_issues = (
+        db.query(VeritasEvidenceProvenanceRecord)
+        .filter(VeritasEvidenceProvenanceRecord.tenant_id == tenant_id, VeritasEvidenceProvenanceRecord.file_hash == "")
+        .all()
+    )
+
+    overrides = (
+        db.query(VeritasFeedback)
+        .filter(VeritasFeedback.tenant_id == tenant_id, VeritasFeedback.action == FEEDBACK_ACTION_OVERRIDE_EVIDENCE_GATE)
+        .all()
+    )
+
+    recent_scores = [a.readiness_score for a in assessments[:20]]
+    trend = "insufficient_data" if len(recent_scores) < 2 else (
+        "improving" if recent_scores[0] > recent_scores[-1] else
+        "declining" if recent_scores[0] < recent_scores[-1] else "stable"
+    )
+
+    return {
+        "evidence_readiness_overview": readiness_overview,
+        "pending_baseline_reviews": [
+            {"baseline_source_type": a.baseline_source_type, "baseline_source_id": a.baseline_source_id, "status": a.resulting_status}
+            for a in pending_baseline_reviews
+        ],
+        "missing_baseline_cases": [a.id for a in missing_baseline_cases],
+        "insufficient_image_quality_cases": [a.id for a in insufficient_image_quality_cases],
+        "incomplete_coverage_cases": [a.id for a in incomplete_coverage_cases],
+        "evidence_conflicts": [
+            {"id": c.id, "conflict_type": c.conflict_type, "severity": c.severity, "recommended_resolution": c.recommended_resolution}
+            for c in conflicts
+        ],
+        "superseded_baselines": [
+            {"baseline_source_type": a.baseline_source_type, "baseline_source_id": a.baseline_source_id} for a in superseded_baselines
+        ],
+        "unresolved_provenance_issues": [p.id for p in provenance_issues],
+        "supervisor_overrides": [
+            {"id": o.id, "assessment_id": o.assessment_id, "submitted_by": o.submitted_by, "override_reason": o.override_reason}
+            for o in overrides
+        ],
+        "evidence_quality_trend": trend,
+        "human_review_required": True,
+    }

--- a/backend/app/services/vulcan_aegis_integration_service.py
+++ b/backend/app/services/vulcan_aegis_integration_service.py
@@ -1,0 +1,78 @@
+"""Project Vulcan, Section 12: Integration With Aegis.
+
+There is no pre-existing "Aegis" platform anywhere in this codebase (verified
+via `grep -rn "aegis" app/` before writing this file). Rather than fabricate
+one, this computes an honest, minimal process-variation signal from real
+`Inspection.technician` concentration among the findings behind a Vulcan
+assessment -- the closest real, already-captured field to "process/workflow
+pattern." This is deliberately narrower than the brief's illustrative
+"evening shift" example, which this codebase has no data to support; the
+signal is always described in terms of what was actually measured.
+
+"No agent may overwrite the other's conclusion": `combine_conclusions` only
+ever concatenates both sides' text into a new `combined_conclusion` string --
+it never mutates or replaces Vulcan's own `reasoning_narrative` or an Aegis
+conclusion already stored in `aegis_conclusion_json`.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+from app.models.inspection_finding import InspectionFinding
+
+
+def compute_process_variation_signal(db, tenant_id: str, instrument_identity: str, zone: str | None = None) -> dict:
+    """Section 12: Aegis's evidence -- real technician concentration, never fabricated."""
+    from app.services.vulcan_progression_service import _inspections_for_identity
+
+    inspections = _inspections_for_identity(db, tenant_id, instrument_identity)
+    if zone:
+        ids = [i.id for i in inspections]
+        zoned_ids = {
+            f.inspection_id
+            for f in db.query(InspectionFinding).filter(InspectionFinding.inspection_id.in_(ids), InspectionFinding.zone == zone)
+        } if ids else set()
+        inspections = [i for i in inspections if i.id in zoned_ids]
+
+    technicians = [i.technician for i in inspections if i.technician]
+    sample_size = len(technicians)
+    if sample_size < 2:
+        return {
+            "process_variation_detected": False,
+            "sample_size": sample_size,
+            "concentrated_on": "",
+            "concentration_pct": 0.0,
+            "narrative": "Insufficient technician-attributed inspection history to assess process variation.",
+        }
+
+    counts = Counter(technicians)
+    top_technician, top_count = counts.most_common(1)[0]
+    concentration_pct = round(100.0 * top_count / sample_size, 1)
+    detected = concentration_pct >= 60.0
+
+    narrative = (
+        f"{concentration_pct}% of the relevant inspections were performed by the same technician "
+        f"({top_count} of {sample_size}), a possible contributing process-variation pattern."
+        if detected
+        else "No single technician accounts for a majority of the relevant inspections; "
+        "no clear process-variation concentration detected."
+    )
+
+    return {
+        "process_variation_detected": detected,
+        "sample_size": sample_size,
+        "concentrated_on": top_technician if detected else "",
+        "concentration_pct": concentration_pct,
+        "narrative": narrative,
+    }
+
+
+def combine_conclusions(vulcan_narrative: str, aegis_conclusion: dict) -> str:
+    """Combine both agents' evidence without overwriting either side."""
+    if not aegis_conclusion.get("process_variation_detected"):
+        return vulcan_narrative
+    return (
+        f"{vulcan_narrative} Instrument failures may involve both repeated process exposure "
+        f"({aegis_conclusion['narrative']}) and progressive material degradation. Human review required "
+        "to confirm either contributor before action."
+    )

--- a/backend/app/services/vulcan_anatomy_zone_service.py
+++ b/backend/app/services/vulcan_anatomy_zone_service.py
@@ -1,0 +1,51 @@
+"""Project Vulcan, Section 4: Anatomy-Zone Reliability Analysis.
+
+Groups an instrument's real finding history (via `vulcan_progression_service`)
+by anatomy zone, and attaches the real family-level "recommended manual
+inspection" guidance already curated in `instrument_family_profiles.py`
+(inspection_priorities / manual_steps) rather than inventing new guidance
+text per zone.
+"""
+from __future__ import annotations
+
+from app.services.instrument_anatomy import get_anatomy
+from app.services.vulcan_failure_taxonomy_service import classify_finding_type
+from app.services.vulcan_progression_service import findings_timeline
+
+
+def _manual_inspection_guidance(instrument_type: str) -> list[str]:
+    return get_anatomy(instrument_type).get("manual_steps", []) if instrument_type else []
+
+
+def zone_reliability_analysis(db, tenant_id: str, instrument_identity: str, instrument_type: str) -> dict:
+    """Section 4 output: one entry per zone that has real finding history."""
+    timeline = findings_timeline(db, tenant_id, instrument_identity)
+    zones = sorted({row["zone"] for row in timeline if row["zone"]})
+    manual_steps = _manual_inspection_guidance(instrument_type)
+
+    zone_reports = []
+    for zone in zones:
+        zone_timeline = [row for row in timeline if row["zone"] == zone]
+        severities = [row["severity_index"] for row in zone_timeline]
+        taxonomy = [classify_finding_type(row["finding_type"]) for row in zone_timeline]
+        leaves = sorted({t["taxonomy_leaf"] for t in taxonomy})
+        severity_trend = (
+            "worsening" if len(severities) >= 2 and severities[-1] > severities[0]
+            else "improving" if len(severities) >= 2 and severities[-1] < severities[0]
+            else "stable"
+        )
+        zone_reports.append({
+            "anatomy_zone": zone,
+            "failure_categories": leaves,
+            "recurrence_count": len(zone_timeline),
+            "severity_trend": severity_trend,
+            "latest_severity_index": severities[-1] if severities else 0,
+            "recommended_manual_inspection": manual_steps,
+        })
+
+    zone_reports.sort(key=lambda z: z["recurrence_count"], reverse=True)
+    return {
+        "instrument_identity": instrument_identity,
+        "instrument_type": instrument_type,
+        "zones": zone_reports,
+    }

--- a/backend/app/services/vulcan_executive_analytics_service.py
+++ b/backend/app/services/vulcan_executive_analytics_service.py
@@ -1,0 +1,171 @@
+"""Project Vulcan, Section 14: Executive Reliability Analytics.
+
+Every metric here is a live aggregation over real `VulcanReliabilityAssessment`
+and `RepairRequest` rows (plus real `Inspection.facility_name` and
+`SurgicalCase.service_line` joins where those fields exist). Presents
+observations, never unsupported causation -- no metric claims a cause, only
+counts/rates/averages of what was actually recorded.
+
+"Reliability by manufacturer/model" is reported by manufacturer only:
+`VulcanReliabilityAssessment` does not carry a per-instrument model field
+(no module in this codebase tracks model at the per-physical-instrument
+level, only at the `InstrumentKnowledge` manufacturer+family reference-data
+level) -- rather than fabricate a model breakdown, this is left as a known
+gap and documented as such.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.or_connect import REPAIR_REPLACED, REPAIR_RETURNED, RepairRequest, SurgicalCase
+from app.models.vulcan_reliability import (
+    DISPOSITION_REMOVE_FROM_SERVICE,
+    REPAIR_OUTCOME_EFFECTIVE,
+    REPAIR_OUTCOME_FAILURE_RECURRED,
+)
+from app.services.vulcan_repair_effectiveness_service import classify_repair_outcome
+from app.services.vulcan_watchlist_service import _latest_per_instrument, retirement_candidates
+
+
+def most_failure_prone_instrument_families(db: Session, tenant_id: str) -> list[dict]:
+    counts: dict[str, int] = defaultdict(int)
+    for row in _latest_per_instrument(db, tenant_id):
+        counts[row.instrument_family or "unspecified"] += 1
+    return sorted(({"instrument_family": k, "instrument_count": v} for k, v in counts.items()), key=lambda r: r["instrument_count"], reverse=True)
+
+
+def most_common_failure_zones(db: Session, tenant_id: str) -> list[dict]:
+    counts: dict[str, int] = defaultdict(int)
+    for row in _latest_per_instrument(db, tenant_id):
+        if row.anatomy_zone:
+            counts[row.anatomy_zone] += 1
+    return sorted(({"anatomy_zone": k, "instrument_count": v} for k, v in counts.items()), key=lambda r: r["instrument_count"], reverse=True)
+
+
+def repeat_repair_rate(db: Session, tenant_id: str) -> dict:
+    counts: dict[str, int] = defaultdict(int)
+    for r in db.query(RepairRequest).filter(RepairRequest.tenant_id == tenant_id):
+        counts[r.instrument_identity] += 1
+    total = len(counts)
+    repeat = sum(1 for c in counts.values() if c >= 2)
+    return {"instruments_with_repairs": total, "instruments_with_repeat_repairs": repeat,
+            "repeat_repair_rate_pct": round(100.0 * repeat / total, 1) if total else 0.0}
+
+
+def repair_recurrence_rate(db: Session, tenant_id: str) -> dict:
+    repairs = (
+        db.query(RepairRequest)
+        .filter(RepairRequest.tenant_id == tenant_id, RepairRequest.status.in_([REPAIR_RETURNED, REPAIR_REPLACED]))
+        .all()
+    )
+    outcomes = [classify_repair_outcome(db, tenant_id, r)["repair_outcome"] for r in repairs]
+    total = len(outcomes)
+    recurred = sum(1 for o in outcomes if o == REPAIR_OUTCOME_FAILURE_RECURRED)
+    return {"completed_repairs_evaluated": total, "repairs_with_recurrence": recurred,
+            "repair_recurrence_rate_pct": round(100.0 * recurred / total, 1) if total else 0.0}
+
+
+def corrosion_progression_summary(db: Session, tenant_id: str) -> dict:
+    counts: dict[str, int] = defaultdict(int)
+    for row in _latest_per_instrument(db, tenant_id):
+        if row.failure_category == "corrosion":
+            counts[row.progression] += 1
+    return dict(counts)
+
+
+def instruments_removed_from_service(db: Session, tenant_id: str) -> list[dict]:
+    from app.services.vulcan_reliability_agent_service import to_dict
+    return [
+        to_dict(r) for r in _latest_per_instrument(db, tenant_id)
+        if r.recommended_disposition == DISPOSITION_REMOVE_FROM_SERVICE or r.final_disposition == DISPOSITION_REMOVE_FROM_SERVICE
+    ]
+
+
+def reliability_by_manufacturer(db: Session, tenant_id: str) -> list[dict]:
+    scores: dict[str, list[float]] = defaultdict(list)
+    for row in _latest_per_instrument(db, tenant_id):
+        scores[row.manufacturer_name or "unspecified"].append(row.reliability_score)
+    return sorted(
+        ({"manufacturer_name": k, "average_reliability_score": round(sum(v) / len(v), 1), "instrument_count": len(v)}
+         for k, v in scores.items()),
+        key=lambda r: r["average_reliability_score"],
+    )
+
+
+def reliability_by_facility(db: Session, tenant_id: str) -> list[dict]:
+    facility_by_identity: dict[str, str] = {}
+    for i in db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id):
+        identity = (
+            f"barcode:{i.instrument_barcode}" if i.instrument_barcode
+            else f"udi:{i.instrument_udi}" if i.instrument_udi else None
+        )
+        if identity and identity not in facility_by_identity and i.facility_name:
+            facility_by_identity[identity] = i.facility_name
+
+    scores: dict[str, list[float]] = defaultdict(list)
+    for row in _latest_per_instrument(db, tenant_id):
+        facility = facility_by_identity.get(row.instrument_identity, "unspecified")
+        scores[facility].append(row.reliability_score)
+    return sorted(
+        ({"facility_name": k, "average_reliability_score": round(sum(v) / len(v), 1), "instrument_count": len(v)}
+         for k, v in scores.items()),
+        key=lambda r: r["average_reliability_score"],
+    )
+
+
+def reliability_by_service_line(db: Session, tenant_id: str) -> list[dict]:
+    case_service_line = {
+        c.id: c.service_line for c in db.query(SurgicalCase).filter(SurgicalCase.tenant_id == tenant_id)
+    }
+    service_line_by_identity: dict[str, str] = {}
+    for i in db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id):
+        identity = (
+            f"barcode:{i.instrument_barcode}" if i.instrument_barcode
+            else f"udi:{i.instrument_udi}" if i.instrument_udi else None
+        )
+        if identity and identity not in service_line_by_identity and i.case_id:
+            line = case_service_line.get(i.case_id)
+            if line:
+                service_line_by_identity[identity] = line
+
+    scores: dict[str, list[float]] = defaultdict(list)
+    for row in _latest_per_instrument(db, tenant_id):
+        line = service_line_by_identity.get(row.instrument_identity, "unspecified")
+        scores[line].append(row.reliability_score)
+    return sorted(
+        ({"service_line": k, "average_reliability_score": round(sum(v) / len(v), 1), "instrument_count": len(v)}
+         for k, v in scores.items()),
+        key=lambda r: r["average_reliability_score"],
+    )
+
+
+def avoided_repeat_repair_opportunities(db: Session, tenant_id: str) -> dict:
+    """Repairs classified `effective` -- evidence a repeat repair was not needed."""
+    repairs = (
+        db.query(RepairRequest)
+        .filter(RepairRequest.tenant_id == tenant_id, RepairRequest.status.in_([REPAIR_RETURNED, REPAIR_REPLACED]))
+        .all()
+    )
+    outcomes = [classify_repair_outcome(db, tenant_id, r)["repair_outcome"] for r in repairs]
+    effective = sum(1 for o in outcomes if o == REPAIR_OUTCOME_EFFECTIVE)
+    return {"completed_repairs_evaluated": len(outcomes), "effective_repairs": effective}
+
+
+def executive_summary(db: Session, tenant_id: str) -> dict:
+    return {
+        "most_failure_prone_instrument_families": most_failure_prone_instrument_families(db, tenant_id),
+        "most_common_failure_zones": most_common_failure_zones(db, tenant_id),
+        "repeat_repair_rate": repeat_repair_rate(db, tenant_id),
+        "repair_recurrence_rate": repair_recurrence_rate(db, tenant_id),
+        "corrosion_progression": corrosion_progression_summary(db, tenant_id),
+        "instruments_removed_from_service": instruments_removed_from_service(db, tenant_id),
+        "reliability_by_manufacturer": reliability_by_manufacturer(db, tenant_id),
+        "reliability_by_facility": reliability_by_facility(db, tenant_id),
+        "reliability_by_service_line": reliability_by_service_line(db, tenant_id),
+        "retirement_candidates": retirement_candidates(db, tenant_id),
+        "avoided_repeat_repair_opportunities": avoided_repeat_repair_opportunities(db, tenant_id),
+        "human_review_required": True,
+    }

--- a/backend/app/services/vulcan_failure_taxonomy_service.py
+++ b/backend/app/services/vulcan_failure_taxonomy_service.py
@@ -1,0 +1,114 @@
+"""Project Vulcan, Section 2: Instrument Failure Taxonomy.
+
+Maps real `InspectionFinding.finding_type` strings (the actual detection
+vocabulary logged by the CV pipeline -- "blood", "corrosion", "crack",
+"insulation_damage", etc., see `baseline_comparison_scoring_service.CLEANING_KPIS`
+and `KPI_LABELS`) onto Vulcan's more granular taxonomy leaves declared in
+`app.models.vulcan_reliability.FAILURE_TAXONOMY`. Where the real detection
+vocabulary is coarser than a taxonomy leaf (e.g. a single "corrosion" finding
+type maps onto one specific leaf, not several), this is an honest one-to-one
+or many-to-one mapping -- never a fabricated finer-grained classification the
+CV pipeline never actually produced.
+"""
+from __future__ import annotations
+
+from app.models.vulcan_reliability import (
+    FAIL_ANATOMY_NOT_RECOGNIZED,
+    FAIL_BENT_COMPONENT,
+    FAIL_CORROSION,
+    FAIL_CRACK,
+    FAIL_DAMAGED_HINGE,
+    FAIL_DAMAGED_O_RING,
+    FAIL_DAMAGED_RATCHET,
+    FAIL_DEBRIS,
+    FAIL_DISCOLORATION,
+    FAIL_IMAGE_QUALITY_LIMITATION,
+    FAIL_INSUFFICIENT_EVIDENCE,
+    FAIL_INSULATION_BREACH,
+    FAIL_LOOSE_JOINT,
+    FAIL_MISSING_COMPONENT,
+    FAIL_ORGANIC_RESIDUE,
+    FAIL_PITTING,
+    FAIL_RETAINED_BLOOD,
+    FAIL_RETAINED_BONE,
+    FAIL_RUST,
+    FAIL_TISSUE,
+    FAILURE_TAXONOMY,
+    TAXONOMY_GROUP_CLEANING,
+    TAXONOMY_GROUP_CONDITION,
+    TAXONOMY_GROUP_MECHANICAL,
+    TAXONOMY_GROUP_UNKNOWN,
+)
+
+# Real `finding_type` strings actually produced by the CV/scoring pipeline
+# (see CLEANING_KPIS/KPI_LABELS) mapped onto the closest Vulcan taxonomy leaf.
+_FINDING_TYPE_TO_LEAF: dict[str, str] = {
+    "blood": FAIL_RETAINED_BLOOD,
+    "bone": FAIL_RETAINED_BONE,
+    "tissue": FAIL_TISSUE,
+    "other_organic_residue": FAIL_ORGANIC_RESIDUE,
+    "debris": FAIL_DEBRIS,
+    "rust": FAIL_RUST,
+    "discoloration": FAIL_DISCOLORATION,
+    "corrosion": FAIL_CORROSION,
+    "pitting": FAIL_PITTING,
+    "crack": FAIL_CRACK,
+    "insulation_damage": FAIL_INSULATION_BREACH,
+    "missing_component": FAIL_MISSING_COMPONENT,
+    # additional real finding_type values seen elsewhere in the pipeline.
+    "loose_joint": FAIL_LOOSE_JOINT,
+    "damaged_hinge": FAIL_DAMAGED_HINGE,
+    "damaged_ratchet": FAIL_DAMAGED_RATCHET,
+    "bent_component": FAIL_BENT_COMPONENT,
+    "damaged_o_ring": FAIL_DAMAGED_O_RING,
+    "o_ring_wear": FAIL_DAMAGED_O_RING,
+}
+
+_LEAF_TO_GROUP: dict[str, str] = {
+    leaf: group for group, leaves in FAILURE_TAXONOMY.items() for leaf in leaves
+}
+
+
+def classify_finding_type(finding_type: str) -> dict:
+    """Classify a real `finding_type` string into a Vulcan taxonomy leaf/group.
+
+    Falls back to the Unknown group (`insufficient_evidence`) rather than
+    guessing at a fabricated classification for a finding_type not in the
+    real vocabulary above.
+    """
+    leaf = _FINDING_TYPE_TO_LEAF.get((finding_type or "").strip().lower())
+    if leaf is None:
+        return {
+            "finding_type": finding_type,
+            "taxonomy_leaf": FAIL_INSUFFICIENT_EVIDENCE,
+            "taxonomy_group": TAXONOMY_GROUP_UNKNOWN,
+            "recognized": False,
+        }
+    return {
+        "finding_type": finding_type,
+        "taxonomy_leaf": leaf,
+        "taxonomy_group": _LEAF_TO_GROUP.get(leaf, TAXONOMY_GROUP_UNKNOWN),
+        "recognized": True,
+    }
+
+
+def taxonomy_tree() -> dict:
+    """Full taxonomy for the forensics workspace's filter dropdowns."""
+    return {"groups": FAILURE_TAXONOMY}
+
+
+def is_cleaning_related(finding_type: str) -> bool:
+    return classify_finding_type(finding_type)["taxonomy_group"] == TAXONOMY_GROUP_CLEANING
+
+
+def is_condition_related(finding_type: str) -> bool:
+    return classify_finding_type(finding_type)["taxonomy_group"] == TAXONOMY_GROUP_CONDITION
+
+
+def is_mechanical(finding_type: str) -> bool:
+    return classify_finding_type(finding_type)["taxonomy_group"] == TAXONOMY_GROUP_MECHANICAL
+
+
+def image_quality_unknown(finding_type: str) -> bool:
+    leaf = classify_finding_type(finding_type)["taxonomy_leaf"]
+    return leaf in (FAIL_INSUFFICIENT_EVIDENCE, FAIL_IMAGE_QUALITY_LIMITATION, FAIL_ANATOMY_NOT_RECOGNIZED)

--- a/backend/app/services/vulcan_feedback_service.py
+++ b/backend/app/services/vulcan_feedback_service.py
@@ -1,0 +1,94 @@
+"""Project Vulcan, Section 13: Supervisor and Repair Feedback.
+
+`VulcanFeedback` is a new table (distinct from the pipeline's own
+`SupervisorReview` -- see `app.models.vulcan_reliability` module docstring)
+because Vulcan's checklist needs progression/repair-effectiveness/probable-
+contributor correctness fields and repair-vendor/manufacturer response text
+`SupervisorReview` was never built for.
+
+This is the ONLY place `final_disposition` is ever set -- on both the new
+`VulcanFeedback` row and, when provided, back onto the originating
+`VulcanReliabilityAssessment.final_disposition`/`finalized_by`/`finalized_at`.
+Vulcan's own orchestrator (`vulcan_reliability_agent_service`) never writes to
+these fields -- this is the structural enforcement of "Vulcan cannot
+independently finalize irreversible disposition."
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.vulcan_reliability import VulcanFeedback, VulcanReliabilityAssessment
+
+
+def submit_feedback(
+    db: Session, tenant_id: str, assessment_id: int, *, submitted_by: str, submitted_role: str = "",
+    failure_classification_correct: bool | None = None, anatomy_zone_correct: bool | None = None,
+    progression_correct: bool | None = None, repair_effectiveness_correct: bool | None = None,
+    probable_contributor_correct: bool | None = None, final_disposition: str = "",
+    supervisor_rationale: str = "", repair_vendor_response: str = "", manufacturer_response: str = "",
+) -> VulcanFeedback:
+    assessment = (
+        db.query(VulcanReliabilityAssessment)
+        .filter(VulcanReliabilityAssessment.id == assessment_id, VulcanReliabilityAssessment.tenant_id == tenant_id)
+        .first()
+    )
+    if assessment is None:
+        raise ValueError("Vulcan reliability assessment not found for this tenant")
+
+    feedback = VulcanFeedback(
+        assessment_id=assessment_id,
+        tenant_id=tenant_id,
+        failure_classification_correct=failure_classification_correct,
+        anatomy_zone_correct=anatomy_zone_correct,
+        progression_correct=progression_correct,
+        repair_effectiveness_correct=repair_effectiveness_correct,
+        probable_contributor_correct=probable_contributor_correct,
+        final_disposition=final_disposition,
+        supervisor_rationale=supervisor_rationale,
+        repair_vendor_response=repair_vendor_response,
+        manufacturer_response=manufacturer_response,
+        submitted_by=submitted_by,
+        submitted_role=submitted_role,
+    )
+    db.add(feedback)
+
+    if final_disposition:
+        assessment.final_disposition = final_disposition
+        assessment.finalized_by = submitted_by
+        assessment.finalized_at = datetime.now(timezone.utc)
+
+    db.commit()
+    db.refresh(feedback)
+    return feedback
+
+
+def _feedback_to_dict(row: VulcanFeedback) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "assessment_id": row.assessment_id,
+        "tenant_id": row.tenant_id,
+        "failure_classification_correct": row.failure_classification_correct,
+        "anatomy_zone_correct": row.anatomy_zone_correct,
+        "progression_correct": row.progression_correct,
+        "repair_effectiveness_correct": row.repair_effectiveness_correct,
+        "probable_contributor_correct": row.probable_contributor_correct,
+        "final_disposition": row.final_disposition,
+        "supervisor_rationale": row.supervisor_rationale,
+        "repair_vendor_response": row.repair_vendor_response,
+        "manufacturer_response": row.manufacturer_response,
+        "submitted_by": row.submitted_by,
+        "submitted_role": row.submitted_role,
+    }
+
+
+def feedback_for_assessment(db: Session, tenant_id: str, assessment_id: int) -> list[dict]:
+    rows = (
+        db.query(VulcanFeedback)
+        .filter(VulcanFeedback.tenant_id == tenant_id, VulcanFeedback.assessment_id == assessment_id)
+        .order_by(VulcanFeedback.created_at.asc())
+        .all()
+    )
+    return [_feedback_to_dict(r) for r in rows]

--- a/backend/app/services/vulcan_forensics_service.py
+++ b/backend/app/services/vulcan_forensics_service.py
@@ -1,0 +1,94 @@
+"""Project Vulcan, Section 9: Instrument Forensics Workspace.
+
+Composes one instrument's full forensic record for `/instrument-forensics`:
+identity, real Digital Twin / anatomy profile references (by version string
+only -- never copied), inspection/finding history, repair history, reliability
+score, probable contributors, and recommended disposition. Filtering supports
+every facet the brief names.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.models.or_connect import RepairRequest
+from app.models.vulcan_reliability import VulcanReliabilityAssessment
+from app.services.instrument_anatomy import anatomy_profile
+from app.services.vulcan_progression_service import _inspections_for_identity, findings_timeline
+from app.services.vulcan_reliability_agent_service import to_dict
+from app.services.vulcan_repair_effectiveness_service import repair_history_for_instrument
+
+
+def instrument_forensics_record(db: Session, tenant_id: str, instrument_identity: str, instrument_type: str = "") -> dict:
+    """Section 9: full forensics workspace payload for one instrument."""
+    latest_assessment = (
+        db.query(VulcanReliabilityAssessment)
+        .filter(
+            VulcanReliabilityAssessment.tenant_id == tenant_id,
+            VulcanReliabilityAssessment.instrument_identity == instrument_identity,
+        )
+        .order_by(VulcanReliabilityAssessment.created_at.desc())
+        .first()
+    )
+    inspections = _inspections_for_identity(db, tenant_id, instrument_identity)
+    timeline = findings_timeline(db, tenant_id, instrument_identity)
+    repairs = repair_history_for_instrument(db, tenant_id, instrument_identity)
+    profile = anatomy_profile(instrument_type) if instrument_type else None
+
+    return {
+        "instrument_identity": instrument_identity,
+        "anatomy_profile": profile,
+        "inspection_history": [
+            {"inspection_id": i.id, "created_at": i.created_at.isoformat() if i.created_at else None,
+             "facility_name": i.facility_name, "disposition": i.disposition}
+            for i in inspections
+        ],
+        "finding_timeline": [
+            {**row, "created_at": row["created_at"].isoformat() if row["created_at"] else None} for row in timeline
+        ],
+        "repair_history": repairs,
+        "latest_assessment": to_dict(latest_assessment) if latest_assessment else None,
+    }
+
+
+def search_forensics(
+    db: Session, tenant_id: str, *, manufacturer: str = "", instrument_family: str = "",
+    anatomy_zone: str = "", failure_category: str = "", repair_vendor: str = "",
+    facility: str = "", date_from=None, date_to=None,
+) -> list[dict]:
+    """Section 9 filters: manufacturer/instrument family/model/anatomy zone/
+    failure category/repair vendor/facility/date range."""
+    q = db.query(VulcanReliabilityAssessment).filter(VulcanReliabilityAssessment.tenant_id == tenant_id)
+    if manufacturer:
+        q = q.filter(VulcanReliabilityAssessment.manufacturer_name == manufacturer)
+    if instrument_family:
+        q = q.filter(VulcanReliabilityAssessment.instrument_family == instrument_family)
+    if anatomy_zone:
+        q = q.filter(VulcanReliabilityAssessment.anatomy_zone == anatomy_zone)
+    if failure_category:
+        q = q.filter(VulcanReliabilityAssessment.failure_category == failure_category)
+    if date_from:
+        q = q.filter(VulcanReliabilityAssessment.created_at >= date_from)
+    if date_to:
+        q = q.filter(VulcanReliabilityAssessment.created_at <= date_to)
+    rows = q.order_by(VulcanReliabilityAssessment.created_at.desc()).all()
+
+    results = [to_dict(r) for r in rows]
+
+    if repair_vendor:
+        identities_with_vendor = {
+            r.instrument_identity for r in
+            db.query(RepairRequest).filter(RepairRequest.tenant_id == tenant_id, RepairRequest.vendor_name == repair_vendor)
+        }
+        results = [r for r in results if r["instrument_identity"] in identities_with_vendor]
+
+    if facility:
+        identities_with_facility = {
+            i.instrument_barcode and f"barcode:{i.instrument_barcode}" or (i.instrument_udi and f"udi:{i.instrument_udi}")
+            for i in db.query(models.Inspection).filter(
+                models.Inspection.tenant_id == tenant_id, models.Inspection.facility_name == facility,
+            )
+        }
+        results = [r for r in results if r["instrument_identity"] in identities_with_facility]
+
+    return results

--- a/backend/app/services/vulcan_probable_cause_service.py
+++ b/backend/app/services/vulcan_probable_cause_service.py
@@ -1,0 +1,86 @@
+"""Project Vulcan, Section 6: Probable Cause Classification.
+
+Every probable cause is a "probable contributor," never a definitive root
+cause, and always carries evidence, confidence, at least one alternative
+explanation, and a recommended verification step -- per the brief's explicit
+instruction not to claim causation.
+"""
+from __future__ import annotations
+
+from app.models.vulcan_reliability import (
+    CAUSE_ASSEMBLY_DAMAGE,
+    CAUSE_HANDLING_DAMAGE,
+    CAUSE_HEAVY_USE,
+    CAUSE_INADEQUATE_DRYING,
+    CAUSE_INCOMPLETE_CLEANING,
+    CAUSE_MATERIAL_DEGRADATION,
+    CAUSE_MOISTURE_EXPOSURE,
+    CAUSE_NORMAL_WEAR,
+    CAUSE_REPAIR_RECURRENCE,
+    CAUSE_SUSPECTED_MANUFACTURING_DESIGN_ISSUE,
+    CAUSE_UNKNOWN,
+    REPAIR_OUTCOME_FAILURE_RECURRED,
+    TAXONOMY_GROUP_CLEANING,
+    TAXONOMY_GROUP_CONDITION,
+    TAXONOMY_GROUP_INSULATION,
+    TAXONOMY_GROUP_MECHANICAL,
+    TAXONOMY_GROUP_POWERED_ORTHOPEDIC,
+    TAXONOMY_GROUP_SCOPE_SPECIFIC,
+    TAXONOMY_GROUP_UNKNOWN,
+)
+
+_GROUP_CANDIDATE_CAUSES = {
+    TAXONOMY_GROUP_CLEANING: [CAUSE_INCOMPLETE_CLEANING],
+    TAXONOMY_GROUP_CONDITION: [CAUSE_MOISTURE_EXPOSURE, CAUSE_INADEQUATE_DRYING, CAUSE_NORMAL_WEAR],
+    TAXONOMY_GROUP_MECHANICAL: [CAUSE_HEAVY_USE, CAUSE_HANDLING_DAMAGE, CAUSE_ASSEMBLY_DAMAGE, CAUSE_NORMAL_WEAR],
+    TAXONOMY_GROUP_SCOPE_SPECIFIC: [CAUSE_HANDLING_DAMAGE, CAUSE_MATERIAL_DEGRADATION],
+    TAXONOMY_GROUP_POWERED_ORTHOPEDIC: [CAUSE_HEAVY_USE, CAUSE_MATERIAL_DEGRADATION],
+    TAXONOMY_GROUP_INSULATION: [CAUSE_HANDLING_DAMAGE, CAUSE_MATERIAL_DEGRADATION],
+    TAXONOMY_GROUP_UNKNOWN: [CAUSE_UNKNOWN],
+}
+
+_ALTERNATIVE_EXPLANATIONS = {
+    TAXONOMY_GROUP_CLEANING: "A single missed pass during manual brushing/flushing is also plausible and would not indicate a systemic process issue.",
+    TAXONOMY_GROUP_CONDITION: "Lighting or image-angle variation may exaggerate the apparent surface change.",
+    TAXONOMY_GROUP_MECHANICAL: "Normal cumulative use over the instrument's service life may account for the same finding without any single damaging event.",
+    TAXONOMY_GROUP_SCOPE_SPECIFIC: "Component wear consistent with expected service life may account for the finding independent of any single incident.",
+    TAXONOMY_GROUP_POWERED_ORTHOPEDIC: "High-torque procedures naturally accelerate wear on cutting surfaces without indicating a defect.",
+    TAXONOMY_GROUP_INSULATION: "Minor surface marking from routine tray handling may resemble early insulation wear without an actual breach.",
+    TAXONOMY_GROUP_UNKNOWN: "Insufficient evidence is available to distinguish among possible contributors.",
+}
+
+_VERIFICATION = {
+    TAXONOMY_GROUP_CLEANING: "Re-inspect after a supervised reclean and compare against the approved baseline images.",
+    TAXONOMY_GROUP_CONDITION: "Compare current images with the approved baseline and prior inspection images under consistent lighting.",
+    TAXONOMY_GROUP_MECHANICAL: "Manual function check by a supervisor or clinical engineering, comparing to manufacturer tolerance specifications.",
+    TAXONOMY_GROUP_SCOPE_SPECIFIC: "Bench test the affected component (o-ring/seal/lens/sheath) against manufacturer specification.",
+    TAXONOMY_GROUP_POWERED_ORTHOPEDIC: "Manufacturer or clinical engineering evaluation of the cutting surface against wear tolerance.",
+    TAXONOMY_GROUP_INSULATION: "Electrical insulation integrity test before further clinical use.",
+    TAXONOMY_GROUP_UNKNOWN: "Recapture images meeting coverage requirements before a probable cause can be assessed.",
+}
+
+
+def classify_probable_causes(
+    taxonomy_group: str, *, repair_outcome: str | None = None, recurrence_count: int = 0,
+) -> list[dict]:
+    """Section 6: probable contributors for one taxonomy group + repair context."""
+    candidates = list(_GROUP_CANDIDATE_CAUSES.get(taxonomy_group, [CAUSE_UNKNOWN]))
+    if repair_outcome == REPAIR_OUTCOME_FAILURE_RECURRED and CAUSE_REPAIR_RECURRENCE not in candidates:
+        candidates.insert(0, CAUSE_REPAIR_RECURRENCE)
+    if recurrence_count >= 3 and taxonomy_group == TAXONOMY_GROUP_MECHANICAL:
+        candidates.append(CAUSE_SUSPECTED_MANUFACTURING_DESIGN_ISSUE)
+
+    confidence = "high" if recurrence_count >= 3 else "moderate" if recurrence_count >= 1 else "low"
+    alternative = _ALTERNATIVE_EXPLANATIONS.get(taxonomy_group, _ALTERNATIVE_EXPLANATIONS[TAXONOMY_GROUP_UNKNOWN])
+    verification = _VERIFICATION.get(taxonomy_group, _VERIFICATION[TAXONOMY_GROUP_UNKNOWN])
+
+    return [
+        {
+            "probable_cause": cause,
+            "evidence": f"{recurrence_count} matching finding(s) observed in taxonomy group '{taxonomy_group}'.",
+            "confidence": confidence,
+            "alternative_explanations": [alternative],
+            "recommended_verification": verification,
+        }
+        for cause in candidates
+    ]

--- a/backend/app/services/vulcan_progression_service.py
+++ b/backend/app/services/vulcan_progression_service.py
@@ -1,0 +1,120 @@
+"""Project Vulcan, Section 3: Failure Progression Model.
+
+Tracks condition progression using real `InspectionFinding` rows (severity_index
+0 none / 1 minor / 2 moderate / 3 severe, see
+`baseline_comparison_scoring_service._severity_index`) for one physical
+instrument, optionally scoped to one anatomy zone. Never fabricates a trend
+when there isn't enough real history -- fewer than two matching findings
+always yields `insufficient_history`.
+"""
+from __future__ import annotations
+
+from app.db import models
+from app.models.inspection_finding import InspectionFinding
+from app.models.vulcan_reliability import (
+    PROGRESSION_IMPROVING,
+    PROGRESSION_INSUFFICIENT_HISTORY,
+    PROGRESSION_INTERMITTENT,
+    PROGRESSION_RAPIDLY_WORSENING,
+    PROGRESSION_SLOWLY_WORSENING,
+    PROGRESSION_STABLE,
+    PROGRESSION_UNRESOLVED,
+)
+
+
+def _inspections_for_identity(db, tenant_id: str, instrument_identity: str) -> list:
+    if instrument_identity.startswith("barcode:"):
+        value = instrument_identity.removeprefix("barcode:")
+        return (
+            db.query(models.Inspection)
+            .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.instrument_barcode == value)
+            .order_by(models.Inspection.created_at.asc())
+            .all()
+        )
+    if instrument_identity.startswith("udi:"):
+        value = instrument_identity.removeprefix("udi:")
+        return (
+            db.query(models.Inspection)
+            .filter(models.Inspection.tenant_id == tenant_id, models.Inspection.instrument_udi == value)
+            .order_by(models.Inspection.created_at.asc())
+            .all()
+        )
+    return []
+
+
+def findings_timeline(db, tenant_id: str, instrument_identity: str, zone: str | None = None) -> list[dict]:
+    """Real, time-ordered finding history for one instrument (optionally one zone)."""
+    inspections = _inspections_for_identity(db, tenant_id, instrument_identity)
+    if not inspections:
+        return []
+    inspection_by_id = {i.id: i for i in inspections}
+    ids = list(inspection_by_id.keys())
+    q = db.query(InspectionFinding).filter(InspectionFinding.inspection_id.in_(ids))
+    if zone:
+        q = q.filter(InspectionFinding.zone == zone)
+    findings = q.all()
+    timeline = []
+    for f in findings:
+        insp = inspection_by_id.get(f.inspection_id)
+        timeline.append({
+            "inspection_id": f.inspection_id,
+            "created_at": insp.created_at if insp else f.created_at,
+            "finding_type": f.finding_type,
+            "zone": f.zone,
+            "severity_index": f.severity_index,
+        })
+    timeline.sort(key=lambda row: row["created_at"])
+    return timeline
+
+
+def compute_progression(db, tenant_id: str, instrument_identity: str, zone: str | None = None) -> dict:
+    """Classify progression for one instrument (+ optional zone) from real history."""
+    timeline = findings_timeline(db, tenant_id, instrument_identity, zone=zone)
+    recurrence_count = len(timeline)
+
+    if recurrence_count < 2:
+        return {
+            "progression": PROGRESSION_INSUFFICIENT_HISTORY,
+            "recurrence_count": recurrence_count,
+            "severity_sequence": [row["severity_index"] for row in timeline],
+            "days_span": 0,
+            "confidence": "low",
+            "evidence": timeline,
+        }
+
+    severities = [row["severity_index"] for row in timeline]
+    first_at, last_at = timeline[0]["created_at"], timeline[-1]["created_at"]
+    days_span = max(0, (last_at - first_at).days) if first_at and last_at else 0
+
+    diffs = [b - a for a, b in zip(severities, severities[1:])]
+    non_decreasing = all(d >= 0 for d in diffs)
+    non_increasing = all(d <= 0 for d in diffs)
+    net_change = severities[-1] - severities[0]
+
+    if non_decreasing and net_change >= 2:
+        progression = PROGRESSION_RAPIDLY_WORSENING
+        confidence = "high"
+    elif non_decreasing and net_change == 1:
+        progression = PROGRESSION_SLOWLY_WORSENING
+        confidence = "moderate"
+    elif non_increasing and net_change < 0:
+        progression = PROGRESSION_IMPROVING
+        confidence = "moderate"
+    elif non_decreasing and net_change == 0 and max(severities) >= 2:
+        progression = PROGRESSION_UNRESOLVED
+        confidence = "moderate"
+    elif non_decreasing and net_change == 0:
+        progression = PROGRESSION_STABLE
+        confidence = "moderate"
+    else:
+        progression = PROGRESSION_INTERMITTENT
+        confidence = "low"
+
+    return {
+        "progression": progression,
+        "recurrence_count": recurrence_count,
+        "severity_sequence": severities,
+        "days_span": days_span,
+        "confidence": confidence,
+        "evidence": timeline,
+    }

--- a/backend/app/services/vulcan_reliability_agent_service.py
+++ b/backend/app/services/vulcan_reliability_agent_service.py
@@ -1,0 +1,276 @@
+"""Project Vulcan, Section 1 & 11: Instrument Reliability Agent orchestrator.
+
+Composes every other Vulcan service (taxonomy, progression, anatomy-zone,
+repair effectiveness, probable cause, reliability score, Aegis integration)
+into one persisted `VulcanReliabilityAssessment`, plus the Section 11
+clinical-reasoning narrative. Never finalizes disposition irreversibly --
+`recommended_disposition` is always Vulcan's own advisory output;
+`final_disposition` stays blank until a supervisor acts via
+`vulcan_feedback_service`.
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.instrument_knowledge import InstrumentKnowledge
+from app.models.vulcan_reliability import (
+    DISCLAIMER,
+    DISPOSITION_CLINICAL_ENGINEERING_REVIEW,
+    DISPOSITION_CONTINUE_ROUTINE_INSPECTION,
+    DISPOSITION_INCREASE_INSPECTION_FREQUENCY,
+    DISPOSITION_MANUFACTURER_EVALUATION,
+    DISPOSITION_QUARANTINE_PENDING_REVIEW,
+    DISPOSITION_RECLEAN_AND_REINSPECT,
+    DISPOSITION_REMOVE_FROM_SERVICE,
+    DISPOSITION_REPAIR_EVALUATION,
+    DISPOSITION_SUPERVISOR_REVIEW,
+    FAIL_CRACK,
+    PROGRESSION_INSUFFICIENT_HISTORY,
+    PROGRESSION_RAPIDLY_WORSENING,
+    PROGRESSION_SLOWLY_WORSENING,
+    PROGRESSION_UNRESOLVED,
+    RELIABILITY_ELEVATED_CONCERN,
+    RELIABILITY_MONITOR,
+    RELIABILITY_RELIABLE,
+    RELIABILITY_REPAIR_MANUFACTURER_REVIEW,
+    REPAIR_OUTCOME_FAILURE_RECURRED,
+    TAXONOMY_GROUP_CLEANING,
+    VULCAN_AGENT_VERSION,
+    VulcanReliabilityAssessment,
+)
+from app.services.baseline_comparison_scoring_service import _GENERIC_SCALE, _SEVERITY_SCALES
+from app.services.instrument_anatomy import anatomy_profile, get_anatomy
+from app.services.vulcan_aegis_integration_service import combine_conclusions, compute_process_variation_signal
+from app.services.vulcan_anatomy_zone_service import zone_reliability_analysis
+from app.services.vulcan_failure_taxonomy_service import classify_finding_type
+from app.services.vulcan_probable_cause_service import classify_probable_causes
+from app.services.vulcan_progression_service import compute_progression, findings_timeline
+from app.services.vulcan_repair_effectiveness_service import repair_history_for_instrument
+from app.services.vulcan_reliability_score_service import compute_reliability_score
+
+
+def _severity_label(finding_type: str, severity_index: int) -> str:
+    scale = _SEVERITY_SCALES.get(finding_type, _GENERIC_SCALE)
+    idx = max(0, min(3, severity_index))
+    return scale[idx]
+
+
+def _lookup_manufacturer(db: Session, tenant_id: str, instrument_family: str) -> str:
+    row = (
+        db.query(InstrumentKnowledge)
+        .filter(InstrumentKnowledge.tenant_id == tenant_id, InstrumentKnowledge.instrument_family == instrument_family)
+        .first()
+    )
+    return row.manufacturer if row else ""
+
+
+def recommend_disposition(
+    *, reliability_cat: str, taxonomy_leaf: str, taxonomy_group: str, progression: str, repair_outcome: str | None,
+) -> str:
+    """Section 8: recommended disposition -- always advisory, never final."""
+    if taxonomy_leaf == FAIL_CRACK and progression in (
+        PROGRESSION_RAPIDLY_WORSENING, PROGRESSION_SLOWLY_WORSENING, PROGRESSION_UNRESOLVED,
+    ):
+        return DISPOSITION_REMOVE_FROM_SERVICE
+
+    if reliability_cat == RELIABILITY_RELIABLE:
+        return DISPOSITION_CONTINUE_ROUTINE_INSPECTION
+    if reliability_cat == RELIABILITY_MONITOR:
+        return DISPOSITION_RECLEAN_AND_REINSPECT if taxonomy_group == TAXONOMY_GROUP_CLEANING else DISPOSITION_INCREASE_INSPECTION_FREQUENCY
+    if reliability_cat == RELIABILITY_ELEVATED_CONCERN:
+        return DISPOSITION_SUPERVISOR_REVIEW
+    if reliability_cat == RELIABILITY_REPAIR_MANUFACTURER_REVIEW:
+        return DISPOSITION_MANUFACTURER_EVALUATION if repair_outcome == REPAIR_OUTCOME_FAILURE_RECURRED else DISPOSITION_REPAIR_EVALUATION
+    # remove_from_service_candidate
+    return DISPOSITION_QUARANTINE_PENDING_REVIEW if progression == PROGRESSION_INSUFFICIENT_HISTORY else DISPOSITION_REMOVE_FROM_SERVICE
+
+
+_DISPOSITION_NEXT_ROLE = {
+    DISPOSITION_CONTINUE_ROUTINE_INSPECTION: "SPD technician",
+    DISPOSITION_INCREASE_INSPECTION_FREQUENCY: "SPD technician",
+    DISPOSITION_RECLEAN_AND_REINSPECT: "SPD technician",
+    DISPOSITION_SUPERVISOR_REVIEW: "SPD supervisor",
+    DISPOSITION_REPAIR_EVALUATION: "repair vendor",
+    DISPOSITION_CLINICAL_ENGINEERING_REVIEW: "clinical engineering",
+    DISPOSITION_MANUFACTURER_EVALUATION: "manufacturer",
+    DISPOSITION_QUARANTINE_PENDING_REVIEW: "SPD supervisor",
+    DISPOSITION_REMOVE_FROM_SERVICE: "SPD supervisor",
+}
+
+
+def _build_narrative(
+    *, instrument_family_display: str, zone: str, finding_type: str, severity_index: int,
+    recurrence_count: int, days_span: int, progression: str, repair_outcome: str | None, disposition: str,
+) -> str:
+    if not zone or not finding_type:
+        return (
+            f"Insufficient inspection history is available for this instrument to produce an "
+            f"evidence-based reliability narrative. {DISCLAIMER}"
+        )
+
+    severity_label = _severity_label(finding_type, severity_index)
+    zone_text = zone.replace("_", " ")
+    subject = f"{severity_label.capitalize()} {finding_type.replace('_', ' ')}"
+
+    recurrence_clause = (
+        f"The same anatomy zone has been flagged {recurrence_count} times in {days_span} days. "
+        if recurrence_count >= 2 else ""
+    )
+    recurrence_verb = "recurred" if repair_outcome == REPAIR_OUTCOME_FAILURE_RECURRED else "been detected"
+    repair_clause = " after repair" if repair_outcome == REPAIR_OUTCOME_FAILURE_RECURRED else ""
+
+    trend_word = {
+        PROGRESSION_RAPIDLY_WORSENING: "declining rapidly",
+        PROGRESSION_SLOWLY_WORSENING: "declining",
+        PROGRESSION_UNRESOLVED: "not improving",
+        PROGRESSION_INSUFFICIENT_HISTORY: "not yet established",
+    }.get(progression, "stable")
+
+    next_role = _DISPOSITION_NEXT_ROLE.get(disposition, "SPD supervisor")
+    disposition_text = disposition.replace("_", " ")
+
+    return (
+        f"{subject} has {recurrence_verb} in the {instrument_family_display} {zone_text} region{repair_clause}. "
+        f"{recurrence_clause}"
+        f"Instrument reliability is {trend_word}. "
+        f"Recommend {disposition_text} -- hold for {next_role} evaluation before returning the instrument "
+        f"to the pre-sterilization workflow."
+    )
+
+
+def run_reliability_assessment(
+    db: Session, tenant_id: str, instrument_identity: str, instrument_type: str = "",
+    *, supervisor_concern: bool = False, digital_twin_version: str = "", baseline_version: str = "",
+    anatomy_profile_version: str = "",
+) -> VulcanReliabilityAssessment:
+    """Section 1: run the full Vulcan pipeline and persist one assessment."""
+    zone_report = zone_reliability_analysis(db, tenant_id, instrument_identity, instrument_type)
+    zones = zone_report["zones"]
+    zone_name = zones[0]["anatomy_zone"] if zones else ""
+
+    progression_result = compute_progression(db, tenant_id, instrument_identity, zone=zone_name or None)
+    timeline = findings_timeline(db, tenant_id, instrument_identity, zone=zone_name or None)
+    latest = timeline[-1] if timeline else None
+    finding_type = latest["finding_type"] if latest else ""
+    severity_index = latest["severity_index"] if latest else 0
+    taxonomy = classify_finding_type(finding_type) if finding_type else {
+        "taxonomy_leaf": "insufficient_evidence", "taxonomy_group": "unknown",
+    }
+
+    repairs = repair_history_for_instrument(db, tenant_id, instrument_identity)
+    zone_repairs = [r for r in repairs if zone_name and r["anatomy_zone"] == zone_name]
+    latest_repair = zone_repairs[-1] if zone_repairs else None
+    repair_outcome = latest_repair["repair_outcome"] if latest_repair else None
+
+    anatomy = get_anatomy(instrument_type) if instrument_type else {"high_risk_zones": [], "family": "unknown"}
+    is_high_risk_zone = zone_name in anatomy.get("high_risk_zones", [])
+
+    probable_causes = classify_probable_causes(
+        taxonomy["taxonomy_group"], repair_outcome=repair_outcome, recurrence_count=progression_result["recurrence_count"],
+    )
+
+    score_result = compute_reliability_score(
+        progression=progression_result["progression"],
+        recurrence_count=progression_result["recurrence_count"],
+        latest_severity_index=severity_index,
+        repair_outcome=repair_outcome,
+        is_high_risk_zone=is_high_risk_zone,
+        supervisor_concern=supervisor_concern,
+        evidence_confidence=progression_result["confidence"],
+    )
+
+    disposition = recommend_disposition(
+        reliability_cat=score_result["reliability_category"],
+        taxonomy_leaf=taxonomy["taxonomy_leaf"],
+        taxonomy_group=taxonomy["taxonomy_group"],
+        progression=progression_result["progression"],
+        repair_outcome=repair_outcome,
+    )
+
+    profile = anatomy_profile(instrument_type) if instrument_type else {"instrument_family": "unknown"}
+    instrument_family = profile.get("instrument_family", "unknown")
+    manufacturer_name = _lookup_manufacturer(db, tenant_id, instrument_family)
+
+    narrative = _build_narrative(
+        instrument_family_display=instrument_family.replace("_", " "),
+        zone=zone_name, finding_type=finding_type, severity_index=severity_index,
+        recurrence_count=progression_result["recurrence_count"], days_span=progression_result["days_span"],
+        progression=progression_result["progression"], repair_outcome=repair_outcome, disposition=disposition,
+    )
+
+    aegis_conclusion = compute_process_variation_signal(db, tenant_id, instrument_identity, zone=zone_name or None)
+    combined_conclusion = combine_conclusions(narrative, aegis_conclusion)
+
+    row = VulcanReliabilityAssessment(
+        tenant_id=tenant_id,
+        instrument_identity=instrument_identity,
+        instrument_family=instrument_family,
+        manufacturer_name=manufacturer_name,
+        anatomy_zone=zone_name,
+        failure_category=taxonomy["taxonomy_leaf"],
+        progression=progression_result["progression"],
+        recurrence_count=progression_result["recurrence_count"],
+        reliability_score=score_result["reliability_score"],
+        reliability_category=score_result["reliability_category"],
+        score_breakdown_json=json.dumps(score_result["score_breakdown"]),
+        probable_causes_json=json.dumps(probable_causes),
+        recommended_disposition=disposition,
+        reasoning_narrative=narrative,
+        confidence=progression_result["confidence"],
+        evidence_json=json.dumps({"timeline": [
+            {**e, "created_at": e["created_at"].isoformat() if e["created_at"] else None} for e in timeline
+        ], "repairs": repairs}),
+        rules_applied_json=json.dumps([
+            "failure_taxonomy_classification", "progression_model", "anatomy_zone_analysis",
+            "repair_effectiveness_analysis", "probable_cause_classification", "reliability_score",
+            "recommended_disposition", "aegis_process_variation_signal",
+        ]),
+        digital_twin_version=digital_twin_version,
+        baseline_version=baseline_version,
+        anatomy_profile_version=anatomy_profile_version,
+        agent_version=VULCAN_AGENT_VERSION,
+        aegis_conclusion_json=json.dumps(aegis_conclusion),
+        combined_conclusion=combined_conclusion,
+        human_review_required=True,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def to_dict(row: VulcanReliabilityAssessment) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "tenant_id": row.tenant_id,
+        "instrument_identity": row.instrument_identity,
+        "instrument_family": row.instrument_family,
+        "manufacturer_name": row.manufacturer_name,
+        "anatomy_zone": row.anatomy_zone,
+        "failure_category": row.failure_category,
+        "progression": row.progression,
+        "recurrence_count": row.recurrence_count,
+        "reliability_score": row.reliability_score,
+        "reliability_category": row.reliability_category,
+        "score_breakdown": json.loads(row.score_breakdown_json or "{}"),
+        "probable_causes": json.loads(row.probable_causes_json or "[]"),
+        "recommended_disposition": row.recommended_disposition,
+        "reasoning_narrative": row.reasoning_narrative,
+        "confidence": row.confidence,
+        "evidence": json.loads(row.evidence_json or "{}"),
+        "rules_applied": json.loads(row.rules_applied_json or "[]"),
+        "digital_twin_version": row.digital_twin_version,
+        "baseline_version": row.baseline_version,
+        "anatomy_profile_version": row.anatomy_profile_version,
+        "agent_version": row.agent_version,
+        "aegis_conclusion": json.loads(row.aegis_conclusion_json) if row.aegis_conclusion_json else None,
+        "combined_conclusion": row.combined_conclusion,
+        "human_review_required": row.human_review_required,
+        "final_disposition": row.final_disposition,
+        "finalized_by": row.finalized_by,
+        "finalized_at": row.finalized_at.isoformat() if row.finalized_at else None,
+        "disclaimer": row.disclaimer,
+    }

--- a/backend/app/services/vulcan_reliability_score_service.py
+++ b/backend/app/services/vulcan_reliability_score_service.py
@@ -1,0 +1,88 @@
+"""Project Vulcan, Section 7: Instrument Reliability Score.
+
+0-100 composite score with a transparent, itemized breakdown. Deliberately
+excludes sterilization-cycle counts (the brief's explicit exclusion) --
+scoring draws only from real finding/repair/supervisor/baseline evidence.
+"""
+from __future__ import annotations
+
+from app.models.vulcan_reliability import (
+    PROGRESSION_INTERMITTENT,
+    PROGRESSION_RAPIDLY_WORSENING,
+    PROGRESSION_SLOWLY_WORSENING,
+    PROGRESSION_UNRESOLVED,
+    REPAIR_OUTCOME_FAILURE_RECURRED,
+    REPAIR_OUTCOME_NEW_DEFECT_DETECTED,
+    REPAIR_OUTCOME_PARTIALLY_EFFECTIVE,
+    REPAIR_OUTCOME_UNABLE_TO_DETERMINE,
+    reliability_category,
+)
+
+_PROGRESSION_PENALTY = {
+    PROGRESSION_RAPIDLY_WORSENING: 25,
+    PROGRESSION_SLOWLY_WORSENING: 12,
+    PROGRESSION_UNRESOLVED: 15,
+    PROGRESSION_INTERMITTENT: 8,
+}
+
+_REPAIR_OUTCOME_PENALTY = {
+    REPAIR_OUTCOME_FAILURE_RECURRED: 15,
+    REPAIR_OUTCOME_NEW_DEFECT_DETECTED: 12,
+    REPAIR_OUTCOME_PARTIALLY_EFFECTIVE: 6,
+    REPAIR_OUTCOME_UNABLE_TO_DETERMINE: 2,
+}
+
+
+def compute_reliability_score(
+    *,
+    progression: str,
+    recurrence_count: int,
+    latest_severity_index: int,
+    repair_outcome: str | None = None,
+    is_high_risk_zone: bool = False,
+    supervisor_concern: bool = False,
+    baseline_deviation: bool = False,
+    evidence_confidence: str = "moderate",
+) -> dict:
+    """Section 7: composite score 0-100 with a transparent breakdown.
+
+    Never reads sterilization-cycle counts -- the brief's explicit exclusion.
+    """
+    breakdown: dict[str, int] = {}
+
+    progression_penalty = _PROGRESSION_PENALTY.get(progression, 0)
+    if progression_penalty:
+        breakdown["progression"] = -progression_penalty
+
+    recurrence_penalty = min(20, max(0, recurrence_count - 1) * 5)
+    if recurrence_penalty:
+        breakdown["repeated_findings"] = -recurrence_penalty
+
+    severity_penalty = max(0, latest_severity_index) * 5
+    if severity_penalty:
+        breakdown["structural_condition"] = -severity_penalty
+
+    repair_penalty = _REPAIR_OUTCOME_PENALTY.get(repair_outcome or "", 0)
+    if repair_penalty:
+        breakdown["repair_recurrence"] = -repair_penalty
+
+    if is_high_risk_zone:
+        breakdown["anatomy_zone_risk"] = -5
+
+    if supervisor_concern:
+        breakdown["supervisor_concerns"] = -10
+
+    if baseline_deviation:
+        breakdown["baseline_deviation"] = -8
+
+    if evidence_confidence == "low":
+        breakdown["evidence_quality"] = -5
+
+    score = 100 + sum(breakdown.values())
+    score = max(0, min(100, score))
+
+    return {
+        "reliability_score": float(score),
+        "reliability_category": reliability_category(score),
+        "score_breakdown": breakdown,
+    }

--- a/backend/app/services/vulcan_repair_effectiveness_service.py
+++ b/backend/app/services/vulcan_repair_effectiveness_service.py
@@ -1,0 +1,116 @@
+"""Project Vulcan, Section 5: Repair Effectiveness Intelligence.
+
+Composes the real `RepairRequest` row (`app.models.or_connect`, tracks repair
+date/vendor/type/status/return dates/failure_category) with the real
+`InspectionFinding` rows before and after the repair to classify repair
+outcome. `RepairRequest` has no zone column of its own, so the affected zone
+is derived honestly from the findings on the inspection that triggered the
+repair -- never fabricated.
+
+Never claims a vendor performed a bad repair -- outcomes describe what the
+evidence shows (recurrence/new defect/effective), not vendor fault.
+"""
+from __future__ import annotations
+
+from app.models.inspection_finding import InspectionFinding
+from app.models.or_connect import REPAIR_REPLACED, REPAIR_RETURNED, RepairRequest
+from app.models.vulcan_reliability import (
+    REPAIR_OUTCOME_EFFECTIVE,
+    REPAIR_OUTCOME_FAILURE_RECURRED,
+    REPAIR_OUTCOME_NEW_DEFECT_DETECTED,
+    REPAIR_OUTCOME_PARTIALLY_EFFECTIVE,
+    REPAIR_OUTCOME_UNABLE_TO_DETERMINE,
+)
+from app.services.vulcan_progression_service import _inspections_for_identity
+
+
+def _findings_for_inspection(db, inspection_id: int) -> list[InspectionFinding]:
+    return db.query(InspectionFinding).filter(InspectionFinding.inspection_id == inspection_id).all()
+
+
+def _pre_repair_zone(db, repair: RepairRequest) -> tuple[str, list[InspectionFinding]]:
+    pre_findings = _findings_for_inspection(db, repair.inspection_id)
+    if not pre_findings:
+        return "", []
+    worst = max(pre_findings, key=lambda f: f.severity_index)
+    return worst.zone, pre_findings
+
+
+def classify_repair_outcome(db, tenant_id: str, repair: RepairRequest) -> dict:
+    """Section 5: classify one repair's real-world outcome from evidence."""
+    zone, pre_findings = _pre_repair_zone(db, repair)
+    pre_types = {f.finding_type for f in pre_findings}
+
+    if repair.status not in (REPAIR_RETURNED, REPAIR_REPLACED):
+        return {
+            "repair_request_id": repair.id,
+            "instrument_identity": repair.instrument_identity,
+            "anatomy_zone": zone,
+            "repair_outcome": REPAIR_OUTCOME_UNABLE_TO_DETERMINE,
+            "time_to_recurrence_days": None,
+            "evidence": {"reason": "repair not yet returned/replaced"},
+        }
+
+    return_date = repair.actual_return_date or repair.expected_return_date
+    inspections = _inspections_for_identity(db, tenant_id, repair.instrument_identity)
+    post_repair_inspections = [
+        i for i in inspections if return_date and i.created_at and i.created_at > return_date
+    ]
+
+    if not post_repair_inspections:
+        return {
+            "repair_request_id": repair.id,
+            "instrument_identity": repair.instrument_identity,
+            "anatomy_zone": zone,
+            "repair_outcome": REPAIR_OUTCOME_UNABLE_TO_DETERMINE,
+            "time_to_recurrence_days": None,
+            "evidence": {"reason": "no post-repair inspection on record yet"},
+        }
+
+    first_recurrence_at = None
+    outcome = REPAIR_OUTCOME_EFFECTIVE
+    for insp in post_repair_inspections:
+        post_findings = _findings_for_inspection(db, insp.id)
+        same_zone = [f for f in post_findings if zone and f.zone == zone]
+        if not same_zone:
+            continue
+        first_recurrence_at = insp.created_at
+        recurring_types = {f.finding_type for f in same_zone}
+        max_severity = max((f.severity_index for f in same_zone), default=0)
+        pre_max_severity = max((f.severity_index for f in pre_findings), default=0)
+        if recurring_types - pre_types:
+            outcome = REPAIR_OUTCOME_NEW_DEFECT_DETECTED
+        elif max_severity >= pre_max_severity and max_severity >= 1:
+            outcome = REPAIR_OUTCOME_FAILURE_RECURRED
+        elif max_severity >= 1:
+            outcome = REPAIR_OUTCOME_PARTIALLY_EFFECTIVE
+        break
+
+    time_to_recurrence_days = None
+    if first_recurrence_at and return_date:
+        time_to_recurrence_days = max(0, (first_recurrence_at - return_date).days)
+
+    return {
+        "repair_request_id": repair.id,
+        "instrument_identity": repair.instrument_identity,
+        "anatomy_zone": zone,
+        "repair_outcome": outcome,
+        "time_to_recurrence_days": time_to_recurrence_days,
+        "evidence": {
+            "pre_repair_finding_types": sorted(pre_types),
+            "post_repair_inspections_reviewed": len(post_repair_inspections),
+            "vendor_name": repair.vendor_name,
+            "repair_type": repair.repair_type,
+            "failure_category": repair.failure_category,
+        },
+    }
+
+
+def repair_history_for_instrument(db, tenant_id: str, instrument_identity: str) -> list[dict]:
+    repairs = (
+        db.query(RepairRequest)
+        .filter(RepairRequest.tenant_id == tenant_id, RepairRequest.instrument_identity == instrument_identity)
+        .order_by(RepairRequest.created_at.asc())
+        .all()
+    )
+    return [classify_repair_outcome(db, tenant_id, r) for r in repairs]

--- a/backend/app/services/vulcan_watchlist_service.py
+++ b/backend/app/services/vulcan_watchlist_service.py
@@ -1,0 +1,130 @@
+"""Project Vulcan, Section 10: Reliability Watchlists.
+
+Every watchlist is a live query over `VulcanReliabilityAssessment` (and
+`RepairRequest` for repeat-repair) -- zero new tables. Each entry carries the
+assessment's own evidence/reasoning fields so every watchlist row is
+explainable and auditable, per the brief's explicit requirement.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from app.models.or_connect import RepairRequest
+from app.models.vulcan_reliability import (
+    DISPOSITION_MANUFACTURER_EVALUATION,
+    DISPOSITION_RETIREMENT_CANDIDATE,
+    FAIL_CRACK,
+    FAIL_DAMAGED_DRILL_FLUTE,
+    FAIL_DAMAGED_HINGE,
+    FAIL_DAMAGED_O_RING,
+    FAIL_LOOSE_JOINT,
+    FAIL_MISALIGNMENT,
+    FAIL_RUST,
+    FAILURE_TAXONOMY,
+    PROGRESSION_RAPIDLY_WORSENING,
+    PROGRESSION_SLOWLY_WORSENING,
+    RELIABILITY_REMOVE_FROM_SERVICE_CANDIDATE,
+    TAXONOMY_GROUP_CLEANING,
+    TAXONOMY_GROUP_INSULATION,
+    VulcanReliabilityAssessment,
+)
+from app.services.vulcan_reliability_agent_service import to_dict
+
+_CORROSION_LEAF = "corrosion"
+_STRUCTURAL_LEAVES = (FAIL_CRACK, FAIL_MISALIGNMENT, FAIL_LOOSE_JOINT, FAIL_DAMAGED_HINGE)
+
+
+def _latest_per_instrument(db: Session, tenant_id: str) -> list[VulcanReliabilityAssessment]:
+    rows = (
+        db.query(VulcanReliabilityAssessment)
+        .filter(VulcanReliabilityAssessment.tenant_id == tenant_id)
+        .order_by(VulcanReliabilityAssessment.created_at.asc())
+        .all()
+    )
+    latest: dict[str, VulcanReliabilityAssessment] = {}
+    for row in rows:
+        latest[row.instrument_identity] = row
+    return list(latest.values())
+
+
+def recurring_corrosion(db: Session, tenant_id: str) -> list[dict]:
+    return [to_dict(r) for r in _latest_per_instrument(db, tenant_id) if r.failure_category == _CORROSION_LEAF and r.recurrence_count >= 2]
+
+
+def recurring_rust(db: Session, tenant_id: str) -> list[dict]:
+    return [to_dict(r) for r in _latest_per_instrument(db, tenant_id) if r.failure_category == FAIL_RUST and r.recurrence_count >= 2]
+
+
+def repeated_cleaning_failure(db: Session, tenant_id: str) -> list[dict]:
+    cleaning_leaves = set(FAILURE_TAXONOMY.get(TAXONOMY_GROUP_CLEANING, []))
+    return [to_dict(r) for r in _latest_per_instrument(db, tenant_id) if r.failure_category in cleaning_leaves and r.recurrence_count >= 2]
+
+
+def repeat_repair(db: Session, tenant_id: str) -> list[dict]:
+    counts: dict[str, int] = defaultdict(int)
+    for r in db.query(RepairRequest).filter(RepairRequest.tenant_id == tenant_id):
+        counts[r.instrument_identity] += 1
+    repeat_identities = {identity for identity, count in counts.items() if count >= 2}
+    return [to_dict(r) for r in _latest_per_instrument(db, tenant_id) if r.instrument_identity in repeat_identities]
+
+
+def structural_defect_progression(db: Session, tenant_id: str) -> list[dict]:
+    return [
+        to_dict(r) for r in _latest_per_instrument(db, tenant_id)
+        if r.failure_category in _STRUCTURAL_LEAVES
+        and r.progression in (PROGRESSION_RAPIDLY_WORSENING, PROGRESSION_SLOWLY_WORSENING)
+    ]
+
+
+def damaged_o_rings(db: Session, tenant_id: str) -> list[dict]:
+    return [to_dict(r) for r in _latest_per_instrument(db, tenant_id) if r.failure_category == FAIL_DAMAGED_O_RING]
+
+
+def insulation_failures(db: Session, tenant_id: str) -> list[dict]:
+    insulation_leaves = set(FAILURE_TAXONOMY.get(TAXONOMY_GROUP_INSULATION, []))
+    return [to_dict(r) for r in _latest_per_instrument(db, tenant_id) if r.failure_category in insulation_leaves]
+
+
+def drill_flute_failures(db: Session, tenant_id: str) -> list[dict]:
+    return [
+        to_dict(r) for r in _latest_per_instrument(db, tenant_id)
+        if r.failure_category == FAIL_DAMAGED_DRILL_FLUTE or r.anatomy_zone == "flutes"
+    ]
+
+
+def box_lock_failures(db: Session, tenant_id: str) -> list[dict]:
+    return [to_dict(r) for r in _latest_per_instrument(db, tenant_id) if r.anatomy_zone == "box lock"]
+
+
+def instruments_awaiting_manufacturer_review(db: Session, tenant_id: str) -> list[dict]:
+    return [to_dict(r) for r in _latest_per_instrument(db, tenant_id) if r.recommended_disposition == DISPOSITION_MANUFACTURER_EVALUATION]
+
+
+def retirement_candidates(db: Session, tenant_id: str) -> list[dict]:
+    return [
+        to_dict(r) for r in _latest_per_instrument(db, tenant_id)
+        if r.recommended_disposition == DISPOSITION_RETIREMENT_CANDIDATE
+        or r.reliability_category == RELIABILITY_REMOVE_FROM_SERVICE_CANDIDATE
+    ]
+
+
+WATCHLISTS = {
+    "recurring_corrosion": recurring_corrosion,
+    "recurring_rust": recurring_rust,
+    "repeated_cleaning_failure": repeated_cleaning_failure,
+    "repeat_repair": repeat_repair,
+    "structural_defect_progression": structural_defect_progression,
+    "damaged_o_rings": damaged_o_rings,
+    "insulation_failures": insulation_failures,
+    "drill_flute_failures": drill_flute_failures,
+    "box_lock_failures": box_lock_failures,
+    "instruments_awaiting_manufacturer_review": instruments_awaiting_manufacturer_review,
+    "retirement_candidates": retirement_candidates,
+}
+
+
+def run_watchlist(db: Session, tenant_id: str, name: str) -> list[dict] | None:
+    fn = WATCHLISTS.get(name)
+    return fn(db, tenant_id) if fn else None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -118,6 +118,7 @@ def _force_import_models():
         "app.models.nova_agent_platform",
         "app.models.vulcan_reliability",
         "app.models.sage_education",
+        "app.models.veritas_evidence",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -120,6 +120,7 @@ def _force_import_models():
         "app.models.sage_education",
         "app.models.veritas_evidence",
         "app.models.sentinelx_risk",
+        "app.models.maestro_orchestration",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -117,6 +117,7 @@ def _force_import_models():
         "app.models.genesis_ai_intelligence_cloud",
         "app.models.nova_agent_platform",
         "app.models.vulcan_reliability",
+        "app.models.sage_education",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -116,6 +116,7 @@ def _force_import_models():
         "app.models.guardianx_assurance",
         "app.models.genesis_ai_intelligence_cloud",
         "app.models.nova_agent_platform",
+        "app.models.vulcan_reliability",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -121,6 +121,7 @@ def _force_import_models():
         "app.models.veritas_evidence",
         "app.models.sentinelx_risk",
         "app.models.maestro_orchestration",
+        "app.models.council_leadership",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -119,6 +119,7 @@ def _force_import_models():
         "app.models.vulcan_reliability",
         "app.models.sage_education",
         "app.models.veritas_evidence",
+        "app.models.sentinelx_risk",
     ]:
         try:
             importlib.import_module(model_path)

--- a/backend/tests/test_council_leadership.py
+++ b/backend/tests/test_council_leadership.py
@@ -1,0 +1,451 @@
+"""LumenAI AI Leadership Platform — Project Council: Multi-Agent
+Leadership Teams & Governed Consensus Intelligence tests.
+
+Covers the 17 named scenarios from the sprint brief's Section 22, plus a
+route smoke test. Council is a pure read-and-synthesize leadership layer
+over already-built specialists -- see `app/models/council_leadership.py`
+for the naming disambiguation from Olympus's unrelated Network
+Governance Council.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.council_leadership import (
+    CONSENSUS_INSUFFICIENT_EVIDENCE,
+    CONSENSUS_SAFETY_DISSENT,
+    CONSENSUS_SPLIT,
+    CONSENSUS_UNANIMOUS,
+    DEFAULT_TEAM_DEFINITIONS,
+    OUTCOME_INEFFECTIVE,
+)
+from app.models.inspection_finding import InspectionFinding
+from app.services import (
+    council_consensus_service,
+    council_decision_options_service,
+    council_dissent_service,
+    council_human_decision_service,
+    council_orchestration_service,
+    council_outcome_service,
+    council_specialist_assessment_service,
+    council_team_registry_service,
+)
+from app.services.council_brief_service import executive_brief, manager_brief, supervisor_brief
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    db.add(models.TenantMembership(tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+def _mk_inspection(db, tenant_id, *, barcode="BC1", instrument_type="kerrison rongeur"):
+    row = models.Inspection(
+        tenant_id=tenant_id, file_name="t.jpg", instrument_type=instrument_type, instrument_barcode=barcode,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mk_finding(db, tenant_id, inspection_id, *, finding_type="corrosion", zone="jaw", severity_index=2):
+    row = InspectionFinding(tenant_id=tenant_id, inspection_id=inspection_id, finding_type=finding_type, zone=zone, severity_index=severity_index)
+    db.add(row)
+    db.commit()
+    return row
+
+
+def _open_and_convene_reliability_case(db, tenant_id):
+    insp = _mk_inspection(db, tenant_id, barcode=uid("BC"))
+    _mk_finding(db, tenant_id, insp.id)
+    case = council_orchestration_service.open_case(
+        db, tenant_id, case_type="recurring_instrument_failure", source_event="Recurring corrosion in O-ring region",
+        inspection_ids=[insp.id], instrument_ids=[f"barcode:{insp.instrument_barcode}"], risk_level="high", urgency="urgent",
+    )
+    return council_orchestration_service.convene(db, tenant_id, case.id)
+
+
+# ── 1. Council selects appropriate specialists by case type ──────────────
+
+def test_council_selects_appropriate_specialists_by_case_type():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        team_key, specialists = council_orchestration_service.select_specialists_for_case(db, tenant_id, "education_need")
+        assert team_key == "education"
+        assert set(specialists) == set(DEFAULT_TEAM_DEFINITIONS["education"]["required_specialists"])
+
+        team_key2, specialists2 = council_orchestration_service.select_specialists_for_case(db, tenant_id, "enterprise_trend")
+        assert team_key2 == "executive"
+        assert set(specialists2) == set(DEFAULT_TEAM_DEFINITIONS["executive"]["required_specialists"])
+    finally:
+        db.close()
+
+
+# ── 2. specialist assessments are captured independently ─────────────────
+
+def test_specialist_assessments_captured_independently():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        insp = _mk_inspection(db, tenant_id, barcode=uid("BC"))
+        _mk_finding(db, tenant_id, insp.id)
+        case = council_orchestration_service.open_case(
+            db, tenant_id, case_type="recurring_instrument_failure",
+            inspection_ids=[insp.id], instrument_ids=[f"barcode:{insp.instrument_barcode}"],
+        )
+        rows = council_specialist_assessment_service.run_independent_assessments(db, tenant_id, case, case_specialists := ["vulcan", "veritas", "sentinelx"])
+        assert len(rows) == len(case_specialists)
+        assert {r.specialist_key for r in rows} == set(case_specialists)
+        for row in rows:
+            assert row.is_revision is False
+            assert row.supersedes_assessment_id is None
+    finally:
+        db.close()
+
+
+# ── 3. original assessments remain immutable ──────────────────────────────
+
+def test_original_assessments_remain_immutable():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        insp = _mk_inspection(db, tenant_id, barcode=uid("BC"))
+        case = council_orchestration_service.open_case(db, tenant_id, case_type="repair_recurrence", inspection_ids=[insp.id])
+
+        original = council_specialist_assessment_service.submit_assessment(
+            db, tenant_id, case.id, "vulcan", {"conclusion": "Initial read: reliable.", "recommended_action": "Continue monitoring."},
+        )
+        revision = council_specialist_assessment_service.submit_revision(
+            db, tenant_id, case, "vulcan", {"conclusion": "Revised after seeing Sentinel-X: elevated concern.", "recommended_action": "Hold for repair evaluation."},
+        )
+        assert revision.supersedes_assessment_id == original.id
+        assert revision.is_revision is True
+
+        db.refresh(original)
+        assert original.conclusion == "Initial read: reliable."
+        assert original.is_revision is False
+
+        all_rows = council_specialist_assessment_service.assessments_for_case(db, tenant_id, case.id)
+        assert len(all_rows) == 2
+        latest = council_specialist_assessment_service.latest_assessments_for_case(db, tenant_id, case.id)
+        assert len(latest) == 1
+        assert latest[0]["conclusion"].startswith("Revised")
+    finally:
+        db.close()
+
+
+# ── 4. unanimous agreement produces UNANIMOUS status ──────────────────────
+
+def test_unanimous_agreement_produces_unanimous_status():
+    assessments = [
+        {"specialist_key": "vulcan", "recommended_action": "Reclean and repeat inspection.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+        {"specialist_key": "veritas", "recommended_action": "Reclean and repeat inspection.", "confidence": "high", "urgency": "routine", "evidence_limitations": ""},
+    ]
+    result = council_consensus_service.classify_consensus(assessments, ["vulcan", "veritas"])
+    assert result["status"] == CONSENSUS_UNANIMOUS
+
+
+# ── 5. material disagreement produces SPLIT_DECISION ──────────────────────
+
+def test_material_disagreement_produces_split_decision():
+    assessments = [
+        {"specialist_key": "vulcan", "recommended_action": "Hold for repair evaluation.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+        {"specialist_key": "veritas", "recommended_action": "Manufacturer evaluation.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+        {"specialist_key": "sage", "recommended_action": "Reclean and repeat inspection.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+    ]
+    result = council_consensus_service.classify_consensus(assessments, ["vulcan", "veritas", "sage"])
+    assert result["status"] == CONSENSUS_SPLIT
+
+
+# ── 6. missing evidence produces INSUFFICIENT_EVIDENCE ────────────────────
+
+def test_missing_evidence_produces_insufficient_evidence():
+    assessments = [
+        {"specialist_key": "vulcan", "recommended_action": "Hold for repair evaluation.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+    ]
+    result = council_consensus_service.classify_consensus(assessments, ["vulcan", "veritas"])
+    assert result["status"] == CONSENSUS_INSUFFICIENT_EVIDENCE
+
+
+# ── 7. unresolved safety dissent cannot be majority-overridden ───────────
+
+def test_unresolved_safety_dissent_cannot_be_majority_overridden():
+    assessments = [
+        {"specialist_key": "vulcan", "recommended_action": "Proceed with increased monitoring.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+        {"specialist_key": "veritas", "recommended_action": "Proceed with increased monitoring.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+        {"specialist_key": "aegis", "recommended_action": "Proceed with increased monitoring.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+        {"specialist_key": "sage", "recommended_action": "Proceed with increased monitoring.", "confidence": "moderate", "urgency": "routine", "evidence_limitations": ""},
+        {"specialist_key": "sentinelx", "recommended_action": "Hold for supervisor review.", "confidence": "high", "urgency": "urgent", "evidence_limitations": ""},
+    ]
+    result = council_consensus_service.classify_consensus(assessments, ["vulcan", "veritas", "aegis", "sage", "sentinelx"])
+    assert result["status"] == CONSENSUS_SAFETY_DISSENT
+    assert "sentinelx" in result["dissenting_specialists"]
+
+
+# ── 8. dissent remains visible in final report ────────────────────────────
+
+def test_dissent_remains_visible_in_final_report():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_id)
+        dissent = council_dissent_service.dissent_for_case(db, tenant_id, case.id)
+        if case.consensus_status in (CONSENSUS_SAFETY_DISSENT, CONSENSUS_SPLIT):
+            assert dissent
+        for d in dissent:
+            assert d["dissenting_specialist"]
+            assert d["proposed_alternative_action"] or d["additional_evidence_required"]
+    finally:
+        db.close()
+
+
+# ── 9. decision options include tradeoffs and authority requirements ─────
+
+def test_decision_options_include_tradeoffs_and_authority():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_id)
+        options = council_decision_options_service.options_for_case(db, tenant_id, case.id)
+        assert options
+        for opt in options:
+            assert opt["option_title"]
+            assert opt["required_authority"]
+            assert opt["evidence_strength"] in ("low", "moderate", "high")
+            assert opt["reversibility"] in ("reversible", "irreversible")
+            assert opt["financial_impact"] == ""
+    finally:
+        db.close()
+
+
+# ── 10. technician cannot finalize Council decision ───────────────────────
+
+def test_technician_cannot_finalize_council_decision():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_id)
+        assert council_human_decision_service.can_approve("viewer", case.required_approval_tier) is False
+        assert council_human_decision_service.can_approve("operator", case.required_approval_tier) is False
+
+        raised = False
+        try:
+            council_human_decision_service.finalize_decision(
+                db, tenant_id, case.id, approver="tech@local.dev", approver_role="operator", decision="Proceed.",
+            )
+        except PermissionError:
+            raised = True
+        assert raised
+    finally:
+        db.close()
+
+
+# ── 11. correct human role can approve within scope ───────────────────────
+
+def test_correct_human_role_can_approve_within_scope():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_id)
+        assert council_human_decision_service.can_approve("admin", case.required_approval_tier) is True
+
+        decision = council_human_decision_service.finalize_decision(
+            db, tenant_id, case.id, approver="admin@local.dev", approver_role="admin", decision="Hold for repair evaluation.",
+        )
+        assert decision.decision == "Hold for repair evaluation."
+        db.refresh(case)
+        assert case.status == "resolved"
+    finally:
+        db.close()
+
+
+# ── 12. cross-tenant Council access is denied ─────────────────────────────
+
+def test_cross_tenant_council_access_is_denied():
+    tenant_a = uid("council-t")
+    tenant_b = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_a)
+        case_id = case.id
+        assert council_orchestration_service.get_case(db, tenant_b, case_id) is None
+        assert council_orchestration_service.list_cases(db, tenant_b) == []
+
+        _seed_membership(db, tenant_a)
+        _seed_membership(db, tenant_b)
+    finally:
+        db.close()
+
+    r = client.get(f"/api/council/cases/{case_id}", headers=_headers(AUTH_ADMIN, tenant_b))
+    assert r.status_code == 404
+
+
+# ── 13. outcome review links back to original recommendation ─────────────
+
+def test_outcome_review_links_back_to_original_recommendation():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_id)
+        row = council_outcome_service.record_outcome_review(db, tenant_id, case.id, issue_resolved=True, recurred=False)
+        reviews = council_outcome_service.outcome_reviews_for_case(db, tenant_id, case.id)
+        assert len(reviews) == 1
+        assert reviews[0]["council_case_id"] == case.id
+        assert reviews[0]["id"] == row.id
+    finally:
+        db.close()
+
+
+# ── 14. ineffective recommendation creates learning signal ───────────────
+
+def test_ineffective_recommendation_creates_learning_signal():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_id)
+        before_action = case.recommended_action
+
+        row = council_outcome_service.record_outcome_review(db, tenant_id, case.id, issue_resolved=False, recurred=True)
+        assert row.classification == OUTCOME_INEFFECTIVE
+        assert row.knowledge_update_recommended is True
+
+        db.refresh(case)
+        assert case.recommended_action == before_action  # never automatically rewritten
+    finally:
+        db.close()
+
+
+# ── 15. Council configuration changes are versioned ───────────────────────
+
+def test_council_configuration_changes_are_versioned():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        council_team_registry_service.ensure_default_teams(db, tenant_id)
+        original = council_team_registry_service.get_team_config(db, tenant_id, "reliability")
+        assert original.version == 1
+
+        updated = council_team_registry_service.update_team_config(
+            db, tenant_id, "reliability", quorum_requirement=4, owner="qa@local.dev",
+        )
+        assert updated.version == 2
+        assert updated.is_current is True
+
+        history = council_team_registry_service.team_config_history(db, tenant_id, "reliability")
+        assert len(history) == 2
+        assert history[0]["version"] == 1
+        assert history[0]["is_current"] is False
+
+        raised = False
+        try:
+            council_team_registry_service.update_team_config(
+                db, tenant_id, "reliability", required_specialists=["vulcan", "aegis", "maestro"],
+            )
+        except ValueError:
+            raised = True
+        assert raised  # can't drop mandatory safety specialists (veritas, sentinelx)
+    finally:
+        db.close()
+
+
+# ── 16. no agent automatically changes clinical rules ─────────────────────
+
+def test_no_agent_automatically_changes_clinical_rules():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_id)
+        team_before = council_team_registry_service.get_team_config(db, tenant_id, case.team_key)
+        version_before = team_before.version
+
+        council_outcome_service.record_outcome_review(db, tenant_id, case.id, issue_resolved=False, recurred=True)
+
+        team_after = council_team_registry_service.get_team_config(db, tenant_id, case.team_key)
+        assert team_after.version == version_before  # outcome review never mutates team/rule configuration
+    finally:
+        db.close()
+
+
+# ── 17. Council brief remains grounded in case evidence ───────────────────
+
+def test_council_brief_remains_grounded_in_case_evidence():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        case = _open_and_convene_reliability_case(db, tenant_id)
+
+        sup = supervisor_brief(db, tenant_id, case.id)
+        assert sup["council_case_id"] == case.id
+        assert sup["specialist_recommendation"] == case.recommended_action
+
+        mgr = manager_brief(db, tenant_id, case.id)
+        assert mgr["council_case_id"] == case.id
+        assert mgr["recommended_owner"] == case.required_human_approver
+
+        exe = executive_brief(db, tenant_id, case.id)
+        assert exe["council_case_id"] == case.id
+        assert exe["recommended_strategic_action"] == case.recommended_action
+    finally:
+        db.close()
+
+
+# ── Route smoke test ──────────────────────────────────────────────────────
+
+def test_open_convene_and_workspace_routes():
+    tenant_id = uid("council-t")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        insp = _mk_inspection(db, tenant_id, barcode=uid("BC"))
+        _mk_finding(db, tenant_id, insp.id)
+        barcode = insp.instrument_barcode
+        inspection_id = insp.id
+    finally:
+        db.close()
+
+    r = client.post(
+        "/api/council/cases",
+        json={"case_type": "recurring_instrument_failure", "inspection_ids": [inspection_id], "instrument_ids": [f"barcode:{barcode}"], "urgency": "urgent"},
+        headers=_headers(AUTH_ADMIN, tenant_id),
+    )
+    assert r.status_code == 201
+    case_id = r.json()["id"]
+
+    r2 = client.post(f"/api/council/cases/{case_id}/convene", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["consensus_status"]
+    assert body["human_review_required"] is True
+
+    r3 = client.get("/api/council/workspace", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r3.status_code == 200
+    assert "active_case_count" in r3.json()
+
+    r4 = client.get(f"/api/council/cases/{case_id}", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r4.status_code == 200
+    assert "dissent" in r4.json()
+
+    r5 = client.get("/api/council/teams", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r5.status_code == 200

--- a/backend/tests/test_maestro_orchestration.py
+++ b/backend/tests/test_maestro_orchestration.py
@@ -1,0 +1,302 @@
+"""LumenAI AI Specialist — Project Maestro: Operational Orchestration &
+Decision Intelligence tests.
+
+Covers the 7 named scenarios from the sprint brief's Section 11
+(orchestration; priority ranking; leadership recommendations; operational
+health; decision journal; daily brief generation; specialist
+coordination), plus a route smoke test. Maestro is a pure
+read-and-synthesize layer over already-built specialists -- see
+`app/models/maestro_orchestration.py` for the naming disambiguation from
+Phase 22's `app.agents.orchestrator` and Nova's
+`nova_orchestration_service.py`, neither of which this file touches.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.inspection_finding import InspectionFinding
+from app.models.maestro_orchestration import (
+    BRIEF_TYPES,
+    DECISION_STATUS_PENDING,
+    RECOMMENDATION_GENERATE_CAPA_DRAFT,
+    RECOMMENDATION_SCHEDULE_COMPETENCY,
+)
+from app.models.or_connect import REPAIR_PENDING, RepairRequest
+from app.models.patient_safety import ExecutiveRiskSignal
+from app.models.sage_education import SageKnowledgeGap
+from app.models.sentinelx_risk import SentinelXRiskAssessment
+from app.models.vulcan_reliability import VulcanReliabilityAssessment
+from app.services import (
+    maestro_daily_brief_service,
+    maestro_decision_journal_service,
+    maestro_orchestration_service,
+    maestro_priority_engine_service,
+    maestro_recommendation_engine_service,
+)
+from app.services.maestro_health_index_service import compute_operational_health
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    db.add(models.TenantMembership(tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+def _seed_sentinelx_assessments(db, tenant_id: str) -> None:
+    for identity, score in (("barcode:LOW1", 30.0), ("barcode:HIGH1", 85.0)):
+        db.add(SentinelXRiskAssessment(
+            tenant_id=tenant_id, instrument_identity=identity, anatomy_zone="jaw serration",
+            facility_name="Main OR", risk_score=score, risk_level="high" if score > 50 else "low",
+        ))
+    db.commit()
+
+
+def _seed_vulcan_equipment(db, tenant_id: str) -> None:
+    db.add(VulcanReliabilityAssessment(
+        tenant_id=tenant_id, instrument_identity="barcode:WORST1", instrument_family="kerrison rongeur",
+        reliability_score=20.0, reliability_category="corrosion_concern", recommended_disposition="review",
+    ))
+    db.commit()
+
+
+def _seed_sage_gap(db, tenant_id: str) -> None:
+    db.add(SageKnowledgeGap(
+        tenant_id=tenant_id, competency_domain="brushing_technique", scope_type="technician",
+        scope_value="tech-1", occurrence_count=5, narrative="Recurring brushing technique gap observed.",
+        status="open",
+    ))
+    db.commit()
+
+
+def _seed_capa_pattern(db, tenant_id: str) -> list[int]:
+    ids = []
+    for _ in range(3):
+        insp = models.Inspection(tenant_id=tenant_id, file_name="t.jpg", instrument_type="kerrison rongeur", created_at=datetime.now(timezone.utc))
+        db.add(insp)
+        db.commit()
+        db.refresh(insp)
+        f = InspectionFinding(tenant_id=tenant_id, inspection_id=insp.id, finding_type="rust", zone="jaw serration", severity_index=2)
+        db.add(f)
+        db.commit()
+        ids.append(insp.id)
+    return ids
+
+
+def _seed_repair_backlog(db, tenant_id: str) -> None:
+    db.add(RepairRequest(
+        tenant_id=tenant_id, inspection_id=1, instrument_identity="barcode:REPAIR1", vendor_name="Acme Repair",
+        repair_type="sharpening", status=REPAIR_PENDING, created_at=datetime.now(timezone.utc) - timedelta(days=20),
+    ))
+    db.commit()
+
+
+def _seed_executive_risk(db, tenant_id: str) -> None:
+    db.add(ExecutiveRiskSignal(
+        tenant_id=tenant_id, event_source="vendor_registry", event_type="high_risk_vendor",
+        risk_tier="critical", confidence_score=0.9, human_review_status="pending",
+        association_reason="Vendor has an unresolved recall exposure.",
+    ))
+    db.commit()
+
+
+def _seed_all(db, tenant_id: str) -> None:
+    _seed_sentinelx_assessments(db, tenant_id)
+    _seed_vulcan_equipment(db, tenant_id)
+    _seed_sage_gap(db, tenant_id)
+    _seed_capa_pattern(db, tenant_id)
+    _seed_repair_backlog(db, tenant_id)
+    _seed_executive_risk(db, tenant_id)
+
+
+# ── 1. orchestration runs end-to-end from real specialist signals ────────
+
+def test_orchestration_runs_end_to_end():
+    tenant_id = uid("maestro-t")
+    db = SessionLocal()
+    try:
+        _seed_all(db, tenant_id)
+        result = maestro_orchestration_service.run_daily_orchestration(db, tenant_id)
+        assert result["priority_item_count"] > 0
+        assert result["recommendation_count"] > 0
+        assert result["operational_health"]["human_review_required"] is True
+        assert result["daily_brief"]["narrative"]
+        assert result["human_review_required"] is True
+    finally:
+        db.close()
+
+
+# ── 2. priority engine ranks categories by real signal strength ──────────
+
+def test_priority_ranking_orders_by_score():
+    tenant_id = uid("maestro-t")
+    db = SessionLocal()
+    try:
+        _seed_sentinelx_assessments(db, tenant_id)
+        _seed_vulcan_equipment(db, tenant_id)
+        rows = maestro_priority_engine_service.compute_priorities(db, tenant_id)
+        assert len(rows) >= 2
+        scores = [r.priority_score for r in rows]
+        assert scores == sorted(scores, reverse=True)
+        ranks = [r.rank for r in rows]
+        assert ranks == list(range(1, len(rows) + 1))
+    finally:
+        db.close()
+
+
+# ── 3. leadership recommendations cite real evidence ──────────────────────
+
+def test_leadership_recommendations_cite_evidence():
+    tenant_id = uid("maestro-t")
+    db = SessionLocal()
+    try:
+        _seed_sage_gap(db, tenant_id)
+        _seed_capa_pattern(db, tenant_id)
+        recommendations = maestro_recommendation_engine_service.generate_recommendations(db, tenant_id)
+        assert recommendations
+        for rec in recommendations:
+            assert rec.rationale
+            assert rec.evidence_json and rec.evidence_json != "{}"
+            assert rec.human_review_required is True
+        types = {r.recommendation_type for r in recommendations}
+        assert RECOMMENDATION_SCHEDULE_COMPETENCY in types or RECOMMENDATION_GENERATE_CAPA_DRAFT in types
+    finally:
+        db.close()
+
+
+# ── 4. operational health composes a real cross-specialist index ─────────
+
+def test_operational_health_computes_composite():
+    tenant_id = uid("maestro-t")
+    db = SessionLocal()
+    try:
+        _seed_vulcan_equipment(db, tenant_id)
+        snapshot = compute_operational_health(db, tenant_id)
+        assert snapshot.equipment_score is not None
+        assert snapshot.human_review_required is True
+        breakdown = snapshot.breakdown_json
+        assert breakdown and breakdown != "{}"
+    finally:
+        db.close()
+
+
+# ── 5. decision journal requires a real leader decision and advances status ──
+
+def test_decision_journal_records_and_advances_status():
+    tenant_id = uid("maestro-t")
+    db = SessionLocal()
+    try:
+        _seed_sage_gap(db, tenant_id)
+        recommendations = maestro_recommendation_engine_service.generate_recommendations(db, tenant_id)
+        assert recommendations
+        rec = recommendations[0]
+        assert rec.status == DECISION_STATUS_PENDING
+
+        raised = False
+        try:
+            maestro_decision_journal_service.record_decision(
+                db, tenant_id, rec.id, leader_decision="", decided_by="manager@local.dev",
+            )
+        except ValueError:
+            raised = True
+        assert raised
+
+        entry = maestro_decision_journal_service.record_decision(
+            db, tenant_id, rec.id, leader_decision="Approved and assigned to SPD lead.",
+            decided_by="manager@local.dev", decided_role="spd_manager", new_status="completed",
+        )
+        assert entry.leader_decision
+        assert entry.evidence_json == rec.evidence_json
+
+        db.refresh(rec)
+        assert rec.status == "completed"
+    finally:
+        db.close()
+
+
+# ── 6. daily brief generation produces a narrative per brief type ────────
+
+def test_daily_brief_generation_produces_narrative_per_type():
+    tenant_id = uid("maestro-t")
+    db = SessionLocal()
+    try:
+        _seed_all(db, tenant_id)
+        maestro_priority_engine_service.compute_priorities(db, tenant_id)
+        for brief_type in BRIEF_TYPES:
+            row = maestro_daily_brief_service.generate_brief(db, tenant_id, brief_type)
+            assert row.narrative
+            assert row.content_json and row.content_json != "{}"
+    finally:
+        db.close()
+
+
+# ── 7. specialist coordination composes real, non-fabricated signals ─────
+
+def test_specialist_coordination_composes_real_signals():
+    tenant_id = uid("maestro-t")
+    db = SessionLocal()
+    try:
+        _seed_all(db, tenant_id)
+        rows = maestro_priority_engine_service.compute_priorities(db, tenant_id)
+        specialists = {r.source_specialist for r in rows}
+        assert specialists.issubset({
+            "sentinelx", "sage", "vulcan", "capa_suggestion_service", "or_connect", "executive_risk_signal",
+        })
+        assert specialists  # never empty when real data exists across categories
+
+        workspace = maestro_orchestration_service.leadership_workspace_summary(db, tenant_id)
+        assert "enterprise_status" in workspace
+        assert "shift_readiness" in workspace
+        assert workspace["human_review_required"] is True
+    finally:
+        db.close()
+
+
+# ── Route smoke test ──────────────────────────────────────────────────────
+
+def test_orchestration_and_workspace_routes():
+    tenant_id = uid("maestro-t")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        _seed_all(db, tenant_id)
+    finally:
+        db.close()
+
+    r = client.post("/api/maestro/run", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["priority_item_count"] > 0
+    assert body["human_review_required"] is True
+
+    r2 = client.get("/api/maestro/workspace", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r2.status_code == 200
+    assert "top_priorities" in r2.json()
+
+    r3 = client.get("/api/maestro/priorities", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r3.status_code == 200
+
+    r4 = client.get("/api/maestro/recommendations", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r4.status_code == 200
+
+    r5 = client.get("/api/maestro/timeline", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r5.status_code == 200
+    assert "horizons" in r5.json()

--- a/backend/tests/test_sage_education.py
+++ b/backend/tests/test_sage_education.py
@@ -1,0 +1,401 @@
+"""LumenAI AI Specialist — Project Sage: SPD Education, Competency &
+Workforce Intelligence tests.
+
+Covers the 14 named scenarios from the sprint brief's Section 20, plus route
+smoke/permission tests.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.sage_education import SageLearningPlan
+from app.models.supervisor_review import SupervisorReview
+from app.services import (
+    sage_aegis_vulcan_integration_service,
+    sage_effectiveness_service,
+    sage_feedback_service,
+    sage_gap_detection_service,
+    sage_learning_plan_service,
+    sage_microlearning_service,
+    sage_workforce_privacy_service,
+)
+from app.services.vulcan_reliability_agent_service import run_reliability_assessment
+from app.models.inspection_finding import InspectionFinding
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    db.add(models.TenantMembership(tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+def _mk_inspection(db, tenant_id, *, technician, coverage_pct=None, ai_confidence=None, has_image=True, created_at=None):
+    row = models.Inspection(
+        tenant_id=tenant_id, file_name="test.jpg", technician=technician,
+        coverage_pct=coverage_pct, ai_confidence=ai_confidence, has_image=has_image,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mk_review(db, tenant_id, inspection_id, **kwargs):
+    row = SupervisorReview(tenant_id=tenant_id, inspection_id=inspection_id, agreement=kwargs.pop("agreement", "agree"), **kwargs)
+    db.add(row)
+    db.commit()
+    return row
+
+
+# ── 1. repeated missed anatomy zones produce an education recommendation ─────
+
+def test_repeated_missed_anatomy_zones_produce_education_recommendation():
+    tenant_id = uid("sage-t")
+    technician = uid("tech") + "@local.dev"
+    db = SessionLocal()
+    try:
+        for _ in range(2):
+            insp = _mk_inspection(db, tenant_id, technician=technician)
+            _mk_review(db, tenant_id, insp.id, missing_zone_correct=False, corrected_missing_zone="serrations", instrument_family="kerrison")
+
+        gaps = sage_gap_detection_service.detect_missed_anatomy_zones(db, tenant_id, technician)
+        assert len(gaps) == 1
+        assert gaps[0]["occurrence_count"] == 2
+        assert gaps[0]["recommended_education"]
+        assert "targeted education" in gaps[0]["narrative"].lower() or "verification" in gaps[0]["narrative"].lower() or "observation" in gaps[0]["narrative"].lower()
+    finally:
+        db.close()
+
+
+# ── 2. one isolated error does not automatically create a competency failure ─
+
+def test_one_isolated_error_does_not_create_gap():
+    tenant_id = uid("sage-t")
+    technician = uid("tech") + "@local.dev"
+    db = SessionLocal()
+    try:
+        insp = _mk_inspection(db, tenant_id, technician=technician)
+        _mk_review(db, tenant_id, insp.id, missing_zone_correct=False, corrected_missing_zone="serrations", instrument_family="kerrison")
+
+        gaps = sage_gap_detection_service.detect_missed_anatomy_zones(db, tenant_id, technician)
+        assert gaps == []
+    finally:
+        db.close()
+
+
+# ── 3. rigid-scope and flexible-endoscope education remain distinct ──────────
+
+def test_rigid_scope_and_flexible_endoscope_remain_distinct():
+    tenant_id = uid("sage-t")
+    technician = uid("tech") + "@local.dev"
+    db = SessionLocal()
+    try:
+        for _ in range(2):
+            insp = _mk_inspection(db, tenant_id, technician=technician)
+            _mk_review(db, tenant_id, insp.id, zone_correct=False, instrument_family="rigid_scope")
+        for _ in range(2):
+            insp = _mk_inspection(db, tenant_id, technician=technician)
+            _mk_review(db, tenant_id, insp.id, zone_correct=False, instrument_family="flexible_endoscope")
+
+        gaps = sage_gap_detection_service.detect_anatomy_label_errors(db, tenant_id, technician)
+        families = {g["instrument_family"] for g in gaps}
+        assert families == {"rigid_scope", "flexible_endoscope"}
+        assert len(gaps) == 2
+    finally:
+        db.close()
+
+
+# ── 4. drill-bit flute gap produces anatomy-specific guidance ────────────────
+
+def test_drill_bit_flute_gap_produces_anatomy_specific_guidance():
+    tenant_id = uid("sage-t")
+    technician = uid("tech") + "@local.dev"
+    db = SessionLocal()
+    try:
+        for _ in range(2):
+            insp = _mk_inspection(db, tenant_id, technician=technician)
+            _mk_review(db, tenant_id, insp.id, missing_zone_correct=False, corrected_missing_zone="flutes", instrument_family="drill_bit")
+
+        gaps = sage_gap_detection_service.detect_missed_anatomy_zones(db, tenant_id, technician)
+        assert len(gaps) == 1
+        assert "flutes" in gaps[0]["recommended_education"]
+        assert gaps[0]["anatomy_zone"] == "flutes"
+    finally:
+        db.close()
+
+
+# ── 5. blood-versus-rust confusion produces targeted education ──────────────
+
+def test_blood_versus_rust_confusion_produces_targeted_education():
+    tenant_id = uid("sage-t")
+    technician = uid("tech") + "@local.dev"
+    db = SessionLocal()
+    try:
+        insp1 = _mk_inspection(db, tenant_id, technician=technician)
+        _mk_review(db, tenant_id, insp1.id, finding_correct=False, finding_type="blood")
+        insp2 = _mk_inspection(db, tenant_id, technician=technician)
+        _mk_review(db, tenant_id, insp2.id, finding_correct=False, finding_type="rust")
+
+        gaps = sage_gap_detection_service.detect_finding_confusion(db, tenant_id, technician)
+        assert len(gaps) == 1
+        assert gaps[0]["finding_category"] == "blood_vs_rust"
+        assert "blood" in gaps[0]["recommended_education"] and "rust" in gaps[0]["recommended_education"]
+    finally:
+        db.close()
+
+
+# ── 6. approved knowledge sources are included in microlearning ──────────────
+
+def test_approved_knowledge_sources_included_in_microlearning():
+    tenant_id = uid("sage-t")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        module = sage_microlearning_service.build_module_from_finding(db, tenant_id, "corrosion")
+        assert module is not None
+        data = sage_microlearning_service._to_dict(module)
+        assert data["inspection_steps"]
+        assert any("clinical_mentor" in ref or "education_library" in ref or ref for ref in data["source_refs"])
+        assert data["source_refs"]
+    finally:
+        db.close()
+
+
+# ── 7. unapproved guidance is excluded ────────────────────────────────────────
+
+def test_unapproved_guidance_is_excluded():
+    tenant_id = uid("sage-t")
+    db = SessionLocal()
+    try:
+        module = sage_microlearning_service.build_module_from_finding(db, tenant_id, "totally_unrecognized_finding_xyz")
+        assert module is None
+    finally:
+        db.close()
+
+
+# ── 8. supervisor approval is required before assignment ────────────────────
+
+def test_supervisor_approval_required_before_assignment():
+    tenant_id = uid("sage-t")
+    technician = uid("tech") + "@local.dev"
+    db = SessionLocal()
+    try:
+        plan = sage_learning_plan_service.create_learning_plan(
+            db, tenant_id, learner_or_group=technician, created_by="sage-system",
+        )
+        assert plan.approved_by == ""
+        visible = sage_learning_plan_service.list_plans_for_learner(db, tenant_id, technician)
+        assert visible == []
+
+        sage_learning_plan_service.approve_learning_plan(db, tenant_id, plan.id, approved_by="supervisor@local.dev")
+        visible_after = sage_learning_plan_service.list_plans_for_learner(db, tenant_id, technician)
+        assert len(visible_after) == 1
+        assert visible_after[0]["approved_by"] == "supervisor@local.dev"
+    finally:
+        db.close()
+
+
+# ── 9. technician can view only their learning plan ──────────────────────────
+
+def test_technician_can_view_only_their_own_learning_plan():
+    tenant_id = uid("sage-t")
+    tech_a = uid("tech-a") + "@local.dev"
+    tech_b = uid("tech-b") + "@local.dev"
+    db = SessionLocal()
+    try:
+        plan_a = sage_learning_plan_service.create_learning_plan(db, tenant_id, learner_or_group=tech_a, created_by="sage-system")
+        plan_b = sage_learning_plan_service.create_learning_plan(db, tenant_id, learner_or_group=tech_b, created_by="sage-system")
+        sage_learning_plan_service.approve_learning_plan(db, tenant_id, plan_a.id, approved_by="supervisor@local.dev")
+        sage_learning_plan_service.approve_learning_plan(db, tenant_id, plan_b.id, approved_by="supervisor@local.dev")
+
+        visible_to_a = sage_learning_plan_service.list_plans_for_learner(db, tenant_id, tech_a)
+        assert len(visible_to_a) == 1
+        assert visible_to_a[0]["learner_or_group"] == tech_a
+        assert all(p["learner_or_group"] != tech_b for p in visible_to_a)
+    finally:
+        db.close()
+
+
+# ── 10. viewer cannot access individual competency data ──────────────────────
+
+def test_viewer_cannot_access_individual_competency_data():
+    tenant_id = uid("sage-t")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+        _seed_membership(db, tenant_id, role="viewer")
+    finally:
+        db.close()
+
+    r = client.get("/api/sage/gaps", headers=_headers(AUTH_VIEWER, tenant_id))
+    assert r.status_code == 403
+
+    r2 = client.get("/api/sage/learning-plans", headers=_headers(AUTH_VIEWER, tenant_id))
+    assert r2.status_code == 403
+
+    assert sage_workforce_privacy_service.can_view_individual_competency("viewer", "viewer@local.dev", "someone-else@local.dev") is False
+
+
+# ── 11. learning effectiveness compares pre/post metrics correctly ──────────
+
+def test_learning_effectiveness_compares_pre_post_metrics_correctly():
+    tenant_id = uid("sage-t")
+    technician = uid("tech") + "@local.dev"
+    db = SessionLocal()
+    try:
+        plan_created_at = datetime.now(timezone.utc) - timedelta(days=60)
+        plan_completed_at = datetime.now(timezone.utc) - timedelta(days=10)
+
+        # Before window: low coverage, poor accuracy.
+        for _ in range(3):
+            insp = _mk_inspection(db, tenant_id, technician=technician, coverage_pct=50, created_at=plan_created_at - timedelta(days=5))
+            _mk_review(db, tenant_id, insp.id, finding_correct=False, zone_correct=False)
+
+        # After window: high coverage, good accuracy.
+        for _ in range(3):
+            insp = _mk_inspection(db, tenant_id, technician=technician, coverage_pct=95, created_at=plan_completed_at + timedelta(days=5))
+            _mk_review(db, tenant_id, insp.id, finding_correct=True, zone_correct=True)
+
+        plan = SageLearningPlan(tenant_id=tenant_id, learner_or_group=technician, created_by="sage-system")
+        plan.created_at = plan_created_at
+        plan.completed_at = plan_completed_at
+        plan.completion_status = "completed"
+        db.add(plan)
+        db.commit()
+        db.refresh(plan)
+
+        result = sage_effectiveness_service.measure_learning_plan_effectiveness(db, tenant_id, plan, window_days=30)
+        assert result.effectiveness in ("improved", "partially_improved")
+        before = result.before_metrics_json
+        after = result.after_metrics_json
+        assert "50" in before or "50.0" in before
+        assert "95" in after or "95.0" in after
+    finally:
+        db.close()
+
+
+# ── 12. insufficient evidence returns an inconclusive effectiveness result ──
+
+def test_insufficient_evidence_returns_inconclusive_effectiveness_result():
+    tenant_id = uid("sage-t")
+    technician = uid("tech") + "@local.dev"
+    db = SessionLocal()
+    try:
+        plan = SageLearningPlan(tenant_id=tenant_id, learner_or_group=technician, created_by="sage-system")
+        plan.completion_status = "completed"
+        plan.completed_at = datetime.now(timezone.utc)
+        db.add(plan)
+        db.commit()
+        db.refresh(plan)
+
+        result = sage_effectiveness_service.measure_learning_plan_effectiveness(db, tenant_id, plan, window_days=30)
+        assert result.effectiveness == "insufficient_evidence"
+    finally:
+        db.close()
+
+
+# ── 13. Aegis, Vulcan, and Sage evidence remain separately auditable ────────
+
+def test_aegis_vulcan_sage_evidence_separately_auditable():
+    tenant_id = uid("sage-t")
+    barcode = uid("instr")
+    identity = f"barcode:{barcode}"
+    db = SessionLocal()
+    try:
+        base = datetime.now(timezone.utc) - timedelta(days=20)
+        for day in (0, 10):
+            insp = models.Inspection(
+                tenant_id=tenant_id, file_name="t.jpg", instrument_type="kerrison rongeur",
+                instrument_barcode=barcode, technician="tech-a@local.dev", created_at=base + timedelta(days=day),
+            )
+            db.add(insp)
+            db.commit()
+            db.refresh(insp)
+            db.add(InspectionFinding(tenant_id=tenant_id, inspection_id=insp.id, finding_type="corrosion", zone="jaw", severity_index=2))
+            db.commit()
+
+        vulcan_row = run_reliability_assessment(db, tenant_id, identity, instrument_type="kerrison rongeur")
+        sage_result = sage_aegis_vulcan_integration_service.sage_recommendation_from_vulcan(vulcan_row)
+
+        assert sage_result["source_vulcan_assessment_id"] == vulcan_row.id
+        assert sage_result["recommendation"] != vulcan_row.reasoning_narrative
+
+        aegis_result = sage_aegis_vulcan_integration_service.sage_recommendation_from_aegis(db, tenant_id, identity, zone="jaw")
+        assert "source_aegis_signal" in aegis_result
+        assert "recommendation" in aegis_result
+        # The three evidence sources are all independently present and distinguishable.
+        assert vulcan_row.reasoning_narrative
+        assert aegis_result["source_aegis_signal"] is not vulcan_row.reasoning_narrative
+    finally:
+        db.close()
+
+
+# ── 14. Sage cannot make disciplinary or employment decisions ───────────────
+
+def test_sage_cannot_make_disciplinary_or_employment_decisions():
+    assert "disciplinary_action" in sage_workforce_privacy_service.PROHIBITED_ACTIONS
+    assert "employment_decision" in sage_workforce_privacy_service.PROHIBITED_ACTIONS
+    assert "public_employee_ranking" in sage_workforce_privacy_service.PROHIBITED_ACTIONS
+
+    assert "terminate_employee" not in sage_feedback_service.VALID_ACTIONS
+    assert "discipline" not in sage_feedback_service.VALID_ACTIONS
+
+    tenant_id = uid("sage-t")
+    db = SessionLocal()
+    try:
+        try:
+            sage_feedback_service.record_feedback(db, tenant_id, action="terminate_employee", submitted_by="someone@local.dev")
+            raised = False
+        except ValueError:
+            raised = True
+        assert raised
+    finally:
+        db.close()
+
+
+# ── Route smoke tests ─────────────────────────────────────────────────────────
+
+def test_taxonomy_and_workspace_routes():
+    tenant_id = uid("sage-t")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+    finally:
+        db.close()
+
+    r = client.get("/api/sage/taxonomy", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r.status_code == 200
+    assert "anatomy_recognition" in r.json()["domains"]
+
+    r2 = client.get("/api/sage/workspace", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r2.status_code == 200
+    assert r2.json()["human_review_required"] is True
+
+    r3 = client.get("/api/sage/my-learning", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r3.status_code == 200
+    assert r3.json()["learner"] == "admin@local.dev"
+
+    r4 = client.get("/api/sage/executive-summary", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r4.status_code == 200
+    assert "no individual technician is ranked" in r4.json()["note"]

--- a/backend/tests/test_sentinel_x_risk.py
+++ b/backend/tests/test_sentinel_x_risk.py
@@ -1,0 +1,218 @@
+"""LumenAI AI Specialist — Project Sentinel-X: Clinical Risk Intelligence &
+Patient Safety Agent tests.
+
+Covers the 8 named scenarios from the sprint brief's Section 13, plus a
+route smoke test. Distinct from the pre-existing, unrelated
+`test_sentinel_orchestration.py` ("Project Sentinel" v3.0).
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.inspection_finding import InspectionFinding
+from app.models.sentinelx_risk import SentinelXRiskAssessment
+from app.services import (
+    sentinelx_override_service,
+    sentinelx_patient_safety_watch_service,
+    sentinelx_risk_scoring_service,
+)
+from app.services.sentinelx_risk_agent_service import run_risk_assessment
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    db.add(models.TenantMembership(tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+def _mk_inspection(db, tenant_id, *, barcode, instrument_type="kerrison rongeur", created_at=None):
+    row = models.Inspection(
+        tenant_id=tenant_id, file_name="t.jpg", instrument_type=instrument_type, instrument_barcode=barcode,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mk_finding(db, tenant_id, inspection_id, *, finding_type, zone, severity_index):
+    row = InspectionFinding(tenant_id=tenant_id, inspection_id=inspection_id, finding_type=finding_type, zone=zone, severity_index=severity_index)
+    db.add(row)
+    db.commit()
+    return row
+
+
+def _identity(barcode: str) -> str:
+    return f"barcode:{barcode}"
+
+
+# ── 1. blood in serration produces high risk ──────────────────────────────
+
+def test_blood_in_serration_produces_high_risk():
+    result = sentinelx_risk_scoring_service.compute_risk_score(
+        finding_type="blood", severity_index=3, anatomy_zone_high_risk=True,
+    )
+    assert result["risk_level"] in ("high", "critical")
+
+
+# ── 2. cosmetic discoloration remains low risk ────────────────────────────
+
+def test_cosmetic_discoloration_remains_low_risk():
+    blood = sentinelx_risk_scoring_service.compute_risk_score(finding_type="blood", severity_index=3, anatomy_zone_high_risk=True)
+    discoloration = sentinelx_risk_scoring_service.compute_risk_score(finding_type="discoloration", severity_index=1, anatomy_zone_high_risk=False)
+    assert discoloration["risk_level"] in ("very_low", "low")
+    assert discoloration["risk_score"] < blood["risk_score"]
+
+
+# ── 3. corrosion recurrence increases risk ────────────────────────────────
+
+def test_corrosion_recurrence_increases_risk():
+    low_recurrence = sentinelx_risk_scoring_service.compute_risk_score(finding_type="corrosion", severity_index=2, recurrence_count=0)
+    high_recurrence = sentinelx_risk_scoring_service.compute_risk_score(finding_type="corrosion", severity_index=2, recurrence_count=4)
+    assert high_recurrence["risk_score"] > low_recurrence["risk_score"]
+    assert "recurrence" in high_recurrence["score_breakdown"]
+
+
+# ── 4. Digital Twin decline increases risk ────────────────────────────────
+
+def test_digital_twin_decline_increases_risk():
+    stable = sentinelx_risk_scoring_service.compute_risk_score(finding_type="corrosion", severity_index=2, digital_twin_condition_trend="stable")
+    declining = sentinelx_risk_scoring_service.compute_risk_score(finding_type="corrosion", severity_index=2, digital_twin_condition_trend="declining")
+    assert declining["risk_score"] > stable["risk_score"]
+
+
+# ── 5. missing evidence reduces confidence ────────────────────────────────
+
+def test_missing_evidence_reduces_confidence():
+    missing_evidence = sentinelx_risk_scoring_service.compute_risk_score(finding_type="corrosion", severity_index=2, evidence_readiness_score=None)
+    strong_evidence = sentinelx_risk_scoring_service.compute_risk_score(finding_type="corrosion", severity_index=2, evidence_readiness_score=95)
+    assert missing_evidence["score_breakdown"]["evidence_readiness_gap"] > strong_evidence["score_breakdown"].get("evidence_readiness_gap", 0)
+    assert missing_evidence["risk_score"] > strong_evidence["risk_score"]
+
+
+# ── 6. repeat anatomy failures escalate priority ──────────────────────────
+
+def test_repeat_anatomy_failures_escalate_priority():
+    tenant_id = uid("sentx-t")
+    barcode = uid("instr")
+    identity = _identity(barcode)
+    db = SessionLocal()
+    try:
+        for _ in range(2):
+            row = SentinelXRiskAssessment(
+                tenant_id=tenant_id, instrument_identity=identity, anatomy_zone="jaw serration",
+                risk_score=65.0, risk_level="high",
+            )
+            db.add(row)
+        db.commit()
+
+        fired = sentinelx_patient_safety_watch_service.scan_for_alerts(db, tenant_id)
+        assert any(a.alert_type == "repeat_anatomy_failure" and a.instrument_identity == identity for a in fired)
+    finally:
+        db.close()
+
+
+# ── 7. risk explanation includes supporting evidence ──────────────────────
+
+def test_risk_explanation_includes_supporting_evidence():
+    tenant_id = uid("sentx-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        base = datetime.now(timezone.utc) - timedelta(days=10)
+        for day in (0, 5):
+            insp = _mk_inspection(db, tenant_id, barcode=barcode, created_at=base + timedelta(days=day))
+            _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=2)
+
+        row = run_risk_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+        assert row.reasoning_narrative
+        assert "corrosion" in row.reasoning_narrative.lower()
+        assert row.evidence_json and row.evidence_json != "{}"
+        assert row.score_breakdown_json and row.score_breakdown_json != "{}"
+    finally:
+        db.close()
+
+
+# ── 8. supervisor override remains auditable ──────────────────────────────
+
+def test_supervisor_override_remains_auditable():
+    tenant_id = uid("sentx-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        insp = _mk_inspection(db, tenant_id, barcode=barcode)
+        _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=2)
+        row = run_risk_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+        original_level = row.risk_level
+
+        override = sentinelx_override_service.submit_override(
+            db, tenant_id, row.id, overridden_risk_level="critical", rationale="Manual clinical review confirmed higher risk.",
+            submitted_by="supervisor@local.dev", submitted_role="spd_manager",
+        )
+        assert override.original_risk_level == original_level
+        assert override.overridden_risk_level == "critical"
+
+        db.refresh(row)
+        assert row.risk_level == original_level  # never silently mutated
+
+        history = sentinelx_override_service.overrides_for_assessment(db, tenant_id, row.id)
+        assert len(history) == 1
+
+        raised = False
+        try:
+            sentinelx_override_service.submit_override(db, tenant_id, row.id, overridden_risk_level="low", rationale="", submitted_by="supervisor@local.dev")
+        except ValueError:
+            raised = True
+        assert raised
+    finally:
+        db.close()
+
+
+# ── Route smoke test ──────────────────────────────────────────────────────
+
+def test_assess_and_dashboard_routes():
+    tenant_id = uid("sentx-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        insp = _mk_inspection(db, tenant_id, barcode=barcode)
+        _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=2)
+    finally:
+        db.close()
+
+    r = client.post(
+        "/api/sentinelx/assess", json={"instrument_identity": _identity(barcode), "instrument_type": "kerrison rongeur"},
+        headers=_headers(AUTH_ADMIN, tenant_id),
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["risk_level"]
+    assert body["human_review_required"] is True
+
+    r2 = client.get("/api/sentinelx/dashboard", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r2.status_code == 200
+    assert "enterprise_risk" in r2.json()
+
+    r3 = client.get("/api/sentinelx/supervisor-workspace", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r3.status_code == 200

--- a/backend/tests/test_veritas_evidence.py
+++ b/backend/tests/test_veritas_evidence.py
@@ -1,0 +1,387 @@
+"""LumenAI AI Specialist — Project Veritas: Baseline Governance, Evidence
+Integrity & Clinical Data Quality tests.
+
+Covers the 16 named scenarios from the sprint brief's Section 22, plus route
+permission smoke tests.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.baseline_library import BaselineLibraryEntry
+from app.models.retained_image import ImageLabel, RetainedImage
+from app.services import (
+    veritas_baseline_governance_service,
+    veritas_baseline_matching_service,
+    veritas_baseline_resolution_service,
+    veritas_conflict_detection_service,
+    veritas_feedback_service,
+    veritas_image_quality_service,
+    veritas_readiness_score_service,
+    veritas_specialist_collaboration_service,
+    veritas_training_dataset_service,
+)
+from app.services.veritas_evidence_agent_service import run_evidence_assessment, to_dict as assessment_to_dict
+from app.services.vulcan_aegis_integration_service import compute_process_variation_signal
+from app.services.vulcan_reliability_agent_service import run_reliability_assessment
+from app.models.inspection_finding import InspectionFinding
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_OPERATOR = {"Authorization": "Bearer operator-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    db.add(models.TenantMembership(tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+def _mk_inspection(db, tenant_id, *, instrument_type="kerrison rongeur", barcode=None, coverage_pct=None,
+                    ai_confidence=None, has_image=True, inspected_zones=None):
+    row = models.Inspection(
+        tenant_id=tenant_id, file_name="t.jpg", instrument_type=instrument_type, instrument_barcode=barcode,
+        coverage_pct=coverage_pct, ai_confidence=ai_confidence, has_image=has_image,
+        inspected_zones_json="null" if inspected_zones is None else __import__("json").dumps(inspected_zones),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mk_baseline(db, *, instrument_category, manufacturer="Acme", model="X1", baseline_type="manufacturer", approval_status="approved", baseline_version="1.0"):
+    row = BaselineLibraryEntry(
+        instrument_category=instrument_category, manufacturer_name=manufacturer, model_name=model,
+        baseline_type=baseline_type, approval_status=approval_status, baseline_version=baseline_version,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+# ── 1. approved manufacturer baseline has highest priority ──────────────────
+
+def test_approved_manufacturer_baseline_has_highest_priority():
+    category = uid("instr-cat")
+    db = SessionLocal()
+    try:
+        tenant_id = uid("veritas-t")
+        _mk_baseline(db, instrument_category=category, baseline_type="vendor", baseline_version="2.0")
+        _mk_baseline(db, instrument_category=category, baseline_type="manufacturer", baseline_version="3.0")
+
+        resolution = veritas_baseline_resolution_service.resolve_governed_baseline(db, tenant_id, category)
+        assert resolution.baseline_tier == "manufacturer"
+        assert resolution.baseline_version == "3.0"
+    finally:
+        db.close()
+
+
+# ── 2. unapproved baseline cannot drive final scoring ────────────────────────
+
+def test_unapproved_baseline_cannot_drive_final_scoring():
+    category = uid("instr-cat")
+    db = SessionLocal()
+    try:
+        tenant_id = uid("veritas-t")
+        _mk_baseline(db, instrument_category=category, approval_status="pending")
+
+        resolution = veritas_baseline_resolution_service.resolve_governed_baseline(db, tenant_id, category)
+        assert resolution.resolution_status == "SUPERVISOR_REVIEW_REQUIRED"
+        assert "No approved baseline" in resolution.message
+        assert veritas_baseline_governance_service.is_usable_for_scoring("pending_review") is False
+    finally:
+        db.close()
+
+
+# ── 3. rigid-scope baseline does not match flexible endoscope ───────────────
+
+def test_rigid_scope_baseline_does_not_match_flexible_endoscope():
+    result = veritas_baseline_matching_service.classify_match(
+        instrument_type="rigid scope", baseline_instrument_category="flexible endoscope",
+    )
+    assert result["match_classification"] == "mismatch"
+
+
+# ── 4. anatomy-zone mismatch creates evidence conflict ───────────────────────
+
+def test_anatomy_zone_mismatch_creates_evidence_conflict():
+    conflicts = veritas_conflict_detection_service.detect_conflicts(match_classification="mismatch")
+    assert any(c["conflict_type"] == "instrument_family_differs_from_baseline" for c in conflicts)
+
+    tag_conflicts = veritas_conflict_detection_service.detect_conflicts(ai_zone="jaw", tagged_zone="o-ring area")
+    assert any(c["conflict_type"] == "image_tag_differs_from_predicted_zone" for c in tag_conflicts)
+
+
+# ── 5. poor image quality requires recapture guidance ────────────────────────
+
+def test_poor_image_quality_requires_recapture_guidance():
+    result = veritas_image_quality_service.assess_image_quality(has_image=True, ai_confidence=0.15)
+    assert result["quality_status"] == "insufficient"
+    assert result["recommended_recapture_steps"]
+
+
+# ── 6. missing critical zone lowers evidence readiness ──────────────────────
+
+def test_missing_critical_zone_lowers_evidence_readiness():
+    complete = veritas_readiness_score_service.compute_evidence_readiness_score(
+        match_classification="exact", baseline_governance_status="approved", image_quality_status="excellent",
+        coverage_status="complete", instrument_identity_confidence="high", provenance_complete=True,
+        supervisor_validated=True, model_compatible=True, has_conflicts=False,
+    )
+    insufficient_coverage = veritas_readiness_score_service.compute_evidence_readiness_score(
+        match_classification="exact", baseline_governance_status="approved", image_quality_status="excellent",
+        coverage_status="insufficient", instrument_identity_confidence="high", provenance_complete=True,
+        supervisor_validated=True, model_compatible=True, has_conflicts=False,
+    )
+    assert insufficient_coverage["readiness_score"] < complete["readiness_score"]
+
+
+# ── 7. complete approved evidence produces strong readiness ─────────────────
+
+def test_complete_approved_evidence_produces_strong_readiness():
+    result = veritas_readiness_score_service.compute_evidence_readiness_score(
+        match_classification="exact", baseline_governance_status="approved", image_quality_status="excellent",
+        coverage_status="complete", instrument_identity_confidence="high", provenance_complete=True,
+        supervisor_validated=True, model_compatible=True, has_conflicts=False,
+    )
+    assert result["readiness_category"] == "strong_evidence"
+    assert result["readiness_score"] >= 90
+
+
+# ── 8. duplicate images are detected ──────────────────────────────────────────
+
+def test_duplicate_images_are_detected():
+    tenant_id = uid("veritas-t")
+    db = SessionLocal()
+    try:
+        sha = "a" * 64
+        img1 = RetainedImage(tenant_id=tenant_id, sha256=sha, consent_recorded=True, uploaded_by="tech@local.dev", exif_stripped=True)
+        img2 = RetainedImage(tenant_id=tenant_id, sha256=sha, consent_recorded=True, uploaded_by="tech@local.dev", exif_stripped=True)
+        db.add_all([img1, img2])
+        db.commit()
+        db.refresh(img1)
+        db.refresh(img2)
+        db.add(ImageLabel(tenant_id=tenant_id, image_id=img2.id, finding_type="corrosion", severity="moderate", is_gold=True))
+        db.commit()
+
+        entry = veritas_training_dataset_service.evaluate_for_training(db, tenant_id, img2.id, usage_rights="internal", image_quality_threshold_met=True)
+        assert entry.is_duplicate is True
+        assert entry.dataset_status == "quarantined"
+    finally:
+        db.close()
+
+
+# ── 9. superseded baseline is not selected ───────────────────────────────────
+
+def test_superseded_baseline_is_not_selected():
+    category = uid("instr-cat")
+    db = SessionLocal()
+    try:
+        tenant_id = uid("veritas-t")
+        baseline = _mk_baseline(db, instrument_category=category)
+        resolution = veritas_baseline_resolution_service.resolve_governed_baseline(db, tenant_id, category)
+        assert resolution.baseline_source_id == baseline.id
+
+        veritas_baseline_governance_service.record_governance_action(
+            db, tenant_id, baseline_source_type=resolution.baseline_source_type, baseline_source_id=baseline.id,
+            action="supersede", performed_by="reviewer@local.dev",
+        )
+        status = veritas_baseline_governance_service.effective_status(db, tenant_id, resolution.baseline_source_type, baseline.id)
+        assert status == "superseded"
+        assert veritas_baseline_governance_service.is_usable_for_scoring(status) is False
+    finally:
+        db.close()
+
+
+# ── 10. supervisor override requires reason ──────────────────────────────────
+
+def test_supervisor_override_requires_reason():
+    tenant_id = uid("veritas-t")
+    db = SessionLocal()
+    try:
+        raised = False
+        try:
+            veritas_feedback_service.submit_feedback(
+                db, tenant_id, action="override_evidence_gate", submitted_by="supervisor@local.dev", override_reason="",
+            )
+        except veritas_feedback_service.OverrideReasonRequiredError:
+            raised = True
+        assert raised
+    finally:
+        db.close()
+
+
+# ── 11. technician cannot approve baseline ───────────────────────────────────
+
+def test_technician_cannot_approve_baseline():
+    tenant_id = uid("veritas-t")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+        _seed_membership(db, tenant_id, role="operator")
+    finally:
+        db.close()
+
+    r = client.post(
+        "/api/veritas/baselines/baseline_library/1/governance-action", json={"action": "approve"},
+        headers=_headers(AUTH_OPERATOR, tenant_id),
+    )
+    assert r.status_code == 403
+
+
+# ── 12. viewer cannot override evidence gate ─────────────────────────────────
+
+def test_viewer_cannot_override_evidence_gate():
+    tenant_id = uid("veritas-t")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+        _seed_membership(db, tenant_id, role="viewer")
+    finally:
+        db.close()
+
+    r = client.post(
+        "/api/veritas/feedback", json={"action": "override_evidence_gate", "override_reason": "confirmed manually"},
+        headers=_headers(AUTH_VIEWER, tenant_id),
+    )
+    assert r.status_code == 403
+
+
+# ── 13. training candidate requires supervisor validation ───────────────────
+
+def test_training_candidate_requires_supervisor_validation():
+    tenant_id = uid("veritas-t")
+    db = SessionLocal()
+    try:
+        img = RetainedImage(tenant_id=tenant_id, sha256="b" * 64, consent_recorded=True, uploaded_by="tech@local.dev", exif_stripped=True)
+        db.add(img)
+        db.commit()
+        db.refresh(img)
+        db.add(ImageLabel(tenant_id=tenant_id, image_id=img.id, finding_type="corrosion", severity="moderate", is_gold=False))
+        db.commit()
+
+        entry = veritas_training_dataset_service.evaluate_for_training(db, tenant_id, img.id, usage_rights="internal", image_quality_threshold_met=True)
+        assert entry.supervisor_validated is False
+        assert entry.dataset_status != "approved_for_training"
+    finally:
+        db.close()
+
+
+# ── 14. PHI/rights review status is stored ───────────────────────────────────
+
+def test_phi_rights_review_status_is_stored():
+    tenant_id = uid("veritas-t")
+    db = SessionLocal()
+    try:
+        img = RetainedImage(tenant_id=tenant_id, sha256="c" * 64, consent_recorded=True, uploaded_by="tech@local.dev", exif_stripped=True)
+        db.add(img)
+        db.commit()
+        db.refresh(img)
+        db.add(ImageLabel(tenant_id=tenant_id, image_id=img.id, finding_type="corrosion", severity="moderate", is_gold=True))
+        db.commit()
+
+        entry = veritas_training_dataset_service.evaluate_for_training(db, tenant_id, img.id, usage_rights="research_use", image_quality_threshold_met=True)
+        data = veritas_training_dataset_service.to_dict(entry)
+        assert data["phi_review_status"] == "cleared"
+        assert data["usage_rights"] == "research_use"
+    finally:
+        db.close()
+
+
+# ── 15. evidence provenance includes model and baseline versions ────────────
+
+def test_evidence_provenance_includes_model_and_baseline_versions():
+    tenant_id = uid("veritas-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _mk_inspection(db, tenant_id, barcode=barcode, coverage_pct=90, ai_confidence=0.9, inspected_zones=["jaw", "serrations", "box lock", "hinge", "spring", "ratchet"])
+        insp = db.query(models.Inspection).filter(models.Inspection.tenant_id == tenant_id).first()
+
+        row = run_evidence_assessment(db, tenant_id, insp.id, model_version="v1.2.3", dataset_version="ds-2024.06")
+        assert row.model_version == "v1.2.3"
+        assert row.dataset_version == "ds-2024.06"
+    finally:
+        db.close()
+
+
+# ── 16. Aegis, Vulcan, Sage, and Veritas outputs remain separately traceable ─
+
+def test_aegis_vulcan_sage_veritas_outputs_remain_separately_traceable():
+    tenant_id = uid("veritas-t")
+    barcode = uid("instr")
+    identity = f"barcode:{barcode}"
+    db = SessionLocal()
+    try:
+        base = datetime.now(timezone.utc)
+        insp1 = models.Inspection(tenant_id=tenant_id, file_name="a.jpg", instrument_type="kerrison rongeur", instrument_barcode=barcode, technician="tech-a@local.dev", coverage_pct=90, ai_confidence=0.9, has_image=True, created_at=base)
+        db.add(insp1)
+        db.commit()
+        db.refresh(insp1)
+        db.add(InspectionFinding(tenant_id=tenant_id, inspection_id=insp1.id, finding_type="corrosion", zone="jaw", severity_index=2))
+        db.commit()
+
+        vulcan_row = run_reliability_assessment(db, tenant_id, identity, instrument_type="kerrison rongeur")
+        aegis_signal = compute_process_variation_signal(db, tenant_id, identity, zone="jaw")
+
+        veritas_row = run_evidence_assessment(db, tenant_id, insp1.id)
+        veritas_dict = assessment_to_dict(veritas_row)
+
+        vulcan_support = veritas_specialist_collaboration_service.evidence_support_for_vulcan([veritas_dict])
+        aegis_support = veritas_specialist_collaboration_service.evidence_support_for_aegis(aegis_signal, veritas_dict)
+
+        # Each source's evidence is independently present and none was overwritten by another.
+        assert vulcan_support["source_veritas_assessment_ids"] == [veritas_row.id]
+        assert aegis_support["source_aegis_conclusion"] == aegis_signal
+        assert aegis_support["source_veritas_assessment_id"] == veritas_row.id
+        assert veritas_row.reasoning_narrative != vulcan_row.reasoning_narrative
+    finally:
+        db.close()
+
+
+# ── Route smoke tests ─────────────────────────────────────────────────────────
+
+def test_assess_and_workspace_routes():
+    tenant_id = uid("veritas-t")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+        insp = _mk_inspection(db, tenant_id, coverage_pct=80, ai_confidence=0.8, inspected_zones=["jaw"])
+    finally:
+        db.close()
+
+    r = client.post(f"/api/veritas/assess/{insp.id}", json={}, headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r.status_code == 201
+    body = r.json()
+    assert body["recommended_gate"]
+    assert body["human_review_required"] is True
+
+    r2 = client.get("/api/veritas/workspace", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r2.status_code == 200
+    assert "evidence_readiness_overview" in r2.json()
+
+    r3 = client.get("/api/veritas/data-quality", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r3.status_code == 200
+
+    r4 = client.get("/api/veritas/watchlists", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r4.status_code == 200
+    assert "no_approved_baseline" in r4.json()

--- a/backend/tests/test_vulcan_reliability.py
+++ b/backend/tests/test_vulcan_reliability.py
@@ -1,0 +1,415 @@
+"""LumenAI AI Specialist — Project Vulcan: Instrument Reliability, Failure
+Analysis & Repair Intelligence tests.
+
+Covers the 12 named scenarios from the sprint brief's Section 17, plus route
+smoke tests for the Instrument Forensics Workspace / watchlists / executive
+analytics endpoints.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.db import models
+from app.db.session import SessionLocal
+from app.main import app
+from app.models.inspection_finding import InspectionFinding
+from app.models.or_connect import REPAIR_RETURNED, RepairRequest
+from app.models.vulcan_reliability import (
+    DISPOSITION_REMOVE_FROM_SERVICE,
+    RELIABILITY_REMOVE_FROM_SERVICE_CANDIDATE,
+)
+from app.services import (
+    vulcan_aegis_integration_service,
+    vulcan_anatomy_zone_service,
+    vulcan_feedback_service,
+    vulcan_probable_cause_service,
+    vulcan_progression_service,
+    vulcan_reliability_agent_service,
+    vulcan_repair_effectiveness_service,
+)
+
+client = TestClient(app)
+AUTH_ADMIN = {"Authorization": "Bearer dev-token"}
+AUTH_VIEWER = {"Authorization": "Bearer viewer-token"}
+
+_counter = [0]
+
+
+def uid(prefix: str) -> str:
+    _counter[0] += 1
+    return f"{prefix}-{int(time.time() * 1000) % 1_000_000}-{_counter[0]}"
+
+
+def _seed_membership(db, tenant_id: str, *, role: str = "admin") -> None:
+    db.add(models.TenantMembership(tenant_id=tenant_id, user_email=f"{role}@local.dev", role=role, is_enabled=True))
+    db.commit()
+
+
+def _headers(base: dict, tenant_id: str) -> dict:
+    return {**base, "x-tenant-id": tenant_id}
+
+
+def _mk_inspection(db, tenant_id, *, barcode, instrument_type="kerrison rongeur", technician="", facility_name="", created_at=None):
+    row = models.Inspection(
+        tenant_id=tenant_id, file_name="test.jpg", instrument_type=instrument_type,
+        instrument_barcode=barcode, technician=technician, facility_name=facility_name,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mk_finding(db, tenant_id, inspection_id, *, finding_type, zone, severity_index):
+    row = InspectionFinding(
+        tenant_id=tenant_id, inspection_id=inspection_id, finding_type=finding_type,
+        zone=zone, severity_index=severity_index,
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+def _identity(barcode: str) -> str:
+    return f"barcode:{barcode}"
+
+
+# ── 1. repeated corrosion creates progression signal ──────────────────────────
+
+def test_repeated_corrosion_creates_progression_signal():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        base = datetime.now(timezone.utc) - timedelta(days=60)
+        for day, severity in [(0, 1), (25, 2), (55, 2)]:
+            insp = _mk_inspection(db, tenant_id, barcode=barcode, created_at=base + timedelta(days=day))
+            _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=severity)
+
+        result = vulcan_progression_service.compute_progression(db, tenant_id, _identity(barcode), zone="jaw")
+        assert result["recurrence_count"] == 3
+        assert result["progression"] != "insufficient_history"
+        assert result["days_span"] >= 50
+    finally:
+        db.close()
+
+
+# ── 2. stable cosmetic discoloration does not trigger removal ────────────────
+
+def test_stable_cosmetic_discoloration_does_not_trigger_removal():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        base = datetime.now(timezone.utc) - timedelta(days=30)
+        for day in (0, 15, 29):
+            insp = _mk_inspection(db, tenant_id, barcode=barcode, created_at=base + timedelta(days=day))
+            _mk_finding(db, tenant_id, insp.id, finding_type="discoloration", zone="jaw", severity_index=1)
+
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+        assert row.progression == "stable"
+        assert row.recommended_disposition != DISPOSITION_REMOVE_FROM_SERVICE
+        assert row.reliability_category != RELIABILITY_REMOVE_FROM_SERVICE_CANDIDATE
+    finally:
+        db.close()
+
+
+# ── 3. crack progression triggers remove-from-service review ─────────────────
+
+def test_crack_progression_triggers_remove_from_service_review():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        base = datetime.now(timezone.utc) - timedelta(days=40)
+        for day, severity in [(0, 1), (20, 2), (39, 3)]:
+            insp = _mk_inspection(db, tenant_id, barcode=barcode, created_at=base + timedelta(days=day))
+            _mk_finding(db, tenant_id, insp.id, finding_type="crack", zone="jaw", severity_index=severity)
+
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+        assert row.recommended_disposition == DISPOSITION_REMOVE_FROM_SERVICE
+    finally:
+        db.close()
+
+
+# ── 4. repeat failure after repair affects reliability score ─────────────────
+
+def test_repeat_failure_after_repair_affects_reliability_score():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        base = datetime.now(timezone.utc) - timedelta(days=60)
+        insp1 = _mk_inspection(db, tenant_id, barcode=barcode, created_at=base)
+        _mk_finding(db, tenant_id, insp1.id, finding_type="corrosion", zone="jaw", severity_index=2)
+
+        return_date = base + timedelta(days=10)
+        repair = RepairRequest(
+            tenant_id=tenant_id, inspection_id=insp1.id, instrument_identity=_identity(barcode),
+            vendor_name="Acme Repair", repair_type="jaw_resurface", status=REPAIR_RETURNED,
+            actual_return_date=return_date,
+        )
+        db.add(repair)
+        db.commit()
+        db.refresh(repair)
+
+        insp2 = _mk_inspection(db, tenant_id, barcode=barcode, created_at=return_date + timedelta(days=15))
+        _mk_finding(db, tenant_id, insp2.id, finding_type="corrosion", zone="jaw", severity_index=2)
+
+        outcome = vulcan_repair_effectiveness_service.classify_repair_outcome(db, tenant_id, repair)
+        assert outcome["repair_outcome"] == "failure_recurred"
+
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+        assert "repair_recurrence" in row.score_breakdown_json
+    finally:
+        db.close()
+
+
+# ── 5. insufficient history produces limited-confidence result ───────────────
+
+def test_insufficient_history_produces_limited_confidence_result():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        insp = _mk_inspection(db, tenant_id, barcode=barcode)
+        _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=1)
+
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+        assert row.progression == "insufficient_history"
+        assert row.confidence == "low"
+    finally:
+        db.close()
+
+
+# ── 6. drill-bit flute failure uses correct anatomy language ─────────────────
+
+def test_drill_bit_flute_failure_uses_correct_anatomy_language():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        base = datetime.now(timezone.utc) - timedelta(days=10)
+        for day in (0, 5):
+            insp = _mk_inspection(db, tenant_id, barcode=barcode, instrument_type="drill bit", created_at=base + timedelta(days=day))
+            _mk_finding(db, tenant_id, insp.id, finding_type="bone", zone="flutes", severity_index=2)
+
+        analysis = vulcan_anatomy_zone_service.zone_reliability_analysis(db, tenant_id, _identity(barcode), "drill bit")
+        zones = [z["anatomy_zone"] for z in analysis["zones"]]
+        assert "flutes" in zones
+        flute_zone = next(z for z in analysis["zones"] if z["anatomy_zone"] == "flutes")
+        assert flute_zone["recommended_manual_inspection"]
+
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="drill bit")
+        assert "flutes" in row.reasoning_narrative
+    finally:
+        db.close()
+
+
+# ── 7. rigid-scope O-ring failure uses correct anatomy language ──────────────
+
+def test_rigid_scope_o_ring_failure_uses_correct_anatomy_language():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        base = datetime.now(timezone.utc) - timedelta(days=10)
+        for day in (0, 5):
+            insp = _mk_inspection(db, tenant_id, barcode=barcode, instrument_type="rigid scope", created_at=base + timedelta(days=day))
+            _mk_finding(db, tenant_id, insp.id, finding_type="damaged_o_ring", zone="o-ring area", severity_index=2)
+
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="rigid scope")
+        assert row.anatomy_zone == "o-ring area"
+        assert row.failure_category == "damaged_o_ring"
+        assert "o-ring area" in row.reasoning_narrative
+    finally:
+        db.close()
+
+
+# ── 8. probable cause includes alternative explanation ────────────────────────
+
+def test_probable_cause_includes_alternative_explanation():
+    causes = vulcan_probable_cause_service.classify_probable_causes("condition_related", recurrence_count=3)
+    assert causes
+    for cause in causes:
+        assert cause["alternative_explanations"]
+        assert cause["recommended_verification"]
+        assert cause["confidence"]
+
+
+# ── 9. supervisor can correct failure classification ──────────────────────────
+
+def test_supervisor_can_correct_failure_classification():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        insp = _mk_inspection(db, tenant_id, barcode=barcode)
+        _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=2)
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+
+        feedback = vulcan_feedback_service.submit_feedback(
+            db, tenant_id, row.id, submitted_by="supervisor@local.dev", submitted_role="spd_manager",
+            failure_classification_correct=False, supervisor_rationale="Actually pitting, not corrosion.",
+        )
+        assert feedback.failure_classification_correct is False
+
+        stored = vulcan_feedback_service.feedback_for_assessment(db, tenant_id, row.id)
+        assert len(stored) == 1
+        assert stored[0]["failure_classification_correct"] is False
+    finally:
+        db.close()
+
+
+# ── 10. repair-vendor feedback is stored as a learning signal ────────────────
+
+def test_repair_vendor_feedback_is_stored_as_learning_signal():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        insp = _mk_inspection(db, tenant_id, barcode=barcode)
+        _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=2)
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+
+        feedback = vulcan_feedback_service.submit_feedback(
+            db, tenant_id, row.id, submitted_by="vendor@repaircorp.example",
+            repair_vendor_response="Repair vendor confirms jaw resurfacing was performed within spec.",
+        )
+        assert feedback.repair_vendor_response
+
+        stored = vulcan_feedback_service.feedback_for_assessment(db, tenant_id, row.id)
+        assert stored[0]["repair_vendor_response"]
+    finally:
+        db.close()
+
+
+# ── 11. Vulcan cannot independently finalize irreversible disposition ────────
+
+def test_vulcan_cannot_independently_finalize_disposition():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        base = datetime.now(timezone.utc) - timedelta(days=40)
+        for day, severity in [(0, 1), (20, 2), (39, 3)]:
+            insp = _mk_inspection(db, tenant_id, barcode=barcode, created_at=base + timedelta(days=day))
+            _mk_finding(db, tenant_id, insp.id, finding_type="crack", zone="jaw", severity_index=severity)
+
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+        assert row.recommended_disposition == DISPOSITION_REMOVE_FROM_SERVICE
+        # Vulcan's own compute step never sets final_disposition, no matter how severe.
+        assert row.final_disposition == ""
+        assert row.finalized_by == ""
+        assert row.finalized_at is None
+
+        vulcan_feedback_service.submit_feedback(
+            db, tenant_id, row.id, submitted_by="supervisor@local.dev", submitted_role="spd_manager",
+            final_disposition=DISPOSITION_REMOVE_FROM_SERVICE, supervisor_rationale="Confirmed via manual inspection.",
+        )
+        db.refresh(row)
+        assert row.final_disposition == DISPOSITION_REMOVE_FROM_SERVICE
+        assert row.finalized_by == "supervisor@local.dev"
+        assert row.finalized_at is not None
+    finally:
+        db.close()
+
+
+# ── 12. Aegis and Vulcan evidence remain separately traceable ────────────────
+
+def test_aegis_and_vulcan_evidence_remain_separately_traceable():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id)
+        base = datetime.now(timezone.utc) - timedelta(days=20)
+        for day in (0, 5, 10):
+            insp = _mk_inspection(db, tenant_id, barcode=barcode, technician="tech-a@local.dev", created_at=base + timedelta(days=day))
+            _mk_finding(db, tenant_id, insp.id, finding_type="damaged_drill_flute", zone="flutes", severity_index=2)
+
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="drill bit")
+
+        assert row.aegis_conclusion_json
+        aegis = vulcan_aegis_integration_service.compute_process_variation_signal(db, tenant_id, _identity(barcode), zone="flutes")
+        assert aegis["process_variation_detected"] is True
+
+        # Vulcan's own narrative is untouched by Aegis's signal.
+        assert row.reasoning_narrative
+        assert row.reasoning_narrative != row.combined_conclusion
+        assert row.reasoning_narrative in row.combined_conclusion
+        assert aegis["narrative"] not in row.reasoning_narrative
+    finally:
+        db.close()
+
+
+# ── Route smoke tests ─────────────────────────────────────────────────────────
+
+def test_assess_endpoint_and_forensics_workspace_route():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+        _seed_membership(db, tenant_id, role="viewer")
+        insp = _mk_inspection(db, tenant_id, barcode=barcode)
+        _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=2)
+    finally:
+        db.close()
+
+    r = client.post(
+        "/api/vulcan/assess", json={"instrument_identity": _identity(barcode), "instrument_type": "kerrison rongeur"},
+        headers=_headers(AUTH_ADMIN, tenant_id),
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["recommended_disposition"]
+    assert body["human_review_required"] is True
+
+    r2 = client.get(f"/api/vulcan/forensics/{_identity(barcode)}", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r2.status_code == 200
+    assert r2.json()["latest_assessment"] is not None
+
+    r3 = client.get("/api/vulcan/taxonomy", headers=_headers(AUTH_VIEWER, tenant_id))
+    assert r3.status_code == 200
+    assert "cleaning_related" in r3.json()["groups"]
+
+    r4 = client.get("/api/vulcan/watchlists", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r4.status_code == 200
+    assert "recurring_corrosion" in r4.json()
+
+    r5 = client.get("/api/vulcan/executive-summary", headers=_headers(AUTH_ADMIN, tenant_id))
+    assert r5.status_code == 200
+    assert "human_review_required" in r5.json()
+
+
+def test_viewer_cannot_submit_feedback():
+    tenant_id = uid("vulcan-t")
+    barcode = uid("instr")
+    db = SessionLocal()
+    try:
+        _seed_membership(db, tenant_id, role="admin")
+        _seed_membership(db, tenant_id, role="viewer")
+        insp = _mk_inspection(db, tenant_id, barcode=barcode)
+        _mk_finding(db, tenant_id, insp.id, finding_type="corrosion", zone="jaw", severity_index=2)
+        row = vulcan_reliability_agent_service.run_reliability_assessment(db, tenant_id, _identity(barcode), instrument_type="kerrison rongeur")
+        assessment_id = row.id
+    finally:
+        db.close()
+
+    r = client.post(f"/api/vulcan/feedback/{assessment_id}", json={"final_disposition": "remove_from_service"}, headers=_headers(AUTH_VIEWER, tenant_id))
+    assert r.status_code == 403

--- a/docs/agents/council/bias-and-groupthink-safeguards.md
+++ b/docs/agents/council/bias-and-groupthink-safeguards.md
@@ -1,0 +1,56 @@
+# Project Council — Bias and Groupthink Safeguards
+
+Sections 16 & 17 of the sprint brief.
+
+## Safeguards implemented
+
+- **Independent first-pass assessments** -- every resolver in
+  `council_specialist_assessment_service.py` reads only the case's
+  evidence package and that specialist's own real store, never another
+  specialist's Council assessment.
+- **Mandatory evidence citation** -- every assessment carries
+  `evidence_used`, sourced directly from the specialist's real service
+  output, never fabricated.
+- **Dissent preservation** -- `CouncilSpecialistAssessment` rows are
+  immutable; a revision creates a new row (`is_revision=True`,
+  `supersedes_assessment_id`) rather than overwriting the original.
+  Dissent records are never deleted or hidden (see
+  `dissent-registry.md`).
+- **No majority override of unresolved safety concern** -- `SAFETY_
+  DISSENT` in `council_consensus_service.classify_consensus` fires
+  regardless of how large the majority is, whenever a safety/evidence
+  specialist (Sentinel-X, Veritas) dissents with `urgency="urgent"`.
+- **Uncertainty disclosure** -- `confidence` and `evidence_limitations`
+  are first-class fields on every assessment, never optional.
+- **Alternative explanation requirement** -- every assessor is expected
+  to populate `alternative_explanation` where a real one exists (e.g.
+  Vulcan's probable-cause taxonomy).
+- **Human final authority** -- see `human-decision-authority.md`; no
+  Council output is final until a human decision is recorded.
+- **Outcome review** -- see `outcome-effectiveness.md`.
+- **Agent performance monitoring** -- see Section 17 below.
+- **Configurable recusal** -- a team's optional specialist list lets an
+  organization exclude a specialist it judges out of scope for a given
+  team's decisions, while `SAFETY_VETO_SPECIALISTS` can never be dropped
+  from a required list once required.
+
+**Consensus is not evidence.** The Consensus Engine only ever describes
+*agreement*, never correctness -- nothing in this codebase computes
+"truth" from how many specialists happen to agree.
+
+## Specialist Performance Review (Section 17)
+
+`council_performance_service.specialist_performance_summary` computes,
+per specialist, entirely from already-persisted Council tables:
+
+- `total_assessments`, `confidence_distribution`, `abstention_count`
+- `agreement_rate` -- how often the specialist's recommended action
+  matched the case's eventual recommendation
+- `dissent_count` / `dissent_accuracy` -- how often the specialist's
+  dissent was later confirmed valid by an outcome review
+
+This is aggregate and **non-punitive** reporting only. Critically,
+nothing in this module feeds back into `council_consensus_service.
+classify_consensus` -- a specialist's historical performance can never
+automatically suppress its current safety or evidence dissent. The
+module's own `note` field states this explicitly.

--- a/docs/agents/council/consensus-engine.md
+++ b/docs/agents/council/consensus-engine.md
@@ -1,0 +1,41 @@
+# Project Council — Consensus Engine & Decision Journal Integration
+
+Sections 5 & 13 of the sprint brief.
+
+## Classification (`council_consensus_service.classify_consensus`)
+
+Given the latest (post-revision) assessment per required specialist:
+
+1. **Missing required specialist** -> `INSUFFICIENT_EVIDENCE`.
+2. **Evidence-blocked** -- any specialist with `confidence="low"`, an
+   empty `recommended_action`, and non-empty `evidence_limitations` ->
+   `INSUFFICIENT_EVIDENCE` (Council cannot make a supported
+   recommendation).
+3. **All positions match** -> `UNANIMOUS`.
+4. Otherwise, bucket by normalized `recommended_action` text and find the
+   majority position:
+   - If any dissenter is a safety/evidence specialist
+     (`SAFETY_VETO_SPECIALISTS` -- Sentinel-X, Veritas) with
+     `urgency="urgent"` -> **`SAFETY_DISSENT`, regardless of majority
+     size**. A simple majority never overrides unresolved safety
+     dissent.
+   - Majority >= 80% -> `STRONG_CONSENSUS`.
+   - Majority < 60% -> `SPLIT_DECISION`.
+   - Otherwise -> `CONDITIONAL_CONSENSUS`.
+
+Consensus is never treated as evidence -- classification only describes
+*agreement*, never *correctness*. Every dissenting assessment is recorded
+via `council_dissent_service.record_dissent_records` regardless of the
+final classification, so dissent is never hidden from the final report.
+
+## Decision Journal Integration (Section 13)
+
+Rather than building a second, parallel decision-journal schema, Council
+composes a real `MaestroRecommendation` row (`council_decision_journal_
+service._ensure_maestro_recommendation`) representing its synthesized
+recommendation -- subject, rationale (citing consensus status,
+participating specialists, and dissent), confidence, and the specialists
+consulted -- then records the human decision through Maestro's own
+`maestro_decision_journal_service.record_decision`. This writes into the
+same leadership learning dataset Maestro's Leadership Workspace already
+reads from, rather than a second, disconnected one.

--- a/docs/agents/council/council-case-schema.md
+++ b/docs/agents/council/council-case-schema.md
@@ -1,0 +1,50 @@
+# Project Council — Council Case Schema
+
+Section 3 of the sprint brief.
+
+## `CouncilCase` (`app/models/council_leadership.py`)
+
+The typed record a leadership team convenes around. Key fields:
+
+- `case_type` -- one of the 12 named types (`CASE_TYPES`): high-risk
+  inspection, recurring contamination, recurring instrument failure,
+  repair recurrence, process variation, education need, CAPA escalation,
+  workflow bottleneck, enterprise trend, model performance issue,
+  evidence conflict, innovation proposal.
+- `inspection_ids_json` / `instrument_ids_json` / `digital_twin_refs_json`
+  / `evidence_package_json` -- the shared evidence package every
+  specialist reads from.
+- `risk_level`, `urgency`, `requested_decision`, `facility_id`.
+- `team_key` / `participating_specialists_json` -- assigned at case
+  open time from the Leadership Team Registry.
+- `consensus_status` -- one of the six Consensus Engine outcomes
+  (Section 5), set after `convene()`.
+- `recommended_action` -- the majority position's action text (empty
+  until convened, or when consensus is `INSUFFICIENT_EVIDENCE`).
+- `required_human_approver` / `required_approval_tier` -- the highest
+  authority tier any assessing specialist flagged as necessary (Section
+  8).
+- `status` -- `open` -> `awaiting_evidence` or `awaiting_decision` (after
+  `convene()`) -> `resolved` (after a human decision is finalized).
+- `human_review_required` -- always `True`.
+
+## Related tables
+
+- **`CouncilSpecialistAssessment`** (Section 4) -- one immutable row per
+  specialist per case; `is_revision`/`supersedes_assessment_id` preserve
+  the full history if a specialist revises its conclusion.
+- **`CouncilDissentRecord`** (Section 6) -- one row per specialist not in
+  the consensus majority.
+- **`CouncilDecisionOption`** (Section 7) -- one row per distinct
+  recommended action across all assessments, with tradeoffs.
+- **`CouncilHumanDecision`** (Section 8) -- the final, role-gated human
+  decision.
+- **`CouncilMeetingNotes`** (Section 12) -- structured meeting-mode
+  records; `recorded_by` is required (human-authored only).
+- **`CouncilOutcomeReview`** (Section 14) -- the effectiveness review
+  that closes the learning loop.
+
+Specialist performance (Section 17) is deliberately **not** a table --
+`council_performance_service.specialist_performance_summary` computes it
+on the fly from the tables above, so it can never drift from the
+underlying assessment/dissent/outcome history.

--- a/docs/agents/council/council-orchestration.md
+++ b/docs/agents/council/council-orchestration.md
@@ -1,0 +1,84 @@
+# Project Council — Council Orchestration Engine
+
+LumenAI AI Leadership Platform, Mission & Section 1.
+
+## Naming disambiguation
+
+**"Council" already exists** in one unrelated context: Olympus's Network
+Governance Council (`olympus_governance_council_service.py`,
+`NetworkGovernanceCase` in `app/models/olympus_network.py`) -- a
+cross-hospital, network-level governance body for intelligence-sharing
+disputes between member sites. Project Council is a different,
+single-tenant concept: structured AI leadership *teams* composed of
+already-built LumenAI specialists, convened to review one operational or
+clinical issue and produce a transparent, dissent-preserving
+recommendation for human leadership. `council_` is used as a distinct
+prefix throughout; nothing here touches `NetworkGovernanceCase` or any
+Olympus table. `/council` and `/api/council` were unclaimed before this
+sprint.
+
+## Mission
+
+Council synthesizes evidence from specialist agents, identifies agreement
+and disagreement, evaluates tradeoffs, and gives human leaders a
+transparent recommendation. Council does not replace leadership. It
+answers: which specialists reviewed this issue, where do they agree,
+where do they disagree, what evidence supports each position, what are
+the tradeoffs, what action is recommended, and who must approve it. **No
+recommendation may hide specialist disagreement.**
+
+## Architecture
+
+```
+Inspection/Enterprise Data -> Specialist Agents -> Council Leadership Teams
+  -> Consensus and Dissent Analysis -> Human Leadership Review
+  -> Approved Action -> Outcome Measurement -> Institutional Learning
+```
+
+## What Council composes rather than duplicates
+
+Council is a pure read-and-synthesize layer -- each specialist's
+Council assessment is derived from that specialist's own, already-built
+real service (`council_specialist_assessment_service.py`):
+
+| Specialist | Reused from |
+|---|---|
+| Veritas | `veritas_evidence_agent_service.run_evidence_assessment` |
+| Aegis | `vulcan_aegis_integration_service.compute_process_variation_signal` |
+| Vulcan | `vulcan_reliability_agent_service.run_reliability_assessment` |
+| Sage | `sage_knowledge_gap_service.list_gaps` |
+| Sentinel-X | `sentinelx_risk_agent_service.run_risk_assessment` |
+| Apollo | `apollo_capa_engine_service.capa_engine_summary` |
+| Athena | `athena_search_service.organizational_search` |
+| Pulse | `pulse_command_center_service.pulse_command_center` |
+| Phoenix | `phoenix_maturity_index_service.compute_platform_maturity_index` |
+| Maestro | `maestro_priority_engine_service.latest_priorities` |
+| Research Agent | `horizon_research_portal_service.research_portal_summary` (read-only network reference) |
+
+Reports reuse Veritas's generic `veritas_reports_service.
+build_report_pdf_bytes`/`build_report_csv_bytes`/`build_report_xlsx_bytes`.
+Decision Journal integration reuses Maestro's own
+`maestro_decision_journal_service.record_decision` directly (see
+`decision-journal-integration` in `docs/agents/council/consensus-engine.md`
+-- Council never builds a second, parallel journal schema).
+
+## The Orchestration Engine (`council_orchestration_service.py`)
+
+1. **`select_specialists_for_case`** -- picks the appropriate leadership
+   team (from `CASE_TYPE_DEFAULT_TEAM`) and its required specialists for
+   a case type.
+2. **`open_case`** -- creates the typed `CouncilCase` and assigns its
+   team. No specialist has assessed anything yet.
+3. **`convene`** -- runs every required specialist's independent
+   assessment (`council_specialist_assessment_service.
+   run_independent_assessments`), classifies consensus
+   (`council_consensus_service`), records dissent
+   (`council_dissent_service`), generates decision options
+   (`council_decision_options_service`), and routes the case to the
+   correct human authority tier.
+
+Agents assess independently before seeing each other's conclusions --
+this is structural, not a runtime lock: every resolver in
+`council_specialist_assessment_service.py` reads only the case's own
+evidence package and that one specialist's real store, never another
+specialist's `CouncilSpecialistAssessment` row.

--- a/docs/agents/council/decision-options.md
+++ b/docs/agents/council/decision-options.md
@@ -1,0 +1,35 @@
+# Project Council — Decision Options and Tradeoff Analysis
+
+Section 7 of the sprint brief.
+
+## Generation (`council_decision_options_service.generate_decision_options`)
+
+One `CouncilDecisionOption` is generated per distinct recommended action
+across the case's assessments -- every option traces back to the
+specific specialist(s) who proposed it:
+
+- `benefits` / `risks` -- pulled from the supporting specialists' own
+  `significance` / `evidence_limitations` text, never invented.
+- `clinical_risk` -- `"high"` if any supporting specialist flagged
+  `urgency="urgent"`, else `"low"`.
+- `operational_impact` -- names which specialist(s) proposed the option.
+- `financial_impact` -- **always left blank.** No real, supportable
+  financial-estimation source exists in this codebase for these options
+  today, and the brief explicitly instructs "do not fabricate financial
+  estimates."
+- `evidence_strength` -- derived from the average confidence of the
+  option's supporting specialists.
+- `reversibility` -- `"irreversible"` if the option's title implies
+  permanent removal/discard/retirement, otherwise `"reversible"`.
+- `required_authority` -- the highest authority tier any supporting
+  specialist flagged as necessary.
+- `expected_time_to_resolution` -- a generic bucket (same day / several
+  days / 1-2 weeks) inferred from the option's action text (e.g. a
+  manufacturer evaluation implies external turnaround).
+
+This mirrors the brief's worked example directly: "Reclean and repeat
+inspection" (fast, doesn't resolve possible structural corrosion), "Hold
+for repair evaluation" (addresses possible degradation, instrument
+unavailable), "Manufacturer evaluation" (design-specific assessment,
+longer turnaround/possible cost) -- each with its own real evidence trail
+rather than a single flattened recommendation.

--- a/docs/agents/council/dissent-registry.md
+++ b/docs/agents/council/dissent-registry.md
@@ -1,0 +1,37 @@
+# Project Council — Dissent Registry
+
+Section 6 of the sprint brief.
+
+## What gets recorded
+
+Every specialist whose recommended action falls outside the consensus
+majority gets a `CouncilDissentRecord`
+(`council_dissent_service.record_dissent`):
+
+- `dissenting_specialist`
+- `disputed_conclusion` -- the majority position being disputed
+- `evidence_supporting_dissent` -- the dissenter's own evidence
+- `risk_if_ignored` -- the dissenter's `significance` field
+- `additional_evidence_required` -- the dissenter's `evidence_limitations`
+- `proposed_alternative_action` -- the dissenter's `recommended_action`
+- `escalation_level` -- `"safety_critical"` if the dissenter is a
+  safety/evidence specialist (Sentinel-X, Veritas) reporting `urgency=
+  "urgent"`, otherwise `"standard"`
+
+## Always displayed prominently
+
+Dissent is never hidden from the final report. Every case-detail view
+(`GET /api/council/cases/{id}`) includes the full dissent list alongside
+the consensus outcome, and `council_agreement_map_service.
+build_agreement_map` separately calls out `dissenting_specialists` next
+to the consensus position, so a leader reading the case summary sees the
+disagreement in the same view as the recommendation -- exactly the shape
+of the brief's own worked example:
+
+> Council majority: Proceed with increased monitoring.
+> Sentinel-X dissent: Moderate corrosion in a high-risk drill-bit flute
+> may represent progressive integrity failure.
+> Veritas limitation: Current image quality is insufficient to
+> distinguish corrosion from lighting artifact.
+> Council outcome: INSUFFICIENT_EVIDENCE.
+> Next action: Capture a new flute image and obtain supervisor review.

--- a/docs/agents/council/human-decision-authority.md
+++ b/docs/agents/council/human-decision-authority.md
@@ -1,0 +1,33 @@
+# Project Council — Human Decision Authority
+
+Section 8 of the sprint brief.
+
+## Mapping the brief's five-tier scale onto LumenAI's actual RBAC
+
+LumenAI's real tenant RBAC has four roles: `admin`, `spd_manager`,
+`operator`, `viewer`. The brief calls for five authority tiers
+(technician, supervisor, SPD manager, director, clinical/quality
+governance). `council_leadership.py` layers the five-tier scale on top of
+the real four roles via `ROLE_AUTHORITY_TIER`:
+
+| Tenant role | Authority tier | Brief's equivalent |
+|---|---|---|
+| `viewer` / `operator` | 0 | Technician -- may view recommendations, cannot finalize. |
+| `spd_manager` | 2 | Supervisor + SPD Manager scope. |
+| `admin` | 4 | Director + Clinical/Quality Governance scope (ceiling). |
+
+`APPROVAL_TIER_BY_ROLE_NAME` maps the five conceptual roles to tiers
+0-4. A `CouncilCase`'s `required_approval_tier` is set at `convene()`
+time to the highest tier any assessing specialist flagged as necessary
+(`human_role_required` on each `CouncilSpecialistAssessment`).
+
+## Enforcement
+
+`council_human_decision_service.finalize_decision` calls `can_approve
+(approver_role, case.required_approval_tier)` and raises
+`PermissionError` (surfaced as HTTP 403) if the deciding user's role tier
+is insufficient. A technician-equivalent role (`viewer`/`operator`) can
+always read a case's recommendation but can never finalize its decision.
+Every finalized decision records `approver`, `approver_role`, `decision`,
+`rationale`, `conditions`, and `decided_at` -- a complete, auditable
+record.

--- a/docs/agents/council/leadership-team-registry.md
+++ b/docs/agents/council/leadership-team-registry.md
@@ -1,0 +1,45 @@
+# Project Council — Leadership Team Registry
+
+Sections 2 & 15 of the sprint brief.
+
+## The six default teams (`DEFAULT_TEAM_DEFINITIONS`)
+
+| Team | Required specialists | Purpose |
+|---|---|---|
+| Clinical Quality Council | Sentinel-X, Veritas, Apollo, Athena, Vulcan | High-risk findings, evidence quality, clinical significance, quality implications, institutional guidance. |
+| Operations Council | Maestro, Aegis, Pulse, Vulcan, Sentinel-X | Workload prioritization, workflow risk, repair impact, staffing pressure, immediate operational response. |
+| Education Council | Sage, Aegis, Athena, Apollo, Veritas | Knowledge gaps, competency needs, approved educational content, effectiveness measurement. |
+| Reliability Council | Vulcan, Veritas, Sentinel-X, Aegis, Maestro | Recurring instrument failure, repair recurrence, process exposure, clinical risk, disposition options. |
+| Executive Council | Maestro, Sentinel-X, Pulse, Phoenix, Apollo, Aegis | Enterprise priorities, executive risks, resource options, quality priorities, strategic recommendations. |
+| Research and Innovation Council | Phoenix, Athena, Veritas, Sentinel-X, Research Agent | New hypotheses, model improvements, evidence needs, pilots, research proposals, innovation opportunities. |
+
+`council_team_registry_service.ensure_default_teams(db, tenant_id)`
+provisions these six teams for a tenant the first time Council is used
+there -- idempotent, so it's safe to call on every request.
+
+## Case-type routing (`CASE_TYPE_DEFAULT_TEAM`)
+
+Each of the 12 Council Case types (Section 3) has a default team it
+routes to out of the box (e.g. `recurring_instrument_failure` ->
+Reliability Council, `education_need` -> Education Council,
+`enterprise_trend` -> Executive Council). Organizations may reconfigure
+which specialists sit on a team, but the case-type routing itself is a
+platform default, not per-tenant configurable in this release.
+
+## Versioned, audited configuration
+
+`update_team_config` never mutates a team's current configuration row --
+it marks the current row `is_current=False` and inserts a new row with
+`version` incremented by one and `approval_status="pending_review"`. The
+full configuration history is always queryable via
+`team_config_history`, mirroring Veritas's append-only baseline
+governance action pattern.
+
+## Mandatory safety review can't be configured away
+
+`SAFETY_VETO_SPECIALISTS` (Sentinel-X, Veritas) can never be removed from
+a team's required specialist list if they were already required --
+`update_team_config` raises `ValueError` if an organization's proposed
+change would drop one of them. Optional specialists and everything else
+(decision scope, escalation rules, quorum requirement, evidence
+requirements, review frequency) are freely configurable.

--- a/docs/agents/council/outcome-effectiveness.md
+++ b/docs/agents/council/outcome-effectiveness.md
@@ -1,0 +1,31 @@
+# Project Council — Outcome Effectiveness Review
+
+Section 14 of the sprint brief.
+
+## Classification (`council_outcome_service.classify_outcome`)
+
+| Inputs | Classification |
+|---|---|
+| `issue_resolved is None` | `insufficient_follow_up_data` |
+| `unintended_consequence=True` | `unintended_consequence` |
+| Resolved, did not recur | `effective` |
+| Resolved, recurred | `partially_effective` |
+| Not resolved, but risk decreased or operational performance improved | `partially_effective` |
+| Otherwise | `ineffective` |
+
+## Learning signal, never automatic rule rewriting
+
+`record_outcome_review` sets `knowledge_update_recommended=True` whenever
+the classification is `ineffective` or `unintended_consequence`, or
+whenever `dissent_valid=True` was reported (a specialist's dissent turned
+out to be correct). This is a **signal for a human to review** -- Council
+never automatically rewrites a clinical rule, the Knowledge Graph, or a
+specialist's scoring logic as a result. Any such change remains a
+separate, explicit, human-triggered action elsewhere in the platform.
+
+## Closing the loop
+
+Every `CouncilOutcomeReview` links back to its `council_case_id`, so the
+original recommendation, its dissent, and its eventual outcome are always
+traceable in one place -- the leadership learning dataset the brief calls
+for.

--- a/docs/agents/maestro/decision-journal.md
+++ b/docs/agents/maestro/decision-journal.md
@@ -1,0 +1,61 @@
+# Project Maestro — Operational Health Index, Decision Journal & Leadership Workspace
+
+Sections 7, 8, 9 of the sprint brief.
+
+## Operational Health Index (Section 7)
+
+`maestro_health_index_service.compute_operational_health(db, tenant_id)`
+reuses five of Phoenix's already-computed platform maturity dimensions
+(`phoenix_maturity_index_service.compute_platform_maturity_index`)
+directly — Quality, Workflow, Education, Digital Twins (renamed
+`digital_twin_score`), Knowledge — plus Phoenix's executive-intelligence
+(audit-readiness) dimension, renamed `enterprise_score`. **Equipment** is
+the one genuinely new dimension: the average Vulcan Instrument Reliability
+Score across the tenant's most recent 200 `VulcanReliabilityAssessment`
+rows (`None` if no rows exist yet — never fabricated).
+
+`overall_score` is the average of whichever of the 7 dimension scores are
+actually present; a `MaestroOperationalHealthSnapshot` persists all 7 plus
+`breakdown_json`, which traces back to the source Phoenix maturity
+snapshot's `id` for full auditability. `human_review_required` is always
+`True`.
+
+## Decision Journal (Section 8)
+
+`maestro_decision_journal_service.record_decision(db, tenant_id,
+recommendation_id, *, leader_decision, decided_by, ...)` is the leadership
+knowledge base: for every recommendation a leader acts on, it records the
+evidence and specialists consulted (copied from the recommendation at
+decision time), Maestro's confidence, what the leader actually decided,
+the outcome, and lessons learned.
+
+`leader_decision` is required and non-empty — a `ValueError` is raised
+otherwise, since an empty journal entry would defeat its purpose as an
+audit record. Recording a decision is also the *only* place a
+recommendation's `status` moves out of `pending` (via the optional
+`new_status` parameter) — Maestro itself never silently advances a
+recommendation's status.
+
+## Leadership Workspace (Section 9, `/maestro`)
+
+`maestro_orchestration_service.leadership_workspace_summary(db,
+tenant_id)` composes the single `/maestro` payload:
+
+- **Top Priorities** — `maestro_priority_engine_service.latest_priorities`
+- **Operational Health** — the latest `MaestroOperationalHealthSnapshot`
+- **Open Risks** — Sentinel-X's `risk_dashboard_summary` (enterprise,
+  facility, anatomy risk)
+- **Today's Recommendations** — pending `MaestroRecommendation`s with
+  `timeline_horizon="today"`
+- **Pending Executive Decisions** — all pending recommendations
+- **Shift Readiness** — Sentinel-X's `supervisor_workspace_summary`
+  pending-review count, open patient safety alert count, and escalating
+  trends
+- **Enterprise Status** — overall operational health plus enterprise-wide
+  average/high-or-critical risk percentage
+
+Every field is a direct read of an already-computed specialist output;
+nothing here is computed fresh outside of the Priority Engine, Health
+Index, and Recommendation Engine themselves. `human_review_required` is
+always `True`, and the response carries Maestro's `DISCLAIMER`: it never
+replaces human leadership.

--- a/docs/agents/maestro/leadership-intelligence.md
+++ b/docs/agents/maestro/leadership-intelligence.md
@@ -1,0 +1,53 @@
+# Project Maestro — Leadership Recommendation Engine, Daily Brief & Executive Coordination
+
+Sections 3, 4, 5 of the sprint brief.
+
+## Leadership Recommendation Engine (Sections 3 & 5)
+
+`maestro_recommendation_engine_service.generate_recommendations(db,
+tenant_id)` runs the Priority Engine, then converts each real priority
+item (plus any pending Veritas baseline conflict) into one specific,
+evidence-linked `MaestroRecommendation`:
+
+| Trigger | Recommendation | Example |
+|---|---|---|
+| `highest_risk_facility` / `highest_risk_instrument` | `move_supervisor` | "Move supervisor to review \<facility/instrument\>." |
+| `highest_risk_workflow` | `inspection_priorities` | "Review process-variation workflow controls." |
+| `highest_risk_technician_education_need` | `schedule_competency` | "Schedule \<domain\> competency." |
+| `highest_risk_equipment` (corrosion-related) | `review_corrosion_trend` | "Review \<instrument\> corrosion trend." |
+| `highest_risk_equipment` (other) | `equipment_utilization` | "Review utilization for \<instrument\>." |
+| `highest_priority_capa` | `generate_capa_draft` | "Generate CAPA draft." |
+| `highest_priority_inspection` | `inspection_priorities` | "Prioritize \<inspection\>." |
+| `highest_priority_repair` | `escalate_repair_backlog` | "Escalate repair backlog." |
+| `highest_priority_executive_issue` | `quality_initiatives` | "Address executive risk: \<issue\>." |
+| Unresolved Veritas baseline conflict | `publish_baseline` | "Publish updated baseline." |
+
+`generate_strategic_recommendations(db, tenant_id)` produces the six
+broader, periodic Section 5 categories (`resource_allocation`,
+`staffing_changes`, `inspection_priorities`, `equipment_utilization`,
+`education_priorities`, `quality_initiatives`) from the Operational Health
+Index and the current priority list, rather than any single item — these
+are the weekly/quarterly leadership-planning recommendations.
+
+Every recommendation is advisory only: `status` starts `pending` and only
+a Decision Journal entry (Section 8) advances it. Actually materializing a
+CAPA from a `generate_capa_draft` recommendation is a separate,
+human-triggered call to `maestro_capa_integration_service.
+create_capa_from_recommendation` — nothing runs automatically.
+
+## Daily Operational Brief (Section 4)
+
+`maestro_daily_brief_service.generate_brief(db, tenant_id, brief_type)`
+composes the same real signals (top priorities, pending recommendations,
+operational health, open Sentinel-X patient safety alerts) into one of
+five brief types (`BRIEF_TYPES`): `morning_brief`, `afternoon_update`,
+`end_of_day_summary`, `weekend_readiness`, `shift_handoff` — each with a
+narrative framed for that moment in the day.
+
+## Executive Coordination (Section 5) & Strategy Timeline (Section 6)
+
+`maestro_timeline_service.strategy_timeline(db, tenant_id)` is a pure
+query over `MaestroRecommendation`, grouped by `timeline_horizon`
+(`today`, `this_week`, `this_month`, `quarter`, `year`) and, within each
+horizon, by `status` (`pending`, `completed`, `blocked`, `escalated`,
+`dismissed`) — there is no separate timeline table.

--- a/docs/agents/maestro/operational-orchestration.md
+++ b/docs/agents/maestro/operational-orchestration.md
@@ -1,0 +1,87 @@
+# Project Maestro — Operational Orchestration
+
+LumenAI AI Specialist, Mission & Section 1.
+
+## Naming disambiguation
+
+**"Orchestrator"/"orchestration" already exists** as two unrelated,
+pre-existing systems in this codebase:
+
+- Phase 22's `app/agents/orchestrator.py` (`run_pipeline(db, inspection,
+  tenant_id)`) — the hardcoded 10-step per-inspection Vision/Anatomy/
+  Clinical Reasoning agent pipeline, computed live and never cached.
+- Nova's `nova_orchestration_service.py` — `AgentTaskRun`, Nova's own
+  configurable ordered pipeline of `agent_key`s for its task platform.
+
+Maestro is a **different, higher-level concept**: an executive layer that
+reads the *outputs* of every specialist (including both systems above) to
+rank operational priorities for SPD leadership. `maestro_orchestration_
+service.py` never touches or extends either existing orchestration system.
+`/maestro` and `/api/maestro` were unclaimed before this sprint.
+
+## What Maestro does
+
+Rather than presenting dozens of dashboards, Maestro answers the most
+important leadership question: **"What should I do first today, and
+why?"** It is a pure read-and-synthesize layer over every other LumenAI
+specialist — it never replaces human leadership. Every recommendation is
+explainable, evidence-based, auditable, role-aware, and subject to human
+approval (`human_review_required` is always `True`).
+
+## Architecture
+
+```
+Sentinel-X (risk)  ─┐
+Vulcan (reliability)├─► Priority Engine ─► Leadership Recommendation Engine ─► Decision Journal
+Sage (education)    │        │                        │
+Veritas (evidence)  │        ▼                        ▼
+Aegis (process)     │  Operational Health      Daily Operational Brief
+Phoenix (maturity)  │      Index                       │
+Pulse (live ops)    │                                  ▼
+Forge/CAPA          ┘                          Leadership Workspace (/maestro)
+```
+
+## What is composed vs. genuinely new
+
+Maestro composes real, already-computed specialist output — it never
+re-derives a score another module already owns:
+
+| Signal | Reused from |
+|---|---|
+| Vision/Anatomy/Clinical Reasoning | `app.agents.orchestrator.run_pipeline` (Phase 22) |
+| Knowledge | `knowledge_graph_service.learning_confidence` |
+| Digital Twin | `instrument_condition_service.instrument_condition_history` |
+| Evidence integrity | `veritas_evidence_agent_service.run_evidence_assessment` |
+| Process variation | `vulcan_aegis_integration_service.compute_process_variation_signal` |
+| Instrument reliability | `vulcan_reliability_agent_service.run_reliability_assessment` |
+| Education gaps | `sage_knowledge_gap_service.list_gaps` / `sage_learning_plan_service.list_plans` |
+| Clinical risk | `sentinelx_risk_agent_service.run_risk_assessment` / `sentinelx_dashboard_service.risk_dashboard_summary` / `sentinelx_supervisor_workspace_service.supervisor_workspace_summary` |
+| Live operations | `pulse_command_center_service.pulse_command_center` |
+| Platform maturity | `phoenix_maturity_index_service.compute_platform_maturity_index` |
+| Approval workflow | `forge_approval_service` |
+| CAPA drafting | `capa_suggestion_service.generate_capa_suggestions` / `create_capa_from_suggestion` |
+| Conversational Q&A (read-only reference) | Catalyst's `catalyst_query_engine.answer_query` — Maestro never calls it directly |
+
+Five tables are genuinely new: `MaestroPriorityItem`, `MaestroRecommendation`,
+`MaestroDailyBrief`, `MaestroOperationalHealthSnapshot`,
+`MaestroDecisionJournalEntry`. The Strategy Timeline (Section 6) is a pure
+query over `MaestroRecommendation`, not a separate table.
+
+## Deterministic, not an autonomous LLM
+
+`maestro_orchestration_service.run_daily_orchestration` is a deterministic
+Python function that calls the Priority Engine, the Recommendation Engine,
+the Health Index, and the Daily Brief generator in sequence. There is no
+LLM/embedding API call anywhere in Maestro.
+
+## API
+
+Prefix `/api/maestro`. Key endpoint: `POST /api/maestro/run` (runs the full
+daily orchestration); `GET /api/maestro/workspace` (the `/maestro`
+Leadership Workspace payload).
+
+## Frontend
+
+Route `/maestro` — `MaestroLeadershipWorkspace.tsx`, showing Top
+Priorities, Operational Health, Open Risks, Today's Recommendations,
+Pending Executive Decisions, Shift Readiness, and Enterprise Status.

--- a/docs/agents/maestro/priority-engine.md
+++ b/docs/agents/maestro/priority-engine.md
@@ -1,0 +1,41 @@
+# Project Maestro — Priority Engine
+
+Section 2 of the sprint brief.
+
+## The 9 priority categories
+
+`app/models/maestro_orchestration.py::PRIORITY_CATEGORIES` — each ranked
+from one specialist's real, already-persisted output; a category with no
+real data to report is skipped, never fabricated:
+
+| Category | Resolved from |
+|---|---|
+| `highest_risk_instrument` | Sentinel-X `supervisor_workspace_summary` → `highest_risk_instruments[0]` |
+| `highest_risk_workflow` | Sentinel-X `risk_dashboard_summary` → `workflow_risk.process_variation_flagged_count` |
+| `highest_risk_facility` | Sentinel-X `risk_dashboard_summary` → `facility_risk[0]` (heatmap) |
+| `highest_risk_technician_education_need` | Sage `list_gaps(status="open")`, highest `occurrence_count` |
+| `highest_risk_equipment` | Vulcan `VulcanReliabilityAssessment`, lowest `reliability_score` of the last 200 rows |
+| `highest_priority_capa` | `capa_suggestion_service.generate_capa_suggestions`, highest `occurrences` |
+| `highest_priority_inspection` | Sentinel-X `supervisor_workspace_summary` → `highest_risk_inspections[0]` |
+| `highest_priority_repair` | `RepairRequest` (or_connect), oldest pending |
+| `highest_priority_executive_issue` | `ExecutiveRiskSignal`, highest unreviewed risk tier |
+
+## Ranking
+
+`maestro_priority_engine_service.compute_priorities(db, tenant_id)` runs
+every category resolver, persists one `MaestroPriorityItem` row per
+category that produced real data, and ranks the resulting set across
+categories by `priority_score` (descending). `rank` is assigned 1..N over
+that combined, cross-category ordering — this is Maestro's only original
+computation; every input score itself comes straight from the owning
+specialist.
+
+`latest_priorities(db, tenant_id)` returns the most recent run's items
+(matched by `created_at`), already in rank order, for read-only display
+without re-computing.
+
+## Auditability
+
+Every `MaestroPriorityItem` carries `source_specialist`, `rationale`, and
+`evidence_json` — a leader can always trace a ranked priority back to the
+exact specialist output that produced it.

--- a/docs/agents/sage/adaptive-learning-plans.md
+++ b/docs/agents/sage/adaptive-learning-plans.md
@@ -1,0 +1,42 @@
+# Project Sage — Adaptive Learning Plans
+
+LumenAI AI Specialist, Section 5, and Educator/Supervisor Workspace
+(Section 12).
+
+## Approval gate
+
+A `SageLearningPlan` is created with `approved_by = ""`. It is not visible
+to its learner via `/api/sage/my-learning` until an authorized educator,
+supervisor, or manager calls `POST /api/sage/learning-plans/{id}/approve` --
+mirrors Vulcan's `recommended_disposition`/`final_disposition` split:
+Sage's own recommendation never becomes an assigned plan on its own.
+
+## Override reason required for high-confidence recommendations
+
+`sage_learning_plan_service.reject_or_edit_learning_plan` raises
+`OverrideReasonRequiredError` if the plan's own `confidence == "high"` and no
+`override_reason` is supplied — enforced in the service layer, not just
+documented in the brief.
+
+## Plan fields (Section 5)
+
+learner or group, identified need, supporting evidence, learning objective,
+instrument family, anatomy zone, finding category, education content,
+practice activity, return demonstration, evaluator, due date, completion
+status, effectiveness review — every field the brief names is a real column
+on `SageLearningPlan`.
+
+## API
+
+```
+POST /api/sage/learning-plans
+POST /api/sage/learning-plans/{id}/approve
+POST /api/sage/learning-plans/{id}/reject-or-edit
+POST /api/sage/learning-plans/{id}/complete
+GET  /api/sage/learning-plans
+GET  /api/sage/learning-plans/{id}
+```
+
+All leadership-only. A technician's own approved plans are only reachable
+via `GET /api/sage/my-learning`, which resolves the learner from the
+authenticated identity.

--- a/docs/agents/sage/aegis-vulcan-sage-collaboration.md
+++ b/docs/agents/sage/aegis-vulcan-sage-collaboration.md
@@ -1,0 +1,47 @@
+# Project Sage — Integration With Aegis and Vulcan
+
+LumenAI AI Specialist, Sections 13 & 14.
+
+## Separation of responsibility
+
+Aegis remains responsible for process analysis. Vulcan remains responsible
+for instrument reliability. Sage remains responsible only for education and
+competency support. `sage_aegis_vulcan_integration_service.py` reads each
+agent's real conclusion and returns a Sage-specific recommendation — it
+never mutates or overwrites the source.
+
+## Aegis -> Sage (Section 13)
+
+`sage_recommendation_from_aegis` calls
+`vulcan_aegis_integration_service.compute_process_variation_signal` directly
+(Sage has no separate Aegis client — there is one real, minimal Aegis
+signal in this codebase, built for Vulcan, and Sage reads the same
+function). If a process-concentration pattern is detected, Sage recommends
+focused brushing/inspection education for the affected workflow. The
+underlying Aegis signal is returned verbatim as `source_aegis_signal` --
+never edited.
+
+## Vulcan -> Sage (Section 14)
+
+`sage_recommendation_from_vulcan` takes a real, already-persisted
+`VulcanReliabilityAssessment` row and recommends differentiation education
+when the failure category is one this codebase's own severity scale
+recognizes as visually confusable with a benign cosmetic finding (e.g.
+corrosion/rust vs. cosmetic discoloration, pitting vs. cosmetic wear -- see
+`_AMBIGUOUS_CONDITION_PAIRS`). The Vulcan assessment's ID and category are
+referenced (`source_vulcan_assessment_id`), never copied into or blended
+with Sage's own recommendation text.
+
+## Separately traceable, by construction
+
+Every returned dict keeps the source agent's evidence under its own key
+(`source_aegis_signal` / `source_vulcan_assessment_id`) alongside Sage's own
+`recommendation` string — there is no shared/blended conclusion field, so
+Aegis, Vulcan, and Sage evidence can always be inspected independently.
+
+## API
+
+```
+GET /api/sage/aegis-recommendation?instrument_identity=...&zone=...
+GET /api/sage/vulcan-recommendation/{assessment_id}
+```

--- a/docs/agents/sage/competency-gap-detection.md
+++ b/docs/agents/sage/competency-gap-detection.md
@@ -1,0 +1,51 @@
+# Project Sage — Competency Gap Detection
+
+LumenAI AI Specialist, Section 3.
+
+## Never a single-error conclusion
+
+`sage_gap_detection_service.py` requires at least two occurrences
+(`_MIN_OCCURRENCES = 2`) of the same real pattern before it ever produces a
+gap. One isolated supervisor correction never becomes a competency gap.
+
+## Real evidence sources
+
+- **Missed anatomy zones** — `SupervisorReview.missing_zone_correct == False`
+  grouped by `corrected_missing_zone` (repeated serration/O-ring/drill-bit
+  flute omissions).
+- **Anatomy label errors** — `SupervisorReview.zone_correct == False` grouped
+  by `instrument_family`, so rigid-scope and flexible-endoscope gaps remain
+  distinct rows, never merged.
+- **Finding confusion** (e.g. blood vs. rust) — both members of a known
+  confusable pair (`_CONFUSION_PAIRS`) are each individually corrected for
+  the same technician.
+- **Low inspection coverage** — repeated `Inspection.coverage_pct` below 70%.
+- **Image-capture issues** — repeated `SupervisorReview.image_view_correct
+  == False`. This codebase only measures the aggregate "image view correct"
+  signal, not focus/lighting/angle individually — never fabricated beyond
+  what is actually tracked.
+- **Disposition errors** — repeated `SupervisorReview.override_action`
+  (a supervisor overriding the AI's recommended disposition).
+
+## Non-punitive language
+
+Every gap's `narrative` is one of three fixed, non-punitive phrases scaled
+to confidence:
+
+| Confidence | Narrative |
+|---|---|
+| low (2 occurrences) | "Additional observation may be appropriate." |
+| moderate (3-4) | "Targeted education may be beneficial." |
+| high (5+) | "Competency verification is recommended." |
+
+Sage never concludes that an individual is incompetent.
+
+## API
+
+```
+POST /api/sage/gaps/detect/{technician}
+GET  /api/sage/gaps?competency_domain=...&instrument_family=...&anatomy_zone=...
+```
+
+Both are leadership-only (`admin`/`spd_manager`) — individual-level gap data
+is never exposed to a `viewer` or a peer technician.

--- a/docs/agents/sage/competency-taxonomy.md
+++ b/docs/agents/sage/competency-taxonomy.md
@@ -1,0 +1,33 @@
+# Project Sage — Competency Taxonomy
+
+LumenAI AI Specialist, Section 2.
+
+## Structure
+
+Seven domains, 52 leaves total, declared in
+`app/models/sage_education.py` (`COMPETENCY_TAXONOMY`):
+
+| Domain | Leaves |
+|---|---|
+| Instrument identification | manufacturer recognition, instrument-family recognition, model recognition, instrument differentiation, rigid scope vs flexible endoscope, powered vs manual instrument |
+| Anatomy recognition | serrations, grooves, box locks, hinges, ratchets, drill-bit flutes, threaded regions, lumens, cannulated channels, O-ring areas, scope ports, insulation edges, handle seams |
+| Inspection technique | visual inspection, magnification, borescope inspection, articulation and actuation, image capture, lighting, focus, angle selection, inspection coverage |
+| Contamination recognition | blood, bone, tissue, organic residue, debris |
+| Condition recognition | rust, corrosion, discoloration, pitting, crack, wear, missing components, insulation damage |
+| Clinical decision support | reclean, repeat inspection, supervisor review, repair evaluation, manufacturer evaluation, remove from service |
+| Documentation | inspection evidence, supervisor notes, baseline selection, anatomy-zone labeling, final disposition |
+
+## Mapping real signal onto the taxonomy
+
+`sage_competency_taxonomy_service.py` maps real, already-recorded signal onto
+taxonomy leaves rather than fabricating new tracking:
+
+- `finding_type` strings (the CV pipeline's real vocabulary) map onto the
+  contamination/condition leaves.
+- `SupervisorReview` boolean-correction fields (`zone_correct`,
+  `instrument_family_correct`, `image_view_correct`) map onto anatomy/
+  instrument-identification/technique leaves.
+
+```
+GET /api/sage/taxonomy
+```

--- a/docs/agents/sage/learning-effectiveness.md
+++ b/docs/agents/sage/learning-effectiveness.md
@@ -1,0 +1,46 @@
+# Project Sage — Learning Effectiveness Engine
+
+LumenAI AI Specialist, Section 9.
+
+## Real before/after metrics, one learner at a time
+
+`sage_effectiveness_service.measure_learning_plan_effectiveness` compares a
+completed `SageLearningPlan`'s before-window (ending at plan creation) and
+after-window (starting at plan completion), both real, windowed
+recomputations over:
+
+| Brief metric | Real source |
+|---|---|
+| Inspection coverage | `Inspection.coverage_pct` |
+| Supervisor correction rate | `SupervisorReview.agreement != "agree"` |
+| Image quality | `Inspection.ai_confidence` (this codebase has no separate image-quality score; AI confidence on image-based inspections is the closest real proxy) |
+| Finding accuracy | `SupervisorReview.finding_correct` |
+| Anatomy accuracy | `SupervisorReview.zone_correct` |
+| Workflow compliance | `SupervisorReview.image_view_correct` + `missing_zone_correct` |
+
+## Classification
+
+A metric only counts as "improved" or "declined" if it moves at least 5
+percentage points (`_CHANGE_THRESHOLD_PCT`) in the relevant direction
+(lower is better for correction rate; higher is better for everything else).
+
+| Result | Rule |
+|---|---|
+| `insufficient_evidence` | no metric has data in both windows |
+| `improved` | every tracked metric improved |
+| `declined` | every tracked metric declined, or declines outnumber improvements |
+| `partially_improved` | more metrics improved than declined |
+| `unchanged` | equal improved/declined counts (including zero) |
+
+## Never claims causation
+
+The narrative always frames the result as "an observed pattern, not a
+confirmed causal effect of the education itself."
+
+## API
+
+```
+POST /api/sage/learning-plans/{id}/measure-effectiveness
+```
+
+Only callable for a `completed` plan (422 otherwise).

--- a/docs/agents/sage/microlearning-generator.md
+++ b/docs/agents/sage/microlearning-generator.md
@@ -1,0 +1,36 @@
+# Project Sage — Microlearning Generator
+
+LumenAI AI Specialist, Section 6.
+
+## Only approved sources
+
+`sage_microlearning_service.build_module_from_finding` generates a module
+*only* from `education_library.get_article` (itself built from
+`clinical_mentor.FINDING_EDUCATION` + `instrument_anatomy.py` + the IFU
+reference note) — the platform's one approved-content library, covering 12
+contamination/condition categories (`education_library.CATEGORIES`).
+
+A `finding_type` outside that library returns `None` — Sage refuses to
+author unsupported clinical guidance rather than fabricate a module.
+
+## Module fields (Section 6)
+
+Learning objective, why it matters, anatomy overview, common findings,
+inspection steps, corrective actions, knowledge check, source references,
+and approval status — all real columns on `SageMicrolearningModule`,
+populated directly from the approved article, never invented text.
+
+## Approval workflow
+
+Every module starts `approval_status = "draft"`. `POST
+/api/sage/microlearning/{id}/approve` is required before a module appears in
+`GET /api/sage/microlearning?approval_status=approved` (the default view
+used by the Sage Workspace and Technician Learning Center).
+
+## API
+
+```
+POST /api/sage/microlearning/{finding_type}
+POST /api/sage/microlearning/{module_id}/approve
+GET  /api/sage/microlearning
+```

--- a/docs/agents/sage/sage-education-agent.md
+++ b/docs/agents/sage/sage-education-agent.md
@@ -1,0 +1,86 @@
+# Project Sage — Education and Competency Agent
+
+LumenAI AI Specialist, Mission & Section 1.
+
+## What Sage does
+
+Sage converts validated inspection findings, supervisor feedback, process
+trends, instrument failures, and institutional knowledge into targeted
+workforce-development recommendations. It determines what knowledge gap may
+exist, which competency is affected, who may need education, which
+instrument or anatomy zone should be taught, what validated evidence
+supports the education, and whether education improved future performance.
+
+Sage supports technicians, supervisors, educators, and SPD leaders. It does
+**not** discipline employees, independently determine competency, or replace
+supervisor and educator judgment.
+
+## Architecture position
+
+```
+Inspection Findings -> Supervisor Validation -> Aegis Process Intelligence ->
+Vulcan Reliability Intelligence -> Knowledge Graph -> Competency Gap Analysis
+-> Targeted Education -> Human Assignment and Approval -> Effectiveness
+Measurement -> Institutional Learning
+```
+
+## Deterministic, not an autonomous LLM
+
+Sage is a deterministic Python orchestrator composing real, already-recorded
+signal. There is no LLM/embedding API call anywhere in Sage.
+
+## What is reused vs. genuinely new
+
+Sage does not build a parallel competency store. It composes:
+
+- `CompetencyEvent` (`app/models/competency_event.py`) via
+  `competency_service.py` -- the existing per-technician event log
+  (finding_reviewed / supervisor_correction / repeated_error /
+  education_completed / annual_competency / procedure_validation /
+  simulation_passed / simulation_failed / knowledge_contribution).
+- `SupervisorReview` (`app/models/supervisor_review.py`) -- the ML
+  ground-truth label store, joined to `Inspection.technician` -- Sage's real
+  evidence for gap detection.
+- `Inspection.coverage_pct` / `Inspection.ai_confidence` -- real,
+  already-persisted per-inspection fields.
+- `education_library.get_article` / `clinical_mentor.FINDING_EDUCATION` --
+  the platform's one approved-content source for microlearning.
+- `athena_memory_service.list_memory_entries` -- Athena's institutional
+  knowledge composition, called through rather than re-queried.
+- `apollo_quality_twin_service.twin_history` -- Apollo's competency/education
+  scores, read-only.
+- `RetainedImage`/`ImageLabel` (`app/models/retained_image.py`) -- the real,
+  governed image store, curated (not duplicated) for education use.
+- `vulcan_aegis_integration_service.compute_process_variation_signal` and
+  `VulcanReliabilityAssessment` -- read, never overwritten.
+
+Genuinely new: seven tables (`SageKnowledgeGap`, `SageLearningPlan`,
+`SageMicrolearningModule`, `SageAssessment`, `SageEducationImageEntry`,
+`SageEffectivenessAssessment`, `SageFeedback`) and fifteen service modules.
+
+## Responsibilities (Section 1)
+
+- identify recurring knowledge gaps
+- identify repeated anatomy-zone errors
+- identify inspection coverage weaknesses
+- identify image-capture quality issues
+- recommend targeted education
+- recommend competency reassessment
+- create education drafts
+- link education to findings and evidence
+- measure post-education performance
+- capture supervisor and educator feedback
+
+Every recommendation includes evidence, confidence, and a human approval
+requirement (`human_review_required = True` on every new table).
+
+## API
+
+```
+POST /api/sage/gaps/detect/{technician}
+GET  /api/sage/gaps
+```
+
+See `docs/agents/sage/competency-gap-detection.md`,
+`docs/agents/sage/adaptive-learning-plans.md`, and
+`docs/agents/sage/learning-effectiveness.md` for the full pipeline.

--- a/docs/agents/sage/workforce-privacy.md
+++ b/docs/agents/sage/workforce-privacy.md
@@ -1,0 +1,36 @@
+# Project Sage — Workforce Privacy and Fairness
+
+LumenAI AI Specialist, Section 16.
+
+## What Sage must never do
+
+`sage_workforce_privacy_service.PROHIBITED_ACTIONS` documents the six
+safeguards the brief names: no public employee ranking, no disciplinary
+action, no protected-characteristic inference, no unvalidated-AI-finding
+performance action, no unauthorized individual exposure, no employment
+decisions. Nothing in Sage's route layer or service layer performs any of
+these — every table's status fields are advisory/educational only.
+
+## Access control
+
+`can_view_individual_competency(role, viewer_identity, subject_identity)` --
+true only if the viewer IS the subject (self-view, Section 11) or the
+viewer holds an authorized leadership role (`admin`/`spd_manager`). Every
+individual-level Sage route (`/gaps`, `/learning-plans`, `/assessments`,
+`/executive-summary`) is leadership-only at the route layer
+(`require_tenant_roles`); `/my-learning` resolves the learner from the
+authenticated identity, never a client-supplied parameter, so a technician
+can never request a peer's data through it.
+
+## Access logging
+
+`log_individual_access` routes through the platform's existing hash-chained,
+tamper-evident audit trail (`enterprise_audit_service.
+record_enterprise_audit_event`) rather than a new, weaker log table --
+every individual-level gap-detection call is recorded there.
+
+## Executive aggregates only
+
+`sage_executive_intelligence_service.executive_workforce_intelligence`
+returns counts and rates grouped by domain/instrument-family/anatomy-zone
+only — no technician name ever appears in that summary.

--- a/docs/agents/sentinel-x/clinical-risk-agent.md
+++ b/docs/agents/sentinel-x/clinical-risk-agent.md
@@ -1,0 +1,75 @@
+# Project Sentinel-X — Clinical Risk Agent
+
+LumenAI AI Specialist, Mission & Section 1.
+
+## Naming disambiguation
+
+**"Sentinel" already exists** as a major, unrelated system in this codebase
+-- "Project Sentinel" v3.0 ("Autonomous Clinical Intelligence
+Orchestration"): `app/models/sentinel_orchestration.py`
+(`SentinelRiskSignal`, `ClinicalWatchlistEntry`, `DigitalTwinFlag`,
+`SentinelAlert`, `SentinelRecommendation`, `SentinelHealthSnapshot`), routes
+at `/api/sentinel`, frontend route `/sentinel`, and nine `sentinel_*.py`
+services. Project Sentinel-X is a different, newer sprint and deliberately
+uses a distinct `sentinelx_` file/model/route prefix (`/api/sentinelx`)
+everywhere. It never touches or duplicates that system's tables. The
+brief's own frontend route (`/risk`) does not collide with `/sentinel`.
+
+## What Sentinel-X does
+
+Continuously evaluates clinical, operational, and inspection risk before an
+instrument proceeds through the pre-sterilization workflow — the patient-
+safety intelligence layer of LumenAI. It does not replace human clinical
+judgment. It prioritizes risk and explains why.
+
+## Architecture
+
+```
+Inspection -> Vision AI -> Anatomy AI -> Knowledge Graph -> Digital Twin ->
+Evidence Validation (Veritas) -> Process Intelligence (Aegis) ->
+Instrument Reliability (Vulcan) -> Education Intelligence (Sage) ->
+Clinical Risk Assessment -> Supervisor Review
+```
+
+## Deterministic, not an autonomous LLM
+
+`sentinelx_risk_agent_service.run_risk_assessment` is a deterministic
+Python orchestrator. There is no LLM/embedding API call anywhere.
+
+## What is composed vs. genuinely new
+
+Sentinel-X does not re-derive any specialist's own analysis. It calls:
+
+- `vulcan_reliability_agent_service.run_reliability_assessment` — instrument
+  reliability, progression, recurrence count, anatomy zone.
+- `vulcan_aegis_integration_service.compute_process_variation_signal` —
+  process variation.
+- `veritas_evidence_agent_service.run_evidence_assessment` — evidence
+  readiness (when an `inspection_id` is available).
+- `instrument_condition_service.instrument_condition_history` — the real
+  per-instrument Digital Twin condition trend (improving/stable/
+  declining/insufficient_data). Note: `digital_twin_engine.py` tracks SPD
+  workflow/throughput twins, a different concept — Sentinel-X does not read
+  from there.
+- `knowledge_graph_service.learning_confidence` — knowledge/clinical
+  recommendation confidence, derived live from `SupervisorReview`.
+- `InspectionFinding` (via `vulcan_progression_service.findings_timeline`) —
+  the real per-finding log.
+
+Genuinely new: three tables (`SentinelXRiskAssessment`,
+`SentinelXPatientSafetyAlert`, `SentinelXSupervisorOverride`) and ten
+service modules.
+
+## Responsibilities (Section 1)
+
+Evaluate contamination severity, anatomy-zone risk, recurrence, Digital
+Twin condition, inspection confidence, evidence readiness, process
+variation, repair history, and workflow status — then generate an
+explainable risk assessment.
+
+## API
+
+```
+POST /api/sentinelx/assess
+GET  /api/sentinelx/assessments/{id}
+```

--- a/docs/agents/sentinel-x/patient-safety-model.md
+++ b/docs/agents/sentinel-x/patient-safety-model.md
@@ -1,0 +1,47 @@
+# Project Sentinel-X — Patient Safety Watch, Predictive Risk & Supervisor Workspace
+
+LumenAI AI Specialist, Sections 5, 8, 10, 13.
+
+## Patient Safety Watch (Section 5)
+
+`sentinelx_patient_safety_watch_service.scan_for_alerts` fires proactive
+alerts only from real, repeated patterns (never a single event) across
+already-persisted `SentinelXRiskAssessment` rows: repeat contamination,
+repeat corrosion, repeat repair, repeat anatomy failures, high-risk
+instruments, and escalating Digital Twins. `SentinelXPatientSafetyAlert` is
+a new table, deliberately distinct from the pre-existing `SentinelAlert`
+(Project Sentinel v3.0).
+
+## Predictive Risk (Section 8)
+
+`sentinelx_predictive_service.py` produces five named forecasts (escalating
+corrosion, repeat blood findings, inspection backlog risk, high-risk
+workflows, recurring anatomy failures) as **deterministic trend
+extrapolation over real signal** — never a trained forecasting model. Every
+forecast states its `confidence` and its `assumptions` explicitly, so it is
+never mistaken for a statistically validated prediction.
+
+## Supervisor Workspace (Section 10)
+
+`sentinelx_supervisor_workspace_service.supervisor_workspace_summary`
+surfaces the highest-risk inspections/instruments, pending reviews,
+critical anatomy zones, escalating trends, and recommended priorities —
+all derived from real, already-persisted assessments.
+
+## Auditable Supervisor Override (Sections 10, 13)
+
+Sentinel-X's own risk level is always advisory. `sentinelx_override_service.
+submit_override` requires a non-empty `rationale` (raises otherwise) and
+persists an append-only `SentinelXSupervisorOverride` row — it never
+mutates the original assessment's `risk_level`/`risk_score`, so both the
+AI's original determination and the supervisor's override remain
+independently auditable.
+
+## API
+
+```
+GET  /api/sentinelx/predictive/{instrument_identity}
+GET  /api/sentinelx/supervisor-workspace
+POST /api/sentinelx/overrides
+GET  /api/sentinelx/overrides/{assessment_id}
+```

--- a/docs/agents/sentinel-x/risk-matrix.md
+++ b/docs/agents/sentinel-x/risk-matrix.md
@@ -1,0 +1,51 @@
+# Project Sentinel-X — SPD Risk Matrix & Dynamic Risk Scoring
+
+LumenAI AI Specialist, Sections 3 & 4.
+
+## SPD Risk Matrix (Section 3)
+
+`app/models/sentinelx_risk.py`'s `SPD_RISK_MATRIX` maps real finding_type
+strings (this codebase's actual CV/taxonomy vocabulary) onto three
+configurable weight tiers:
+
+| Tier | Finding types |
+|---|---|
+| Highest | blood, bone, tissue, organic residue, debris, corrosion, rust, crack, insulation damage/breach, missing component, damaged O-ring, obstruction |
+| Medium | wear, worn cutting edge, pitting, loose joint, damaged hinge, damaged ratchet |
+| Low | discoloration, staining, surface degradation |
+
+An unrecognized finding_type defaults to `medium` (never silently `low`) —
+`spd_risk_weight`/`spd_risk_weight_value` in `app/models/sentinelx_risk.py`.
+
+## Dynamic Risk Scoring (Section 4)
+
+`sentinelx_risk_scoring_service.compute_risk_score` produces a 0-100 score
+where **higher = more risk** — deliberately the inverse convention of
+Vulcan's reliability score and Veritas's readiness score (both "higher is
+better"), so a caller can never mistake one score type for another.
+
+| Factor | Points |
+|---|---|
+| Finding severity × SPD weight | 0-54 |
+| Anatomy-zone high-risk | 0 or 10 |
+| Recurrence | 0-25 |
+| Digital Twin condition trend | -5 to +20 |
+| Evidence readiness gap (Veritas) | 0-15, or 10 if no evidence assessment exists |
+| Repair recurrence (Vulcan) | 0 or 15 |
+| Supervisor concern | 0 or 10 |
+| Process variation (Aegis) | 0 or 8 |
+| Knowledge confidence (low/unknown) | 0-10 |
+
+## Categories
+
+| Range | Level |
+|---|---|
+| 80-100 | Critical |
+| 60-79 | High |
+| 40-59 | Moderate |
+| 20-39 | Low |
+| 0-19 | Very Low |
+
+`risk_level(score)` in `app/models/sentinelx_risk.py` is the single source
+of truth for this banding. Every score's `score_breakdown` is persisted
+verbatim so the contribution of each factor is always explainable.

--- a/docs/agents/sentinel-x/risk-taxonomy.md
+++ b/docs/agents/sentinel-x/risk-taxonomy.md
@@ -1,0 +1,24 @@
+# Project Sentinel-X — Risk Taxonomy
+
+LumenAI AI Specialist, Section 2.
+
+## Nine categories, multi-label
+
+A finding may belong to multiple categories at once —
+`sentinelx_risk_taxonomy_service.classify_categories` returns a list, never
+a single enum.
+
+| Category | Assigned when |
+|---|---|
+| Patient Safety | the finding_type carries the SPD Risk Matrix's `highest` weight |
+| Clinical Quality | any real finding_type is present |
+| Inspection Quality | evidence readiness score < 75 |
+| Instrument Integrity | a condition/mechanical finding_type, or a declining Digital Twin trend |
+| Workflow | Aegis process variation detected |
+| Operational | recurrence_count > 0 or repair recurrence |
+| Education | Knowledge Graph clinical recommendation confidence < 0.5 |
+| Compliance | evidence readiness score < 75 (paired with Inspection Quality) |
+| Enterprise | recurrence_count >= 3 (an enterprise-notable pattern) |
+
+Every category is assigned only when a real, already-computed signal from
+another specialist or the Knowledge Graph supports it — never a guess.

--- a/docs/agents/veritas/baseline-governance.md
+++ b/docs/agents/veritas/baseline-governance.md
@@ -1,0 +1,56 @@
+# Project Veritas — Baseline Governance Rules
+
+LumenAI AI Specialist, Sections 3 & 13.
+
+## Three pre-existing, divergent vocabularies
+
+- `BaselineLibraryEntry.approval_status`: pending/approved/deprecated
+- `EnterpriseVendorBaselineSubscription`: `baseline_status`/`approval_status`
+  with its own `_APPROVED_VALUES` set
+- `Inspection.baseline_status`: not_checked/approved_baseline_found/
+  pending_baseline_review/no_approved_baseline/baseline_not_available/approved
+
+None matches this brief's seven-status vocabulary (draft / pending_review /
+approved / conditionally_approved / superseded / rejected / archived).
+Rather than rewrite any of those tables, `VeritasBaselineGovernanceAction`
+is a new, **append-only** governance-action log keyed to
+`(baseline_source_type, baseline_source_id)`.
+
+## Effective status = latest action
+
+A baseline's canonical Veritas status is the `resulting_status` of its
+latest governance action — `veritas_baseline_governance_service.
+effective_status`. With no governance history yet, a real, already-approved
+baseline (i.e. one `resolve_baseline` returned) is treated as `approved`
+rather than defaulting to `pending_review`, since it already passed the
+real approval filter; a baseline with no history at all otherwise defaults
+to `pending_review`.
+
+## Only approved/conditionally-approved baselines score
+
+`is_usable_for_scoring(status)` gates every downstream readiness
+calculation — a `draft`, `pending_review`, `superseded`, `rejected`, or
+`archived` baseline never drives a clinical recommendation.
+
+## Every action is its own audit event
+
+`VeritasBaselineGovernanceAction` rows are never edited or deleted — each
+`approve`/`conditionally_approve`/`reject`/`supersede`/`archive`/
+`request_additional_images` call creates a new row, satisfying "every
+action requires an audit event" by construction.
+
+## Baseline Review Workspace (Section 13)
+
+`compare_candidates` lets an authorized reviewer compare multiple baseline
+candidates' governance history side by side before approving one.
+
+## API
+
+```
+POST /api/veritas/baselines/{source_type}/{source_id}/governance-action
+GET  /api/veritas/baselines/{source_type}/{source_id}/governance-history
+POST /api/veritas/baselines/compare
+```
+
+All governance-action writes are leadership-only (`admin`/`spd_manager`) —
+a technician (`operator` role) may never alter baseline governance status.

--- a/docs/agents/veritas/baseline-resolution.md
+++ b/docs/agents/veritas/baseline-resolution.md
@@ -1,0 +1,50 @@
+# Project Veritas — Baseline Resolution Hierarchy
+
+LumenAI AI Specialist, Section 2.
+
+## Built on the real resolution engine
+
+`veritas_baseline_resolution_service.resolve_governed_baseline` calls
+`baseline_comparison_scoring_service.resolve_baseline` directly (which
+already implements manufacturer -> vendor -> hospital priority across both
+real baseline sources) and enriches the result with manufacturer/model/
+reviewer/image-count fields fetched from whichever real table matched.
+
+Since `resolve_baseline` doesn't expose *which* table (`BaselineLibraryEntry`
+vs. `EnterpriseVendorBaselineSubscription`) produced a hit, Veritas calls the
+same two private resolution helpers (`_resolve_from_library`,
+`_resolve_from_uploaded`) directly to track that distinction honestly.
+
+## Five-tier hierarchy, mapped onto three real tiers
+
+The brief names five priority tiers (manufacturer / manufacturer-authorized
+/ vendor / organization / instrument-specific historical). This codebase's
+real baseline sources only distinguish three (manufacturer / vendor /
+hospital) — "manufacturer-authorized" and "instrument-specific historical"
+are not separately tracked anywhere and are honestly folded into the
+nearest real tier rather than fabricated as if a five-tier system existed.
+
+## Never a silent substitution
+
+`resolve_baseline` already only returns *approved* entries. When nothing
+approved is found, Veritas returns `resolution_status =
+SUPERVISOR_REVIEW_REQUIRED` with the brief's exact message:
+
+> "No approved baseline is available for this instrument and anatomy zone.
+> A final baseline-dependent score cannot be issued."
+
+## Anatomy zone is carried through, not filtered on
+
+Neither real baseline table tracks anatomy zone. `anatomy_zone` on
+`VeritasBaselineResolution` is the caller's requested zone, kept for
+display/audit only — never used as a fabricated filter the underlying
+tables can't actually support.
+
+## API
+
+```
+POST /api/veritas/assess/{inspection_id}
+```
+
+(Baseline resolution runs as the first step of the full evidence
+assessment; see `veritas-evidence-agent.md`.)

--- a/docs/agents/veritas/evidence-provenance-ledger.md
+++ b/docs/agents/veritas/evidence-provenance-ledger.md
@@ -1,0 +1,35 @@
+# Project Veritas — Evidence Provenance Ledger
+
+LumenAI AI Specialist, Section 7.
+
+## A different concept from GuardianX's EvidenceLedgerEntry
+
+`guardianx_assurance.EvidenceLedgerEntry` (Project GuardianX, v5.2) records
+what evidence backed an *AI-assurance* conclusion (knowledge/model/workflow
+versions + digital signature) — it has no file_hash/storage_location/
+modification_history/usage_scope fields and is not per-inspection-image
+provenance. `VeritasEvidenceProvenanceRecord` is the per-evidence-object
+ledger the brief actually asks for, covering all ten evidence types
+(inspection image, manufacturer/vendor/organization baseline, supervisor
+annotation, repair record, IFU reference, knowledge article, model
+prediction, final disposition).
+
+## Reference by ID, never a duplicate
+
+Every provenance record points at real evidence (a `RetainedImage`, an
+`Inspection`, a baseline row) by ID (`instrument_id`, `inspection_id`,
+`baseline_id`) — the same reference-by-ID discipline Sage's
+`SageEducationImageEntry` established for education images.
+
+## Modification history
+
+`append_modification` appends an `{actor, change, at}` entry to
+`modification_history_json` — an append-only trail of who changed what,
+never an overwrite of prior history.
+
+## API
+
+```
+POST /api/veritas/provenance
+GET  /api/veritas/provenance?inspection_id=...&evidence_type=...
+```

--- a/docs/agents/veritas/evidence-readiness-score.md
+++ b/docs/agents/veritas/evidence-readiness-score.md
@@ -1,0 +1,41 @@
+# Project Veritas — Evidence Readiness Score
+
+LumenAI AI Specialist, Section 8.
+
+## 0–100 composite, with a transparent breakdown
+
+`veritas_readiness_score_service.compute_evidence_readiness_score` starts at
+100 and applies itemized penalties, returned verbatim in
+`VeritasEvidenceReadinessAssessment.score_breakdown_json`:
+
+| Factor | Penalty |
+|---|---|
+| Baseline match quality (exact/compatible/partial/uncertain/mismatch/unavailable) | 0-40 |
+| Baseline governance status (approved/conditionally approved/other) | 0-25 |
+| Image quality (excellent/acceptable/limited/insufficient) | 0-30 |
+| Anatomy-zone coverage (complete/acceptable/incomplete/insufficient/not assessed) | 0-30 |
+| Instrument identity confidence (high/moderate/low) | 0-15 |
+| Evidence provenance completeness | 0 or -10 |
+| Supervisor validation status | 0 or -5 |
+| Model compatibility | 0 or -20 |
+| Conflicting evidence present | 0 or -15 |
+
+Score is clamped to [0, 100].
+
+## This evaluates evidence quality, not instrument cleanliness
+
+The brief is explicit that this score answers a different question than
+Vulcan's Instrument Reliability Score — the two are never conflated or
+combined into a single number.
+
+## Categories
+
+| Range | Category |
+|---|---|
+| 90-100 | Strong Evidence |
+| 75-89 | Moderate Evidence |
+| 50-74 | Limited Evidence |
+| 0-49 | Insufficient Evidence |
+
+`readiness_category(score)` (in `app/models/veritas_evidence.py`) is the
+single source of truth for this banding.

--- a/docs/agents/veritas/image-quality-assessment.md
+++ b/docs/agents/veritas/image-quality-assessment.md
@@ -1,0 +1,40 @@
+# Project Veritas — Image Quality Assessment
+
+LumenAI AI Specialist, Section 5.
+
+## No real CV quality model exists
+
+A repo-wide search before writing any code confirmed: no focus/blur/
+lighting/glare/exposure/obstruction/framing/magnification/orientation/
+duplication/compression-artifact detector exists anywhere in this
+codebase. `app/cv/image_validator.py` only does SSRF/format/size
+validation; `app/cv/ssim_comparator.py` is an explicit mock/fallback
+comparator.
+
+## Honest reporting, not fabrication
+
+`veritas_image_quality_service.assess_image_quality` reports every one of
+those per-signal metrics as `{"available": false}` — the same discipline
+Nova's observability summary and Vulcan's Aegis integration already
+established in this codebase. A `note` field states plainly what is and
+isn't measured.
+
+## Coarse, documented proxy
+
+`quality_status` (excellent/acceptable/limited/insufficient) is derived
+only from two real signals:
+
+1. Whether an image was actually captured (`Inspection.has_image`).
+2. The AI confidence already computed for that inspection
+   (`Inspection.ai_confidence`), bucketed at 85% / 65% / 40% thresholds.
+
+This is explicitly a proxy, not a quality metric — confidence measures the
+model's certainty in its finding, not image sharpness or lighting. The
+docstring and `note` field say so directly so no caller mistakes it for a
+real quality detector.
+
+## Never a high-confidence result from insufficient evidence
+
+`quality_status = insufficient` (no image, or very low confidence) always
+contributes its maximum penalty in the Evidence Readiness Score and can
+trigger the `ADDITIONAL_IMAGE_REQUIRED` evidence gate.

--- a/docs/agents/veritas/specialist-collaboration.md
+++ b/docs/agents/veritas/specialist-collaboration.md
@@ -1,0 +1,46 @@
+# Project Veritas — Collaboration With Other Agents
+
+LumenAI AI Specialist, Section 16.
+
+## No specialist may overwrite Veritas evidence findings
+
+Every function in `veritas_specialist_collaboration_service.py` reads
+another specialist's real, already-persisted output by reference and
+returns a Veritas-specific opinion in a separate dict — it never mutates or
+merges into the source. The orchestrator preserves separate agent
+conclusions by construction.
+
+## Aegis
+
+`evidence_support_for_aegis(aegis_conclusion, veritas_assessment)` — does
+Veritas's evidence readiness support Aegis's process conclusion? Aegis's
+own signal (`vulcan_aegis_integration_service.compute_process_variation_
+signal`'s output) is referenced verbatim, never edited.
+
+## Vulcan
+
+`evidence_support_for_vulcan(veritas_assessments)` — confirms instrument-
+condition progression comparisons used comparable images/anatomy zones/
+baseline versions, flagging when the assessments being compared resolved
+against different baselines.
+
+## Sage
+
+`evidence_support_for_sage(sage_image_entry, veritas_training_entry)` —
+cross-checks Sage's own education-image curation
+(`SageEducationImageEntry.phi_review_status`/`supervisor_validated`)
+against Veritas's independent training-dataset gate
+(`VeritasTrainingDatasetEntry.dataset_status`), so education content only
+uses approved, correctly labeled, rights-cleared images.
+
+## Clinical Reasoning Agent
+
+`evidence_support_for_clinical_reasoning(veritas_assessment)` — packages
+evidence limitations and readiness status for the reasoning engine to
+consider before finalizing a recommendation.
+
+## API
+
+```
+GET /api/veritas/collaboration/clinical-reasoning/{assessment_id}
+```

--- a/docs/agents/veritas/training-dataset-assurance.md
+++ b/docs/agents/veritas/training-dataset-assurance.md
@@ -1,0 +1,42 @@
+# Project Veritas — Training Dataset Assurance
+
+LumenAI AI Specialist, Section 15.
+
+## Mirrors Sage's curation-gate pattern, extended
+
+`veritas_training_dataset_service.evaluate_for_training` gates a real
+`RetainedImage`/`ImageLabel` pair into a training-dataset status, following
+the exact reference-by-ID pattern Sage's `SageEducationImageEntry`
+established (`supervisor_validated` + `phi_review_status` + `usage_rights`),
+extended with the training-specific checks this section names:
+
+- correct instrument family / anatomy zone
+- confirmed finding + severity label (from the image's gold `ImageLabel`)
+- image quality threshold met (caller-supplied, since no real per-image
+  quality score exists — see `image-quality-assessment.md`)
+- duplicate detection (same `RetainedImage.sha256` as another image)
+- provenance completeness (`sha256` + `consent_recorded` + `uploaded_by`
+  all present)
+
+## Dataset statuses
+
+| Status | When |
+|---|---|
+| `quarantined` | duplicate image detected |
+| `excluded` | no consent recorded |
+| `pending_validation` | any other check fails (listed in `status_reason`) |
+| `approved_for_training` | every check passes |
+
+## Never allows unvalidated evidence into training
+
+An image only reaches `approved_for_training` when it is gold-labeled
+(`ImageLabel.is_gold`), PHI-cleared, rights-declared, and not a duplicate —
+exactly the brief's "do not allow unvalidated inspection images into
+approved training sets."
+
+## API
+
+```
+POST /api/veritas/training-dataset/{retained_image_id}/evaluate
+GET  /api/veritas/training-dataset?dataset_status=...
+```

--- a/docs/agents/veritas/veritas-evidence-agent.md
+++ b/docs/agents/veritas/veritas-evidence-agent.md
@@ -1,0 +1,78 @@
+# Project Veritas — Evidence Assurance Agent
+
+LumenAI AI Specialist, Mission & Section 1.
+
+## What Veritas does
+
+Veritas evaluates whether an inspection has sufficient, reliable, and
+governed evidence to support an AI recommendation. It validates instrument
+identity, manufacturer and model association, anatomy-zone alignment,
+baseline availability/approval status/version, image quality, inspection
+coverage, evidence provenance, supervisor validation, model and dataset
+versions, and audit completeness.
+
+Veritas does **not** independently approve an instrument. It determines
+whether the evidence is trustworthy enough for the inspection workflow to
+proceed and identifies what additional evidence is required.
+
+## Architecture position
+
+```
+Instrument Identification -> Anatomy Profile -> Inspection Images ->
+Baseline Resolution -> Evidence Integrity Review -> AI Analysis ->
+Clinical Reasoning -> Supervisor Validation -> Governed Decision Record
+```
+
+Veritas never bypasses Instrument Intelligence, Anatomy Intelligence, RBAC,
+tenant isolation, or human validation.
+
+## Deterministic, not an autonomous LLM
+
+Veritas is a deterministic Python orchestrator
+(`veritas_evidence_agent_service.run_evidence_assessment`) composing real,
+already-built infrastructure. There is no LLM/embedding API call anywhere.
+
+## What is reused vs. genuinely new
+
+- **Baseline resolution** — `baseline_comparison_scoring_service.
+  resolve_baseline` (manufacturer -> vendor -> hospital priority across
+  `BaselineLibraryEntry` and `EnterpriseVendorBaselineSubscription`) is
+  called directly, never re-implemented.
+- **Coverage** — `inspection_coverage.compute_coverage` is called directly.
+- **Image quality** — no real CV quality model exists in this codebase;
+  Veritas reports this honestly (see `docs/agents/veritas/
+  image-quality-assessment.md`) rather than fabricating a score.
+- **Model/dataset versions** — read from `ModelRegistryEntry`
+  (`app/models/model_registry.py`), never duplicated.
+- **Image provenance** — `RetainedImage`/`ImageLabel` referenced by ID,
+  never copied.
+
+Genuinely new: seven tables (`VeritasBaselineResolution`,
+`VeritasBaselineGovernanceAction`, `VeritasEvidenceProvenanceRecord`,
+`VeritasEvidenceReadinessAssessment`, `VeritasEvidenceConflict`,
+`VeritasTrainingDatasetEntry`, `VeritasFeedback`) and sixteen service
+modules.
+
+## Responsibilities (Section 1)
+
+- resolve the correct baseline
+- verify baseline approval and version
+- validate image-to-instrument association
+- assess image quality
+- assess required-zone coverage
+- detect missing or conflicting evidence
+- identify stale or superseded baselines
+- verify evidence provenance
+- calculate Evidence Readiness Score
+- recommend additional evidence capture
+- prevent unsupported final AI conclusions
+
+Every result is explainable (`reasoning_narrative`) and auditable
+(`score_breakdown_json`, `limitations_json`, full governance-action log).
+
+## API
+
+```
+POST /api/veritas/assess/{inspection_id}
+GET  /api/veritas/assessments/{id}
+```

--- a/docs/agents/vulcan/aegis-vulcan-collaboration.md
+++ b/docs/agents/vulcan/aegis-vulcan-collaboration.md
@@ -1,0 +1,42 @@
+# Project Vulcan — Integration With Aegis
+
+LumenAI AI Specialist, Section 12.
+
+## Aegis does not pre-exist in this codebase
+
+A `grep -rn "aegis" app/` before writing any Vulcan code returned zero
+matches. Rather than fabricate a full "process variation" platform to match
+the brief's illustrative example (an "evening shift" pattern this codebase
+has no shift data to support), `vulcan_aegis_integration_service.py` builds
+a real, honestly minimal process-variation signal from the one relevant
+real field this codebase actually has: `Inspection.technician` concentration
+among the findings behind a Vulcan assessment.
+
+## Signal
+
+`compute_process_variation_signal` looks at the technicians attributed to
+the relevant inspections. With fewer than two technician-attributed
+inspections, it reports no signal (insufficient sample). Otherwise it
+reports the most-concentrated technician's share; a concentration >= 60%
+is flagged as a possible process-variation contributor — always described
+in terms of what was actually measured, never dressed up as the brief's
+"evening shift" example.
+
+## Vulcan and Aegis never overwrite each other
+
+- Vulcan's own reasoning lives in `reasoning_narrative`.
+- Aegis's conclusion lives in a separate field, `aegis_conclusion_json`.
+- `combine_conclusions` only ever *appends* a combined-conclusion sentence
+  into `combined_conclusion` — it never mutates or replaces either side's
+  own field.
+
+This satisfies "no agent may overwrite the other's conclusion" and keeps
+both agents' evidence separately traceable in the persisted assessment row.
+
+## Example (Section 12 illustrative pattern, adapted to real data)
+
+> Vulcan identifies recurring corrosion in orthopedic drill-bit flutes.
+> Aegis's real signal shows one technician performed a concentrated share
+> of the relevant inspections. Combined conclusion: instrument failures may
+> involve both repeated process exposure and progressive material
+> degradation — human review required to confirm either contributor.

--- a/docs/agents/vulcan/failure-progression-model.md
+++ b/docs/agents/vulcan/failure-progression-model.md
@@ -1,0 +1,45 @@
+# Project Vulcan — Failure Progression Model
+
+LumenAI AI Specialist, Section 3.
+
+## Real history, never fabricated trends
+
+`vulcan_progression_service.compute_progression` classifies condition
+progression from real `InspectionFinding.severity_index` sequences (0 none /
+1 minor / 2 moderate / 3 severe) for one instrument identity, optionally
+scoped to one anatomy zone. Fewer than two matching findings always yields
+`insufficient_history` — Vulcan does not predict a trend it has no evidence
+for.
+
+## Progression states
+
+| State | Condition |
+|---|---|
+| `rapidly_worsening` | severity non-decreasing, net increase >= 2 |
+| `slowly_worsening` | severity non-decreasing, net increase == 1 |
+| `improving` | severity strictly decreasing |
+| `unresolved` | severity flat at moderate/severe (>= 2), not improving |
+| `stable` | severity flat at none/minor |
+| `intermittent` | severity oscillates (neither monotonic) |
+| `insufficient_history` | fewer than 2 matching findings |
+
+## Example (matches the brief's illustrative progression)
+
+```
+Inspection 1: minor surface discoloration   (severity 1)
+Inspection 2: surface rust                  (severity 1-2)
+Inspection 3: moderate corrosion            (severity 2)
+Inspection 4: pitting                       (severity 3)
+Inspection 5: remove from service           (severity 3, disposition escalation)
+```
+
+This sequence classifies as `rapidly_worsening` (net severity change >= 2
+across the window), which — combined with the reliability score's
+progression penalty — drives the recommended disposition toward repair or
+removal review.
+
+## API
+
+```
+GET /api/vulcan/progression?instrument_identity=...&zone=...
+```

--- a/docs/agents/vulcan/failure-taxonomy.md
+++ b/docs/agents/vulcan/failure-taxonomy.md
@@ -1,0 +1,36 @@
+# Project Vulcan — Instrument Failure Taxonomy
+
+LumenAI AI Specialist, Section 2.
+
+## Structure
+
+Seven groups, 36 leaves total, declared in
+`app/models/vulcan_reliability.py` (`FAILURE_TAXONOMY`):
+
+| Group | Leaves |
+|---|---|
+| Cleaning-related | retained blood, retained bone, tissue, organic residue, debris, obstruction |
+| Condition-related | rust, corrosion, pitting, discoloration, surface degradation, staining |
+| Mechanical | crack, misalignment, loose joint, damaged hinge, damaged ratchet, damaged serration, worn cutting edge, bent component, missing component |
+| Scope-specific | damaged O-ring, damaged seal, lens damage, light-post damage, sheath damage, port damage, channel damage |
+| Powered/orthopedic | damaged drill flute, damaged thread, worn cutting tip, damaged hub, metal deformation |
+| Insulation-related | insulation breach, peeling insulation, exposed conductor, surface nick |
+| Unknown | insufficient evidence, image quality limitation, anatomy not recognized, manufacturer evaluation required |
+
+## Mapping real detections onto the taxonomy
+
+`vulcan_failure_taxonomy_service.classify_finding_type` maps the CV
+pipeline's real `InspectionFinding.finding_type` vocabulary (`blood`, `bone`,
+`corrosion`, `insulation_damage`, etc. — see
+`baseline_comparison_scoring_service.CLEANING_KPIS`/`KPI_LABELS`) onto the
+closest taxonomy leaf. A `finding_type` outside the known mapping
+classifies as Unknown (`insufficient_evidence`) rather than guessing —
+Vulcan never fabricates a finer-grained classification the CV pipeline
+never actually produced.
+
+```
+GET /api/vulcan/taxonomy
+```
+
+Returns the full `{group: [leaves]}` tree for the Instrument Forensics
+Workspace's failure-category filter.

--- a/docs/agents/vulcan/instrument-forensics-workspace.md
+++ b/docs/agents/vulcan/instrument-forensics-workspace.md
@@ -1,0 +1,41 @@
+# Project Vulcan — Instrument Forensics Workspace
+
+LumenAI AI Specialist, Section 9.
+
+## Route
+
+`/instrument-forensics` (frontend), backed by `/api/vulcan/forensics/*`.
+
+## Displayed per instrument
+
+- instrument identity (barcode/UDI, honest `untracked:` fallback)
+- Digital Twin / anatomy profile references (version strings + live anatomy
+  profile lookup)
+- inspection history and finding timeline
+- severity trend
+- repair history (with classified outcome)
+- recurring zones
+- reliability score + breakdown
+- probable contributors + alternative explanations
+- recommended disposition
+- supervisor review (via Section 13 feedback)
+
+## Filters
+
+Manufacturer, instrument family, anatomy zone, failure category, repair
+vendor, facility, and date range — implemented in
+`vulcan_forensics_service.search_forensics`. "Model" is not filterable at
+the per-physical-instrument level: no module in this codebase tracks model
+per physical instrument (only `InstrumentKnowledge` reference data does, at
+the manufacturer+family level) — documented rather than fabricated.
+
+## API
+
+```
+GET /api/vulcan/forensics/{instrument_identity}?instrument_type=...
+GET /api/vulcan/forensics/search?manufacturer=...&instrument_family=...&anatomy_zone=...&failure_category=...&repair_vendor=...&facility=...&date_from=...&date_to=...
+```
+
+`forensics/search` is registered before the `forensics/{instrument_identity}`
+path match in the router so the literal `search` path is never shadowed by
+the identity parameter route.

--- a/docs/agents/vulcan/instrument-reliability-agent.md
+++ b/docs/agents/vulcan/instrument-reliability-agent.md
@@ -1,0 +1,82 @@
+# Project Vulcan — Instrument Reliability Agent
+
+LumenAI AI Specialist, Mission & Section 1.
+
+## What Vulcan does
+
+Vulcan investigates recurring instrument defects, condition changes, repair
+patterns, and premature failures. It determines what is failing, where the
+failure occurs, whether it is recurring, how the condition is progressing,
+whether prior repairs were effective, and whether the issue is
+cleaning-related, maintenance-related, use-related, design-related, or
+undetermined.
+
+Vulcan supports pre-sterilization inspection and asset-quality decisions. It
+does not certify instrument safety independently — supervisor, clinical
+engineering, repair vendor, and manufacturer review remain available where
+appropriate.
+
+## Deterministic, not an autonomous LLM
+
+Vulcan is a deterministic Python orchestrator
+(`vulcan_reliability_agent_service.run_reliability_assessment`) composing
+real evidence from existing data. There is no LLM or embedding API call
+anywhere in Vulcan — the same invariant every prior sprint in this codebase
+protects.
+
+## Architecture position
+
+```
+Instrument Intelligence -> Anatomy Intelligence -> Zone Intelligence ->
+Inspection Findings -> Digital Twin History -> Repair History ->
+Failure Analysis -> Reliability Assessment -> Recommended Disposition ->
+Human Validation -> Knowledge Capture
+```
+
+## What is reused vs. genuinely new
+
+Vulcan composes real, pre-existing data rather than inventing a parallel
+instrument-history store:
+
+- **Finding history** — `InspectionFinding` (v1.5) already logs one row per
+  actionable finding; this *is* the progression/anatomy-zone history Vulcan
+  analyzes.
+- **Repair history** — `RepairRequest` (`app/models/or_connect.py`) already
+  tracks vendor, repair type, status, return dates, and a coarse
+  `failure_category`. Vulcan's granular taxonomy maps onto it for
+  repair-effectiveness correlation.
+- **Instrument identity/anatomy** — `Inspection.instrument_udi`/
+  `instrument_barcode` (the real cross-inspection identity key, via the
+  established `_instrument_identity` helper) and `instrument_anatomy.py`'s
+  real anatomy-zone taxonomy.
+- **Digital Twin / baseline versions** — referenced by version string only
+  in the audit trail, never copied.
+
+Genuinely new: three tables (`VulcanReliabilityAssessment`,
+`VulcanRepairEffectivenessAssessment`, `VulcanFeedback`) and twelve service
+modules (`vulcan_*_service.py`).
+
+## Responsibilities (Section 1)
+
+- monitor recurring defects
+- compare current and prior inspections
+- identify repeated anatomy-zone failures
+- evaluate repair effectiveness
+- identify worsening corrosion or wear
+- detect repeat removal-from-service events
+- identify instruments with abnormal failure frequency
+- recommend repair, monitoring, manufacturer evaluation, or retirement
+
+Every conclusion carries evidence (`evidence_json`) and a confidence label
+(`confidence`).
+
+## API
+
+```
+POST /api/vulcan/assess
+GET  /api/vulcan/assessments/{id}
+```
+
+See `docs/agents/vulcan/reliability-score.md` for the scoring rubric and
+`docs/agents/vulcan/instrument-forensics-workspace.md` for the full
+investigative UI.

--- a/docs/agents/vulcan/reliability-score.md
+++ b/docs/agents/vulcan/reliability-score.md
@@ -1,0 +1,42 @@
+# Project Vulcan — Instrument Reliability Score
+
+LumenAI AI Specialist, Section 7.
+
+## 0–100 composite, with a transparent breakdown
+
+`vulcan_reliability_score_service.compute_reliability_score` starts at 100
+and applies itemized penalties, returned verbatim in
+`VulcanReliabilityAssessment.score_breakdown_json` so every point deducted
+is traceable to a real factor:
+
+| Factor | Penalty |
+|---|---|
+| Progression (`rapidly_worsening`/`slowly_worsening`/`unresolved`/`intermittent`) | up to -25 |
+| Repeated findings (recurrence count) | up to -20 |
+| Structural condition (latest severity index) | up to -15 |
+| Repair recurrence (repair outcome) | up to -15 |
+| Anatomy-zone risk (high-risk zone per `instrument_anatomy.py`) | -5 |
+| Supervisor concerns flagged | -10 |
+| Baseline deviation | -8 |
+| Evidence quality (low-confidence progression) | -5 |
+
+Score is clamped to [0, 100].
+
+## Explicit exclusion
+
+**Sterilization-cycle counts are never read by this service** — the brief's
+explicit instruction. No factor above touches cycle-count data.
+
+## Categories
+
+| Range | Category |
+|---|---|
+| 90-100 | Reliable |
+| 75-89 | Monitor |
+| 50-74 | Elevated Concern |
+| 25-49 | Repair / Manufacturer Review |
+| 0-24 | Remove From Service Candidate |
+
+`reliability_category(score)` (in `app/models/vulcan_reliability.py`) is the
+single source of truth for this banding, reused by both the score service
+and the orchestrator's disposition logic.

--- a/docs/agents/vulcan/repair-effectiveness.md
+++ b/docs/agents/vulcan/repair-effectiveness.md
@@ -1,0 +1,40 @@
+# Project Vulcan — Repair Effectiveness Intelligence
+
+LumenAI AI Specialist, Section 5.
+
+## Composing real repair + finding evidence
+
+`vulcan_repair_effectiveness_service.classify_repair_outcome` composes the
+real `RepairRequest` row (`app/models/or_connect.py` — repair date, vendor,
+type, status, return dates, coarse `failure_category`) with the real
+`InspectionFinding` rows on the inspection that triggered the repair and any
+inspections after the instrument's return.
+
+`RepairRequest` has no zone column of its own. The affected anatomy zone is
+derived from the pre-repair inspection's most severe finding — never
+fabricated.
+
+## Outcome classification
+
+| Outcome | Meaning |
+|---|---|
+| `effective` | no recurrence in the same zone after return |
+| `partially_effective` | recurrence at lower severity than before |
+| `failure_recurred` | recurrence at the same/greater severity |
+| `new_defect_detected` | a previously-unseen finding type appears in the same zone |
+| `unable_to_determine` | repair not yet returned, or no post-repair inspection exists yet |
+
+`time_to_recurrence_days` is computed from real timestamps (return date to
+first recurring inspection), never estimated.
+
+## No unsupported vendor claims
+
+Outcomes describe what the inspection evidence shows — recurrence, new
+defect, or no recurrence — never a statement that a vendor performed a bad
+repair.
+
+## API
+
+```
+GET /api/vulcan/repair-effectiveness?instrument_identity=...
+```

--- a/frontend/src/components/CouncilWorkspace.tsx
+++ b/frontend/src/components/CouncilWorkspace.tsx
@@ -1,0 +1,244 @@
+/**
+ * LumenAI AI Leadership Platform — Project Council: Multi-Agent
+ * Leadership Teams & Governed Consensus Intelligence.
+ *
+ * Frontend route `/council`, API prefix `/api/council`. Council convenes
+ * LumenAI's specialist agents as a structured leadership team -- it
+ * synthesizes evidence, surfaces agreement and disagreement, and
+ * evaluates tradeoffs, but never replaces leadership. No recommendation
+ * may hide specialist disagreement, and a simple majority never
+ * overrides unresolved safety dissent.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Json = Record<string, unknown>;
+
+const TABS = ["Workspace", "Cases", "Teams", "Performance", "Notifications"] as const;
+type Tab = (typeof TABS)[number];
+
+const CASE_TYPES = [
+  "high_risk_inspection", "recurring_contamination", "recurring_instrument_failure", "repair_recurrence",
+  "process_variation", "education_need", "capa_escalation", "workflow_bottleneck", "enterprise_trend",
+  "model_performance_issue", "evidence_conflict", "innovation_proposal",
+];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function JsonView({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+function CaseList({ cases, onSelect }: { cases: Json[]; onSelect: (id: number) => void }) {
+  if (!cases.length) return <p className="text-xs text-slate-400">No cases.</p>;
+  return (
+    <ul className="space-y-2">
+      {cases.map((c) => (
+        <li key={c.id as number} className="cursor-pointer rounded border border-slate-100 p-2 hover:bg-slate-50" onClick={() => onSelect(c.id as number)}>
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-slate-800">Case #{c.id as number} — {c.case_type as string}</span>
+            <span className="text-xs text-slate-400">{c.consensus_status as string || "pending"}</span>
+          </div>
+          <p className="mt-1 text-xs text-slate-500">{c.recommended_action as string}</p>
+          <p className="mt-1 text-xs text-slate-400">team: {c.team_key as string} · status: {c.status as string}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function CouncilWorkspace() {
+  const [activeTab, setActiveTab] = useState<Tab>("Workspace");
+
+  const [workspace, setWorkspace] = useState<Json | null>(null);
+  const [cases, setCases] = useState<Json[]>([]);
+  const [teams, setTeams] = useState<Json[]>([]);
+  const [performance, setPerformance] = useState<Json | null>(null);
+  const [notifications, setNotifications] = useState<Json[]>([]);
+  const [selectedCaseId, setSelectedCaseId] = useState<number | null>(null);
+  const [caseDetail, setCaseDetail] = useState<Json | null>(null);
+
+  const [newCaseType, setNewCaseType] = useState(CASE_TYPES[0]);
+  const [newSourceEvent, setNewSourceEvent] = useState("");
+  const [newInstrumentIdentity, setNewInstrumentIdentity] = useState("");
+
+  function loadWorkspace() {
+    api.get("/api/council/workspace").then(setWorkspace).catch(() => {});
+  }
+
+  useEffect(() => {
+    if (activeTab === "Workspace") loadWorkspace();
+    if (activeTab === "Cases") api.get("/api/council/cases").then((r: Json) => setCases((r.cases as Json[]) || [])).catch(() => {});
+    if (activeTab === "Teams") api.get("/api/council/teams").then((r: Json) => setTeams((r.teams as Json[]) || [])).catch(() => {});
+    if (activeTab === "Performance") api.get("/api/council/performance").then(setPerformance).catch(() => {});
+    if (activeTab === "Notifications") api.get("/api/council/notifications").then((r: Json) => setNotifications((r.notifications as Json[]) || [])).catch(() => {});
+  }, [activeTab]);
+
+  function openAndConvene() {
+    api.post("/api/council/cases", {
+      case_type: newCaseType,
+      source_event: newSourceEvent,
+      instrument_ids: newInstrumentIdentity ? [newInstrumentIdentity] : [],
+    }).then((created: Json) => {
+      const id = created.id as number;
+      return api.post(`/api/council/cases/${id}/convene`, {}).then(() => id);
+    }).then((id: number) => {
+      setSelectedCaseId(id);
+      loadCaseDetail(id);
+      setActiveTab("Cases");
+      api.get("/api/council/cases").then((r: Json) => setCases((r.cases as Json[]) || [])).catch(() => {});
+    }).catch(() => {});
+  }
+
+  function loadCaseDetail(id: number) {
+    api.get(`/api/council/cases/${id}`).then(setCaseDetail).catch(() => {});
+  }
+
+  function selectCase(id: number) {
+    setSelectedCaseId(id);
+    loadCaseDetail(id);
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <div>
+        <h1 className="text-xl font-bold text-slate-800">Council — Multi-Agent Leadership Teams</h1>
+        <p className="text-xs text-slate-400">
+          Council convenes LumenAI's specialist agents as a structured leadership team to synthesize evidence,
+          surface agreement and disagreement, and evaluate tradeoffs. Council does not replace leadership -- no
+          recommendation may hide specialist disagreement, and a simple majority never overrides unresolved
+          safety dissent.
+        </p>
+      </div>
+
+      <Section title="Open a new Council Case">
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="text-xs text-slate-600">
+            Case type
+            <select className="mt-1 block rounded border border-slate-200 p-1 text-sm" value={newCaseType} onChange={(e) => setNewCaseType(e.target.value)}>
+              {CASE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </label>
+          <label className="text-xs text-slate-600">
+            Source event
+            <input className="mt-1 block rounded border border-slate-200 p-1 text-sm" value={newSourceEvent} onChange={(e) => setNewSourceEvent(e.target.value)} />
+          </label>
+          <label className="text-xs text-slate-600">
+            Instrument identity
+            <input className="mt-1 block rounded border border-slate-200 p-1 text-sm" value={newInstrumentIdentity} onChange={(e) => setNewInstrumentIdentity(e.target.value)} />
+          </label>
+          <button onClick={openAndConvene} className="rounded bg-indigo-600 px-3 py-1 text-sm text-white">
+            Open &amp; Convene
+          </button>
+        </div>
+      </Section>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Workspace" && workspace && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="Urgent Cases">
+            <CaseList cases={(workspace.urgent_cases as Json[]) || []} onSelect={selectCase} />
+          </Section>
+          <Section title="Safety Dissent">
+            <CaseList cases={(workspace.safety_dissent_cases as Json[]) || []} onSelect={selectCase} />
+          </Section>
+          <Section title="Split Decisions">
+            <CaseList cases={(workspace.split_decision_cases as Json[]) || []} onSelect={selectCase} />
+          </Section>
+          <Section title="Awaiting Evidence">
+            <CaseList cases={(workspace.awaiting_evidence as Json[]) || []} onSelect={selectCase} />
+          </Section>
+          <Section title="Awaiting Human Decision">
+            <CaseList cases={(workspace.awaiting_decision as Json[]) || []} onSelect={selectCase} />
+          </Section>
+          <Section title="Recently Resolved">
+            <CaseList cases={(workspace.recently_resolved as Json[]) || []} onSelect={selectCase} />
+          </Section>
+          <Section title="Outcome Effectiveness">
+            <JsonView data={workspace.outcome_effectiveness} />
+          </Section>
+          <Section title="Specialist Participation">
+            <JsonView data={workspace.specialist_participation} />
+          </Section>
+          <Section title="Recurring Decision Themes">
+            <JsonView data={workspace.recurring_decision_themes} />
+          </Section>
+        </div>
+      )}
+
+      {activeTab === "Cases" && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="All Cases">
+            <CaseList cases={cases} onSelect={selectCase} />
+          </Section>
+          {selectedCaseId && caseDetail && (
+            <Section title={`Case #${selectedCaseId} Detail`}>
+              <div className="space-y-3">
+                <div>
+                  <h4 className="text-xs font-semibold text-slate-600">1. Issue Summary</h4>
+                  <JsonView data={caseDetail.case} />
+                </div>
+                <div>
+                  <h4 className="text-xs font-semibold text-slate-600">3. Specialist Assessments</h4>
+                  <JsonView data={caseDetail.assessments} />
+                </div>
+                <div>
+                  <h4 className="text-xs font-semibold text-slate-600">4. Agreement Map</h4>
+                  <JsonView data={caseDetail.agreement_map} />
+                </div>
+                <div>
+                  <h4 className="text-xs font-semibold text-slate-600">5. Dissent</h4>
+                  <JsonView data={caseDetail.dissent} />
+                </div>
+                <div>
+                  <h4 className="text-xs font-semibold text-slate-600">6. Decision Options</h4>
+                  <JsonView data={caseDetail.decision_options} />
+                </div>
+                <div>
+                  <h4 className="text-xs font-semibold text-slate-600">9. Final Human Decision(s)</h4>
+                  <JsonView data={caseDetail.human_decisions} />
+                </div>
+              </div>
+            </Section>
+          )}
+        </div>
+      )}
+
+      {activeTab === "Teams" && (
+        <Section title="Leadership Team Registry">
+          <JsonView data={teams} />
+        </Section>
+      )}
+
+      {activeTab === "Performance" && performance && (
+        <Section title="Specialist Performance Review (aggregate, non-punitive)">
+          <JsonView data={performance} />
+        </Section>
+      )}
+
+      {activeTab === "Notifications" && (
+        <Section title="Notifications and Escalations">
+          <JsonView data={notifications} />
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/InstrumentForensicsWorkspace.tsx
+++ b/frontend/src/components/InstrumentForensicsWorkspace.tsx
@@ -1,0 +1,174 @@
+/**
+ * LumenAI AI Specialist — Project Vulcan: Instrument Forensics Workspace.
+ *
+ * Frontend route `/instrument-forensics`, API prefix `/api/vulcan`. Vulcan is
+ * a deterministic, evidence-based reliability agent -- not an autonomous LLM
+ * -- and every conclusion shown here is advisory, confidence-scored, and
+ * requires human review before any operational action.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Json = Record<string, unknown>;
+
+const WATCHLIST_NAMES = [
+  "recurring_corrosion", "recurring_rust", "repeated_cleaning_failure", "repeat_repair",
+  "structural_defect_progression", "damaged_o_rings", "insulation_failures", "drill_flute_failures",
+  "box_lock_failures", "instruments_awaiting_manufacturer_review", "retirement_candidates",
+];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function JsonView({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function InstrumentForensicsWorkspace() {
+  const [instrumentIdentity, setInstrumentIdentity] = useState("");
+  const [instrumentType, setInstrumentType] = useState("");
+  const [record, setRecord] = useState<Json | null>(null);
+
+  const [filters, setFilters] = useState({
+    manufacturer: "", instrument_family: "", anatomy_zone: "", failure_category: "",
+    repair_vendor: "", facility: "", date_from: "", date_to: "",
+  });
+  const [searchResults, setSearchResults] = useState<Json[] | null>(null);
+
+  const [watchlistName, setWatchlistName] = useState(WATCHLIST_NAMES[0]);
+  const [watchlistEntries, setWatchlistEntries] = useState<Json[] | null>(null);
+
+  const [executiveSummary, setExecutiveSummary] = useState<Json | null>(null);
+
+  useEffect(() => {
+    api.get("/api/vulcan/executive-summary").then(setExecutiveSummary).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    api
+      .get(`/api/vulcan/watchlists/${watchlistName}`)
+      .then((r: Json) => setWatchlistEntries(r.entries as Json[]))
+      .catch(() => {});
+  }, [watchlistName]);
+
+  function lookupInstrument() {
+    if (!instrumentIdentity) return;
+    api
+      .get(`/api/vulcan/forensics/${encodeURIComponent(instrumentIdentity)}?instrument_type=${encodeURIComponent(instrumentType)}`)
+      .then(setRecord)
+      .catch(() => setRecord(null));
+  }
+
+  function assessInstrument() {
+    if (!instrumentIdentity) return;
+    api
+      .post("/api/vulcan/assess", { instrument_identity: instrumentIdentity, instrument_type: instrumentType })
+      .then(() => lookupInstrument())
+      .catch(() => {});
+  }
+
+  function runSearch() {
+    const params = new URLSearchParams();
+    Object.entries(filters).forEach(([k, v]) => {
+      if (v) params.set(k, v);
+    });
+    api
+      .get(`/api/vulcan/forensics/search?${params.toString()}`)
+      .then((r: Json) => setSearchResults(r.results as Json[]))
+      .catch(() => setSearchResults(null));
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Instrument Forensics Workspace</h1>
+      <p className="text-xs text-slate-400">
+        Vulcan investigates recurring instrument defects, condition changes, repair patterns, and premature
+        failures. It does not certify instrument safety independently -- supervisor, clinical engineering,
+        repair vendor, and manufacturer review remain available where appropriate. Every conclusion is
+        evidence-based, confidence-scored, and human-reviewed.
+      </p>
+
+      <Section title="Instrument Lookup">
+        <div className="flex flex-wrap gap-2">
+          <input
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+            placeholder="instrument_identity (e.g. barcode:ABC123)"
+            value={instrumentIdentity}
+            onChange={(e) => setInstrumentIdentity(e.target.value)}
+          />
+          <input
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+            placeholder="instrument_type (e.g. kerrison rongeur)"
+            value={instrumentType}
+            onChange={(e) => setInstrumentType(e.target.value)}
+          />
+          <button className="rounded bg-slate-100 px-3 py-1 text-sm text-slate-700" onClick={lookupInstrument}>
+            Load Forensics Record
+          </button>
+          <button className="rounded bg-indigo-600 px-3 py-1 text-sm text-white" onClick={assessInstrument}>
+            Run Vulcan Assessment
+          </button>
+        </div>
+        {record && (
+          <div className="mt-3 space-y-3">
+            {(record.latest_assessment as Json | null) && (
+              <div className="rounded border border-indigo-200 bg-indigo-50 p-3 text-sm text-slate-700">
+                <p className="font-semibold">{(record.latest_assessment as Json).reasoning_narrative as string}</p>
+                <p className="mt-1 text-xs text-slate-500">
+                  Reliability: {(record.latest_assessment as Json).reliability_category as string} (
+                  {(record.latest_assessment as Json).reliability_score as number}) — Confidence:{" "}
+                  {(record.latest_assessment as Json).confidence as string} — Recommended disposition:{" "}
+                  {(record.latest_assessment as Json).recommended_disposition as string}
+                </p>
+              </div>
+            )}
+            <JsonView data={record} />
+          </div>
+        )}
+      </Section>
+
+      <Section title="Forensics Search Filters">
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+          {(Object.keys(filters) as (keyof typeof filters)[]).map((key) => (
+            <input
+              key={key}
+              className="rounded border border-slate-300 px-2 py-1 text-sm"
+              placeholder={key.replace(/_/g, " ")}
+              value={filters[key]}
+              onChange={(e) => setFilters((f) => ({ ...f, [key]: e.target.value }))}
+            />
+          ))}
+        </div>
+        <button className="mt-2 rounded bg-slate-100 px-3 py-1 text-sm text-slate-700" onClick={runSearch}>
+          Search
+        </button>
+        {searchResults && <div className="mt-3"><JsonView data={searchResults} /></div>}
+      </Section>
+
+      <Section title="Reliability Watchlists">
+        <select
+          className="rounded border border-slate-300 px-2 py-1 text-sm"
+          value={watchlistName}
+          onChange={(e) => setWatchlistName(e.target.value)}
+        >
+          {WATCHLIST_NAMES.map((name) => (
+            <option key={name} value={name}>
+              {name.replace(/_/g, " ")}
+            </option>
+          ))}
+        </select>
+        {watchlistEntries && <div className="mt-3"><JsonView data={watchlistEntries} /></div>}
+      </Section>
+
+      <Section title="Executive Reliability Analytics">
+        {executiveSummary && <JsonView data={executiveSummary} />}
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/components/MaestroLeadershipWorkspace.tsx
+++ b/frontend/src/components/MaestroLeadershipWorkspace.tsx
@@ -1,0 +1,215 @@
+/**
+ * LumenAI AI Specialist — Project Maestro: Operational Orchestration &
+ * Decision Intelligence.
+ *
+ * Frontend route `/maestro`, API prefix `/api/maestro`. Maestro is a pure
+ * read-and-synthesize leadership layer over every other specialist -- it
+ * never replaces human leadership. Every recommendation is explainable,
+ * evidence-based, auditable, role-aware, and subject to human approval;
+ * "What should I do first today, and why?"
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Json = Record<string, unknown>;
+
+const TABS = [
+  "Leadership Workspace", "Priorities", "Recommendations", "Strategy Timeline", "Decision Journal", "Daily Briefs",
+] as const;
+type Tab = (typeof TABS)[number];
+
+const BRIEF_TYPES = ["morning_brief", "afternoon_update", "end_of_day_summary", "weekend_readiness", "shift_handoff"];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function JsonView({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+function PriorityList({ items }: { items: Json[] }) {
+  if (!items.length) return <p className="text-xs text-slate-400">No active priorities.</p>;
+  return (
+    <ol className="space-y-2">
+      {items.map((item) => (
+        <li key={item.id as number} className="rounded border border-slate-100 p-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-slate-800">#{item.rank as number} — {item.subject as string}</span>
+            <span className="text-xs text-slate-400">{item.category as string}</span>
+          </div>
+          <p className="mt-1 text-xs text-slate-500">{item.rationale as string}</p>
+          <p className="mt-1 text-xs text-slate-400">score {item.priority_score as number} · via {item.source_specialist as string}</p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function RecommendationList({ items }: { items: Json[] }) {
+  if (!items.length) return <p className="text-xs text-slate-400">No pending recommendations.</p>;
+  return (
+    <ol className="space-y-2">
+      {items.map((item) => (
+        <li key={item.id as number} className="rounded border border-slate-100 p-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-slate-800">{item.subject as string}</span>
+            <span className="text-xs text-slate-400">{item.status as string} · {item.timeline_horizon as string}</span>
+          </div>
+          <p className="mt-1 text-xs text-slate-500">{item.rationale as string}</p>
+          <p className="mt-1 text-xs text-slate-400">confidence: {item.confidence as string} · type: {item.recommendation_type as string}</p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export default function MaestroLeadershipWorkspace() {
+  const [activeTab, setActiveTab] = useState<Tab>("Leadership Workspace");
+
+  const [workspace, setWorkspace] = useState<Json | null>(null);
+  const [priorities, setPriorities] = useState<Json[]>([]);
+  const [recommendations, setRecommendations] = useState<Json[]>([]);
+  const [timeline, setTimeline] = useState<Json | null>(null);
+  const [journal, setJournal] = useState<Json[]>([]);
+  const [briefType, setBriefType] = useState(BRIEF_TYPES[0]);
+  const [brief, setBrief] = useState<Json | null>(null);
+
+  function loadWorkspace() {
+    api.get("/api/maestro/workspace").then(setWorkspace).catch(() => {});
+  }
+
+  useEffect(() => {
+    if (activeTab === "Leadership Workspace") loadWorkspace();
+    if (activeTab === "Priorities") api.get("/api/maestro/priorities").then((r: Json) => setPriorities((r.priorities as Json[]) || [])).catch(() => {});
+    if (activeTab === "Recommendations") api.get("/api/maestro/recommendations").then((r: Json) => setRecommendations((r.recommendations as Json[]) || [])).catch(() => {});
+    if (activeTab === "Strategy Timeline") api.get("/api/maestro/timeline").then(setTimeline).catch(() => {});
+    if (activeTab === "Decision Journal") api.get("/api/maestro/decisions").then((r: Json) => setJournal((r.journal as Json[]) || [])).catch(() => {});
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (activeTab === "Daily Briefs") {
+      api.get(`/api/maestro/briefs/${briefType}/latest`).then(setBrief).catch(() => setBrief(null));
+    }
+  }, [activeTab, briefType]);
+
+  function runOrchestration() {
+    api.post("/api/maestro/run", {}).then(loadWorkspace).catch(() => {});
+  }
+
+  function generateBrief() {
+    api.post(`/api/maestro/briefs/${briefType}/generate`, {}).then(setBrief).catch(() => {});
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-slate-800">Leadership Workspace</h1>
+          <p className="text-xs text-slate-400">
+            Maestro continuously coordinates every LumenAI specialist to recommend operational priorities for
+            SPD leaders. It never replaces human leadership -- every recommendation is explainable,
+            evidence-based, auditable, role-aware, and subject to human approval.
+          </p>
+        </div>
+        <button onClick={runOrchestration} className="rounded bg-indigo-600 px-3 py-1 text-sm text-white">
+          Run Orchestration
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Leadership Workspace" && workspace && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Section title="Top Priorities">
+            <PriorityList items={(workspace.top_priorities as Json[]) || []} />
+          </Section>
+          <Section title="Operational Health">
+            <JsonView data={workspace.operational_health} />
+          </Section>
+          <Section title="Open Risks">
+            <JsonView data={workspace.open_risks} />
+          </Section>
+          <Section title="Today's Recommendations">
+            <RecommendationList items={(workspace.todays_recommendations as Json[]) || []} />
+          </Section>
+          <Section title="Pending Executive Decisions">
+            <RecommendationList items={(workspace.pending_executive_decisions as Json[]) || []} />
+          </Section>
+          <Section title="Shift Readiness">
+            <JsonView data={workspace.shift_readiness} />
+          </Section>
+          <Section title="Enterprise Status">
+            <JsonView data={workspace.enterprise_status} />
+          </Section>
+        </div>
+      )}
+
+      {activeTab === "Priorities" && (
+        <Section title="Ranked Priorities">
+          <PriorityList items={priorities} />
+        </Section>
+      )}
+
+      {activeTab === "Recommendations" && (
+        <Section title="Leadership Recommendations">
+          <RecommendationList items={recommendations} />
+        </Section>
+      )}
+
+      {activeTab === "Strategy Timeline" && timeline && (
+        <Section title="Strategy Timeline (by horizon)">
+          <JsonView data={timeline.horizons} />
+        </Section>
+      )}
+
+      {activeTab === "Decision Journal" && (
+        <Section title="Decision Journal">
+          <JsonView data={journal} />
+        </Section>
+      )}
+
+      {activeTab === "Daily Briefs" && (
+        <Section title="Daily Operational Brief">
+          <div className="mb-3 flex flex-wrap gap-1">
+            {BRIEF_TYPES.map((bt) => (
+              <button
+                key={bt}
+                onClick={() => setBriefType(bt)}
+                className={`rounded px-2 py-1 text-xs ${briefType === bt ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+              >
+                {bt}
+              </button>
+            ))}
+            <button onClick={generateBrief} className="rounded bg-emerald-600 px-2 py-1 text-xs text-white">
+              Generate
+            </button>
+          </div>
+          {brief ? (
+            <div>
+              <p className="mb-2 text-sm text-slate-700">{brief.narrative as string}</p>
+              <JsonView data={brief.content} />
+            </div>
+          ) : (
+            <p className="text-xs text-slate-400">No brief generated yet.</p>
+          )}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MyLearningCenter.tsx
+++ b/frontend/src/components/MyLearningCenter.tsx
@@ -1,0 +1,68 @@
+/**
+ * LumenAI AI Specialist — Project Sage, Section 11: Technician Learning
+ * Center.
+ *
+ * Frontend route `/my-learning`, API prefix `/api/sage/my-learning`. Shows
+ * only the authenticated user's OWN authorized learning information -- the
+ * backend resolves the learner from the authenticated identity, never a
+ * client-supplied parameter, so peer performance is never exposed here.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Json = Record<string, unknown>;
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function JsonView({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function MyLearningCenter() {
+  const [data, setData] = useState<Json | null>(null);
+
+  useEffect(() => {
+    api.get("/api/sage/my-learning").then(setData).catch(() => {});
+  }, []);
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">My Learning</h1>
+      <p className="text-xs text-slate-400">
+        Your own assigned education, due dates, completed modules, and competency status. This view never
+        shows a coworker's performance.
+      </p>
+
+      <Section title="Assigned Modules">
+        {data && <JsonView data={data.assigned_modules} />}
+      </Section>
+
+      <Section title="Due Dates">
+        {data && <JsonView data={data.due_dates} />}
+      </Section>
+
+      <Section title="Completed Education">
+        {data && <JsonView data={data.completed_education} />}
+      </Section>
+
+      <Section title="Competency Status">
+        {data && <JsonView data={data.competency_status} />}
+      </Section>
+
+      <Section title="Supervisor Feedback">
+        {data && <JsonView data={data.supervisor_feedback} />}
+      </Section>
+
+      <Section title="Assessments">
+        {data && <JsonView data={data.assessments} />}
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/components/SageWorkspace.tsx
+++ b/frontend/src/components/SageWorkspace.tsx
@@ -1,0 +1,140 @@
+/**
+ * LumenAI AI Specialist — Project Sage: SPD Education, Competency &
+ * Workforce Intelligence.
+ *
+ * Frontend route `/sage`, API prefix `/api/sage`. Sage does not discipline
+ * employees, independently determine competency, or replace supervisor and
+ * educator judgment -- every recommendation here requires human approval
+ * before assignment.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Json = Record<string, unknown>;
+
+const TABS = [
+  "Workspace", "Knowledge Gaps", "Learning Plans", "Microlearning",
+  "Assessments", "Image Library", "Executive Summary",
+] as const;
+type Tab = (typeof TABS)[number];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function JsonView({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function SageWorkspace() {
+  const [activeTab, setActiveTab] = useState<Tab>("Workspace");
+
+  const [workspace, setWorkspace] = useState<Json | null>(null);
+  const [gaps, setGaps] = useState<Json[] | null>(null);
+  const [plans, setPlans] = useState<Json[] | null>(null);
+  const [modules, setModules] = useState<Json[] | null>(null);
+  const [assessments, setAssessments] = useState<Json[] | null>(null);
+  const [images, setImages] = useState<Json[] | null>(null);
+  const [executiveSummary, setExecutiveSummary] = useState<Json | null>(null);
+
+  const [gapTechnician, setGapTechnician] = useState("");
+
+  useEffect(() => {
+    if (activeTab === "Workspace") api.get("/api/sage/workspace").then(setWorkspace).catch(() => {});
+    if (activeTab === "Knowledge Gaps") api.get("/api/sage/gaps").then((r: Json) => setGaps(r.gaps as Json[])).catch(() => {});
+    if (activeTab === "Learning Plans") api.get("/api/sage/learning-plans").then((r: Json) => setPlans(r.plans as Json[])).catch(() => {});
+    if (activeTab === "Microlearning") api.get("/api/sage/microlearning").then((r: Json) => setModules(r.modules as Json[])).catch(() => {});
+    if (activeTab === "Assessments") api.get("/api/sage/assessments").then((r: Json) => setAssessments(r.assessments as Json[])).catch(() => {});
+    if (activeTab === "Image Library") api.get("/api/sage/images").then((r: Json) => setImages(r.images as Json[])).catch(() => {});
+    if (activeTab === "Executive Summary") api.get("/api/sage/executive-summary").then(setExecutiveSummary).catch(() => {});
+  }, [activeTab]);
+
+  function runGapDetection() {
+    if (!gapTechnician) return;
+    api
+      .post(`/api/sage/gaps/detect/${encodeURIComponent(gapTechnician)}`, {})
+      .then((r: Json) => setGaps(r.gaps as Json[]))
+      .catch(() => {});
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Sage — Education, Competency &amp; Workforce Intelligence</h1>
+      <p className="text-xs text-slate-400">
+        Sage supports technicians, supervisors, educators, and SPD leaders. It does not discipline employees,
+        independently determine competency, or replace supervisor and educator judgment. Every recommendation
+        is evidence-based, confidence-scored, non-punitive, and requires human approval before assignment.
+      </p>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Workspace" && (
+        <Section title="Recommended Plans, Overdue Competencies &amp; Recurring Gaps">
+          {workspace && <JsonView data={workspace} />}
+        </Section>
+      )}
+
+      {activeTab === "Knowledge Gaps" && (
+        <Section title="Detected Knowledge Gaps (non-punitive, human-reviewed)">
+          <div className="mb-3 flex gap-2">
+            <input
+              className="rounded border border-slate-300 px-2 py-1 text-sm"
+              placeholder="technician email"
+              value={gapTechnician}
+              onChange={(e) => setGapTechnician(e.target.value)}
+            />
+            <button className="rounded bg-indigo-600 px-3 py-1 text-sm text-white" onClick={runGapDetection}>
+              Run Gap Detection
+            </button>
+          </div>
+          {gaps && <JsonView data={gaps} />}
+        </Section>
+      )}
+
+      {activeTab === "Learning Plans" && (
+        <Section title="Adaptive Learning Plans">
+          {plans && <JsonView data={plans} />}
+        </Section>
+      )}
+
+      {activeTab === "Microlearning" && (
+        <Section title="Approved Microlearning Modules">
+          {modules && <JsonView data={modules} />}
+        </Section>
+      )}
+
+      {activeTab === "Assessments" && (
+        <Section title="Competency Assessments (advisory until validated)">
+          {assessments && <JsonView data={assessments} />}
+        </Section>
+      )}
+
+      {activeTab === "Image Library" && (
+        <Section title="Image-Based Learning Library (PHI-cleared only)">
+          {images && <JsonView data={images} />}
+        </Section>
+      )}
+
+      {activeTab === "Executive Summary" && (
+        <Section title="Executive Workforce Intelligence (aggregate only, no individual ranking)">
+          {executiveSummary && <JsonView data={executiveSummary} />}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SentinelXRiskDashboard.tsx
+++ b/frontend/src/components/SentinelXRiskDashboard.tsx
@@ -1,0 +1,121 @@
+/**
+ * LumenAI AI Specialist — Project Sentinel-X: Clinical Risk Intelligence &
+ * Patient Safety Agent.
+ *
+ * Frontend route `/risk`, API prefix `/api/sentinelx`. Distinct from the
+ * pre-existing, unrelated "Project Sentinel" system at `/sentinel` (API
+ * `/api/sentinel`) -- Sentinel-X never touches that system's data.
+ *
+ * Sentinel-X does not replace human clinical judgment. It prioritizes risk
+ * and explains why -- every assessment is explainable, evidence-based,
+ * confidence-scored, auditable, and subject to human review.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Json = Record<string, unknown>;
+
+const TABS = [
+  "Risk Dashboard", "Supervisor Workspace", "Patient Safety Alerts", "Heatmaps",
+] as const;
+type Tab = (typeof TABS)[number];
+
+const HEATMAP_DIMENSIONS = ["facility", "department", "instrument_family", "anatomy", "manufacturer", "service_line"];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function JsonView({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function SentinelXRiskDashboard() {
+  const [activeTab, setActiveTab] = useState<Tab>("Risk Dashboard");
+
+  const [dashboard, setDashboard] = useState<Json | null>(null);
+  const [supervisorWorkspace, setSupervisorWorkspace] = useState<Json | null>(null);
+  const [alerts, setAlerts] = useState<Json[] | null>(null);
+  const [heatmapDimension, setHeatmapDimension] = useState(HEATMAP_DIMENSIONS[0]);
+  const [heatmap, setHeatmap] = useState<Json | null>(null);
+
+  useEffect(() => {
+    if (activeTab === "Risk Dashboard") api.get("/api/sentinelx/dashboard").then(setDashboard).catch(() => {});
+    if (activeTab === "Supervisor Workspace") api.get("/api/sentinelx/supervisor-workspace").then(setSupervisorWorkspace).catch(() => {});
+    if (activeTab === "Patient Safety Alerts") api.get("/api/sentinelx/alerts").then((r: Json) => setAlerts(r.alerts as Json[])).catch(() => {});
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (activeTab === "Heatmaps") {
+      api.get(`/api/sentinelx/heatmaps/${heatmapDimension}`).then(setHeatmap).catch(() => {});
+    }
+  }, [activeTab, heatmapDimension]);
+
+  function scanForAlerts() {
+    api.post("/api/sentinelx/alerts/scan", {}).then(() => api.get("/api/sentinelx/alerts")).then((r: Json) => setAlerts(r.alerts as Json[])).catch(() => {});
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Clinical Risk Intelligence</h1>
+      <p className="text-xs text-slate-400">
+        Sentinel-X continuously evaluates clinical, operational, and inspection risk before an instrument
+        proceeds through the pre-sterilization workflow. It does not replace human clinical judgment -- it
+        prioritizes risk and explains why.
+      </p>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Risk Dashboard" && (
+        <Section title="Enterprise, Facility, Instrument, Anatomy, Workflow, Education, Knowledge &amp; Digital Twin Risk">
+          {dashboard && <JsonView data={dashboard} />}
+        </Section>
+      )}
+
+      {activeTab === "Supervisor Workspace" && (
+        <Section title="Highest-Risk Inspections, Pending Reviews &amp; Recommended Priorities">
+          {supervisorWorkspace && <JsonView data={supervisorWorkspace} />}
+        </Section>
+      )}
+
+      {activeTab === "Patient Safety Alerts" && (
+        <Section title="Proactive Patient Safety Watch">
+          <button className="mb-3 rounded bg-indigo-600 px-3 py-1 text-sm text-white" onClick={scanForAlerts}>
+            Scan for New Alerts
+          </button>
+          {alerts && <JsonView data={alerts} />}
+        </Section>
+      )}
+
+      {activeTab === "Heatmaps" && (
+        <Section title="Enterprise Risk Heatmap">
+          <select
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+            value={heatmapDimension}
+            onChange={(e) => setHeatmapDimension(e.target.value)}
+          >
+            {HEATMAP_DIMENSIONS.map((d) => (
+              <option key={d} value={d}>{d.replace(/_/g, " ")}</option>
+            ))}
+          </select>
+          {heatmap && <div className="mt-3"><JsonView data={heatmap} /></div>}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/VeritasEvidencePanel.tsx
+++ b/frontend/src/components/VeritasEvidencePanel.tsx
@@ -1,0 +1,77 @@
+/**
+ * LumenAI AI Specialist — Project Veritas, Section 12: Inspection Evidence
+ * Panel.
+ *
+ * A compact panel intended to be embedded in an inspection results view,
+ * showing the resolved baseline, match classification, image quality,
+ * coverage, evidence readiness, limitations, and next action -- the exact
+ * fields the brief's Section 12 example specifies.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Json = Record<string, unknown>;
+
+const READINESS_LABELS: Record<string, string> = {
+  strong_evidence: "Strong",
+  moderate_evidence: "Moderate",
+  limited_evidence: "Limited",
+  insufficient_evidence: "Insufficient",
+};
+
+export default function VeritasEvidencePanel({ inspectionId }: { inspectionId: number }) {
+  const [assessment, setAssessment] = useState<Json | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    api
+      .post(`/api/veritas/assess/${inspectionId}`, {})
+      .then(setAssessment)
+      .catch(() => setAssessment(null))
+      .finally(() => setLoading(false));
+  }, [inspectionId]);
+
+  if (loading) return <div className="text-xs text-slate-400">Assessing evidence...</div>;
+  if (!assessment) return null;
+
+  const readinessLabel = READINESS_LABELS[assessment.readiness_category as string] || (assessment.readiness_category as string);
+  const missingZones = (assessment.missing_zones as string[]) || [];
+  const limitations = (assessment.limitations as string[]) || [];
+
+  return (
+    <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-4 text-sm text-slate-700">
+      <h4 className="mb-2 text-sm font-semibold text-indigo-900">Veritas Evidence</h4>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1">
+        <dt className="text-slate-500">Baseline Match</dt>
+        <dd className="capitalize">{assessment.match_classification as string}</dd>
+
+        <dt className="text-slate-500">Image Quality</dt>
+        <dd className="capitalize">{assessment.image_quality_status as string}</dd>
+
+        <dt className="text-slate-500">Coverage</dt>
+        <dd>{assessment.coverage_pct != null ? `${assessment.coverage_pct}%` : (assessment.coverage_status as string)}</dd>
+
+        {missingZones.length > 0 && (
+          <>
+            <dt className="text-slate-500">Missing Zone(s)</dt>
+            <dd>{missingZones.join(", ")}</dd>
+          </>
+        )}
+
+        <dt className="text-slate-500">Evidence Readiness</dt>
+        <dd>{readinessLabel} — {assessment.readiness_score as number}/100</dd>
+      </dl>
+
+      {limitations.length > 0 && (
+        <p className="mt-2 text-xs text-amber-700">
+          <span className="font-semibold">Limitation:</span> {limitations.join(" ")}
+        </p>
+      )}
+
+      <p className="mt-2 text-xs text-slate-600">
+        <span className="font-semibold">Next Action:</span> {assessment.next_action as string}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/VeritasWorkspace.tsx
+++ b/frontend/src/components/VeritasWorkspace.tsx
@@ -1,0 +1,144 @@
+/**
+ * LumenAI AI Specialist — Project Veritas: Baseline Governance, Evidence
+ * Integrity & Clinical Data Quality.
+ *
+ * Frontend route `/veritas`, API prefix `/api/veritas`. Veritas does not
+ * independently approve an instrument -- it determines whether the
+ * evidence is trustworthy enough for the inspection workflow to proceed
+ * and identifies what additional evidence is required.
+ */
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+type Json = Record<string, unknown>;
+
+const TABS = [
+  "Workspace", "Watchlists", "Data Quality", "Training Dataset", "Reports",
+] as const;
+type Tab = (typeof TABS)[number];
+
+const WATCHLIST_NAMES = [
+  "no_approved_baseline", "baseline_review_overdue", "baseline_superseded",
+  "repeated_poor_image_quality", "repeated_incomplete_coverage", "high_baseline_mismatch",
+  "conflicting_evidence", "unapproved_training_candidates", "missing_provenance",
+  "repeated_evidence_gate_override",
+];
+
+const REPORT_NAMES = [
+  "baseline_governance", "evidence_readiness", "training_dataset_assurance",
+  "provenance_audit", "baseline_review_aging", "data_quality_trend",
+];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-slate-700">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function JsonView({ data }: { data: unknown }) {
+  return <pre className="max-h-96 overflow-auto whitespace-pre-wrap text-xs text-slate-600">{JSON.stringify(data, null, 2)}</pre>;
+}
+
+export default function VeritasWorkspace() {
+  const [activeTab, setActiveTab] = useState<Tab>("Workspace");
+
+  const [workspace, setWorkspace] = useState<Json | null>(null);
+  const [watchlistName, setWatchlistName] = useState(WATCHLIST_NAMES[0]);
+  const [watchlistEntries, setWatchlistEntries] = useState<Json[] | null>(null);
+  const [dataQuality, setDataQuality] = useState<Json | null>(null);
+  const [trainingDataset, setTrainingDataset] = useState<Json[] | null>(null);
+  const [reportName, setReportName] = useState(REPORT_NAMES[0]);
+  const [report, setReport] = useState<Json | null>(null);
+
+  useEffect(() => {
+    if (activeTab === "Workspace") api.get("/api/veritas/workspace").then(setWorkspace).catch(() => {});
+    if (activeTab === "Data Quality") api.get("/api/veritas/data-quality").then(setDataQuality).catch(() => {});
+    if (activeTab === "Training Dataset") api.get("/api/veritas/training-dataset").then((r: Json) => setTrainingDataset(r.entries as Json[])).catch(() => {});
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (activeTab === "Watchlists") {
+      api.get(`/api/veritas/watchlists/${watchlistName}`).then((r: Json) => setWatchlistEntries(r.entries as Json[])).catch(() => {});
+    }
+  }, [activeTab, watchlistName]);
+
+  useEffect(() => {
+    if (activeTab === "Reports") {
+      api.get(`/api/veritas/reports/${reportName}`).then(setReport).catch(() => {});
+    }
+  }, [activeTab, reportName]);
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold text-slate-800">Veritas — Evidence Assurance</h1>
+      <p className="text-xs text-slate-400">
+        Veritas evaluates whether an inspection has sufficient, reliable, and governed evidence to support an
+        AI recommendation. It does not independently approve an instrument. Every evidence decision remains
+        versioned, explainable, auditable, tenant-isolated, and human-governed.
+      </p>
+
+      <div className="flex flex-wrap gap-1">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActiveTab(t)}
+            className={`rounded px-3 py-1 text-sm ${activeTab === t ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "Workspace" && (
+        <Section title="Evidence Readiness Overview, Pending Reviews &amp; Conflicts">
+          {workspace && <JsonView data={workspace} />}
+        </Section>
+      )}
+
+      {activeTab === "Watchlists" && (
+        <Section title="Alerts and Watchlists">
+          <select
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+            value={watchlistName}
+            onChange={(e) => setWatchlistName(e.target.value)}
+          >
+            {WATCHLIST_NAMES.map((name) => (
+              <option key={name} value={name}>{name.replace(/_/g, " ")}</option>
+            ))}
+          </select>
+          {watchlistEntries && <div className="mt-3"><JsonView data={watchlistEntries} /></div>}
+        </Section>
+      )}
+
+      {activeTab === "Data Quality" && (
+        <Section title="Data Quality Monitoring">
+          {dataQuality && <JsonView data={dataQuality} />}
+        </Section>
+      )}
+
+      {activeTab === "Training Dataset" && (
+        <Section title="Training Dataset Assurance">
+          {trainingDataset && <JsonView data={trainingDataset} />}
+        </Section>
+      )}
+
+      {activeTab === "Reports" && (
+        <Section title="Evidence Assurance Reports">
+          <select
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+            value={reportName}
+            onChange={(e) => setReportName(e.target.value)}
+          >
+            {REPORT_NAMES.map((name) => (
+              <option key={name} value={name}>{name.replace(/_/g, " ")}</option>
+            ))}
+          </select>
+          {report && <div className="mt-3"><JsonView data={report} /></div>}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -99,6 +99,7 @@ const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
 const InstrumentForensicsPage = lazy(() => import("./pages/InstrumentForensicsPage"));
 const SageWorkspacePage = lazy(() => import("./pages/SageWorkspacePage"));
 const MyLearningPage = lazy(() => import("./pages/MyLearningPage"));
+const VeritasWorkspacePage = lazy(() => import("./pages/VeritasWorkspacePage"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
@@ -438,6 +439,7 @@ function App() {
                       <Route path="/instrument-forensics" element={<Page name="InstrumentForensics"><InstrumentForensicsPage /></Page>} />
                       <Route path="/sage" element={<Page name="Sage"><SageWorkspacePage /></Page>} />
                       <Route path="/my-learning" element={<Page name="MyLearning"><MyLearningPage /></Page>} />
+                      <Route path="/veritas" element={<Page name="Veritas"><VeritasWorkspacePage /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -102,6 +102,7 @@ const MyLearningPage = lazy(() => import("./pages/MyLearningPage"));
 const VeritasWorkspacePage = lazy(() => import("./pages/VeritasWorkspacePage"));
 const RiskDashboardPage = lazy(() => import("./pages/RiskDashboardPage"));
 const MaestroWorkspacePage = lazy(() => import("./pages/MaestroWorkspacePage"));
+const CouncilWorkspacePage = lazy(() => import("./pages/CouncilWorkspacePage"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
@@ -444,6 +445,7 @@ function App() {
                       <Route path="/veritas" element={<Page name="Veritas"><VeritasWorkspacePage /></Page>} />
                       <Route path="/risk" element={<Page name="RiskDashboard"><RiskDashboardPage /></Page>} />
                       <Route path="/maestro" element={<Page name="Maestro"><MaestroWorkspacePage /></Page>} />
+                      <Route path="/council" element={<Page name="Council"><CouncilWorkspacePage /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -101,6 +101,7 @@ const SageWorkspacePage = lazy(() => import("./pages/SageWorkspacePage"));
 const MyLearningPage = lazy(() => import("./pages/MyLearningPage"));
 const VeritasWorkspacePage = lazy(() => import("./pages/VeritasWorkspacePage"));
 const RiskDashboardPage = lazy(() => import("./pages/RiskDashboardPage"));
+const MaestroWorkspacePage = lazy(() => import("./pages/MaestroWorkspacePage"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
@@ -442,6 +443,7 @@ function App() {
                       <Route path="/my-learning" element={<Page name="MyLearning"><MyLearningPage /></Page>} />
                       <Route path="/veritas" element={<Page name="Veritas"><VeritasWorkspacePage /></Page>} />
                       <Route path="/risk" element={<Page name="RiskDashboard"><RiskDashboardPage /></Page>} />
+                      <Route path="/maestro" element={<Page name="Maestro"><MaestroWorkspacePage /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -100,6 +100,7 @@ const InstrumentForensicsPage = lazy(() => import("./pages/InstrumentForensicsPa
 const SageWorkspacePage = lazy(() => import("./pages/SageWorkspacePage"));
 const MyLearningPage = lazy(() => import("./pages/MyLearningPage"));
 const VeritasWorkspacePage = lazy(() => import("./pages/VeritasWorkspacePage"));
+const RiskDashboardPage = lazy(() => import("./pages/RiskDashboardPage"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
@@ -440,6 +441,7 @@ function App() {
                       <Route path="/sage" element={<Page name="Sage"><SageWorkspacePage /></Page>} />
                       <Route path="/my-learning" element={<Page name="MyLearning"><MyLearningPage /></Page>} />
                       <Route path="/veritas" element={<Page name="Veritas"><VeritasWorkspacePage /></Page>} />
+                      <Route path="/risk" element={<Page name="RiskDashboard"><RiskDashboardPage /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -97,6 +97,8 @@ const IntelligenceCloudPage = lazy(() => import("./pages/IntelligenceCloudPage")
 const AgentsPage = lazy(() => import("./pages/AgentsPage"));
 const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
 const InstrumentForensicsPage = lazy(() => import("./pages/InstrumentForensicsPage"));
+const SageWorkspacePage = lazy(() => import("./pages/SageWorkspacePage"));
+const MyLearningPage = lazy(() => import("./pages/MyLearningPage"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
@@ -434,6 +436,8 @@ function App() {
                       <Route path="/agent-trace" element={<Page name="AgentTrace"><AgentTraceViewer /></Page>} />
                       <Route path="/agents" element={<Page name="Agents"><AgentsPage /></Page>} />
                       <Route path="/instrument-forensics" element={<Page name="InstrumentForensics"><InstrumentForensicsPage /></Page>} />
+                      <Route path="/sage" element={<Page name="Sage"><SageWorkspacePage /></Page>} />
+                      <Route path="/my-learning" element={<Page name="MyLearning"><MyLearningPage /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -96,6 +96,7 @@ const AIAssurancePage = lazy(() => import("./pages/AIAssurancePage"));
 const IntelligenceCloudPage = lazy(() => import("./pages/IntelligenceCloudPage"));
 const AgentsPage = lazy(() => import("./pages/AgentsPage"));
 const AgentTraceViewer = lazy(() => import("./pages/AgentTraceViewer"));
+const InstrumentForensicsPage = lazy(() => import("./pages/InstrumentForensicsPage"));
 const CIOSDashboard = lazy(() => import("./pages/CIOSDashboard"));
 const EnterpriseDashboard = lazy(() => import("./pages/EnterpriseDashboard"));
 const CommercialConsole = lazy(() => import("./pages/CommercialConsole"));
@@ -432,6 +433,7 @@ function App() {
                       <Route path="/intelligence-cloud" element={<Page name="IntelligenceCloud"><IntelligenceCloudPage /></Page>} />
                       <Route path="/agent-trace" element={<Page name="AgentTrace"><AgentTraceViewer /></Page>} />
                       <Route path="/agents" element={<Page name="Agents"><AgentsPage /></Page>} />
+                      <Route path="/instrument-forensics" element={<Page name="InstrumentForensics"><InstrumentForensicsPage /></Page>} />
                       <Route path="/cios-dashboard" element={<Page name="CIOSDashboard"><CIOSDashboard /></Page>} />
                       <Route path="/enterprise" element={<Page name="Enterprise"><EnterpriseDashboard /></Page>} />
                       <Route path="/commercial" element={<Page name="Commercial"><CommercialConsole /></Page>} />

--- a/frontend/src/pages/CouncilWorkspacePage.tsx
+++ b/frontend/src/pages/CouncilWorkspacePage.tsx
@@ -1,0 +1,5 @@
+import CouncilWorkspace from "@/components/CouncilWorkspace";
+
+export default function CouncilWorkspacePage() {
+  return <CouncilWorkspace />;
+}

--- a/frontend/src/pages/InstrumentForensicsPage.tsx
+++ b/frontend/src/pages/InstrumentForensicsPage.tsx
@@ -1,0 +1,5 @@
+import InstrumentForensicsWorkspace from "@/components/InstrumentForensicsWorkspace";
+
+export default function InstrumentForensicsPage() {
+  return <InstrumentForensicsWorkspace />;
+}

--- a/frontend/src/pages/MaestroWorkspacePage.tsx
+++ b/frontend/src/pages/MaestroWorkspacePage.tsx
@@ -1,0 +1,5 @@
+import MaestroLeadershipWorkspace from "@/components/MaestroLeadershipWorkspace";
+
+export default function MaestroWorkspacePage() {
+  return <MaestroLeadershipWorkspace />;
+}

--- a/frontend/src/pages/MyLearningPage.tsx
+++ b/frontend/src/pages/MyLearningPage.tsx
@@ -1,0 +1,5 @@
+import MyLearningCenter from "@/components/MyLearningCenter";
+
+export default function MyLearningPage() {
+  return <MyLearningCenter />;
+}

--- a/frontend/src/pages/RiskDashboardPage.tsx
+++ b/frontend/src/pages/RiskDashboardPage.tsx
@@ -1,0 +1,5 @@
+import SentinelXRiskDashboard from "@/components/SentinelXRiskDashboard";
+
+export default function RiskDashboardPage() {
+  return <SentinelXRiskDashboard />;
+}

--- a/frontend/src/pages/SageWorkspacePage.tsx
+++ b/frontend/src/pages/SageWorkspacePage.tsx
@@ -1,0 +1,5 @@
+import SageWorkspace from "@/components/SageWorkspace";
+
+export default function SageWorkspacePage() {
+  return <SageWorkspace />;
+}

--- a/frontend/src/pages/VeritasWorkspacePage.tsx
+++ b/frontend/src/pages/VeritasWorkspacePage.tsx
@@ -1,0 +1,5 @@
+import VeritasWorkspace from "@/components/VeritasWorkspace";
+
+export default function VeritasWorkspacePage() {
+  return <VeritasWorkspace />;
+}


### PR DESCRIPTION
## Summary

**Project Vulcan** — deterministic AI specialist that investigates recurring instrument defects, condition changes, repair patterns, and premature failures (Instrument Failure Taxonomy, Failure Progression Model, Anatomy-Zone Reliability, Repair Effectiveness Intelligence, 0-100 Instrument Reliability Score, 11 Reliability Watchlists, `/instrument-forensics`).

**Project Sage** — deterministic AI specialist converting validated inspection/supervisor patterns into targeted, non-punitive workforce-development recommendations (Competency Taxonomy, Gap Detection, Adaptive Learning Plans, Microlearning Generator, Learning Effectiveness Engine, `/sage` + `/my-learning`).

**Project Veritas** — deterministic evidence-assurance agent evaluating whether an inspection has sufficient, reliable, governed evidence (Baseline Resolution Hierarchy + Governance lifecycle, Instrument-to-Baseline Matching, honest Image Quality Assessment, Evidence Provenance Ledger, 0-100 Evidence Readiness Score, Conflict Detection, Evidence Gate, `/veritas` + Inspection Evidence Panel, Training Dataset Assurance).

**Project Sentinel-X** — deterministic clinical risk synthesis layer that composes Vulcan/Aegis/Veritas/Knowledge-Graph/Digital-Twin signal into one explainable, 0-100 clinical risk score (higher = more risk — the deliberate inverse of Vulcan/Veritas's scoring convention): a configurable SPD Risk Matrix, a nine-category multi-label Risk Taxonomy, proactive Patient Safety Watch alerts, Enterprise Risk Heatmaps, a real-data Risk Timeline, deterministic Predictive Risk forecasts, the Risk Dashboard at `/risk`, and a Supervisor Workspace with an auditable, rationale-required override path. Uses a `sentinelx_` prefix throughout to avoid any collision with the pre-existing, unrelated "Project Sentinel" v3.0 system already in this codebase (`/api/sentinel`, `/sentinel`).

**Project Maestro** — an executive orchestration layer that answers "What should I do first today, and why?" by ranking 9 operational priority categories, generating evidence-linked leadership recommendations, producing a Daily Operational Brief, a Strategy Timeline, an Operational Health Index, and a Decision Journal — all composed purely from already-built specialists (Sentinel-X, Vulcan, Sage, Veritas, Phoenix, Pulse, Forge/CAPA) rather than re-deriving any score. Never replaces human leadership: every recommendation is explainable, evidence-based, auditable, and subject to human approval. Frontend Leadership Workspace at `/maestro`. Uses a `maestro_` prefix and never touches Phase 22's `app.agents.orchestrator` or Nova's `nova_orchestration_service.py`, despite the shared "orchestration" vocabulary.

**Project Council** — a governed multi-agent leadership framework where AI specialists (Veritas, Aegis, Vulcan, Sage, Sentinel-X, Apollo, Athena, Pulse, Phoenix, Maestro) convene as six configurable leadership teams (Clinical Quality, Operations, Education, Reliability, Executive, Research and Innovation) to review one issue. Each specialist assesses independently, and a Consensus Engine classifies the outcome (UNANIMOUS / STRONG_CONSENSUS / CONDITIONAL_CONSENSUS / SPLIT_DECISION / INSUFFICIENT_EVIDENCE / SAFETY_DISSENT) — critically, **a simple majority never overrides unresolved safety or evidence dissent**. Every dissent is recorded and displayed prominently, never hidden. Adds Decision Options with tradeoff analysis, role-tiered Human Decision Authority routing, an Agreement Map, role-specific Council Briefs, structured Meeting Mode, Decision Journal integration (reusing Maestro's own journal), Outcome Effectiveness Review, and non-punitive Specialist Performance Review. Frontend Leadership Workspace at `/council`. Uses a `council_` prefix and never touches Olympus's unrelated Network Governance Council.

## Why This Change
Six sprint briefs building out LumenAI's deterministic specialist-agent layer, each moving the platform from reporting isolated data points to explainable, evidence-based, human-governed intelligence — culminating in Council, which convenes every specialist (including Maestro's own priority synthesis) as a structured, dissent-preserving leadership team rather than a single flattened answer.

## Scope
**Included:** Vulcan — 3 tables, 12 services, `/api/vulcan/*`, 7 docs, 14 tests. Sage — 7 tables, 15 services, `/api/sage/*`, 8 docs, 15 tests. Veritas — 7 tables, 16 services, `/api/veritas/*`, 8 docs, 17 tests. Sentinel-X — 3 tables, 10 services, `/api/sentinelx/*`, 4 docs, 9 tests. Maestro — 5 tables, 8 services, `/api/maestro/*`, 4 docs, 8 tests. Council — 8 tables, 16 services, `/api/council/*`, 9 docs, 18 tests. All named test scenarios from each brief are covered.

**Excluded:** No changes to the pre-existing Phase 22 multi-agent pipeline, Nova's agent governance layer, the existing "Project Sentinel" v3.0 system, Phoenix's maturity index computation, Olympus's Network Governance Council, or any other prior sprint's tables/routes. No real LLM/embedding calls anywhere — every agent is fully deterministic. No agent automatically rewrites a clinical rule; Council's outcome reviews only ever produce a learning *signal* for human review.

## Testing
- [x] Unit tests: `test_vulcan_reliability.py` (14) + `test_sage_education.py` (15) + `test_veritas_evidence.py` (17) + `test_sentinel_x_risk.py` (9) + `test_maestro_orchestration.py` (8) + `test_council_leadership.py` (18), all passing
- [x] Full backend suite (`PYTHONPATH=. python -m pytest tests -q`): 3329 passed, 2 skipped, 0 failed
- [x] `ruff check backend/app backend/tests`: clean
- [x] `npm run build` (frontend): clean
- [ ] Docker build
- [ ] API/worker runtime validation

## Risks
Additive-only schema changes (33 new tables total across all six sprints, no modifications to existing tables/columns). No changes to existing routes or services. Low risk.

## Rollback Plan
Revert this PR's commits; all new tables are additive and unused by any other module, so no data migration is required to roll back.