### PR TITLE
Fix UTC-midnight flake in OR-Connect dashboard test (Pilot Zero Gate stability)

### DIFF
--- a/backend/tests/test_or_connect.py
+++ b/backend/tests/test_or_connect.py
@@ -343,8 +343,18 @@ class TestRepairIntegration:
 
 class TestCaseIntelligenceDashboard:
     def test_dashboard_returns_todays_cases(self):
-        case = _create_case(scheduled_start=datetime.now(timezone.utc) + timedelta(hours=1))
-        r = client.get("/api/or-connect/dashboard", headers=AUTH_OPERATOR)
+        scheduled = datetime.now(timezone.utc) + timedelta(hours=1)
+        case = _create_case(scheduled_start=scheduled)
+        # Pin the dashboard's date window to the case's own scheduled UTC date.
+        # Requesting the bare endpoint would default the window to "now's" UTC
+        # date, so a case at now+1h that crosses into the next UTC day (suite
+        # running in the last hour before midnight) would fall outside "today"
+        # and the count would be 0 — a real UTC-midnight flake. Pinning the
+        # target_date to the case's date removes all clock dependence.
+        target_date = scheduled.date().isoformat()
+        r = client.get(
+            f"/api/or-connect/dashboard?target_date={target_date}", headers=AUTH_OPERATOR
+        )
         assert r.status_code == 200
         body = r.json()
         assert body["total_cases"] >= 1


### PR DESCRIPTION
## Summary

The **Pilot Zero Gate** failed on the `main` merge of #122 (run [29878099905](https://github.com/johnnychris77/lumen-AI/actions/runs/29878099905), merge commit `4168d68`). Both backend test jobs failed on a **single** test — everything else passed (3730 passed, 1 failed):

```
FAILED tests/test_or_connect.py::TestCaseIntelligenceDashboard::test_dashboard_returns_todays_cases - assert 0 >= 1
```

The run straddled UTC midnight (started 23:45, tests ran ~23:51 → 00:01). This is a **test-only clock-dependence bug**, not a production defect.

## Root cause

The test seeded a surgical case at `now + 1 hour` and then requested the bare `/api/or-connect/dashboard`, which defaults its date window to the **server's current UTC date**. When the suite runs in the last hour before UTC midnight, `now + 1h` lands on the *next* UTC day, so the case correctly falls outside "today's" window and `total_cases` comes back `0` → `assert total_cases >= 1` fails.

Production behavior is correct: a "today's cases" dashboard *should* exclude a case scheduled for tomorrow. The bug is entirely in the test's dependence on wall-clock time.

## Fix

Pin the request's `target_date` query parameter to the seeded case's own scheduled UTC date, so the dashboard window always contains the case regardless of when the suite runs. This removes all clock dependence and, as a bonus, exercises the `target_date` parameter the previous bare-call version did not.

```python
scheduled = datetime.now(timezone.utc) + timedelta(hours=1)
case = _create_case(scheduled_start=scheduled)
target_date = scheduled.date().isoformat()
r = client.get(f"/api/or-connect/dashboard?target_date={target_date}", headers=AUTH_OPERATOR)
```

## Testing

- [x] `pytest tests/test_or_connect.py` → 29 passed (SQLite).
- [x] `ruff check tests/test_or_connect.py` → clean.
- [x] The `main` gate run was also re-run (past midnight) to clear the transient on `main` itself.

## Scope

One test file: `backend/tests/test_or_connect.py`. No production code changed.

## Risks

None — test-only change that makes an existing assertion deterministic.

## Rollback Plan

Revert the commit / delete the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVqKmNua8sWhTdLDHEPyzV)_