### PR TITLE
Directive 008: Dataset Governance and Candidate Model Readiness

### DIFF
--- a/docs/pilot-zero/directive-008/DATASET_ARCHITECTURE.md
+++ b/docs/pilot-zero/directive-008/DATASET_ARCHITECTURE.md
@@ -1,0 +1,82 @@
+# LPZ-DIR-008 — Dataset Architecture
+
+**Purpose:** define the logical structure of a governed dataset — how approved
+Pilot Zero evidence composes into a curated, versioned, reproducible dataset
+suitable for **future** candidate computer-vision models. This is a **governance
+standard**, not new software; each element is mapped to the dataset code already
+present in the repository so the architecture is auditable against reality.
+
+Guardrails: no new product functionality, **no model deployment**, no model
+accuracy/clinical-performance claim, no hospital deployment workflow. Datasets are
+**only** constructed from approved evidence.
+
+## Sources (governed inputs)
+
+| Source | Meaning | System mapping |
+|---|---|---|
+| **Approved Images** | Governed captures (Directive 005), integrity-hashed, no PHI | `RetainedImage` / `DatasetRegistryEntry.retained_image_id`, `image_sha256` |
+| **Approved Metadata** | Acquisition provenance (Directive 005) | `DatasetRegistryEntry` capture fields |
+| **Approved Annotations** | Controlled-taxonomy findings (Directive 006) | `Annotation` / `AnnotationVersion` |
+| **Ground Truth** | Human-approved, ACTIVE labels (Directive 006) | `Annotation` GT (ACTIVE) |
+| **Baselines** | Approved references (Directive 007) | `BaselineLibraryEntry` / `BaselineImageLink` |
+| **Digital Twins** | Instrument identity anchors (Directive 007) | `digital_twin_id` (LCID) |
+| **Audit Records** | Attributable lifecycle events | audit trail |
+
+## Relationships
+
+```
+Inspection
+   ▼
+Image           (approved capture, hashed, no PHI)
+   ▼
+Annotation      (controlled taxonomy, evidence-linked, versioned)
+   ▼
+Ground Truth    (human-approved, immutable, ACTIVE)
+   ▼
+Baseline        (approved reference; GT-gated)
+   ▼
+Digital Twin    (instrument identity anchor)
+   ▼
+Dataset         (curated, versioned, reproducible composition — this directive)
+   ▼
+Candidate Model (FUTURE — separate authorized directive; not built here)
+```
+
+## Logical dataset structure
+
+A governed dataset is a **manifest over approved evidence**, not a copy of pixels:
+
+* **Dataset identity & version** — `DatasetVersion` (immutable once approved).
+* **Members** — `DatasetRegistryEntry` rows, each referencing one approved image
+  by id + `image_sha256`, its ACTIVE Ground Truth, baseline, and `digital_twin_id`.
+* **Partition** — each member's `split_assignment` (train/validation/test).
+* **Provenance** — `lcid`, `usage_rights`, `phi_verification`, `training_eligibility`.
+* **Manifest & checksum** — enumerated members + per-image and dataset-level
+  checksums for reproducibility (`DATASET_VERSIONING_STANDARD.md`).
+
+## Architectural principles
+
+1. **Reference, don't copy.** The dataset references approved evidence; images
+   remain owned by `RetainedImage`. This keeps a single source of truth and makes
+   lineage exact.
+2. **Approved-evidence-only.** A dataset member must trace to ACTIVE Ground Truth
+   and (where used) an approved baseline; unreviewed evidence is ineligible.
+3. **Immutable once approved.** A dataset version is frozen at approval; changes
+   create a new version (`DATASET_VERSIONING_STANDARD.md`).
+4. **Reproducible.** Manifest + checksums + recorded seed reconstruct the exact
+   dataset.
+5. **Fully traceable.** Every member resolves back through GT → annotation → image
+   → inspection → instrument/twin → baseline (`DATASET_LINEAGE_STANDARD.md`).
+6. **Tenant-isolated, no PHI.** Enforced across the composition.
+
+## Governance note (existing system)
+
+The repository already implements the spine: `DatasetVersion` +
+`DatasetRegistryEntry` (with `image_sha256`, `split_assignment`,
+`training_eligibility`, `usage_rights`, `phi_verification`, `lcid`,
+`digital_twin_id`, `baseline_id`), and services `dataset_registry`,
+`dataset_builder`, `dataset_split` (leakage prevention + stratification),
+`dataset_integrity`, `dataset_validation_service`, `dataset_release_service`,
+`dataset_export_service`. This architecture **governs** those pieces as one
+approved-evidence-only pipeline; it adds no code under this directive. Gaps and a
+migration plan are in `DIRECTIVE_008_REPORT.md`.

--- a/docs/pilot-zero/directive-008/DATASET_CLASSIFICATION_STANDARD.md
+++ b/docs/pilot-zero/directive-008/DATASET_CLASSIFICATION_STANDARD.md
@@ -1,0 +1,107 @@
+# LPZ-DIR-008 — Dataset Classification Standard
+
+**Purpose:** define dataset categories so every dataset has a declared purpose,
+permitted uses, approval authority, lifecycle, and restrictions. Categories
+describe **trust level and intended use**, not model performance.
+
+Guardrail: no category implies model accuracy or clinical performance; the
+"training/validation/test" categories describe **data role**, not any trained
+model's quality.
+
+## Categories
+
+### Raw Research Dataset
+* **Purpose:** exploratory collection of evidence for internal study.
+* **Permitted uses:** research/exploration only.
+* **Approval authority:** AI Researcher (research-only flag).
+* **Lifecycle:** Draft → Retired/Archived.
+* **Restrictions:** never used for candidate model training; may contain
+  not-yet-approved evidence and must be labeled research-only.
+
+### Quality Approved Dataset
+* **Purpose:** evidence that has passed image-quality review.
+* **Permitted uses:** input to annotation/Ground Truth datasets.
+* **Approval authority:** Quality Reviewer.
+* **Lifecycle:** Draft → Approved → Superseded.
+* **Restrictions:** quality-approved ≠ training-ready; GT still required.
+
+### Annotation Dataset
+* **Purpose:** images with completed annotations (pre-Ground-Truth).
+* **Permitted uses:** review, adjudication, GT assembly.
+* **Approval authority:** Annotation/Review governance (Directive 006).
+* **Lifecycle:** Draft → Approved → Superseded.
+* **Restrictions:** not training-ready until GT is ACTIVE.
+
+### Ground Truth Dataset
+* **Purpose:** images with **ACTIVE** human-approved Ground Truth.
+* **Permitted uses:** basis for development/training/validation/test datasets.
+* **Approval authority:** Ground Truth Approver (Directive 006).
+* **Lifecycle:** Approved → Superseded (new GT version).
+* **Restrictions:** the foundational trusted layer; never bypassed.
+
+### Development Dataset
+* **Purpose:** curated dataset for model development iteration.
+* **Permitted uses:** future development/experimentation.
+* **Approval authority:** Dataset Approver + Engineering Reviewer.
+* **Lifecycle:** Candidate → Approved → Published → Superseded/Retired.
+* **Restrictions:** development context; not a benchmark of record.
+
+### Validation Dataset
+* **Purpose:** partition used to tune/select during future development.
+* **Permitted uses:** model selection (future work).
+* **Approval authority:** Dataset Approver.
+* **Lifecycle:** frozen with its parent dataset version.
+* **Restrictions:** disjoint from train and test (`DATASET_PARTITION_STANDARD.md`).
+
+### Benchmark Dataset
+* **Purpose:** a governed, stable dataset for comparison over time.
+* **Permitted uses:** future benchmarking; held stable.
+* **Approval authority:** Dataset Approver + Program Administrator.
+* **Lifecycle:** Approved → Published (long-lived) → Superseded.
+* **Restrictions:** changes require a new version; never silently edited.
+
+### Training Dataset
+* **Purpose:** partition designated for future candidate model training.
+* **Permitted uses:** future training (no training under this directive).
+* **Approval authority:** Dataset Approver.
+* **Lifecycle:** frozen with its parent dataset version.
+* **Restrictions:** disjoint from validation and test; no instrument-instance
+  leakage.
+
+### Test Dataset
+* **Purpose:** held-out partition for future unbiased evaluation.
+* **Permitted uses:** future evaluation only.
+* **Approval authority:** Dataset Approver; access-restricted.
+* **Lifecycle:** frozen; ideally sealed until evaluation.
+* **Restrictions:** never seen in train/validation; strict no-leakage.
+
+### Retired Dataset
+* **Purpose:** a dataset withdrawn from use.
+* **Permitted uses:** none for new work; retained for audit.
+* **Approval authority:** Dataset Approver records retirement + reason.
+* **Lifecycle:** Retired → Archived.
+* **Restrictions:** not selectable for new development.
+
+### Archived Dataset
+* **Purpose:** immutable historical retention.
+* **Permitted uses:** audit, lineage, reproduction of past work.
+* **Approval authority:** system-preserved.
+* **Lifecycle:** terminal; nothing leaves Archived.
+* **Restrictions:** read-only.
+
+## Cross-category rules
+
+* **Training/validation/test are disjoint** and derived from an approved Ground
+  Truth Dataset (`DATASET_PARTITION_STANDARD.md`).
+* **Only approved, frozen dataset versions** feed candidate-model readiness
+  (`MODEL_DATASET_READINESS_STANDARD.md`).
+* **Tenant isolation & no PHI** apply to every category.
+* **No overwrite:** category/version changes create new versions.
+
+## Governance note (existing system)
+
+Today `DatasetRegistryEntry` carries `training_eligibility` and `split_assignment`,
+and `DatasetVersion` versions the dataset; the builder/eligibility/release services
+distinguish research vs. training-eligible data. This standard formalizes the
+category vocabulary as a governance overlay; a future authorized change may add an
+explicit `dataset_category` field. No code is changed under this directive.

--- a/docs/pilot-zero/directive-008/DATASET_CREATION_WORKFLOW.md
+++ b/docs/pilot-zero/directive-008/DATASET_CREATION_WORKFLOW.md
@@ -1,0 +1,97 @@
+# LPZ-DIR-008 — Dataset Creation Workflow
+
+**Purpose:** define the governed path by which approved evidence becomes a
+published, reproducible dataset. Datasets are **only** built from approved
+Pilot Zero evidence; each gate is fail-closed.
+
+## Workflow
+
+```
+Approved Images           (Directive 005 — hashed, no PHI)
+      ▼
+Metadata Validation       (acquisition provenance complete)
+      ▼
+Annotation Validation     (Directive 006 — controlled taxonomy, evidence)
+      ▼
+Ground Truth Validation   (Directive 006 — ACTIVE, human-approved)
+      ▼
+Baseline Verification     (Directive 007 — approved baseline where used)
+      ▼
+Quality Review            (image quality + composition adequacy)
+      ▼
+Dataset Candidate         (manifest assembled; partition proposed)
+      ▼
+Engineering Review        (partition, leakage, distributions, reproducibility)
+      ▼
+Approval                  (Dataset Approver; separation of duties)
+      ▼
+Publication               (version frozen; manifest + checksums sealed)
+```
+
+## Stage detail
+
+### 1. Approved Images
+Only governed, integrity-hashed, PHI-verified images (Directive 005) are eligible.
+*System:* `DatasetRegistryEntry.retained_image_id` + `image_sha256`,
+`phi_verification`.
+
+### 2. Metadata Validation
+Required acquisition metadata is present and consistent (device, resolution,
+lighting, instrument identity). Missing required metadata → excluded.
+*System:* `dataset_validation_service`, registry capture fields.
+
+### 3. Annotation Validation
+Each candidate member has a valid annotation under the Directive 006 taxonomy with
+evidence references. *System:* `Annotation` link, `annotation_version`.
+
+### 4. Ground Truth Validation
+Each member must resolve to **ACTIVE** Ground Truth — the "approved evidence only"
+rule. Non-GT members are ineligible (fail-closed). *System:* GT status check.
+
+### 5. Baseline Verification
+Where the dataset's purpose involves baseline comparison, the referenced baseline
+must be an **approved** version (Directive 007). *System:* `baseline_id`,
+baseline lifecycle.
+
+### 6. Quality Review
+Image quality distribution and composition adequacy are reviewed; poor-quality or
+unrepresentative members are handled per `DATASET_QUALITY_STANDARD.md`.
+
+### 7. Dataset Candidate
+The manifest (members + references + proposed partition) is assembled. Not yet
+usable. *System:* `dataset_builder`, `DatasetVersion` (draft).
+
+### 8. Engineering Review
+An Engineering Reviewer verifies the partition (no leakage, no duplicate
+instrument instances across train/test), distributions, seed, and reproducibility
+(`DATASET_PARTITION_STANDARD.md`). *System:* `dataset_split`, `dataset_integrity`.
+
+### 9. Approval
+A **Dataset Approver** (not the dataset's author) approves per governance,
+recording approver, timestamp, rationale, source references, GT/baseline versions,
+checksum, and manifest. *System:* approval fields on `DatasetVersion`.
+
+### 10. Publication
+The dataset version is **frozen**: manifest and checksums are sealed, and the
+version becomes citable for future candidate-model readiness. **No modification
+after approval** — changes create a new version. *System:* frozen `DatasetVersion`.
+
+## Invariants
+
+* **Approved-evidence-only** and **GT-gated** at member level.
+* **Fail-closed:** any missing validation, evidence, or partition check blocks
+  progression.
+* **Separation of duties:** approver ≠ dataset author/engineering reviewer of the
+  same version where feasible.
+* **Reproducible:** manifest + checksums + seed recorded before publication.
+* **Immutable once approved:** new versions, never edits.
+
+## Governance note (existing system)
+
+`dataset_builder`, `dataset_registry`, `dataset_split`, `dataset_integrity`,
+`dataset_validation_service`, and `dataset_release_service` already implement much
+of this pipeline (leakage-safe splitting, integrity gate, validation, release
+builder). Governance additions recorded for a future authorized change: enforce
+the ACTIVE-Ground-Truth precondition and separation-of-duties at the approval
+boundary, and seal a manifest + dataset-level checksum at publication. No code is
+changed under this directive.

--- a/docs/pilot-zero/directive-008/DATASET_LINEAGE_STANDARD.md
+++ b/docs/pilot-zero/directive-008/DATASET_LINEAGE_STANDARD.md
@@ -1,0 +1,76 @@
+# LPZ-DIR-008 — Dataset Lineage Standard
+
+**Purpose:** guarantee that every dataset supports **complete, reconstructable
+lineage** back to the physical instrument and the approved evidence it was built
+from. Lineage is what makes a dataset auditable and scientifically defensible.
+
+## Lineage chain
+
+```
+Dataset            (version, manifest, checksum)
+   ▼
+Ground Truth       (ACTIVE version each member resolves to)
+   ▼
+Annotation         (version, controlled taxonomy, evidence)
+   ▼
+Image              (RetainedImage, image_sha256)
+   ▼
+Inspection         (inspection event)
+   ▼
+Instrument         (instrument identity / UDI)
+   ▼
+Digital Twin       (governed identity anchor)
+   ▼
+Baseline           (approved reference version used)
+   ▼
+Evidence Package   (assembled, auditable bundle)
+```
+
+## Lineage requirements
+
+For **every dataset member**, the following must be recorded and resolvable:
+
+| Link | Recorded reference | System mapping |
+|---|---|---|
+| Dataset → member | member row | `DatasetRegistryEntry` (in `DatasetVersion`) |
+| member → Ground Truth | GT version | `Annotation` GT (ACTIVE) |
+| member → Annotation | annotation version | `annotation_version` |
+| member → Image | image id + checksum | `retained_image_id`, `image_sha256` |
+| member → Inspection | inspection id | `inspection_id` |
+| member → Instrument | instrument identity | `instrument_id`, `lcid` |
+| member → Digital Twin | twin id | `digital_twin_id` |
+| member → Baseline | baseline id/version | `baseline_id` |
+| member → Evidence Package | assembled bundle | evidence/audit facility |
+
+## Rules
+
+1. **No orphan members.** A dataset member with a broken link (missing GT, image,
+   or identity) is ineligible — fail-closed.
+2. **Versions pinned.** Lineage records the exact GT and baseline **versions**, so
+   the dataset is reproducible even after those evolve.
+3. **Bidirectional traceability.** From a dataset one can reach every source; from
+   a piece of evidence one can find every dataset version that uses it (impact
+   analysis, e.g., if evidence is retired).
+4. **Immutable lineage.** Lineage for an approved dataset version is frozen with
+   the version; corrections create a new version.
+5. **Auditable end-to-end.** The full chain is reconstructable from stored
+   references + audit trail; no link is inferred or fabricated.
+
+## Uses of lineage
+
+* **Audit:** prove a dataset was built only from approved evidence.
+* **Reproduction:** rebuild and verify a past dataset version.
+* **Impact analysis:** if an image, annotation, GT, or baseline is corrected or
+  retired, identify every dataset version affected.
+* **Model-readiness:** lineage verification is a required readiness gate
+  (`MODEL_DATASET_READINESS_STANDARD.md`).
+
+## Governance note (existing system)
+
+`DatasetRegistryEntry` already carries the linking columns (`retained_image_id`,
+`image_sha256`, `inspection_id`, `instrument_id`, `lcid`, `digital_twin_id`,
+`baseline_id`, `annotation_version`) and `DatasetVersion` groups members; the LCID
+services maintain identity. Governance additions recorded for a future authorized
+change: pin GT/baseline **versions** into each member, add a reverse
+evidence→datasets index for impact analysis, and produce a per-dataset lineage
+report as part of publication. No code is changed under this directive.

--- a/docs/pilot-zero/directive-008/DATASET_PARTITION_STANDARD.md
+++ b/docs/pilot-zero/directive-008/DATASET_PARTITION_STANDARD.md
@@ -1,0 +1,68 @@
+# LPZ-DIR-008 — Train / Validation / Test Partition Standard
+
+**Purpose:** define partition rules so future candidate-model datasets are
+**leakage-free, representative, and reproducible**. This directive does not train
+models; it governs how partitions are constructed and validated.
+
+## Requirements
+
+### No data leakage
+Train, validation, and test partitions are **disjoint**. No image, and no
+information derived from an image, appears in more than one partition. Near-
+duplicates (same capture, minor variants) must fall in the **same** partition.
+
+### No duplicate instrument instances across train and test
+Partitioning is grouped by **instrument identity / Digital Twin**: all images of a
+given physical instrument (same `digital_twin_id` / instrument instance) go to a
+**single** partition. A model must never be tested on an instrument it saw in
+training. This is the primary leakage guard for reusable instruments.
+
+### Maintain representative distributions
+Partitions preserve, as far as feasible, the distribution of key strata: class
+(finding) balance, instrument family, manufacturer, and image-quality bands. Where
+exact stratification conflicts with the instrument-grouping rule, **instrument
+grouping wins** (no leakage), and the resulting distribution skew is documented.
+
+### Document partition rationale
+Every dataset version records: the partition method, the grouping key (instrument/
+twin), the target ratios (e.g., train/val/test), the strata balanced, and any
+documented skew or exclusions.
+
+### Support reproducibility
+The partition is deterministic given its inputs and seed. Re-running the
+partitioning on the same frozen dataset version yields the same assignment.
+
+### Record random seed where applicable
+When randomization is used (e.g., shuffling groups before assignment), the
+**seed** is recorded in the dataset manifest so the split is exactly reproducible.
+
+## Partition procedure (governed)
+
+1. **Group by instrument/twin.** Collect all eligible members per instrument
+   identity.
+2. **Stratify groups**, not images, across partitions to preserve distributions.
+3. **Assign whole groups** to train/validation/test at the target ratios.
+4. **Verify disjointness** — assert no instrument appears in two partitions and no
+   image is shared.
+5. **Record** method, seed, ratios, resulting distributions, and any skew.
+6. **Freeze** the assignment into the dataset version (`split_assignment`).
+
+## Validation checks (expected outcomes)
+
+* **Leakage check:** intersection of instrument identities across partitions is
+  empty → PASS; any overlap → FAIL (blocks approval).
+* **Duplicate check:** duplicate images (by `image_sha256`) do not span partitions.
+* **Distribution check:** per-stratum proportions reported per partition; large
+  unexplained skew is flagged for review.
+* **Reproducibility check:** re-running with the recorded seed reproduces the
+  identical assignment.
+
+## Governance note (existing system)
+
+`dataset_split` already implements **leakage prevention + stratification**, and
+`DatasetRegistryEntry.split_assignment` stores each member's partition;
+`dataset_integrity` provides an integrity gate. Governance additions recorded for
+a future authorized change: enforce instrument/`digital_twin_id` grouping as the
+partition key, persist the partition **seed** and rationale in the manifest, and
+add an explicit cross-partition instrument-overlap assertion to the approval gate.
+No code is changed under this directive.

--- a/docs/pilot-zero/directive-008/DATASET_QUALITY_STANDARD.md
+++ b/docs/pilot-zero/directive-008/DATASET_QUALITY_STANDARD.md
@@ -1,0 +1,62 @@
+# LPZ-DIR-008 — Dataset Quality Standard
+
+**Purpose:** define the metrics that describe a dataset's quality and
+composition, so datasets are **statistically documented and scientifically
+defensible**. Metrics describe the **data**, not any model. This directive
+computes no model performance and makes no accuracy claim.
+
+Guardrail: every metric is computed from real dataset records; where data is
+insufficient, the metric reports "insufficient data", never a fabricated figure.
+
+## Metric definitions
+
+| Metric | Definition | Purpose |
+|---|---|---|
+| **Class balance** | Distribution of finding/label classes | Detect over/under-representation |
+| **Instrument diversity** | Distinct instruments / families represented | Generalization coverage |
+| **Manufacturer diversity** | Distinct manufacturers represented | Avoid single-vendor bias |
+| **Image quality distribution** | Members by quality band (Excellent…Reject) | Ensure adequate quality mix |
+| **Annotation agreement** | Inter-reviewer agreement of member annotations | Label reliability (Directive 006) |
+| **Ground Truth confidence** | Distribution of reviewer-confidence bands | Trust level of labels |
+| **Unknown rate** | Share of members labeled Unknown/Unable to Determine | Honest uncertainty; taxonomy coverage |
+| **Coverage completeness** | Share of members with required regions imaged | Comparison validity |
+| **Missing metadata** | Share of members missing required metadata | Data completeness gate |
+| **Duplicate detection** | Duplicate/near-duplicate members (by `image_sha256`) | Leakage & inflation guard |
+| **Dataset drift** | Distribution shift vs. a prior version/benchmark | Composition stability over versions |
+
+## Interpretation rules
+
+* **Unknown rate is not a failure metric.** A dataset that honestly records
+  uncertainty is more defensible than one that forces labels; a rising trend may
+  signal a taxonomy gap.
+* **Diversity vs. balance trade-offs** are documented, not silently optimized;
+  instrument-grouping for leakage-safety (`DATASET_PARTITION_STANDARD.md`) takes
+  precedence over perfect class balance.
+* **Duplicates** must be resolved before approval — near-duplicates are kept in a
+  single partition or removed, never split across train/test.
+* **Missing metadata / coverage gaps** reduce eligibility; members below the bar
+  are excluded, with the exclusion documented.
+
+## Documentation requirement
+
+Every published dataset version ships a **quality summary** recording each metric
+(or "insufficient data"), the strata reported, exclusions, and any documented
+skew. This summary is part of the dataset's statistical documentation and is
+required for model-dataset readiness (`MODEL_DATASET_READINESS_STANDARD.md`).
+
+## Thresholds
+
+This directive does **not** set numeric pass/fail thresholds beyond structural
+gates (no unresolved duplicates across partitions; required metadata present for
+eligible members; audit completeness). Credible thresholds require baseline data
+from the operating program and are set later under a separate authorized
+directive.
+
+## Governance note (existing system)
+
+`ImageQualityAssessment`, `dataset_validation_service`, `dataset_integrity`, and
+the annotation analytics service already compute quality, integrity, agreement,
+and Unknown-rate signals from real records; `image_sha256` supports duplicate
+detection. Governance additions recorded for a future authorized change: assemble
+a single dataset-version **quality summary** artifact covering all metrics above,
+and add cross-version drift reporting. No code is changed under this directive.

--- a/docs/pilot-zero/directive-008/DATASET_VERSIONING_STANDARD.md
+++ b/docs/pilot-zero/directive-008/DATASET_VERSIONING_STANDARD.md
@@ -1,0 +1,69 @@
+# LPZ-DIR-008 — Dataset Versioning Standard
+
+**Purpose:** define how datasets are versioned. Core rule: **no dataset is
+modified after approval — new versions are created**, and every version is
+reproducible from its manifest and checksums.
+
+## Required dataset fields
+
+| Field | Meaning | System mapping |
+|---|---|---|
+| **Dataset UUID** | Permanent, immutable identity | `DatasetVersion` id |
+| **Version** | Monotonic version | `DatasetVersion` version / label |
+| **Creation Date** | When created | `created_at` |
+| **Author** | Who assembled it | author field |
+| **Approver** | Who approved it (attributable) | approver field |
+| **Source References** | Member evidence (images, annotations) | `DatasetRegistryEntry` rows (id + `image_sha256`) |
+| **Ground Truth Version** | GT version each member resolves to | `Annotation` GT version |
+| **Baseline Version** | Baseline version(s) used | `baseline_id` + baseline version |
+| **Digital Twin References** | Instrument twins represented | `digital_twin_id` set |
+| **Checksum** | Per-image + dataset-level integrity | `image_sha256` + dataset manifest hash |
+| **Manifest** | Enumerated members + partition | manifest artifact |
+| **License** | Usage rights | `usage_rights` |
+| **Approval Status** | Draft / Approved / Published / Superseded / Retired | `DatasetVersion` status |
+
+## Versioning rules
+
+1. **Immutable after approval.** Once approved/published, a dataset version is
+   frozen. No member is added, removed, or relabeled in place.
+2. **New version for any change.** Adding data, fixing a label, or re-partitioning
+   creates a **new** dataset version with its own UUID/version, manifest, and
+   checksums; the prior version is retained and marked Superseded.
+3. **Manifest is authoritative.** The manifest enumerates every member (image id +
+   `image_sha256`), its GT/baseline/twin references, and its partition — enough to
+   reconstruct the dataset exactly.
+4. **Checksums verify integrity.** Each member carries `image_sha256`; the dataset
+   carries a manifest-level checksum. Verification detects any drift between the
+   recorded manifest and the referenced evidence.
+5. **Reason required.** Every new version records why it was created.
+6. **Retrievable history.** Superseded versions remain retrievable for audit and
+   to reproduce past work.
+7. **Frozen references.** A dataset version pins the exact **GT version** and
+   **baseline version** of each member, so it is reproducible even after GT or
+   baselines evolve.
+
+## Lineage example
+
+```
+DATASET 2026-000007
+  v1  approved 2026-04-01  approver=A  manifest#… checksum#…  reason="initial GT dataset"
+  v2  approved 2026-05-15  approver=B  manifest#… checksum#…  reason="added 40 GT members; re-split"  supersedes v1
+       (v1 retained, marked Superseded — never edited)
+```
+
+## Reproducibility guarantee
+
+Given a dataset version's manifest, checksums, and recorded partition seed, the
+exact dataset (members + partition) can be reconstructed and verified. A mismatch
+between manifest and referenced evidence is a governance failure surfaced by
+checksum verification, not silently ignored.
+
+## Governance note (existing system)
+
+`DatasetVersion` versions datasets today, `DatasetRegistryEntry.image_sha256`
+provides per-image checksums, `dataset_integrity` gates integrity, and
+`dataset_release_service` builds releases. Governance additions recorded for a
+future authorized change: seal a dataset-level manifest hash at approval, pin GT
+and baseline **versions** into each member record, and make "no modification after
+approval" an enforced invariant (writes to an approved version rejected). No code
+is changed under this directive.

--- a/docs/pilot-zero/directive-008/DIRECTIVE_008_REPORT.md
+++ b/docs/pilot-zero/directive-008/DIRECTIVE_008_REPORT.md
@@ -1,0 +1,170 @@
+# LPZ-DIR-008 — Directive Report: Dataset Governance & Candidate Model Readiness
+
+## Executive summary
+
+Directive 008 establishes the **governance framework** by which approved Pilot
+Zero evidence becomes curated, versioned, reproducible datasets suitable for
+**future** candidate computer-vision models. It delivers nine standards (dataset
+architecture, classification, creation workflow, versioning, partitioning, quality,
+lineage, model-dataset readiness, and this report), each grounded in the dataset
+code already present in the repository so the framework is auditable against
+reality.
+
+Every dataset governed by this framework is **reproducible, governed, version
+controlled, fully traceable, statistically documented, scientifically defensible,
+and auditable**, and is **only** constructed from approved evidence (ACTIVE Ground
+Truth; approved baselines). This directive is **governance and documentation
+only**: no new product functionality, **no model deployment or training**, no
+accuracy/clinical-performance claim, and no hospital deployment workflow. No
+application code was modified.
+
+## Dataset architecture
+
+`DATASET_ARCHITECTURE.md` defines the dataset as a **manifest over approved
+evidence** (reference, don't copy), composing approved images/metadata/annotations/
+Ground Truth/baselines/Digital Twins/audit records along the chain Inspection →
+Image → Annotation → Ground Truth → Baseline → Digital Twin → Dataset → Candidate
+Model (future). Members reference approved evidence by id + `image_sha256`.
+
+## Classification
+
+`DATASET_CLASSIFICATION_STANDARD.md` defines eleven categories (Raw Research,
+Quality Approved, Annotation, Ground Truth, Development, Validation, Benchmark,
+Training, Test, Retired, Archived) with purpose, permitted uses, approval
+authority, lifecycle, and restrictions. Train/validation/test are disjoint and
+derived from an approved Ground Truth dataset.
+
+## Workflow
+
+`DATASET_CREATION_WORKFLOW.md`: Approved Images → Metadata Validation → Annotation
+Validation → Ground Truth Validation → Baseline Verification → Quality Review →
+Dataset Candidate → Engineering Review → Approval → Publication — GT-gated,
+fail-closed, with separation of duties, ending in a frozen, checksum-sealed
+version.
+
+## Versioning
+
+`DATASET_VERSIONING_STANDARD.md` requires Dataset UUID, version, dates, author,
+approver, source references, Ground Truth version, baseline version, Digital Twin
+references, checksum, manifest, license, and approval status. **No dataset is
+modified after approval**; changes create new versions; manifest + checksums +
+pinned GT/baseline versions guarantee reproducibility.
+
+## Quality metrics
+
+`DATASET_QUALITY_STANDARD.md` defines class balance, instrument/manufacturer
+diversity, image-quality distribution, annotation agreement, Ground Truth
+confidence, Unknown rate, coverage completeness, missing metadata, duplicate
+detection, and dataset drift — computed from real records, with "insufficient
+data" rather than fabricated figures, and a required per-version quality summary.
+
+## Partition strategy
+
+`DATASET_PARTITION_STANDARD.md` mandates leakage-free, **instrument/Digital-Twin-
+grouped** train/validation/test partitions (no instrument instance spans train and
+test), representative distributions with documented skew, recorded seed, and
+reproducible, deterministic assignment.
+
+## Lineage
+
+`DATASET_LINEAGE_STANDARD.md` guarantees complete, bidirectional lineage Dataset →
+Ground Truth → Annotation → Image → Inspection → Instrument → Digital Twin →
+Baseline → Evidence Package, with no orphan members, pinned versions, immutable
+per-version lineage, and impact analysis.
+
+## Model readiness
+
+`MODEL_DATASET_READINESS_STANDARD.md` defines the ten mandatory, fail-closed
+readiness requirements (approval, metadata, no unresolved conflicts, quality
+threshold, Ground Truth complete, baseline verified, partition validated, lineage
+verified, audit complete, version frozen) and a **readiness certificate** — while
+explicitly asserting no model accuracy/clinical claim and authorizing no training.
+
+## Validation procedures (test requirements) & expected outcomes
+
+Documentation-only directive — these are the validation procedures a future
+authorized implementation change must satisfy. No tests were added or modified.
+
+| # | Validates | Procedure (future) | Expected outcome |
+|---|---|---|---|
+| 1 | Dataset creation | Build a dataset including a member without ACTIVE Ground Truth. | Member rejected; approved-evidence-only enforced (fail-closed). |
+| 2 | Version creation | Modify an approved dataset. | Rejected; a new version is required (immutability). |
+| 3 | Manifest generation | Publish a dataset version. | Manifest enumerates all members + references + partition; reproducible. |
+| 4 | Checksum verification | Alter a referenced image after publication. | Checksum mismatch detected against the sealed manifest. |
+| 5 | Partition validation | Assign one instrument's images to both train and test. | Leakage check FAILs; blocks approval. |
+| 6 | Duplicate detection | Include duplicate images (same `image_sha256`) across partitions. | Duplicates detected; not split across partitions. |
+| 7 | Lineage verification | Break a member's GT/image link. | Member flagged ineligible; lineage verification FAILs. |
+| 8 | Approval workflow | Approve a dataset as its own author. | Rejected by separation-of-duties; independent approver required. |
+| 9 | Dataset immutability | Attempt to add/remove a member from an approved version. | Rejected; approved versions are frozen. |
+
+## Existing-system gap analysis & migration plan
+
+The repository already implements much of this: models `DatasetVersion`,
+`DatasetRegistryEntry` (with `image_sha256`, `split_assignment`,
+`training_eligibility`, `usage_rights`, `phi_verification`, `lcid`,
+`digital_twin_id`, `baseline_id`, `annotation_version`), `ImageQualityAssessment`,
+`DoubleBlindReview`; services `dataset_registry`, `dataset_builder`,
+`dataset_split` (leakage prevention + stratification), `dataset_integrity`
+(reject-gate), `dataset_validation_service`, `dataset_release_service`,
+`dataset_export_service`, `dataset_eligibility_service`.
+
+| Gap | Current state | Migration step (future) | Priority |
+|---|---|---|---|
+| Approved-evidence (GT) precondition | Eligibility referenced, not hard-gated at build | Enforce ACTIVE-GT precondition at member inclusion & approval | High |
+| Immutability after approval | Versioning exists | Reject writes to an approved dataset version | High |
+| Dataset-level manifest + checksum | Per-image `image_sha256` present | Seal a manifest hash at publication; verify on read | High |
+| Instrument-grouped partition key | Leakage-safe split exists | Enforce `digital_twin_id`/instrument grouping + persist seed/rationale | High |
+| Pinned GT/baseline versions | ids referenced | Pin GT & baseline **versions** into each member | Medium |
+| Category vocabulary | `training_eligibility` flag | Add explicit `dataset_category` | Low |
+| Quality summary + drift | Metrics computed piecemeal | Assemble one per-version quality summary + cross-version drift | Medium |
+| Readiness certificate | Integrity/eligibility gates exist | Bind all ten readiness checks into one certificate artifact | Medium |
+
+**No migration step is executed under Directive 008.** Each is a candidate for a
+future directive that explicitly authorizes code changes. Per the directive's
+constraint, **no model training pipeline was implemented** — the existing dataset
+machinery is governed, not extended.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Dataset built from unreviewed evidence | Untrustworthy dataset | Approved-evidence-only, GT-gated (planned enforcement) |
+| Data leakage across train/test | Inflated future results | Instrument-grouped, leakage-checked partitions |
+| Dataset edited after approval | Non-reproducibility | Immutability + new-version rule |
+| Silent evidence drift | Dataset no longer matches manifest | Checksums + manifest verification |
+| Missing lineage | Not auditable/reproducible | Lineage standard; no orphan members |
+| Over-claiming model readiness | False assurance | Readiness = dataset governance only; no model/accuracy claim |
+| Scope creep into training/deployment | Violates directive & freeze | Non-goals restated in every doc; candidate model reserved |
+
+## Dependencies
+
+* **Program:** Directives 001, 002, 004, 005, 006, 007 (all complete).
+* **System:** the dataset models/services above; LCID identity; annotation/GT and
+  baseline governance.
+* **Personnel:** dataset authors, engineering reviewers, Dataset Approvers, quality
+  auditors, with separation of duties.
+
+## Acceptance criteria
+
+All nine deliverables exist under `docs/pilot-zero/directive-008/`, are internally
+consistent and vendor-neutral, make no model accuracy/clinical-performance claim,
+enforce approved-evidence-only and dataset immutability, define leakage-free
+partitioning and complete lineage, and include validation procedures with expected
+outcomes plus an honest gap analysis. **Met.**
+
+## Exit criteria (to operate under this framework — future work)
+
+1. GT-gated dataset creation and separation-of-duties enforced in code.
+2. Dataset immutability + sealed manifest/checksum enforced.
+3. Instrument-grouped, seed-recorded partitioning enforced.
+4. Readiness certificate binding the ten checks produced per dataset version.
+5. Validation procedures 1–9 implemented and passing on a clean database.
+
+## Completion status
+
+**LPZ-DIR-008 Dataset Governance & Candidate Model Readiness framework: COMPLETE
+(documented).** The framework is defined, grounded in the existing system, and
+accompanied by a migration plan and validation procedures. **Code enforcement of
+the migration steps is NOT started (by design — deferred to a future authorized
+directive).** No machine learning model was implemented, trained, or deployed, and
+no accuracy or clinical-performance claim is made.

--- a/docs/pilot-zero/directive-008/MODEL_DATASET_READINESS_STANDARD.md
+++ b/docs/pilot-zero/directive-008/MODEL_DATASET_READINESS_STANDARD.md
@@ -1,0 +1,56 @@
+# LPZ-DIR-008 — Model-Dataset Readiness Standard
+
+**Purpose:** define the **minimum requirements a dataset must meet before it may be
+used for future candidate model training**. This is a governance gate on the
+*dataset*, not a model. **No model is trained, deployed, or evaluated under this
+directive**, and no accuracy or clinical-performance claim is made.
+
+## Readiness requirements (all mandatory)
+
+A dataset version is **model-ready** only when **every** item below is satisfied
+and recorded:
+
+| # | Requirement | Evidence |
+|---|---|---|
+| 1 | **Approval complete** | Dataset version approved by an authorized Dataset Approver (separation of duties). |
+| 2 | **Metadata complete** | All eligible members have required acquisition metadata; missing-metadata members excluded. |
+| 3 | **No unresolved review conflicts** | No member carries an open annotation disagreement (Directive 006). |
+| 4 | **Quality threshold achieved** | Quality summary produced; structural quality gates pass (duplicates resolved, coverage/metadata bars met). |
+| 5 | **Ground Truth complete** | Every member resolves to ACTIVE Ground Truth (Directive 006). |
+| 6 | **Baseline verified** | Referenced baselines are approved versions (Directive 007). |
+| 7 | **Partition validated** | Leakage-free, instrument-grouped train/val/test with recorded seed and rationale (`DATASET_PARTITION_STANDARD.md`). |
+| 8 | **Lineage verified** | Complete lineage for every member (`DATASET_LINEAGE_STANDARD.md`). |
+| 9 | **Audit complete** | All lifecycle transitions have attributable audit events (audit completeness = 100%). |
+| 10 | **Dataset version frozen** | Manifest + checksums sealed; version immutable (`DATASET_VERSIONING_STANDARD.md`). |
+
+## Readiness rule
+
+**Fail-closed:** if any requirement is unmet, the dataset is **not** model-ready.
+There is no partial-ready state — readiness is all-or-nothing and attributable.
+A readiness determination records who certified it, when, against which dataset
+version, and the evidence for each of the ten items.
+
+## What readiness does NOT assert
+
+* It does **not** claim any model will be accurate or clinically valid.
+* It does **not** authorize training, deployment, or evaluation — those require a
+  separate, explicitly-authorized directive.
+* It certifies only that the **dataset** is governed, reproducible, traceable,
+  documented, and frozen — a precondition for *future* candidate work.
+
+## Readiness certificate (artifact)
+
+On passing, a **readiness certificate** is recorded: dataset UUID + version,
+certifier, timestamp, the ten items with evidence references, the quality summary,
+the partition report, and the lineage report. The certificate is the auditable
+statement that the dataset may proceed to future candidate model development.
+
+## Governance note (existing system)
+
+`DatasetRegistryEntry.training_eligibility`, `dataset_integrity` (reject-gate),
+`dataset_validation_service`, and the eligibility/release services already gate
+training-eligibility and integrity today. Governance additions recorded for a
+future authorized change: assemble a single **readiness certificate** binding all
+ten checks to a frozen dataset version, and require it before any candidate
+training directive may consume the dataset. No code is changed under this
+directive.


### PR DESCRIPTION
## Summary
Adds the complete governance framework by which approved Pilot Zero evidence
becomes curated, versioned, reproducible datasets suitable for future candidate
computer-vision models (LPZ-DIR-008). Nine documents under
`docs/pilot-zero/directive-008/` define dataset architecture, classification,
creation workflow, versioning, train/validation/test partitioning, quality
metrics, lineage, model-dataset readiness, and a directive report with validation
procedures and a gap analysis of the existing dataset system.

## Why This Change
Before any dataset feeds future candidate model work, it must be reproducible,
governed, version controlled, fully traceable, statistically documented,
scientifically defensible, and auditable — and built only from approved evidence
(ACTIVE Ground Truth; approved baselines). This directive establishes that
framework and grounds it in the dataset code already in the repository so it is
auditable against reality.

## Scope
**Included:** governance documentation only (9 Markdown files).
**Excluded:** no new product functionality, no model deployment or training, no
model accuracy or clinical-performance claim, and no hospital deployment workflow.
The "Candidate Model" layer is reserved and out of scope. No application code was
modified. Architecture remains frozen.

## Testing
- [ ] Unit tests
- [ ] Manual verification
- [ ] Docker build
- [ ] API/worker runtime validation

Documentation-only change — no code touched, so no backend/frontend build or
pytest run applies. The report defines validation procedures (dataset creation,
version creation, manifest generation, checksum verification, partition
validation, duplicate detection, lineage verification, approval workflow, dataset
immutability) with expected outcomes for a future authorized implementation
change. Documents were reviewed for internal consistency, absence of PHI, and
absence of model/clinical claims.

## Risks
None to runtime, migrations, config, or backward compatibility — no code paths
change. The framework mitigates the process risks it names (dataset from
unreviewed evidence, train/test leakage, post-approval edits, silent evidence
drift, missing lineage, over-claimed readiness, scope creep into training), and
records a prioritized migration plan for closing gaps against the existing system
under a future, separately-authorized directive.

## Rollback Plan
Revert the single documentation commit (or close this PR). No system state,
schema, or deployment is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVqKmNua8sWhTdLDHEPyzV)_