### PR TITLE
Fix disclosed ML pipeline gaps, wire baseline comparator into live path + Sprint 5 readiness-review gate outcome

### DIFF
--- a/backend/app/services/baseline_comparison_scoring_service.py
+++ b/backend/app/services/baseline_comparison_scoring_service.py
@@ -254,10 +254,92 @@ def _live_model_result(
     """
     from app.services.ml.live_inference_adapter import predict as live_predict
 
-    return live_predict(
+    result = live_predict(
         db, tenant_id=tenant_id, image_bytes=image_bytes, instrument_family=instrument_type,
         inspection_id=inspection_id, image_sha256=image_sha256, retained_image_id=retained_image_id,
     )
+    # Section 17 — the baseline comparator is a SEPARATE governed channel,
+    # populated here by the caller (never inside the adapter). It answers
+    # "how does this image differ from the approved reference?", not "what
+    # observation is present?" — nothing below reads it back into the
+    # observation, so a high similarity can never cancel a probable
+    # contamination, and a missing baseline never blocks inference.
+    result["baseline_comparison"] = _live_baseline_comparison(
+        db, tenant_id=tenant_id, instrument_type=instrument_type, image_bytes=image_bytes,
+    )
+    return result
+
+
+def _live_baseline_comparison(
+    db: Session, *, tenant_id: str, instrument_type: str, image_bytes: Optional[bytes],
+) -> dict[str, Any]:
+    """Compatibility-first baseline-image comparison for the live path,
+    composed entirely from Project Atlas + Project Lens infrastructure:
+    resolve the best ACTIVE baseline image for this instrument context
+    (5-level hierarchy), verify the stored bytes' hash on access, and only
+    then compute a perceptual similarity. Every failure mode returns an
+    honest status with ``similarity: None`` — never a fabricated number."""
+    from app.models.baseline_image_library import COMPATIBLE, BaselineImageLink
+    from app.services.baseline_compatibility_service import (
+        CandidateContext,
+        check_compatibility,
+        resolve_baseline_image,
+    )
+    from app.services.baseline_image_library_service import (
+        ImageIdentityMismatchError,
+        load_and_verify_baseline_bytes,
+    )
+    from app.services.ml.image_similarity_service import compare_against_baseline
+
+    candidate = CandidateContext(tenant_id=tenant_id, instrument_family=instrument_type)
+    resolution = resolve_baseline_image(db, candidate=candidate)
+
+    if resolution.baseline_image_link_id is None:
+        comparison = compare_against_baseline(
+            image_bytes=None, baseline_image_bytes=None,
+            candidate_instrument_family=instrument_type, baseline_instrument_family="",
+            baseline_available=False,
+        )
+        comparison["resolution_scope"] = resolution.resolution_scope
+        comparison["resolution_reason"] = resolution.resolution_reason
+        return comparison
+
+    link = db.query(BaselineImageLink).filter(BaselineImageLink.id == resolution.baseline_image_link_id).first()
+    compatibility = check_compatibility(candidate=candidate, baseline_link=link)
+    if compatibility != COMPATIBLE:
+        # Compatibility failed AFTER resolution (e.g. the link was suspended
+        # between queries, or quality gates apply) — report the named
+        # outcome, never a numeric similarity (Atlas Section 7).
+        return {
+            "status": compatibility, "similarity": None,
+            "method": "average_hash_hamming",
+            "baseline_id": link.id if link is not None else None,
+            "baseline_version": resolution.version,
+            "resolution_scope": resolution.resolution_scope,
+            "resolution_reason": resolution.resolution_reason,
+        }
+
+    try:
+        baseline_bytes = load_and_verify_baseline_bytes(db, link=link, accessed_by="live_inference_path")
+    except ImageIdentityMismatchError as exc:
+        return {
+            "status": "BASELINE_INTEGRITY_FAILED", "similarity": None,
+            "method": "average_hash_hamming",
+            "baseline_id": link.id, "baseline_version": resolution.version,
+            "resolution_scope": resolution.resolution_scope,
+            "resolution_reason": str(exc),
+        }
+
+    comparison = compare_against_baseline(
+        image_bytes=image_bytes, baseline_image_bytes=baseline_bytes,
+        candidate_instrument_family=instrument_type,
+        baseline_instrument_family=link.instrument_family or "",
+        baseline_available=True,
+        baseline_id=link.id, baseline_version=resolution.version,
+    )
+    comparison["resolution_scope"] = resolution.resolution_scope
+    comparison["resolution_reason"] = resolution.resolution_reason
+    return comparison
 
 
 def _severity_index(p: float) -> int:

--- a/backend/app/services/ml/candidate_training.py
+++ b/backend/app/services/ml/candidate_training.py
@@ -39,6 +39,7 @@ from app.services.ml.training_execution import (
     _feature_vector,
     _predict_proba,
     _train_logistic_regression,
+    balanced_sample_weights,
     git_commit,
 )
 
@@ -70,13 +71,17 @@ def resolve_candidate_classes(samples: list[dict[str, Any]]) -> list[str]:
 
 def _train_one_vs_rest(
     X: list[list[float]], y: list[str], classes: list[str], *, epochs: int, learning_rate: float,
+    class_weighting: str = "none",
 ) -> dict[str, list[float]]:
     weights_by_class = {}
     for cls in classes:
         y_bin = [1 if label == cls else 0 for label in y]
         if len(set(y_bin)) < 2:
             continue  # cannot fit a one-vs-rest head with only one class present in the split
-        weights_by_class[cls] = _train_logistic_regression(X, y_bin, epochs=epochs, learning_rate=learning_rate)
+        sample_weights = balanced_sample_weights(y_bin) if class_weighting == "balanced" else None
+        weights_by_class[cls] = _train_logistic_regression(
+            X, y_bin, epochs=epochs, learning_rate=learning_rate, sample_weights=sample_weights,
+        )
     return weights_by_class
 
 
@@ -174,7 +179,10 @@ def run_candidate_training(
             "note": "The training split does not contain enough distinct classes after leakage-safe grouping. No metrics fabricated.",
         }
 
-    weights_by_class = _train_one_vs_rest(X_train, y_train, classes, epochs=cfg.epochs, learning_rate=cfg.learning_rate)
+    weights_by_class = _train_one_vs_rest(
+        X_train, y_train, classes, epochs=cfg.epochs, learning_rate=cfg.learning_rate,
+        class_weighting=cfg.class_weighting,
+    )
 
     def _predict_split(split_samples: list[dict]) -> tuple[list[str], list[str], list[float]]:
         y_true = [s["label"] if s["label"] in classes else NEGATIVE_LABEL for s in split_samples]

--- a/backend/app/services/ml/error_analysis.py
+++ b/backend/app/services/ml/error_analysis.py
@@ -20,10 +20,14 @@ never guessed:
     explains the error.
 
 Each error also gets an ``error_type`` (false_positive / false_negative /
-misclassification_between_findings), using "no_actionable_finding" as the
-negative class — a missed real finding (false_negative) is flagged as the
-more dangerous error, consistent with ``app.services.ml.evaluation.
-safety_metrics``.
+misclassification_between_findings). The negative class defaults to
+"no_actionable_finding" (the Genesis/candidate-training taxonomy) but is a
+parameter, because Project Lens uses a different negative label
+("no_observable_abnormality") — before this was parameterized, every Lens
+false negative/positive was miscategorized as
+misclassification_between_findings. A missed real finding (false_negative)
+is flagged as the more dangerous error, consistent with
+``app.services.ml.evaluation.safety_metrics``.
 """
 from __future__ import annotations
 
@@ -39,10 +43,10 @@ ROOT_CAUSES = (
 )
 
 
-def _error_type(true_label: str, predicted_label: str) -> str:
-    if true_label == NEGATIVE_LABEL and predicted_label != NEGATIVE_LABEL:
+def _error_type(true_label: str, predicted_label: str, negative_label: str) -> str:
+    if true_label == negative_label and predicted_label != negative_label:
         return "false_positive"
-    if true_label != NEGATIVE_LABEL and predicted_label == NEGATIVE_LABEL:
+    if true_label != negative_label and predicted_label == negative_label:
         return "false_negative"
     return "misclassification_between_findings"
 
@@ -64,9 +68,11 @@ def _root_cause(sample: dict[str, Any]) -> str:
     return "unknown_pattern"
 
 
-def classify_error(sample: dict[str, Any]) -> dict[str, Any] | None:
+def classify_error(sample: dict[str, Any], *, negative_label: str = NEGATIVE_LABEL) -> dict[str, Any] | None:
     """Classify one sample's prediction. Returns ``None`` if the prediction
-    was correct (not an error)."""
+    was correct (not an error). ``negative_label`` is the taxonomy's
+    no-finding class — pass the caller's own label when it differs from the
+    Genesis default (e.g. Project Lens's "no_observable_abnormality")."""
     true_label = sample.get("true_label")
     predicted_label = sample.get("predicted_label")
     if true_label == predicted_label:
@@ -76,18 +82,18 @@ def classify_error(sample: dict[str, Any]) -> dict[str, Any] | None:
         "true_label": true_label,
         "predicted_label": predicted_label,
         "confidence": sample.get("confidence"),
-        "error_type": _error_type(true_label, predicted_label),
+        "error_type": _error_type(true_label, predicted_label, negative_label),
         "root_cause": _root_cause(sample),
     }
 
 
-def analyze_errors(samples: list[dict[str, Any]]) -> dict[str, Any]:
+def analyze_errors(samples: list[dict[str, Any]], *, negative_label: str = NEGATIVE_LABEL) -> dict[str, Any]:
     """Classify every error in ``samples`` and rank failure modes by
     frequency. Each ``sample`` dict: ``{id, true_label, predicted_label,
     confidence, blur_flag, focus_flag, lighting_flag, exposure_flag,
     cropping_flag, anatomy_zone, annotation_disagreement}`` (all optional
-    except the two labels)."""
-    errors = [e for e in (classify_error(s) for s in samples) if e is not None]
+    except the two labels). ``negative_label`` follows ``classify_error``."""
+    errors = [e for e in (classify_error(s, negative_label=negative_label) for s in samples) if e is not None]
     error_type_counts = Counter(e["error_type"] for e in errors)
     root_cause_counts = Counter(e["root_cause"] for e in errors)
 

--- a/backend/app/services/ml/lens_training_pipeline.py
+++ b/backend/app/services/ml/lens_training_pipeline.py
@@ -32,7 +32,13 @@ from app.services.ml.evaluation import evaluate
 from app.services.ml.lcid_service import is_untracked_twin
 from app.services.ml.lens_calibration import calibrated_confidences, fit_temperature, resolve_abstention_threshold
 from app.services.ml.training_config import TrainingConfig
-from app.services.ml.training_execution import _feature_vector, _predict_proba, _train_logistic_regression, git_commit
+from app.services.ml.training_execution import (
+    _feature_vector,
+    _predict_proba,
+    _train_logistic_regression,
+    balanced_sample_weights,
+    git_commit,
+)
 
 NEGATIVE_LABEL = "no_observable_abnormality"
 PREPROCESSING_VERSION = "lens-pillow-features-v1"  # brightness/sharpness/aspect, see training_execution._feature_vector
@@ -172,14 +178,21 @@ def run_lens_training(
     y_train_bin = _binary_labels(train_samples)
     stage_b_weights: list[float] | None = None
     if has_negative_class and len(set(y_train_bin)) >= 2:
-        stage_b_weights = _train_logistic_regression(X_train, y_train_bin, epochs=cfg.epochs, learning_rate=cfg.learning_rate)
+        stage_b_sample_weights = balanced_sample_weights(y_train_bin) if cfg.class_weighting == "balanced" else None
+        stage_b_weights = _train_logistic_regression(
+            X_train, y_train_bin, epochs=cfg.epochs, learning_rate=cfg.learning_rate,
+            sample_weights=stage_b_sample_weights,
+        )
 
     # ── Stage C — category classifier (multiclass one-vs-rest), abnormal-only ──
     abnormal_train = [s for s in train_samples if s["label"] != NEGATIVE_LABEL]
     X_abnormal = [features_by_id[s["id"]] for s in abnormal_train]
     y_abnormal = [s["label"] for s in abnormal_train]
     stage_c_weights = (
-        _train_one_vs_rest(X_abnormal, y_abnormal, eligible_classes, epochs=cfg.epochs, learning_rate=cfg.learning_rate)
+        _train_one_vs_rest(
+            X_abnormal, y_abnormal, eligible_classes, epochs=cfg.epochs, learning_rate=cfg.learning_rate,
+            class_weighting=cfg.class_weighting,
+        )
         if eligible_classes and len(abnormal_train) >= 2 else {}
     )
 
@@ -233,7 +246,11 @@ def run_lens_training(
     abstention_threshold, threshold_is_data_derived = resolve_abstention_threshold(reliability)
 
     error_source = test_errors or val_errors
-    error_analysis = analyze_errors(error_source) if error_source else None
+    # Pass Lens's own negative label — error_analysis's default is the
+    # Genesis taxonomy's "no_actionable_finding", which no Lens sample ever
+    # carries, so without this every Lens false negative/positive was
+    # miscategorized as misclassification_between_findings.
+    error_analysis = analyze_errors(error_source, negative_label=NEGATIVE_LABEL) if error_source else None
 
     return {
         "training_status": "trained",

--- a/backend/app/services/ml/training_execution.py
+++ b/backend/app/services/ml/training_execution.py
@@ -71,21 +71,39 @@ def _sigmoid(z: float) -> float:
     return 1.0 / (1.0 + math.exp(-z))
 
 
+def balanced_sample_weights(y: list[int]) -> list[float]:
+    """Per-sample weights implementing ``class_weighting="balanced"`` for a
+    binary label vector, using the standard n / (n_classes * n_c) convention:
+    each class contributes equally to the loss regardless of its frequency.
+    Returns all-1.0 weights when only one class is present (nothing to
+    balance — the caller's own single-class guard applies)."""
+    n = len(y)
+    pos = sum(y)
+    neg = n - pos
+    if pos == 0 or neg == 0:
+        return [1.0] * n
+    w_pos = n / (2.0 * pos)
+    w_neg = n / (2.0 * neg)
+    return [w_pos if yi == 1 else w_neg for yi in y]
+
+
 def _train_logistic_regression(
     X: list[list[float]], y: list[int], *, epochs: int, learning_rate: float,
+    sample_weights: list[float] | None = None,
 ) -> list[float]:
     n_features = len(X[0])
     weights = [0.0] * (n_features + 1)  # index 0 is the bias term
-    n = len(X)
+    sw = sample_weights if sample_weights is not None else [1.0] * len(X)
+    total_weight = sum(sw)
     for _ in range(epochs):
         grads = [0.0] * (n_features + 1)
-        for xi, yi in zip(X, y):
+        for xi, yi, wi in zip(X, y, sw):
             z = weights[0] + sum(w * x for w, x in zip(weights[1:], xi))
-            error = _sigmoid(z) - yi
+            error = wi * (_sigmoid(z) - yi)
             grads[0] += error
             for j, x in enumerate(xi):
                 grads[j + 1] += error * x
-        weights = [w - learning_rate * (g / n) for w, g in zip(weights, grads)]
+        weights = [w - learning_rate * (g / total_weight) for w, g in zip(weights, grads)]
     return weights
 
 

--- a/backend/tests/test_candidate_model_training.py
+++ b/backend/tests/test_candidate_model_training.py
@@ -29,6 +29,7 @@ from app.services.ml.candidate_training import (
 )
 from app.services.ml.error_analysis import analyze_errors
 from app.services.ml.evaluation import calibration_report
+from app.services.ml.training_execution import _train_logistic_regression, balanced_sample_weights
 from app.services.ml.explainability import explain_prediction
 from app.services.ml.training_config import TrainingConfig
 
@@ -184,6 +185,47 @@ class TestErrorAnalysisUnit:
         report = analyze_errors(samples)
         assert report["total_errors"] == 3
         assert report["error_type_counts"]["false_negative"] == 2
+
+    def test_custom_negative_label_recognizes_lens_taxonomy(self):
+        # Project Lens's negative class differs from the Genesis default —
+        # a missed contamination against "no_observable_abnormality" must
+        # be a false_negative, never misclassification_between_findings.
+        samples = [
+            {"id": 1, "true_label": "probable_retained_debris", "predicted_label": "no_observable_abnormality", "confidence": 0.9, "anatomy_zone": "hinge"},
+            {"id": 2, "true_label": "no_observable_abnormality", "predicted_label": "probable_corrosion_like_degradation", "confidence": 0.9, "anatomy_zone": "hinge"},
+        ]
+        report = analyze_errors(samples, negative_label="no_observable_abnormality")
+        assert report["error_type_counts"] == {"false_negative": 1, "false_positive": 1}
+        # And the old, unparameterized behavior is exactly the bug this fixes:
+        legacy = analyze_errors(samples)
+        assert legacy["error_type_counts"] == {"misclassification_between_findings": 2}
+
+
+class TestClassWeightingUnit:
+    def test_balanced_weights_equalize_class_contribution(self):
+        # 3 positives, 9 negatives — each class's total weight must be equal
+        # (n / 2 each), per the standard balanced convention.
+        y = [1, 1, 1] + [0] * 9
+        w = balanced_sample_weights(y)
+        pos_total = sum(wi for wi, yi in zip(w, y) if yi == 1)
+        neg_total = sum(wi for wi, yi in zip(w, y) if yi == 0)
+        assert abs(pos_total - neg_total) < 1e-9
+        assert abs(pos_total - len(y) / 2) < 1e-9
+
+    def test_single_class_returns_unit_weights(self):
+        assert balanced_sample_weights([1, 1, 1]) == [1.0, 1.0, 1.0]
+
+    def test_balanced_weighting_changes_trained_model_on_imbalanced_data(self):
+        # TrainingConfig.class_weighting="balanced" was recorded but never
+        # applied before this fix — this pins that it now genuinely alters
+        # the fit on imbalanced data.
+        X = [[0.1, 0.1, 1.0]] * 2 + [[0.9, 0.9, 1.0]] * 10
+        y = [1] * 2 + [0] * 10
+        unweighted = _train_logistic_regression(X, y, epochs=200, learning_rate=0.3)
+        weighted = _train_logistic_regression(
+            X, y, epochs=200, learning_rate=0.3, sample_weights=balanced_sample_weights(y),
+        )
+        assert unweighted != weighted
 
 
 class TestCalibrationUnit:

--- a/backend/tests/test_project_lens.py
+++ b/backend/tests/test_project_lens.py
@@ -8,6 +8,7 @@ import hashlib
 import io
 import itertools
 import os
+import uuid as _uuid
 
 import pytest
 from PIL import Image
@@ -368,6 +369,27 @@ def test_same_filename_different_bytes_is_distinct_identity():
 
 # ── 21 — live baseline comparator wiring (Atlas → live path) ───────────────
 
+def _nonce_img(brightness: int, stripe_period: int = 8) -> bytes:
+    # A random PNG text chunk guarantees a unique SHA-256 across pytest
+    # invocations sharing the same persistent SQLite test DB — without it,
+    # the LCID duplicate gate rejects re-registering last run's identical
+    # bytes (same mitigation as tests/test_baseline_image_library.py::_img).
+    from PIL import PngImagePlugin
+
+    img = Image.new("RGB", (300, 300), (brightness, brightness, brightness))
+    if stripe_period:
+        px = img.load()
+        inverse = 255 - brightness
+        for x in range(0, 300, stripe_period):
+            for y in range(300):
+                px[x, y] = (inverse, inverse, inverse)
+    buf = io.BytesIO()
+    meta = PngImagePlugin.PngInfo()
+    meta.add_text("test-nonce", _uuid.uuid4().hex)
+    img.save(buf, format="PNG", pnginfo=meta)
+    return buf.getvalue()
+
+
 def _make_active_baseline_link(db, *, tenant_id: str, instrument_family: str, image_data: bytes):
     """Create an ACTIVE, governed-consensus baseline image link through the
     real Atlas lifecycle (link → review → activate) — the only resolution
@@ -430,8 +452,9 @@ def test_live_baseline_comparison_no_approved_baseline():
 
     db = SessionLocal()
     try:
+        family = f"lens-no-baseline-{_uuid.uuid4().hex[:8]}"
         result = _live_model_result(
-            db, tenant_id=TENANT, image_bytes=_img(120), instrument_type="lens-no-baseline-family",
+            db, tenant_id=TENANT, image_bytes=_img(120), instrument_type=family,
         )
         comparison = result["baseline_comparison"]
         assert comparison is not None
@@ -450,8 +473,8 @@ def test_live_baseline_comparison_with_active_baseline_produces_similarity():
 
     db = SessionLocal()
     try:
-        family = "lens-live-baseline-family"
-        baseline_bytes = _img(120)
+        family = f"lens-live-baseline-{_uuid.uuid4().hex[:8]}"
+        baseline_bytes = _nonce_img(120)
         _make_active_baseline_link(db, tenant_id=TENANT, instrument_family=family, image_data=baseline_bytes)
         result = _live_model_result(db, tenant_id=TENANT, image_bytes=baseline_bytes, instrument_type=family)
         comparison = result["baseline_comparison"]
@@ -470,8 +493,8 @@ def test_live_baseline_comparison_never_alters_observation():
 
     db = SessionLocal()
     try:
-        family = "lens-separation-family"
-        probe = _img(150, stripe_period=10)
+        family = f"lens-separation-{_uuid.uuid4().hex[:8]}"
+        probe = _nonce_img(150, stripe_period=10)
         without_baseline = _live_model_result(db, tenant_id=TENANT, image_bytes=probe, instrument_type=family)
         _make_active_baseline_link(db, tenant_id=TENANT, instrument_family=family, image_data=probe)
         with_baseline = _live_model_result(db, tenant_id=TENANT, image_bytes=probe, instrument_type=family)

--- a/backend/tests/test_project_lens.py
+++ b/backend/tests/test_project_lens.py
@@ -366,6 +366,123 @@ def test_same_filename_different_bytes_is_distinct_identity():
         db.close()
 
 
+# ── 21 — live baseline comparator wiring (Atlas → live path) ───────────────
+
+def _make_active_baseline_link(db, *, tenant_id: str, instrument_family: str, image_data: bytes):
+    """Create an ACTIVE, governed-consensus baseline image link through the
+    real Atlas lifecycle (link → review → activate) — the only resolution
+    level reachable when the live path knows just the instrument family."""
+    import uuid as _uuid
+
+    from app.models.baseline_library import BaselineLibraryEntry
+    from app.models.baseline_image_library import (
+        IMAGE_TYPE_MANUFACTURER_BASELINE,
+        SOURCE_GOVERNED_CONSENSUS_REFERENCE,
+    )
+    from app.models.retained_image import RetainedImage
+    from app.services import baseline_image_library_service as bil
+    from app.services.ml import dataset_registry
+
+    retained = RetainedImage(
+        tenant_id=tenant_id, deident_name="lens-baseline", instrument_type=instrument_family,
+        content_type="image/png", size_bytes=len(image_data),
+        sha256=hashlib.sha256(image_data).hexdigest(), exif_stripped=True, source="test",
+        consent_recorded=True, uploaded_by="tester", image_bytes=image_data,
+    )
+    db.add(retained)
+    db.commit()
+    db.refresh(retained)
+    version = dataset_registry.create_dataset_version(db, tenant_id=tenant_id, version_label=f"lens-bl-{_uuid.uuid4().hex[:8]}")
+    lcid_entry = dataset_registry.register_image(
+        db, tenant_id=tenant_id, dataset_version_id=version.id, retained_image_id=retained.id,
+        image_sha256=retained.sha256, instrument_family=instrument_family, instrument_model="X1",
+        manufacturer="Acme", anatomy_zone="tip", capture_device="phone", image_resolution="300x300",
+        facility="Test Hospital", operator="tech1", usage_rights="internal_use", phi_verification="verified",
+    )
+    lcid_entry.image_quality = "Good"
+    db.commit()
+    baseline_entry = BaselineLibraryEntry(
+        instrument_category=instrument_family, manufacturer_name="Acme", model_name="X1",
+        baseline_type="manufacturer", approval_status="approved",
+    )
+    db.add(baseline_entry)
+    db.commit()
+    db.refresh(baseline_entry)
+    link = bil.link_lcid_image_to_baseline(
+        db, tenant_id=tenant_id, baseline_library_entry_id=baseline_entry.id, lcid_image_id=lcid_entry.id,
+        anatomy_zone="tip", inspection_view="lateral", image_type=IMAGE_TYPE_MANUFACTURER_BASELINE,
+        source_type=SOURCE_GOVERNED_CONSENSUS_REFERENCE, created_by="ingest@test",
+    )
+    link = bil.submit_for_review(db, link=link, actor="ingest@test")
+    bil.review_baseline_image(
+        db, link=link, reviewer="reviewer@test", reviewer_role="spd_manager", decision="approve",
+        rationale="Reference consensus image.", anatomy_compatibility_confirmed=True,
+        image_quality_assessment="Good",
+    )
+    db.refresh(link)
+    bil.activate_baseline_image(db, link=link, actor="admin@test", actor_role="admin")
+    db.refresh(link)
+    return link
+
+
+def test_live_baseline_comparison_no_approved_baseline():
+    from app.services.baseline_comparison_scoring_service import _live_model_result
+
+    db = SessionLocal()
+    try:
+        result = _live_model_result(
+            db, tenant_id=TENANT, image_bytes=_img(120), instrument_type="lens-no-baseline-family",
+        )
+        comparison = result["baseline_comparison"]
+        assert comparison is not None
+        assert comparison["status"] == "no_approved_baseline"
+        assert comparison["similarity"] is None
+        # The model's own channel is untouched — a missing baseline never
+        # blocks inference (Section 17); the adapter still reports its own
+        # honest state independently.
+        assert result["analysis_status"] in ("completed", "ai_unavailable")
+    finally:
+        db.close()
+
+
+def test_live_baseline_comparison_with_active_baseline_produces_similarity():
+    from app.services.baseline_comparison_scoring_service import _live_model_result
+
+    db = SessionLocal()
+    try:
+        family = "lens-live-baseline-family"
+        baseline_bytes = _img(120)
+        _make_active_baseline_link(db, tenant_id=TENANT, instrument_family=family, image_data=baseline_bytes)
+        result = _live_model_result(db, tenant_id=TENANT, image_bytes=baseline_bytes, instrument_type=family)
+        comparison = result["baseline_comparison"]
+        assert comparison["status"] in ("exact_match", "comparable")
+        assert comparison["similarity"] == 1.0
+        assert comparison["resolution_scope"]
+    finally:
+        db.close()
+
+
+def test_live_baseline_comparison_never_alters_observation():
+    # High baseline similarity must never cancel or change the model's
+    # observation channel — populate both from the same call and assert the
+    # observation is byte-identical to a run with no baseline registered.
+    from app.services.baseline_comparison_scoring_service import _live_model_result
+
+    db = SessionLocal()
+    try:
+        family = "lens-separation-family"
+        probe = _img(150, stripe_period=10)
+        without_baseline = _live_model_result(db, tenant_id=TENANT, image_bytes=probe, instrument_type=family)
+        _make_active_baseline_link(db, tenant_id=TENANT, instrument_family=family, image_data=probe)
+        with_baseline = _live_model_result(db, tenant_id=TENANT, image_bytes=probe, instrument_type=family)
+        assert with_baseline["baseline_comparison"]["similarity"] == 1.0
+        assert without_baseline["baseline_comparison"]["status"] == "no_approved_baseline"
+        assert with_baseline["observation"] == without_baseline["observation"]
+        assert with_baseline["analysis_status"] == without_baseline["analysis_status"]
+    finally:
+        db.close()
+
+
 # ── 20 — Decision Engine receives the model observation unchanged ──────────
 
 def test_decision_engine_receives_observation_unchanged():

--- a/docs/controlled-production/ENTRY_CRITERIA.md
+++ b/docs/controlled-production/ENTRY_CRITERIA.md
@@ -1,0 +1,133 @@
+# Controlled Production Readiness Review — Entry Criteria Assessment
+
+**Project Launch, Sprint 5.** Per the mission's own gate: *"Do not begin
+unless the repository contains real evidence for [the twelve entry
+criteria]. If entry criteria are incomplete, issue
+NOT_READY_FOR_PRODUCTION_REVIEW and list the missing evidence."*
+
+This assessment evaluates each criterion against the repository's actual,
+verifiable evidence — code, registered artifacts, documents, and test
+records — never against a filename's existence or a design document's
+intent. Where a document describes infrastructure *for* producing evidence
+rather than the evidence itself, it is counted as NOT MET.
+
+## Verdict summary
+
+**7 of 12 entry criteria are NOT MET. The review cannot begin.**
+The formal outcome is recorded in `FINAL_RELEASE_DECISION.md`:
+
+**NOT_READY_FOR_PRODUCTION_REVIEW**
+
+## Per-criterion assessment
+
+### 1. Registered trained model artifact — PARTIALLY MET
+A real, reproducible training pipeline exists and produces a real,
+checksummed JSON artifact (`lens_training_pipeline.export_artifact()`,
+verified end-to-end via the documented training command — see
+`docs/model-development/TRAINING_CONFIGURATION.md`). **But no persistent
+registration exists**: `model_artifacts/` is git-ignored, the repository
+ships no production database, and every `ModelRegistryEntry` ever created
+lives in an ephemeral test/dev SQLite database. There is no standing,
+governed artifact for a review board to freeze.
+
+### 2. Validated-candidate model status — NOT MET
+The only model this program has ever trained is registered
+`candidate_stage = "Experimental"`, and structurally cannot be anything
+else: `lens_model_registration.register_lens_model()` grants
+`"Candidate"` only when `data_provenance == "real"`, and this environment
+contains **zero real facility ACTIVE Ground Truth**
+(`docs/model-development/TRAINING_ELIGIBILITY_REPORT.md`). The promotion
+ladder's `Validated Candidate` stage (Shadow, Phase 6) has never been
+reached by any model.
+
+### 3. Locked validation report — NOT MET
+Evaluation/calibration/error-analysis reports exist
+(`EVALUATION_REPORT.md`, `CALIBRATION_REPORT.md`,
+`ERROR_ANALYSIS_REPORT.md`) but they describe **one declared experimental
+run over synthetic images**. `docs/shadow-validation/VALIDATION_REPORT_TEMPLATE.md`
+is, as named, a template — no locked validation report over real clinical
+data exists.
+
+### 4. Baseline image library with active image-backed baselines — NOT MET
+The full Atlas governance layer is implemented and tested
+(`BaselineImageLink`, DRAFT→ACTIVE lifecycle, hash-verified access), and
+the comparator is now wired into the live path (PR #97). **But no ACTIVE
+image-backed baseline exists in any persistent environment** — ACTIVE
+links are created only inside test runs. `KNOWN_LIMITATIONS.md` records
+this directly: "today's environments have zero ACTIVE baseline links."
+
+### 5. Validated baseline comparator — PARTIALLY MET
+The aHash comparator is real, tested standalone
+(`BASELINE_COMPARATOR_VALIDATION.md`), and wired into the live path with
+compatibility-first gating. **But** a documented, reproduced limitation
+stands: it can collide on visibly different images with similar
+brightness/texture statistics (`FALSE_PASS_MANUAL_RETEST.md`, Run 4), and
+it has never been validated against real instrument images.
+
+### 6. Completed supervised advisory pilot — NOT MET
+The Advisor program (Phase 7) built the pilot **infrastructure** —
+advisory display, interaction logging, safety monitoring, dashboards,
+go/no-go gates. **No pilot has ever run.** No facility, no users, no
+inspections, no supervisor reviews. `GENERAL_AVAILABILITY_REPORT.md`
+records clinical readiness as NO GO for exactly this reason.
+
+### 7. Pilot final report — NOT MET
+`docs/advisory-pilot/PILOT_FINAL_REPORT.md` documents the final-report
+*endpoint and promotion gate* (`GET /api/advisory-pilot/final-report`) —
+it is a design/infrastructure document, not the report of a completed
+pilot. Per this sprint's own rule, a filename's existence is not
+evidence.
+
+### 8. Resolved critical safety events — MET
+The one critical safety event this program has surfaced — the false-PASS
+defect (placeholder scoring undeclared contamination near zero) — was
+root-caused, fixed, regression-tested, and manually retested
+(`FALSE_PASS_ROOT_CAUSE.md`, `FALSE_PASS_MANUAL_RETEST.md`). No unresolved
+critical safety event is known. (Necessarily limited: with no pilot, no
+production, and no real users, the event surface this criterion samples
+from is small.)
+
+### 9. Active organization policy — PARTIALLY MET
+The Baseline Decision Policy engine is implemented and tested
+(draft→approval→activation lifecycle, resolution hierarchy, simulation,
+contamination override), and tests exercise active policies. **But no
+persistent environment holds an approved, active organization policy** —
+same ephemeral-database reality as criteria 1 and 4.
+
+### 10. Documented human response data — NOT MET
+No pilot ran, so there are zero real records of technician acceptance/
+modification/rejection, decision time, supervisor workload, trust, or any
+of Section 5's human-AI performance measures. The logging services exist;
+the data does not.
+
+### 11. Support ownership — NOT MET
+Support/on-call material exists as documentation
+(`docs/commercial-readiness/`), but `GENERAL_AVAILABILITY_REPORT.md`
+records operational readiness as CONDITIONAL with "no on-call tooling
+exists" and alerting "disabled by default and not wired to any automatic
+trigger." No named owner, no tested intake, no executed support
+simulation.
+
+### 12. Rollback capability — NOT MET
+Rollback procedures are documented, and the Alembic chain applies/reverts
+cleanly against fresh databases (verified during the migration backfill).
+**But no rollback has ever been executed against a running deployment** —
+`GENERAL_AVAILABILITY_REPORT.md`: "No operational capability
+(monitoring/backup/DR/HA/rollback) has ever been exercised, only
+designed." There is also no controlled production environment reachable
+from this repository in which to exercise one.
+
+## Why the review was not conducted anyway
+
+Sections 7–14 of this sprint require **executed** operational evidence:
+a real deployment, a completed backup **and restore**, a disaster-recovery
+exercise with measured recovery times, alerts delivered to "an actual
+configured destination," tested rollback, and a run support simulation —
+with the explicit instruction that "documentation alone is insufficient"
+and "a runbook without a completed restore test is not production
+evidence." No controlled production environment exists for this
+repository; no alert destination (Slack/Teams/email) is configured
+anywhere. Producing those documents without the executions they attest to
+would be fabricated evidence — the exact failure mode this program's
+honesty constraints exist to prevent. The entry gate exists so that this
+review is not conducted on fabricated inputs, and it is honored here.

--- a/docs/controlled-production/FINAL_RELEASE_DECISION.md
+++ b/docs/controlled-production/FINAL_RELEASE_DECISION.md
@@ -1,0 +1,90 @@
+# Controlled Production Readiness Review — Formal Outcome
+
+**Project Launch, Sprint 5.**
+
+## Decision
+
+# **NOT_READY_FOR_PRODUCTION_REVIEW**
+
+Issued per the mission's entry-criteria clause. The Controlled Production
+Readiness Review **was not conducted**, and therefore none of the six
+board decisions (APPROVE_CONTROLLED_PRODUCTION / CONDITIONAL_APPROVAL /
+CONTINUE_PILOT / RETRAIN / PAUSE / REJECT) was reached — a decision issued
+without the review's required executed evidence would be meaningless at
+best and dangerous at worst.
+
+This decision does not constitute General Availability, and it does not
+change the standing release decision in
+`docs/general-availability/GENERAL_AVAILABILITY_REPORT.md` (CONDITIONAL
+GO for one narrow, fully-disclosed pilot; NO GO for broad launch).
+
+## Missing evidence (the list the entry gate requires)
+
+Full per-criterion detail is in `ENTRY_CRITERIA.md`. The blocking gaps:
+
+1. **No validated-candidate model.** The only trained model is
+   `Experimental`, trained exclusively on one declared synthetic dataset —
+   this environment holds zero real facility ACTIVE Ground Truth, so no
+   model can structurally reach `Candidate`, let alone
+   `Validated Candidate`.
+2. **No locked validation report** over real clinical data (only the
+   synthetic experimental run's reports, plus an unfilled template).
+3. **No completed supervised advisory pilot** — infrastructure exists;
+   no pilot has ever run at any facility with any user.
+4. **No pilot final report** — the doc of that name describes the report
+   endpoint, not a completed pilot.
+5. **No documented human response data** — zero real acceptance/
+   modification/rejection/decision-time/trust records.
+6. **No ACTIVE image-backed baselines in any persistent environment**
+   (the Atlas governance layer is built and tested; the library is empty
+   outside test runs).
+7. **No tested support ownership** (documentation exists; no named owner,
+   no executed support simulation, alerting not wired to any destination).
+8. **No exercised rollback** (documented and migration-tested against
+   fresh databases; never executed against a running deployment — and no
+   controlled production environment exists to execute it in).
+9. **No standing registered artifact, active policy, or production
+   database** — every registry row, policy, and baseline this program has
+   ever created lives in ephemeral test/dev databases.
+
+## What must happen before this review can begin
+
+In dependency order:
+
+1. **Stand up a persistent controlled environment** (real database, object
+   storage, configured alert destination) — the prerequisite for every
+   piece of executed operational evidence Sections 7–14 demand.
+2. **Run a real facility engagement**: ingest real instrument images
+   through Canvas, produce real ACTIVE Ground Truth through the
+   double-blind annotation workflow, and activate real image-backed
+   baselines through the Atlas lifecycle.
+3. **Retrain on the real governed dataset** via the existing documented
+   training command; the registration code will then grant `Candidate`
+   on its own evidence.
+4. **Run the Shadow protocol** (`docs/shadow-validation/`) to a locked
+   validation report, then the **Advisor pilot**
+   (`docs/advisory-pilot/PILOT_PROTOCOL.md`) to a real final report with
+   real human response data.
+5. **Execute and retain the operational evidence**: deployment, backup +
+   restore, DR exercise, delivered alert, model/policy rollback, support
+   simulation.
+6. **Re-run this sprint.** With entry criteria met, conduct the full
+   multidisciplinary review (Sections 1–18) and issue one of the six
+   decisions.
+
+## Owner and authority
+
+This outcome was produced by the engineering review of repository
+evidence. Reconvening the review requires the evidence above plus a
+multidisciplinary board (clinical, engineering, security, legal, support)
+— the six-way decision is that board's to make, not engineering's alone.
+
+## Correct completion statement
+
+LumenAI's Controlled Production Readiness Review was gated at entry:
+the repository does not yet contain the real pilot, validation, baseline,
+and operational evidence the review requires, so the board review was not
+convened and **NOT_READY_FOR_PRODUCTION_REVIEW** was issued with the
+missing-evidence list above. This outcome does not constitute General
+Availability, and no capability has been marked production-ready without
+production evidence.

--- a/docs/general-availability/GENERAL_AVAILABILITY_REPORT.md
+++ b/docs/general-availability/GENERAL_AVAILABILITY_REPORT.md
@@ -233,6 +233,21 @@ statement: the candidate is ready for independent validation and
 prospective shadow-mode evaluation — not clinically validated, pilot-ready,
 or production-ready.
 
+### Addendum update — Project Launch Sprint 5 (Controlled Production Readiness Review)
+
+**The release decision above is unchanged.** The Controlled Production
+Readiness Review was attempted and **gated at entry**: 7 of its 12 entry
+criteria are not met (no validated-candidate model, no completed pilot, no
+pilot final report, no human response data, no ACTIVE image-backed
+baselines in any persistent environment, no tested support ownership, no
+exercised rollback), so the review was not convened and
+**NOT_READY_FOR_PRODUCTION_REVIEW** was issued — see
+`docs/controlled-production/ENTRY_CRITERIA.md` and
+`docs/controlled-production/FINAL_RELEASE_DECISION.md` for the
+per-criterion evidence and the dependency-ordered path to reconvening.
+This independently corroborates this report's Engineering and Clinical
+NO GO findings; it produces no new evidence for a different decision.
+
 ## Summary
 
 LumenAI Version 1.0 is architecturally sound, extensively documented, and

--- a/docs/general-availability/KNOWN_LIMITATIONS.md
+++ b/docs/general-availability/KNOWN_LIMITATIONS.md
@@ -129,17 +129,26 @@ here is new; it is gathered into one place per Section 11's requirement.
   embedding** — appropriate as a first stage per the sprint's own
   guidance, but a coarser signal than a trained embedding model would
   provide.
-- **`error_analysis.py`'s hardcoded negative-label constant
+- ~~**`error_analysis.py`'s hardcoded negative-label constant
   (`"no_actionable_finding"`) does not match Project Lens's new taxonomy's
-  negative label (`"no_observable_abnormality"`)** — every error this
-  sprint's run produced was therefore categorized as
-  `misclassification_between_findings` rather than correctly recognizing
-  false-positive/false-negative cases against the new taxonomy. Disclosed
-  in `docs/model-development/ERROR_ANALYSIS_REPORT.md`; not yet fixed.
-- **`TrainingConfig.class_weighting = "balanced"` is recorded in every
-  training run's configuration but not actually applied** by the
-  pure-Python logistic-regression trainer — a real, disclosed gap between
-  declared policy and implementation.
+  negative label (`"no_observable_abnormality"`)**~~ — **fixed
+  (post-Sprint-2 follow-up)**: the negative label is now a parameter
+  (`analyze_errors(..., negative_label=...)`, default unchanged for the
+  Genesis pipeline), and `run_lens_training()` passes Lens's own label, so
+  Lens false negatives/positives are now correctly categorized instead of
+  all landing in `misclassification_between_findings`. Pinned by
+  `test_custom_negative_label_recognizes_lens_taxonomy`. Note that
+  `ERROR_ANALYSIS_REPORT.md`'s recorded run predates this fix — its
+  error-type counts reflect the old, miscategorized behavior.
+- ~~**`TrainingConfig.class_weighting = "balanced"` is recorded in every
+  training run's configuration but not actually applied**~~ — **fixed
+  (post-Sprint-2 follow-up)**: the trainer now supports per-sample weights
+  (`training_execution.balanced_sample_weights`, standard
+  n / (n_classes · n_c) convention) and both the Lens Stage B/C and
+  Genesis one-vs-rest trainers apply them when
+  `class_weighting == "balanced"`. Pinned by `TestClassWeightingUnit`.
+  Prior recorded runs (including the registered experimental artifact)
+  were trained WITHOUT balancing despite their config recording it.
 - **(Project Vision Sprint 2) `settings.ai_strict_no_placeholder` exists
   but defaults to `False` in every environment, including real
   production** — it is a new, opt-in switch that, when explicitly turned
@@ -189,13 +198,30 @@ full design. What changed and what remains true:
   `DatasetRegistryEntry` → `RetainedImage.image_bytes`. Only `ACTIVE`,
   reviewed, hash-verified images may participate — DRAFT/PENDING_REVIEW/
   APPROVED/SUSPENDED/REJECTED/ARCHIVED images cannot.
-- **`image_similarity_service.compare_against_baseline()` (Project Lens) is
-  still not wired into the live per-inspection scoring path.** This sprint
-  builds the compatibility contract and resolution hierarchy that would
-  feed such a comparator a real, governed baseline image — it deliberately
-  does not call the comparator itself ("do not implement a trained vision
-  model in this sprint," mission constraint). Wiring an actual numeric
-  image comparison into the live disposition path remains future work.
+- ~~**`image_similarity_service.compare_against_baseline()` (Project Lens) is
+  still not wired into the live per-inspection scoring path.**~~ — **wired
+  (post-Sprint-2 follow-up)**, with honest limits:
+  `_live_baseline_comparison()` in
+  `baseline_comparison_scoring_service.py` now populates
+  `live_model_result.baseline_comparison` on every live inspection by
+  composing the Atlas pieces end-to-end — `resolve_baseline_image()` (the
+  5-level hierarchy) → `check_compatibility()` (never a similarity number
+  on an incompatible outcome) → `load_and_verify_baseline_bytes()`
+  (SHA-256 re-verified on every access; a mismatch reports
+  `BASELINE_INTEGRITY_FAILED`, never a score) →
+  `compare_against_baseline()` (aHash similarity). It remains a SEPARATE
+  evidence channel: nothing reads it back into the model observation or
+  the Decision Engine's disposition, so high similarity can never cancel
+  a probable contamination, and a missing baseline never blocks inference
+  (pinned by `test_live_baseline_comparison_never_alters_observation`).
+  **Real limits**: at live-inspection time only the instrument family is
+  known (no anatomy zone, model, or Digital Twin identity is captured on
+  the inspection submission today), so resolution can only ever reach
+  hierarchy level 4 (governed consensus by instrument family) — exact
+  Digital-Twin and manufacturer/model/zone baselines are unreachable from
+  this path until richer capture context is collected; and the aHash
+  collision limitation below still applies to the similarity number
+  itself.
 - **Pre-existing metadata-only `BaselineLibraryEntry` rows are not
   automatically backfilled with an image.** They are classified via `GET
   /api/baseline-library/legacy-report` and marked

--- a/docs/model-development/ERROR_ANALYSIS_REPORT.md
+++ b/docs/model-development/ERROR_ANALYSIS_REPORT.md
@@ -62,3 +62,12 @@ class. This is disclosed here rather than silently producing a
 mislabeled `error_type` — a future sprint should either parameterize
 `error_analysis.py`'s negative label or give Project Lens its own thin
 wrapper that translates labels before calling it.
+
+**Update (post-Sprint-2 follow-up): fixed.** `analyze_errors()` /
+`classify_error()` now take a `negative_label` parameter (default
+unchanged for the Genesis pipeline) and `run_lens_training()` passes
+Lens's own `"no_observable_abnormality"` — pinned by
+`test_custom_negative_label_recognizes_lens_taxonomy`. The run recorded
+ABOVE predates the fix, so its `error_type_counts` still reflect the
+old, miscategorized behavior; the next training run will report real
+false_positive/false_negative counts.


### PR DESCRIPTION
## Latest update (`f7d6493`) — Project Launch Sprint 5: Controlled Production Readiness Review gated at entry

The Sprint 5 mission's own entry gate ("Do not begin unless the repository contains real evidence for [12 criteria]... If entry criteria are incomplete, issue NOT_READY_FOR_PRODUCTION_REVIEW and list the missing evidence") was applied against real repository evidence. **7 of 12 entry criteria are not met** — no validated-candidate model (the only trained model is Experimental, synthetic-data-only, and structurally cannot be promoted without real Ground Truth), no completed advisory pilot, no pilot final report (the doc of that name describes the report *endpoint*), no human response data, no ACTIVE image-backed baselines in any persistent environment, no tested support ownership, no exercised rollback. The board review was therefore **not convened**, and **NOT_READY_FOR_PRODUCTION_REVIEW** was issued.

Conducting the review's Sections 7–14 anyway (executed backup **and restore**, disaster-recovery exercise with measured recovery times, alerts delivered to "an actual configured destination", tested rollback, run support simulation) would have required fabricating operational evidence — no controlled production environment or alert destination exists for this repository. The entry gate exists precisely to prevent a review on fabricated inputs, and it was honored.

**New docs**: `docs/controlled-production/ENTRY_CRITERIA.md` (per-criterion evidence assessment, with the "why the review was not conducted anyway" rationale) and `docs/controlled-production/FINAL_RELEASE_DECISION.md` (formal outcome, blocking-gap list, dependency-ordered path to reconvening: persistent controlled environment → real facility images through Canvas → retrain to Candidate → Shadow protocol → Advisor pilot → executed operational evidence → re-run the review). **GA report**: addendum only — the standing release decision is unchanged.

Also hardens the three new live-baseline tests against persistent-test-DB reruns (per-run unique instrument families and nonce'd PNG bytes — the same mitigation `test_baseline_image_library.py` already uses); verified stable across two consecutive runs against the same database.

---

## Summary
Implements the three actionable post-merge recommendations from the PR #96 close-out review — two disclosed ML-pipeline bugs fixed, and the perceptual-hash baseline comparator finally wired into the live inference path:

1. **Error-analysis negative label parameterized.** `analyze_errors()`/`classify_error()` now take a `negative_label` parameter (default unchanged for the Genesis pipeline); `run_lens_training()` passes Project Lens's own `"no_observable_abnormality"`. Before this, every Lens false negative/positive was miscategorized as `misclassification_between_findings` because the hardcoded Genesis label never matched any Lens sample.
2. **`TrainingConfig.class_weighting="balanced"` is now genuinely applied.** The pure-Python trainer supports per-sample weights (`training_execution.balanced_sample_weights`, standard n / (n_classes · n_c) convention), and both the Lens Stage B/C and Genesis one-vs-rest trainers apply them when the config says `"balanced"`. Previously the setting was recorded in every run's config but silently ignored.
3. **Baseline comparator wired into the live path.** `_live_baseline_comparison()` in `baseline_comparison_scoring_service.py` populates `live_model_result.baseline_comparison` on every live inspection by composing existing infrastructure end-to-end: Atlas's `resolve_baseline_image()` (5-level hierarchy) → `check_compatibility()` (never a similarity number on an incompatible outcome) → `load_and_verify_baseline_bytes()` (SHA-256 re-verified on every access; a mismatch reports `BASELINE_INTEGRITY_FAILED`, never a score) → Lens's `compare_against_baseline()` (aHash similarity). It remains a separate evidence channel: nothing reads it back into the model observation or the Decision Engine's disposition, so high similarity can never cancel a probable contamination, and a missing baseline never blocks inference.

## Why This Change
All three items were real, disclosed gaps carried in `KNOWN_LIMITATIONS.md`: the first two would quietly degrade the first training run on real facility data (miscategorized error types, unbalanced training on imbalanced clinical classes); the third was the original intent of the false-PASS remediation that Project Atlas built the governance layer for but never connected. The Sprint 5 gate outcome documents, honestly, why the platform is not yet reviewable for controlled production and exactly what evidence must exist first.

## Scope
**Included**: `error_analysis.py` parameterization + Lens call site; `training_execution.py` weighted trainer + `candidate_training.py`/`lens_training_pipeline.py` wiring; `_live_baseline_comparison()` in the scoring service; 7 new tests (rerun-hardened); doc updates marking the fixed limitations; Sprint 5 entry-criteria assessment + formal gate outcome docs + GA-report addendum.
**Excluded**: no schema changes, no route changes, no frontend changes (the existing `baseline_comparison` panel in `NewInspectionPage.tsx` already renders the newly-populated field), no change to the Decision Engine or any disposition logic, no re-training of the registered experimental artifact, and — per the Sprint 5 gate — no fabricated operational evidence (no backup/restore/DR/monitoring/support/rollback documents were created without the executions they would attest to).

**Honest limit of the comparator wiring**: at live-inspection time only the instrument family is known (no anatomy zone, model, or Digital Twin identity is captured on the inspection submission today), so baseline resolution can only reach hierarchy level 4 (governed consensus by instrument family). Exact Digital-Twin and manufacturer/model/zone baselines are unreachable from this path until richer capture context is collected — documented in `KNOWN_LIMITATIONS.md`.

## Testing
- [x] Unit tests — full backend suite: **3666 passed, 2 skipped, 0 failed** (7 new tests: Lens-taxonomy error typing, balanced-weight math + fit-changes-on-imbalance, live baseline comparison no-baseline / active-baseline-similarity / never-alters-observation); the three live-baseline tests additionally verified stable across two consecutive runs against the same persistent test database
- [x] Manual verification — `ruff check` clean; frontend build clean
- [ ] Docker build — not run (no dependency or Dockerfile changes)
- [ ] API/worker runtime validation — covered by the HTTP-level tests in the suite; no new routes added

## Risks
Low. No migrations, no config changes, no removed behavior. The trainer change alters future training runs' fitted weights when `class_weighting="balanced"` (the declared, recorded intent) — the already-registered experimental artifact is untouched. The baseline-comparison population is additive inside `live_model_result` (a key that was previously always `null`); the additive-only contract test and the new never-alters-observation test pin that nothing downstream changes. The Sprint 5 commit is documentation plus test hardening only.

## Rollback Plan
`git revert f7d6493` reverts the Sprint 5 gate docs + test hardening independently; `git revert 88a83e4` reverts the ML fixes + comparator wiring independently — both are self-contained with no schema or config dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVqKmNua8sWhTdLDHEPyzV